### PR TITLE
fix(vm): three general interpreter bugs found by re-measuring Config::TOML (#7539)

### DIFF
--- a/news/2026-09/config-toml-crane-three-general-interpreter-fixes.md
+++ b/news/2026-09/config-toml-crane-three-general-interpreter-fixes.md
@@ -1,0 +1,138 @@
+# Three general interpreter fixes found by re-measuring the Config::TOML battery
+
+[#7539](https://github.com/tokuhirom/mutsu/issues/7539) tracks bundling
+`Config::TOML` v0.1.3 and its dependency `Crane` v0.1.2 as a battery, parked
+behind core interpreter blockers. Both upstream suites were re-fetched and
+re-run against a fresh build; the pass counts had **regressed** since the
+ticket's last measurement, and chasing that regression turned up three
+unrelated general bugs.
+
+| Suite | raku | mutsu (ticket, 2026-09-07) | mutsu before this pass | mutsu after |
+| --- | --- | --- | --- | --- |
+| `Config::TOML` v0.1.3 | 19/19 files | 11/19 | 10/19 | **14/19** |
+| `Crane` v0.1.2 | 15/15 files | 4/15 | 2/15 | **4/15** |
+
+Counts are from a release build (`target/release/mutsu`) with a 120s per-file
+budget; a debug build is one file short, `special-cases/03-txn` timing out
+rather than failing.
+
+None of the three fixes is TOML-specific; each is a rule mutsu was getting
+wrong for any program of the same shape.
+
+## 1. A package nested under a setting-provided name was invisible when reached transitively
+
+Rakudo merges a `use`d compunit's declarations stash by stash. A
+`class X::Crane::GetRootContainerKey` therefore lands in the setting's own `X`
+stash — one process-global object every compunit shares — rather than in the
+declaring compunit's `GLOBALish`, which is the only thing the importing
+compunit merges. So `use Crane;` alone makes every `X::Crane::*` exception
+nameable, and Crane's own test files name them directly.
+
+mutsu's #7797 qualified-name gate reconstructs rakudo's lexical rule on top of
+its flat package stores, but had no notion of the setting's own stashes: it
+required the running compunit to have `use`d something under the name's own
+top-level segment. A script that `use`d only `Crane` was refused
+`X::Crane::GetRootContainerKey` outright, aborting four files mid-run.
+
+Measured against rakudo (v2026.07), which draws the line at exactly this
+spelling:
+
+| declared in a transitively-`use`d module | rakudo |
+| --- | --- |
+| `class Zzz::Foo::Alpha` | "Could not find symbol" |
+| `unit module Baz; our sub greet` | "Could not find symbol" |
+| `class X::Zork::Alpha` | resolves |
+| `class IO::Zork` / `class Pod::Zork` | resolves |
+
+The gate now admits a name whose top-level segment is one the setting itself
+provides: the pure-namespace `CORE::` packages (`X`, `CX`, `EXPORTHOW`,
+`Exceptions`, `Metamodel`, `PROCESS`, `Pod`, `RakuAST`, `Rakudo`, plus
+`CompUnit`/`Encoding`/`Systemic`), and every setting *type* that also acts as a
+namespace, which the existing builtin-type list already answers. A fresh
+top-level namespace is still gated exactly as before.
+
+Pinned by `t/modules/setting-nested-package-visibility.t`.
+
+## 2. A from-the-end subscript in container context read instead of binding
+
+Every rvalue index path resolves a `WhateverCode` subscript against the
+subscripted array's length before using it. The two container-producing paths —
+`:=` bind and an `is rw` routine's `return-rw <subscript>` tail — did not: the
+index stayed an unconvertible `WhateverCode`, `index_to_usize` declined it, and
+the autovivifying op fell through to a plain *read*.
+
+```raku
+sub g(\c) is rw { return-rw c[*-1] }
+my @a = 1, 2, 3;
+g(@a) = 9;      # raku: [1, 2, 9]   mutsu: "Cannot modify an immutable Int (3)"
+```
+
+`c[*-0]` on an empty array — the append idiom `Crane::In` is built on, and
+what `Config::TOML` performs for every `[[table]]` entry — silently wrote
+nowhere, so an array-of-tables document came back with an empty array.
+
+Both autovivifying index ops now resolve a `WhateverCode` index against the
+array first. Deliberately narrow: only a `WhateverCode`, never a bare
+`Whatever` (which expands to a full index list and is a slice with its own bind
+semantics), and only against an `Array`.
+
+Pinned by `t/vm/binding/rw-return-from-the-end-index.t`.
+
+## 3. A `:=` rebind of a subscript adopted an ancestor frame's container
+
+The compiler tags a `$x := <subscript>` bind source with a synthetic per-site
+name `__mutsu_bind_index_ref_N`. The tag denotes nothing of its own — the value
+under it is the oracle, a rule the store path already states for the
+immutability decision — and `N` is a constant-pool index, so two unrelated
+routines routinely mint the same name.
+
+The bind's container-promotion did not know that. It asked whether any ancestor
+call frame's saved env held the source name, found a *caller's* identically
+numbered temp through the chained call env, and adopted that stale cell as the
+bind's container. A rebind then kept naming the container the key was looked up
+in instead of the deferred entry for a missing key:
+
+```raku
+sub walk($container, @path) {
+    return unless @path;
+    my $root := $container;
+    $root := $root{@path[0]};
+    say @path[0], ' -> ', $root.WHAT.^name;
+    walk($root, @path[1..*]);
+}
+my %t = a => { b => 1 };
+walk(%t, ['a', 'zz', 'yy']);
+# raku:  a -> Hash   zz -> Any    yy -> Any
+# mutsu: a -> Hash   zz -> Hash   yy -> Hash
+```
+
+A recursive path-walking routine therefore descended into *itself* one step per
+path element. `Config::TOML`'s `pwd` answered `["a", 0, "b", 0, "c"]` where
+rakudo answers `["a", 0, "b", "c"]`, and the parser built a nested Array where
+the TOML said Hash.
+
+The trigger is worth naming, because it makes the bug look signature-sensitive:
+an `@`/`%` **parameter** disqualifies the callee from the slot-only light call
+paths, and only the env-chaining paths can see a caller's temp. The identical
+routine with a signature of plain scalars was always correct.
+
+The synthetic index tag is now excluded from the "does an ancestor frame own
+this source variable?" test, the same way it is already excluded from the
+named-source immutability rule.
+
+Pinned by `t/vm/binding/bind-index-temp-not-an-outer-frame-source.t`.
+
+## What is left on the ticket
+
+`Config::TOML` is at 14/19 and `Crane` at 4/15, so the vendoring steps stay
+parked. The residue splits into:
+
+- `special-cases/03-txn` now passes, but takes **58s on a release build where
+  `raku` takes 4.9s** — a 12x gap on one 350-line TOML document, and a
+  performance finding rather than a wrong answer. Filed separately as a
+  `todo:perf` issue.
+- `grammar-actions/01`, `02`, `04` and the two dumper files are the residues
+  already recorded on the ticket (string-equivalence, Rat/FatRat precision, and
+  the untouched TOML dumper).
+- `Crane`'s remaining files are its own positional/error-handling and ordering
+  gaps plus the object-hash blocker, unchanged by this pass.

--- a/src/runtime/compunit_scope.rs
+++ b/src/runtime/compunit_scope.rs
@@ -241,6 +241,28 @@ impl Interpreter {
         // on purpose, and is why THAT match alone (checked below) is not
         // enough here.
         let top = name.split_once("::").map_or(name, |(top, _)| top);
+        // A package nested under a name the SETTING already provides is
+        // visible from everywhere, however it was reached. Rakudo merges a
+        // `use`d compunit's declarations stash-by-stash, so a
+        // `class X::Crane::GetRootContainerKey` lands in the setting's own
+        // `X` stash — one process-global object every compunit shares —
+        // rather than in the declaring compunit's `GLOBALish`, which is the
+        // only thing the importing compunit merges. Verified against real
+        // rakudo, which draws exactly this line:
+        //
+        // | declared in a transitively-`use`d module | rakudo |
+        // | --- | --- |
+        // | `class Zzz::Foo::Alpha` | "Could not find symbol" |
+        // | `unit module Baz; our sub greet` | "Could not find symbol" |
+        // | `class X::Zork::Alpha` | resolves |
+        // | `class IO::Zork` / `class Pod::Zork` | resolves |
+        //
+        // This is what `use Crane;` relies on to make `X::Crane::*`
+        // resolvable from a script that only ever `use`d `Crane` (Crane's
+        // own `t/*.rakutest` name those exception types directly, #7539).
+        if Self::top_segment_is_setting_package(top) {
+            return true;
+        }
         if self.package_granted_in_unit_chain(executing, top)
             || self.package_granted_in_unit_chain(self.current_unit, top)
         {
@@ -258,6 +280,40 @@ impl Interpreter {
         };
         self.package_visible_in_unit_chain(executing, prefix, declaring_unit)
             || self.package_visible_in_unit_chain(self.current_unit, prefix, declaring_unit)
+    }
+
+    /// Whether `top` is a top-level name the setting itself provides, so that
+    /// a package declared under it is installed into a stash every compunit
+    /// shares (see the call site in
+    /// [`Self::qualified_name_visible_here`] for the rakudo behaviour this
+    /// models).
+    ///
+    /// Two disjoint groups. The pure *namespace* packages, which hold no type
+    /// of their own, are enumerated here because nothing else in the
+    /// interpreter knows them — they are exactly rakudo's `CORE::` entries
+    /// whose HOW is a Package/Module. Everything else is a setting *type*
+    /// that also acts as a namespace (`IO::Path`, `Proc::Async`,
+    /// `Lock::Async`, `Distribution::Hash`, ...), so it is answered by the
+    /// existing builtin-type list rather than duplicated.
+    fn top_segment_is_setting_package(top: &str) -> bool {
+        matches!(
+            top,
+            "CX" | "EXPORTHOW"
+                | "Exceptions"
+                | "Metamodel"
+                | "PROCESS"
+                | "Pod"
+                | "RakuAST"
+                | "Rakudo"
+                | "X"
+                // Setting types whose bare name the builtin-type list below
+                // does not carry (it holds `CompUnit::Repository` and friends
+                // but not the namespace root, and `Encoding`/`Systemic` are
+                // roles rather than instantiable types).
+                | "CompUnit"
+                | "Encoding"
+                | "Systemic"
+        ) || Self::is_builtin_type(top)
     }
 
     /// Whether the top-level `::`-segment `top` is among the packages

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1679,7 +1679,22 @@ impl Interpreter {
             // capture `_`'s CURRENT referent in the target name; `_` itself must
             // never be promoted or written back into any ancestor frame.
             let is_percall_pseudo_var = matches!(resolved_source.as_str(), "_" | "@_" | "%_" | "!");
+            // A `__mutsu_bind_index_ref_N` source is excluded for the reason
+            // given at `synthetic_index_source`: it denotes nothing of its own,
+            // so there is no "source variable" for an ancestor frame to own —
+            // and the tag is numbered per COMPILATION UNIT, so two unrelated
+            // routines routinely mint the same name. Chained call envs then let
+            // a callee's lookup find a CALLER's temp under it, and this
+            // promotion adopted that stale cell as the bind's container: a
+            // rebind (`$root := $root{$k}`) silently kept naming the container
+            // the key was looked up in instead of the deferred entry, so a
+            // recursive path-walking routine descended into itself one step per
+            // path element (Config::TOML's `pwd`, #7539). Only frames that
+            // chain env at all could hit it, which is why the same routine
+            // behaved correctly with a signature of plain scalars (those take
+            // the slot-only light call path).
             let source_in_outer_frame = !is_percall_pseudo_var
+                && !synthetic_index_source
                 && self
                     .call_frames
                     .iter()

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -125,6 +125,48 @@ impl Interpreter {
         }
     }
 
+    /// A from-the-end subscript (`*-1`, `*-0`, `* div 2`) resolved against the
+    /// array it addresses, for the CONTAINER-producing index paths (`:=` bind,
+    /// `return-rw`, an `is rw` routine's subscript tail).
+    ///
+    /// Every rvalue index path already resolves a `WhateverCode` subscript
+    /// against the subscripted value's length before using it
+    /// ([`Interpreter::resolve_whatever_index_for_target`]); the two
+    /// autovivifying paths did not, so `index_to_usize` saw an unconvertible
+    /// `Sub` and fell through to a plain *read*. That made an `is rw` routine
+    /// whose tail is a from-the-end subscript hand back the element's VALUE:
+    /// `sub g(\c) is rw { return-rw c[*-1] }; g(@a) = 9` died with "Cannot
+    /// modify an immutable Int", and `c[*-0]` — the append idiom `Crane::In`
+    /// is built on (#7539) — silently wrote nowhere.
+    ///
+    /// Deliberately narrow, on three axes.
+    ///
+    /// Only a `WhateverCode` (`ValueView::Sub`), never a bare `Whatever`:
+    /// `resolve_whatever_index_for_target` expands `*` to the full index list,
+    /// which is a *slice* and has its own bind semantics further down. Only
+    /// against an `Array`, because the length a from-the-end index is relative
+    /// to is a positional one — a `WhateverCode` key into a Hash stays the key
+    /// object it is. And only when the closure yields a single usable index:
+    /// a `WhateverCode` subscript is just as often a whole SLICE
+    /// (`$result[0..*-2]`, one closure returning a `Range`), which the arms
+    /// below hand to the general subscript path unresolved. Substituting the
+    /// evaluated `Range` there changed which fallback ran and broke
+    /// `roast/S03-sequence/exhaustive.t`'s `test-seq` slices, so anything that
+    /// is not a single non-negative `Int` — a `Range`, a list of indices — is
+    /// handed back exactly as it arrived.
+    fn resolve_whatever_container_index(&mut self, index: Value, resolved: &Value) -> Value {
+        if !matches!(index.view(), ValueView::Sub(_))
+            || !matches!(resolved.view(), ValueView::Array(..))
+        {
+            return index;
+        }
+        let candidate = self.resolve_whatever_index_for_target(index.clone(), Some(resolved));
+        match candidate.view() {
+            ValueView::Int(_) if Self::index_to_usize(&candidate).is_some() => candidate,
+            _ => index,
+        }
+    }
+
     /// Auto-vivifying index: creates intermediate Hash/Array entries and returns
     /// a `HashEntryRef` (hash) or a shared `ContainerRef` cell (array element) so
     /// that `:=` bind to nested elements works.
@@ -142,6 +184,7 @@ impl Interpreter {
             ValueView::Scalar(inner) => inner.clone(),
             _ => target.clone(),
         };
+        let index = self.resolve_whatever_container_index(index, &resolved);
 
         // Junction autothreading: when indexing a hash with a junction key,
         // expand the junction and create a slot ref for each element. EXCEPT on an
@@ -307,6 +350,7 @@ impl Interpreter {
             }
             _ => target.clone(),
         };
+        let index = self.resolve_whatever_container_index(index, &resolved);
 
         match resolved.view() {
             ValueView::Hash(ref map) => {

--- a/t/lib/SettingNestedHost.rakumod
+++ b/t/lib/SettingNestedHost.rakumod
@@ -1,0 +1,7 @@
+use X::SettingNested;
+use SettingNestedOwn;
+
+unit class SettingNestedHost;
+
+method alpha-message(--> Str:D) { X::SettingNested::Alpha.new.message }
+method own-greet(--> Str:D) { SettingNestedOwn::Beta.greet }

--- a/t/lib/SettingNestedOwn.rakumod
+++ b/t/lib/SettingNestedOwn.rakumod
@@ -1,0 +1,6 @@
+# The control for t/modules/setting-nested-package-visibility.t: a package
+# under a FRESH top-level namespace, reached only transitively. Rakudo does not
+# make this one nameable from the outer compunit, and neither may mutsu.
+class SettingNestedOwn::Beta {
+    method greet(--> Str:D) { 'beta' }
+}

--- a/t/lib/X/SettingNested.rakumod
+++ b/t/lib/X/SettingNested.rakumod
@@ -1,0 +1,12 @@
+# Declares packages under two namespaces the SETTING itself provides (`X`,
+# `IO`). Loaded only TRANSITIVELY, through `SettingNestedHost`, so a script
+# that `use`s the host still sees both -- see
+# t/modules/setting-nested-package-visibility.t.
+class X::SettingNested::Alpha {
+    also is Exception;
+    method message(--> Str:D) { 'alpha' }
+}
+
+class IO::SettingNestedProbe {
+    method greet(--> Str:D) { 'io-probe' }
+}

--- a/t/modules/setting-nested-package-visibility.t
+++ b/t/modules/setting-nested-package-visibility.t
@@ -1,0 +1,50 @@
+# A package declared under a name the SETTING provides is visible from every
+# compunit, however it was reached; one under a fresh top-level namespace is
+# visible only where it was `use`d.
+#
+# Rakudo merges a `use`d compunit's declarations stash by stash. A
+# `class X::Crane::GetRootContainerKey` therefore lands in the setting's own
+# `X` stash -- one process-global object every compunit shares -- rather than
+# in the declaring compunit's GLOBALish, which is the only thing the importing
+# compunit merges. So `use Crane;` alone makes `X::Crane::*` nameable, and
+# Crane's own test files rely on exactly that (GH #7539).
+#
+# mutsu's #7797 qualified-name gate reconstructed rakudo's lexical rule on top
+# of its flat package stores, but had no notion of the setting's own stashes,
+# so it refused every one of these transitively-reached `X::` names.
+#
+# Measured against rakudo (v2026.07), which draws the line at exactly this
+# spelling:
+#
+#   declared in a transitively-`use`d module   rakudo
+#   class Zzz::Foo::Alpha                      Could not find symbol
+#   unit module Baz; our sub greet             Could not find symbol
+#   class X::Zork::Alpha                       resolves
+#   class IO::Zork / class Pod::Zork           resolves
+use Test;
+use lib 't/lib';
+
+plan 5;
+
+# `SettingNestedHost` is the only module this file `use`s; it in turn `use`s
+# `X::SettingNested`, which declares all three classes below.
+use SettingNestedHost;
+
+is X::SettingNested::Alpha.new.message, 'alpha',
+   'a transitively-reached X:: class is nameable here';
+
+is IO::SettingNestedProbe.greet, 'io-probe',
+   'a transitively-reached IO:: class is nameable here';
+
+# The declaring module can of course still name its own packages, whatever
+# their namespace -- the gate only ever restricts cross-compunit reach.
+is SettingNestedHost.alpha-message, 'alpha',
+   'the importing module names the X:: class it use()d';
+is SettingNestedHost.own-greet, 'beta',
+   'the importing module names the fresh-namespace class it use()d';
+
+# ... but a fresh top-level namespace does NOT leak to this compunit.
+ok !(try SettingNestedOwn::Beta.greet).defined,
+   'a transitively-reached fresh-namespace class is NOT nameable here';
+
+# vim: expandtab shiftwidth=4

--- a/t/vm/binding/bind-index-temp-not-an-outer-frame-source.t
+++ b/t/vm/binding/bind-index-temp-not-an-outer-frame-source.t
@@ -1,0 +1,120 @@
+# A `:=` rebind whose source is a SUBSCRIPT must not adopt a container from an
+# ancestor call frame.
+#
+# The compiler tags a `$x := <subscript>` source with a synthetic per-site name
+# `__mutsu_bind_index_ref_N`. That tag denotes nothing of its own -- the value
+# under it is the oracle -- and N is a constant-pool index, so two unrelated
+# routines routinely mint the SAME name. Call paths that chain the callee's env
+# onto the caller's then let a lookup under that name find a CALLER's temp, and
+# the bind's container-promotion adopted that stale cell: `$root := $root{$k}`
+# kept naming the container the key was looked up in instead of the deferred
+# entry for the missing key.
+#
+# A recursive path-walking routine therefore descended into ITSELF one step per
+# path element -- `pwd(%toml, <a b c>)` answered `["a", 0, "b", 0, "c"]` where
+# rakudo answers `["a", 0, "b", "c"]`, and `Config::TOML` built a nested Array
+# where the TOML said Hash (GH #7539).
+#
+# The trigger is subtle enough to be worth pinning explicitly: an `@`/`%`
+# PARAMETER disqualifies the callee from the slot-only light call paths, and
+# only the env-chaining paths could see a caller's temp. The identical routine
+# with a signature of plain scalars was always correct, which is why the same
+# code behaved differently for what looked like a cosmetic signature change.
+#
+# Every expectation below was measured against rakudo (v2026.07).
+use Test;
+
+plan 6;
+
+# --- the minimal shape: recursion + an `@` parameter -------------------------
+
+sub walk($container, @path) {
+    return [] unless @path;
+    my $root := $container;
+    $root := $root{@path[0]};
+    [ $root.defined, |walk($root, @path[1..*]) ];
+}
+
+my %t = a => { b => 1 };
+is-deeply walk(%t, ['a', 'zz', 'yy']), [True, False, False],
+   'a rebind to a missing key reads as undefined at every recursion depth';
+
+# The `%` twin, and the shape where the caller is a *different* routine.
+sub inner($container, %opts, $k) {
+    my $root := $container;
+    $root := $root{$k};
+    $root.defined;
+}
+sub outer($container, $k) {
+    my $root := $container;
+    $root := $root{$k};
+    inner($root, {}, 'missing');
+}
+nok outer(%t, 'a'), 'a rebind in a callee with a % parameter is not the caller container';
+
+# --- the `pwd` descent Config::TOML actually performs ------------------------
+
+multi sub pwd(Associative:D $container, @ ($step, *@rest) --> Array:D) {
+    my @step-taken;
+    my $root := $container;
+    $root := $root{$step};
+    push(@step-taken, $step, |pwd($root, @rest));
+    @step-taken;
+}
+multi sub pwd(Associative:D $, @ --> Array:D) { my @step-taken; }
+multi sub pwd(Positional:D $container, @step where .elems > 0 --> Array:D) {
+    my @step-taken;
+    my $root := $container;
+    my Int:D $index = $container.end;
+    $root := $root[$index];
+    push(@step-taken, $index, |pwd($root, @step));
+    @step-taken;
+}
+multi sub pwd(Positional:D $, @ --> Array:D) { my @step-taken; }
+multi sub pwd($container, @ ($step, *@rest) --> Array:D) {
+    my @step-taken;
+    my $root := $container;
+    $root := try $root{$step};
+    push(@step-taken, $step, |pwd($root, @rest));
+    @step-taken;
+}
+multi sub pwd($, @ --> Array:D) { my @step-taken; }
+
+my %toml;
+%toml<a> = [];
+%toml<a>.push({});
+
+is-deeply pwd(%toml, ['a', 'b', 'c']), ['a', 0, 'b', 'c'],
+   'the arraytable path descent stops at the first missing key';
+
+# --- the bind itself still works where the key DOES exist --------------------
+
+sub reach($container, @path) {
+    my $root := $container;
+    $root := $root{@path[0]};
+    $root := $root{@path[1]};
+    $root;
+}
+is reach(%t, ['a', 'b']), 1, 'a chained rebind through existing keys reaches the leaf';
+
+# A rebind to an existing key still hands back a writable container.
+sub bind-leaf($container, @path) is rw {
+    my $root := $container;
+    $root := $root{@path[0]};
+    return-rw $root{@path[1]};
+}
+my %w = a => { b => 1 };
+bind-leaf(%w, ['a', 'b']) = 5;
+is %w<a><b>, 5, 'a rebind through an @ parameter still writes through to the source';
+
+# And a rebind to a MISSING key autovivifies the whole path on write.
+my %v = a => { };
+sub bind-missing($container, @path) is rw {
+    my $root := $container;
+    $root := $root{@path[0]};
+    return-rw $root{@path[1]};
+}
+bind-missing(%v, ['a', 'new']) = 7;
+is %v<a><new>, 7, 'a rebind to a missing key autovivifies on write';
+
+# vim: expandtab shiftwidth=4

--- a/t/vm/binding/rw-return-from-the-end-index.t
+++ b/t/vm/binding/rw-return-from-the-end-index.t
@@ -1,0 +1,59 @@
+# A from-the-end subscript (`*-1`, `*-0`) in CONTAINER context must yield the
+# element's container, not its value.
+#
+# Every rvalue index path resolves a `WhateverCode` subscript against the
+# subscripted array's length before using it. The two container-producing paths
+# -- `:=` bind and an `is rw` routine's `return-rw <subscript>` tail -- did not:
+# the index stayed an unconvertible `WhateverCode`, so the autovivifying op
+# fell through to a plain READ and handed the caller the element's value.
+#
+# `sub g(\c) is rw { return-rw c[*-1] }; g(@a) = 9` therefore died with "Cannot
+# modify an immutable Int", and `c[*-0]` on an empty array -- the append idiom
+# `Crane::In` is built on, which `Config::TOML` uses for every `[[table]]`
+# entry (GH #7539) -- silently wrote nowhere.
+#
+# Every expectation below was measured against rakudo (v2026.07).
+use Test;
+
+plan 8;
+
+sub last-elem(\c) is rw { return-rw c[*-1] }
+sub end-elem(\c) is rw { return-rw c[*-0] }
+sub nth(\c) is rw { return-rw c[1] }
+
+# `*-0` is "one past the last", i.e. an append.
+my @a;
+end-elem(@a) = 42;
+is-deeply @a, [42], 'return-rw c[*-0] appends to an empty array';
+
+end-elem(@a) = 43;
+is-deeply @a, [42, 43], 'return-rw c[*-0] appends again';
+
+my @b = 1, 2;
+last-elem(@b) = 9;
+is-deeply @b, [1, 9], 'return-rw c[*-1] writes the last element';
+
+# The plain-integer index was never broken; it is here so a regression that
+# "fixes" the WhateverCode case by breaking this one is caught too.
+my @c = 1, 2, 3;
+nth(@c) = 7;
+is-deeply @c, [1, 7, 3], 'return-rw c[1] still writes that element';
+
+# Through a hash element, the shape `Crane::In` actually descends into.
+my %h;
+%h<xs> = [];
+end-elem(%h<xs>) = 'first';
+end-elem(%h<xs>) = 'second';
+is-deeply %h<xs>, ['first', 'second'], 'return-rw c[*-0] through a hash element appends';
+
+# Reading through the same routine is unaffected.
+is last-elem(@c), 3, 'return-rw c[*-1] still reads the last element';
+
+# The `:=` twin of the same subscript.
+my @d = 10, 20, 30;
+my $tail := @d[*-1];
+is $tail, 30, 'a := bind to a from-the-end index reads the element';
+$tail = 99;
+is-deeply @d, [10, 20, 99], 'a := bind to a from-the-end index writes through';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Re-ran the upstream `Config::TOML` v0.1.3 and `Crane` v0.1.2 suites against a
fresh build, as [#7539](https://github.com/tokuhirom/mutsu/issues/7539) asks.
The counts had **regressed** since the ticket's last measurement, and chasing
that turned up three unrelated general bugs — none TOML-specific.

| Suite | raku | mutsu (ticket, 2026-09-07) | before this PR | after |
| --- | --- | --- | --- | --- |
| `Config::TOML` v0.1.3 | 19/19 files | 11/19 | 10/19 | **14/19** |
| `Crane` v0.1.2 | 15/15 files | 4/15 | 2/15 | **4/15** |

Release build, 120s per-file budget. A debug build is one file short
(`special-cases/03-txn` times out rather than failing — see "left open").

## 1. A package nested under a setting-provided name was invisible transitively

Rakudo merges a `use`d compunit's declarations stash by stash, so
`class X::Crane::GetRootContainerKey` lands in the setting's own `X` stash —
one process-global object every compunit shares — rather than in the declaring
compunit's `GLOBALish`, which is the only thing the importing compunit merges.
`use Crane;` alone therefore makes every `X::Crane::*` exception nameable, and
Crane's own test files name them directly.

mutsu's #7797 qualified-name gate reconstructs rakudo's lexical rule on top of
mutsu's flat package stores, but had no notion of the setting's stashes: it
required the running compunit to have `use`d something under the name's own
top-level segment. A script that `use`d only `Crane` was refused
`X::Crane::GetRootContainerKey` outright, aborting four files mid-run.

Measured against rakudo v2026.07, which draws the line at exactly this spelling:

| declared in a transitively-`use`d module | rakudo |
| --- | --- |
| `class Zzz::Foo::Alpha` | "Could not find symbol" |
| `unit module Baz; our sub greet` | "Could not find symbol" |
| `class X::Zork::Alpha` | resolves |
| `class IO::Zork` / `class Pod::Zork` | resolves |

The gate now admits a name whose top-level segment is one the setting itself
provides: the pure-namespace `CORE::` packages (`X`, `CX`, `EXPORTHOW`,
`Exceptions`, `Metamodel`, `PROCESS`, `Pod`, `RakuAST`, `Rakudo`, plus
`CompUnit`/`Encoding`/`Systemic`), and every setting *type* that also acts as a
namespace, which the existing builtin-type list already answers. A fresh
top-level namespace is gated exactly as before.

## 2. A from-the-end subscript in container context read instead of binding

Every rvalue index path resolves a `WhateverCode` subscript against the
subscripted array's length before using it. The two container-producing paths —
`:=` bind and an `is rw` routine's `return-rw <subscript>` tail — did not, so
`index_to_usize` saw an unconvertible `Sub` and the autovivifying op fell
through to a plain *read*:

```raku
sub g(\c) is rw { return-rw c[*-1] }
my @a = 1, 2, 3;
g(@a) = 9;      # raku: [1, 2, 9]   mutsu: "Cannot modify an immutable Int (3)"
```

`c[*-0]` on an empty array — the append idiom `Crane::In` is built on, and what
`Config::TOML` performs for every `[[table]]` entry — silently wrote nowhere,
so an array-of-tables document came back with an empty array.

Both autovivifying ops now resolve such an index first, and **only when the
closure yields a single non-negative `Int`**: a `WhateverCode` subscript is just
as often a whole slice (`$result[0..*-2]`, one closure returning a `Range`),
which must keep reaching the general subscript path unresolved. Substituting the
evaluated `Range` there broke `roast/S03-sequence/exhaustive.t`'s `test-seq`
slices, which is what the third axis of the guard exists for.

## 3. A `:=` rebind of a subscript adopted an ancestor frame's container

The compiler tags a `$x := <subscript>` bind source with a synthetic per-site
name `__mutsu_bind_index_ref_N`. The tag denotes nothing of its own — a rule the
store path already states for the immutability decision — and `N` is a
constant-pool index, so unrelated routines routinely mint the same name.

The bind's container-promotion did not know that: it asked whether an ancestor
call frame's saved env held the source name, found a *caller's* identically
numbered temp through the chained call env, and adopted that stale cell as the
bind's container. A rebind then kept naming the container the key was looked up
in instead of the deferred entry for a missing key:

```raku
sub walk($container, @path) {
    return unless @path;
    my $root := $container;
    $root := $root{@path[0]};
    say @path[0], ' -> ', $root.WHAT.^name;
    walk($root, @path[1..*]);
}
my %t = a => { b => 1 };
walk(%t, ['a', 'zz', 'yy']);
# raku:  a -> Hash   zz -> Any    yy -> Any
# mutsu: a -> Hash   zz -> Hash   yy -> Hash
```

A recursive path-walking routine therefore descended into *itself* one step per
path element. `Config::TOML`'s `pwd` answered `["a", 0, "b", 0, "c"]` where
rakudo answers `["a", 0, "b", "c"]`, and the parser built a nested Array where
the TOML said Hash.

Worth naming, because it makes the bug look signature-sensitive: an `@`/`%`
**parameter** disqualifies the callee from the slot-only light call paths, and
only the env-chaining paths can see a caller's temp. The identical routine with
a signature of plain scalars was always correct.

The synthetic index tag is now excluded from the "does an ancestor frame own
this source variable?" test.

## Tests

Three pins, 19 assertions, each verified to **fail without its fix** and to pass
under rakudo v2026.07 as well as mutsu:

- `t/modules/setting-nested-package-visibility.t` (+ three `t/lib` fixtures)
- `t/vm/binding/rw-return-from-the-end-index.t`
- `t/vm/binding/bind-index-temp-not-an-outer-frame-source.t`

## Validation

`cargo fmt --all`, `make check-t-layout`, `make lint` (all four configurations),
`make test` (3,955 files / 42,041 assertions — PASS) and `make roast` (1,436
files / 218,939 assertions) all run locally on the final tree. The only `make
roast` failures are the three this container is documented to produce
(`docs/agent-environments.md`): `6.c/S32-io/file-tests.t` and
`S16-filehandles/filetest.t` run as `uid 0`, and `S32-io/IO-Socket-Async.t` hits
the sandboxed network. `roast/S03-sequence/exhaustive.t` regressed under an
earlier draft of fix 2 and is green on the final one.

## What is left on #7539

The ticket stays open and the vendoring steps stay parked (`Crane` at 4/15 is
still too thin for a per-file whitelist). Remaining residue: the
`grammar-actions` string-equivalence and Rat/FatRat precision gaps and the two
untouched dumper files already recorded on the ticket, `Crane`'s own
positional/error-handling gaps plus the object-hash blocker, and a new
performance finding — `special-cases/03-txn` now passes but takes **58s on a
release build where `raku` takes 4.9s**, filed separately as `todo:perf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W5PbPdR2WYuhRJ8beWJhu

---
_Generated by [Claude Code](https://claude.ai/code/session_014W5PbPdR2WYuhRJ8beWJhu)_