### PR TITLE
fix: report failed chdir and indir calls

### DIFF
--- a/news/2026-09/chdir-rejects-invalid-targets.md
+++ b/news/2026-09/chdir-rejects-invalid-targets.md
@@ -1,0 +1,4 @@
+`chdir` and `indir` now report their `X::IO::Chdir` failure when a bare call
+ends a program. Missing directory leaves, missing root components, and regular
+files are rejected with Raku-compatible messages, while value-position calls
+continue to return a `Failure` without changing `$*CWD`.

--- a/src/runtime/builtins_io_dir.rs
+++ b/src/runtime/builtins_io_dir.rs
@@ -70,7 +70,7 @@ impl Interpreter {
             return Ok(io_exception_failure(
                 "X::IO::Chdir",
                 format!(
-                    "Failed to chdir to '{}': no such file or directory",
+                    "Failed to change the working directory to '{}': does not exist",
                     requested
                 ),
             ));
@@ -78,13 +78,19 @@ impl Interpreter {
         if require_dir && !absolute_target.is_dir() {
             return Ok(io_exception_failure(
                 "X::IO::Chdir",
-                format!("Failed to chdir to '{}': not a directory", requested),
+                format!(
+                    "Failed to change the working directory to '{}': is not a directory",
+                    requested
+                ),
             ));
         }
         if !has_required_mode_bits(&absolute_target, require_read, require_write, require_exec) {
             return Ok(io_exception_failure(
                 "X::IO::Chdir",
-                format!("Failed to chdir to '{}': permission denied", requested),
+                format!(
+                    "Failed to change the working directory to '{}': permission denied",
+                    requested
+                ),
             ));
         }
         let canonical = fs::canonicalize(&absolute_target).unwrap_or(absolute_target);
@@ -157,7 +163,7 @@ impl Interpreter {
             return Ok(io_exception_failure(
                 "X::IO::Chdir",
                 format!(
-                    "Failed to chdir to '{}': no such file or directory",
+                    "Failed to change the working directory to '{}': does not exist",
                     requested
                 ),
             ));
@@ -165,13 +171,19 @@ impl Interpreter {
         if require_dir && !absolute_target.is_dir() {
             return Ok(io_exception_failure(
                 "X::IO::Chdir",
-                format!("Failed to chdir to '{}': not a directory", requested),
+                format!(
+                    "Failed to change the working directory to '{}': is not a directory",
+                    requested
+                ),
             ));
         }
         if !has_required_mode_bits(&absolute_target, require_read, require_write, require_exec) {
             return Ok(io_exception_failure(
                 "X::IO::Chdir",
-                format!("Failed to chdir to '{}': permission denied", requested),
+                format!(
+                    "Failed to change the working directory to '{}': permission denied",
+                    requested
+                ),
             ));
         }
         let saved = self.env.get("$*CWD").cloned();

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -822,8 +822,13 @@ impl Interpreter {
     fn stmt_tail_is_fresh_rvalue(stmt: &Stmt) -> bool {
         match stmt {
             // Bare `EVAL "..."` parses as a `Stmt::Call`; other bare sub calls
-            // are excluded (see the doc comment).
-            Stmt::Call { name, .. } => matches!(name.resolve().as_str(), "EVAL" | "EVALFILE"),
+            // are excluded (see the doc comment). `chdir` and `indir` are
+            // builtins whose Failure result is sunk by a bare statement in
+            // Raku, so a failed navigation must report its exception while
+            // still remaining a Failure in value position.
+            Stmt::Call { name, .. } => {
+                matches!(name.resolve().as_str(), "EVAL" | "EVALFILE")
+            }
             // A `(while ...)` / `(loop ...)` expression tail is a fresh lazy
             // Seq (never a Failure), included so the tail-sink drain above
             // runs its side effects.
@@ -840,6 +845,7 @@ impl Interpreter {
     fn expr_is_fresh_rvalue(expr: &crate::ast::Expr) -> bool {
         use crate::ast::Expr;
         match expr {
+            Expr::Call { name, .. } => matches!(name.resolve().as_str(), "chdir" | "indir"),
             Expr::MethodCall { .. }
             | Expr::DynamicMethodCall { .. }
             | Expr::HyperMethodCall { .. } => true,

--- a/t/io/chdir-path-check.t
+++ b/t/io/chdir-path-check.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# A failed chdir/indir returns a Failure in value position, but a bare call
+# sinks that Failure and reports its exception in Raku. In particular, a
+# missing leaf must not be accepted merely because its parent exists.
+plan 16;
+
+my $mutsu = $*EXECUTABLE.absolute;
+
+sub run-code(Str $code) {
+    my $proc = run $mutsu, '-e', $code, :out, :err;
+    my $out = $proc.out.slurp(:close);
+    my $err = $proc.err.slurp(:close);
+    { :$out, :err($err), exit => $proc.exitcode }
+}
+
+my $base = $*CWD.Str;
+my $missing-leaf = $*CWD.child("mutsu-issue-7776-missing-{$*PID}").Str;
+my $missing-root = "/mutsu-issue-7776-root-{$*PID}";
+my $file = $*CWD.child('Cargo.toml').Str;
+
+# Value position: the operation returns Failure and leaves $*CWD unchanged.
+{
+    my $before = $*CWD.Str;
+    my $result = chdir $missing-leaf;
+    isa-ok $result, Failure, 'a missing leaf under an existing parent returns Failure';
+    is $*CWD.Str, $before, 'a failed chdir leaves $*CWD unchanged';
+    is $result.exception.^name, 'X::IO::Chdir', 'the Failure carries X::IO::Chdir';
+    like $result.exception.message, /'does not exist'/,
+        'the missing-leaf Failure reports that the target does not exist';
+}
+
+{
+    my $before = $*CWD.Str;
+    my $result = indir $missing-leaf, { die 'indir body must not run' };
+    isa-ok $result, Failure, 'indir on a missing leaf returns Failure';
+    is $*CWD.Str, $before, 'a failed indir leaves $*CWD unchanged';
+}
+
+# A bare tail call must sink the Failure, like Raku does.
+{
+    my %result = run-code("chdir {$missing-leaf.raku};");
+    isnt %result<exit>, 0, 'bare chdir to a missing leaf fails';
+    like %result<err>, /'Failed to change the working directory to'/,
+        'bare chdir reports the Raku-compatible error';
+    like %result<err>, /'does not exist'/,
+        'bare chdir identifies the missing target';
+}
+
+{
+    my %result = run-code("indir {$missing-leaf.raku}, { }; ");
+    isnt %result<exit>, 0, 'bare indir to a missing leaf fails';
+}
+
+# Keep the discriminator paths covered too: a missing first component and a
+# regular file are different failures from a missing leaf.
+{
+    my %result = run-code("chdir {$missing-root.raku};");
+    isnt %result<exit>, 0, 'bare chdir to a path with a missing root component fails';
+    like %result<err>, /'does not exist'/,
+        'a missing root component is reported as nonexistent';
+}
+
+{
+    my %result = run-code("chdir {$file.raku};");
+    isnt %result<exit>, 0, 'bare chdir to a regular file fails';
+    like %result<err>, /'is not a directory'/,
+        'a regular file is reported as not a directory';
+}
+
+{
+    my %result = run-code("chdir {$base.raku}; say \$*CWD.Str;");
+    is %result<exit>, 0, 'chdir to an existing directory succeeds';
+    is %result<out>.trim, $base, 'successful chdir reports the new $*CWD';
+}
+
+done-testing;


### PR DESCRIPTION
Fixes #7776.

`chdir` and `indir` already produce a `Failure` for invalid targets, but a bare call in the program tail did not sink that Failure, so mutsu exited successfully without reporting the error. Treat these two navigation builtins as fresh tail rvalues while preserving Failure behavior in value position.

Also align `X::IO::Chdir` messages with Rakudo and add coverage for missing leaves, missing root components, regular files, `indir`, unchanged `$*CWD`, and successful navigation.

Validation:
- `make lint`
- `make test`
- `make roast`