### PR TITLE
fix: enforce container types for variable traits

### DIFF
--- a/news/2026-09/container-traits-reject-noncontainers.md
+++ b/news/2026-09/container-traits-reject-noncontainers.md
@@ -1,0 +1,4 @@
+`is` on an `@` or `%` declaration now binds the named class or role as the
+container, so a type without the corresponding storage protocol rejects its
+initializer instead of silently falling back to Array or Hash. Whole-container
+binding also enforces the implicit Positional or Associative constraint.

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -131,6 +131,119 @@ impl Interpreter {
         Err(err)
     }
 
+    /// Type-check a `:=` bind to an untyped `%`-sigiled target.
+    ///
+    /// `%` variables carry an implicit `Associative` constraint even when no
+    /// element type was declared. Assignment may coerce an arbitrary value to
+    /// a Hash, but binding aliases the RHS and therefore must reject a plain
+    /// object such as `Foo.new`.
+    pub(crate) fn check_associative_bind_value(
+        &mut self,
+        name: &str,
+        value: &Value,
+    ) -> Result<(), RuntimeError> {
+        if !name.starts_with('%') {
+            return Ok(());
+        }
+        // A declaration with a type-named `is` trait stashes its raw
+        // initializer for `ApplyVarTrait`. QuantHash declarations deliberately
+        // use the bind marker to preserve that raw value until the trait handler
+        // populates the container; the handler also owns the custom-container
+        // error for a non-container class/role. Do not mistake that internal
+        // marker for a user `:=` bind here.
+        if self.vardecl_init_raw.is_some() {
+            return Ok(());
+        }
+        if let Some(constraint) = loan_env!(self, var_type_constraint(name)) {
+            let base = constraint
+                .split_once('[')
+                .map(|(head, _)| head)
+                .unwrap_or(&constraint);
+            if matches!(
+                base,
+                "Set"
+                    | "SetHash"
+                    | "Bag"
+                    | "BagHash"
+                    | "Mix"
+                    | "MixHash"
+                    | "Map"
+                    | "Hash"
+                    | "Associative"
+                    | "QuantHash"
+            ) {
+                return Ok(());
+            }
+        }
+        let mut candidate = value.deref_container();
+        let mut mixin_composes_associative = false;
+        if let ValueView::Mixin(inner, mixins) = candidate.view() {
+            mixin_composes_associative = mixins.keys().any(|key| {
+                key.strip_prefix("__mutsu_role__")
+                    .is_some_and(|role| role == "Associative")
+            });
+            candidate = inner.as_ref().clone();
+        }
+        let is_associative = mixin_composes_associative
+            || match candidate.view() {
+                ValueView::Hash(..)
+                | ValueView::Pair(..)
+                | ValueView::ValuePair(..)
+                | ValueView::Set(..)
+                | ValueView::Bag(..)
+                | ValueView::Mix(..) => true,
+                ValueView::Package(name) => {
+                    let name = name.resolve();
+                    let base = name.split('[').next().unwrap_or(&name);
+                    matches!(base, "Associative" | "Hash" | "Map" | "Set" | "Bag" | "Mix")
+                        || (self.registry().classes.contains_key(base)
+                            || self.registry().roles.contains_key(base))
+                            && (self.class_does_role(base, "Associative")
+                                || self
+                                    .class_mro(base)
+                                    .iter()
+                                    .any(|n| n == "Hash" || n == "Map"))
+                }
+                ValueView::Instance { class_name, .. } => {
+                    let class_name = class_name.resolve();
+                    matches!(class_name.as_str(), "Hash" | "Map" | "Set" | "Bag" | "Mix")
+                        || self
+                            .class_composed_roles(&class_name)
+                            .is_some_and(|roles| roles.iter().any(|role| role == "Associative"))
+                        || self
+                            .class_mro(&class_name)
+                            .iter()
+                            .any(|n| n == "Hash" || n == "Map")
+                        || self.has_user_method_including_role(&class_name, "STORE")
+                        || self.has_user_method_including_role(&class_name, "AT-KEY")
+                }
+                _ => false,
+            };
+        if is_associative {
+            return Ok(());
+        }
+        let got_type = crate::runtime::utils::value_type_name(value);
+        let message = format!(
+            "Type check failed in binding; expected Associative but got {}",
+            got_type
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("got".to_string(), value.clone());
+        attrs.insert(
+            "expected".to_string(),
+            Value::package(crate::symbol::Symbol::intern("Associative")),
+        );
+        attrs.insert("symbol".to_string(), Value::str_from(name));
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        let ex = Value::make_instance(
+            crate::symbol::Symbol::intern("X::TypeCheck::Binding"),
+            attrs,
+        );
+        let mut err = RuntimeError::new(message);
+        err.exception = Some(Box::new(ex));
+        Err(err)
+    }
+
     /// Identity-preserving STORE for a declared QuantHash variable:
     /// `%s = <a b>` on a `my %s is SetHash` writes the coerced contents INTO
     /// the variable's existing container node (keeping the node's embedded

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1005,6 +1005,7 @@ impl Interpreter {
                 ));
             }
             if is_bind {
+                self.check_associative_bind_value(name, &raw_popped)?;
                 // `:=` binding preserves containers — skip coercion. But the
                 // bound container must conform to a typed-hash variable's
                 // declared value type: `my Int %h := <untyped hash>` dies

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -623,13 +623,13 @@ impl Interpreter {
             None => trait_name,
         };
 
-        // `my @a is CustomClass` where CustomClass subclasses `Array` (e.g.
-        // `class Array::Rounded is Array {...}`) or composes `Positional`:
-        // back the variable with a blessed instance, so indexing overrides
-        // (AT-POS/ASSIGN-POS/DELETE-POS/...) and other methods dispatch to
-        // the class's own methods, mirroring the `%`-sigil tied-hash block
-        // below. Raku ties an `@` variable to ANY class named by `is` — the
-        // `@` sigil supplies the positional semantics.
+        // `my @a is CustomClass` names the class/role of the positional
+        // container. Raku ties an `@` variable to ANY class named by `is` —
+        // the `@` sigil supplies the positional semantics. Classes that
+        // inherit Array use their constructor to populate the backing array;
+        // custom containers use STORE. A class with neither protocol still
+        // gets the Foo.new binding, and its first initializer store is then
+        // rejected as an immutable value.
         // A user-declared `STORE` names the custom-container protocol
         // (`Language/subscripts.rakudoc`'s `my @string is DNA = 'GAATCC'`), which
         // is what `@`-sigil ties use in real Raku: the variable is bound to
@@ -643,14 +643,6 @@ impl Interpreter {
         if name.starts_with('@')
             && (self.registry().classes.contains_key(&trait_name)
                 || self.registry().roles.contains_key(&trait_name))
-            && (self.class_mro(&trait_name).iter().any(|n| n == "Array")
-                || self.class_does_role(&trait_name, "Positional")
-                || self.has_user_method_including_role(&trait_name, "AT-POS")
-                // Raku ties an `@` variable to ANY class named by `is` — the
-                // `@` sigil supplies the positional semantics, so a plain class
-                // that only implements `STORE` (the documented custom-container
-                // shape) ties just as well as one composing `Positional`.
-                || at_sigil_user_store)
         {
             if has_arg {
                 self.stack.pop();
@@ -662,6 +654,8 @@ impl Interpreter {
             let init_source = self
                 .read_var_trait_target(code, slot, &name_str)
                 .or_else(|| self.get_env_with_main_alias(&name_str));
+            let store_arg = Self::custom_container_store_arg(stashed_init, init_source.clone());
+            let is_array_subclass = self.class_mro(&trait_name).iter().any(|n| n == "Array");
             let init_values: Vec<Value> = match init_source.as_ref().map(Value::view) {
                 Some(ValueView::Array(a, _)) if !a.is_empty() => a.iter().cloned().collect(),
                 Some(ValueView::Seq(s)) if !s.is_empty() => s.iter().cloned().collect(),
@@ -677,7 +671,6 @@ impl Interpreter {
                 if !self.write_var_trait_target(code, eff_slot, &name_str, instance.clone()) {
                     self.set_env_with_main_alias(&name_str, instance.clone());
                 }
-                let store_arg = Self::custom_container_store_arg(stashed_init, init_source);
                 if let Some(list_arg) = store_arg {
                     let stored = self.try_compiled_method_or_interpret(
                         instance.clone(),
@@ -695,26 +688,32 @@ impl Interpreter {
                 }
                 return Ok(());
             }
-            let instance = self.try_compiled_method_or_interpret(type_obj, "new", init_values)?;
+            if is_array_subclass {
+                let instance =
+                    self.try_compiled_method_or_interpret(type_obj, "new", init_values)?;
+                if !self.write_var_trait_target(code, eff_slot, &name_str, instance.clone()) {
+                    self.set_env_with_main_alias(&name_str, instance);
+                }
+                return Ok(());
+            }
+            let instance = self.try_compiled_method_or_interpret(type_obj, "new", vec![])?;
             if !self.write_var_trait_target(code, eff_slot, &name_str, instance.clone()) {
-                self.set_env_with_main_alias(&name_str, instance);
+                self.set_env_with_main_alias(&name_str, instance.clone());
+            }
+            if store_arg.is_some() {
+                return Err(RuntimeError::assignment_ro_typename(
+                    &trait_name,
+                    &crate::runtime::utils::gist_value(&instance),
+                ));
             }
             return Ok(());
         }
 
-        // `my %h is CustomClass` where CustomClass composes `Associative` (e.g.
-        // `does Hash::Agnostic`): back the variable with a blessed instance, so
-        // subscripting (AT-KEY/ASSIGN-KEY/DELETE-KEY), iteration and coercion
-        // methods (.Str/.raku/.List/.Slip/.gist/...) all dispatch to the class's
-        // (possibly role-provided) methods — a "tied hash". The instance keeps
-        // its identity across `%h = ...` (STORE) reassignments.
-        // Raku ties a `%` variable to ANY class named by `is` — the `%` sigil
-        // supplies the associative semantics, so the class need not declare
-        // `does Associative` (e.g. `Hash::str`, which only defines AT-KEY/STORE
-        // via nqp ops). We tie when the class either composes `Associative` or
-        // defines the associative protocol (STORE / AT-KEY), which covers both
-        // the role-composed (`Hash::Agnostic`) and the plain-class (`Hash::str`)
-        // styles without grabbing unrelated `is <Type>` container traits.
+        // `my %h is CustomClass` names the class/role of the associative
+        // container. Raku ties a `%` variable to ANY class named by `is` — the
+        // `%` sigil supplies the associative semantics. A class with no STORE
+        // still receives the Foo.new binding, but an initializer store is
+        // rejected as immutable.
         // A *role* names a tie just as well as a class (`my %h is TypeConverter`):
         // raku puns it, and `Value::package(name).new` already takes the punning
         // path a role-typed attribute (`has %.C is TypeConverter`) uses. The
@@ -723,20 +722,6 @@ impl Interpreter {
         if name.starts_with('%')
             && (self.registry().classes.contains_key(&trait_name)
                 || self.registry().roles.contains_key(&trait_name))
-            && (self.class_does_role(&trait_name, "Associative")
-                || self.has_user_method_including_role(&trait_name, "STORE")
-                || self.has_user_method_including_role(&trait_name, "AT-KEY")
-                // `class Bar is Hash {}` (or `is Map`): a native-inheritance
-                // Associative subclass, not a role composition or a
-                // hand-written AT-KEY/STORE tie. Mirrors the `@`-sigil gate's
-                // `class_mro(...).any(|n| n == "Array")` check above — without
-                // this, `my %h is Bar = ...` fell through to the generic
-                // `trait_mod:<is>` handler, which does not bless a real `Bar`
-                // instance (`.^name` wrongly stayed `Hash`).
-                || self
-                    .class_mro(&trait_name)
-                    .iter()
-                    .any(|n| n == "Hash" || n == "Map"))
         {
             if has_arg {
                 self.stack.pop();
@@ -748,6 +733,12 @@ impl Interpreter {
             let init_source = self
                 .read_var_trait_target(code, slot, &name_str)
                 .or_else(|| self.get_env_with_main_alias(&name_str));
+            let store_arg = Self::custom_container_store_arg(stashed_init, init_source);
+            let has_store = self
+                .class_mro(&trait_name)
+                .iter()
+                .any(|n| n == "Hash" || n == "Map")
+                || self.has_user_method_including_role(&trait_name, "STORE");
             let type_obj = Value::package(crate::symbol::Symbol::intern(&trait_name));
             let instance = self.try_compiled_method_or_interpret(type_obj, "new", vec![])?;
             // Bind the instance to the variable first, then STORE the initializer
@@ -756,29 +747,36 @@ impl Interpreter {
             if !self.write_var_trait_target(code, eff_slot, &name_str, instance.clone()) {
                 self.set_env_with_main_alias(&name_str, instance.clone());
             }
-            if let Some(list_arg) = Self::custom_container_store_arg(stashed_init, init_source) {
-                // Pass the initializer as a single positional list (not as
-                // separate Pair args, which STORE's signature would bind as
-                // *named* arguments); STORE's slurpy `*@values` flattens it.
-                // Raku passes `:INITIALIZE` on the *declaration* assignment
-                // (`my %h is Foo = ...`) but NOT on a later `%h = ...`
-                // reassignment, so a write-once tie can distinguish the initial
-                // population from a forbidden overwrite (WriteOnceHash's STORE
-                // gates on `:$INITIALIZE`). A STORE that ignores it absorbs the
-                // extra named arg through its implicit `*%_`.
-                let stored = self.try_compiled_method_or_interpret(
-                    instance.clone(),
-                    "STORE",
-                    vec![list_arg, Value::pair("INITIALIZE".to_string(), Value::TRUE)],
-                )?;
-                let bound = if Self::is_tie_bindable(&stored) {
-                    stored
-                } else {
-                    instance
-                };
-                if !self.write_var_trait_target(code, eff_slot, &name_str, bound.clone()) {
-                    self.set_env_with_main_alias(&name_str, bound);
+            if has_store {
+                if let Some(list_arg) = store_arg {
+                    // Pass the initializer as a single positional list (not as
+                    // separate Pair args, which STORE's signature would bind as
+                    // *named* arguments); STORE's slurpy `*@values` flattens it.
+                    // Raku passes `:INITIALIZE` on the *declaration* assignment
+                    // (`my %h is Foo = ...`) but NOT on a later `%h = ...`
+                    // reassignment, so a write-once tie can distinguish the initial
+                    // population from a forbidden overwrite (WriteOnceHash's STORE
+                    // gates on `:$INITIALIZE`). A STORE that ignores it absorbs the
+                    // extra named arg through its implicit `*%_`.
+                    let stored = self.try_compiled_method_or_interpret(
+                        instance.clone(),
+                        "STORE",
+                        vec![list_arg, Value::pair("INITIALIZE".to_string(), Value::TRUE)],
+                    )?;
+                    let bound = if Self::is_tie_bindable(&stored) {
+                        stored
+                    } else {
+                        instance
+                    };
+                    if !self.write_var_trait_target(code, eff_slot, &name_str, bound.clone()) {
+                        self.set_env_with_main_alias(&name_str, bound);
+                    }
                 }
+            } else if store_arg.is_some() {
+                return Err(RuntimeError::assignment_ro_typename(
+                    &trait_name,
+                    &crate::runtime::utils::gist_value(&instance),
+                ));
             }
             return Ok(());
         }

--- a/t/oo/role/issue-7775-container-role.t
+++ b/t/oo/role/issue-7775-container-role.t
@@ -1,0 +1,48 @@
+use Test;
+
+plan 8;
+
+# `is` on a sigiled variable names the container itself. A type that cannot
+# store the declaration initializer must therefore fail instead of leaving an
+# ordinary Array or Hash behind.
+dies-ok {
+    EVAL q[role PlainContainer7775 {}; my @a is PlainContainer7775 = 1, 2, 3]
+}, 'a plain role cannot initialize an @ container';
+
+dies-ok {
+    EVAL q[role PlainHash7775 {}; my %h is PlainHash7775 = a => 42]
+}, 'a plain role cannot initialize a % container';
+
+# A user Positional container with the documented STORE protocol remains a
+# valid target. STORE is optional for element access, but is required when the
+# declaration itself supplies initial values.
+class PositionalContainer7775 does Positional {
+    has @!items;
+
+    method STORE(|capture) {
+        @!items = capture.list[0].list;
+        self
+    }
+
+    method AT-POS($index) { @!items[$index] }
+    method ASSIGN-POS($index, $value) { @!items[$index] = $value }
+    method EXISTS-POS($index) { @!items[$index].defined }
+    method elems() { @!items.elems }
+}
+
+my @a is PositionalContainer7775 = 1, 2, 3;
+is @a.^name, 'PositionalContainer7775', 'a user Positional class is bound as the container';
+is @a[1], 2, 'a user Positional class serves element reads';
+@a[1] = 9;
+is @a[1], 9, 'a user Positional class serves element writes';
+
+my Int @typed is Array[Int] = 1, 2, 3;
+is-deeply @typed.List, (1, 2, 3), 'a parameterized Array container still initializes';
+
+dies-ok {
+    EVAL q[class PlainBinding7775 {}; my %h := PlainBinding7775.new]
+}, 'binding a plain object to a % variable fails its Associative check';
+
+dies-ok {
+    EVAL q[class PlainPositionalBinding7775 {}; my @a := PlainPositionalBinding7775.new]
+}, 'binding a plain object to an @ variable fails its Positional check';


### PR DESCRIPTION
Closes #7775

Ensure @/% variables declared with a user class or role as `is` are backed by that type instead of silently retaining Array/Hash. Reject initializer stores for types without the required container protocol, while preserving Array subclasses, custom STORE containers, and role-backed associative bindings.

Add focused regression coverage for plain roles, Positional classes, parameterized arrays, and invalid container binds.