### PR TITLE
fix: parse a `where` clause after a parameter's sub-signature

### DIFF
--- a/news/2026-09/where-after-sub-signature.md
+++ b/news/2026-09/where-after-sub-signature.md
@@ -1,0 +1,58 @@
+# A `where` clause may now follow a sub-signature
+
+A Raku parameter can carry a destructuring sub-signature *and* a `where`
+post-constraint at once — the sub-signature unpacks the argument, the `where`
+tests the argument's own value as `$_`:
+
+```raku
+sub f($x ($a, $b) where { $_.elems == 2 }) { ... }
+```
+
+mutsu parsed either half alone but not the two together. Each of the four
+sub-signature branches in `src/parser/stmt/sub_param/param_inner.rs` — the bare
+`(...)`, `$x (...)`, `&cb (...)` and `@a [...]` spellings — consumed the group,
+then its `is` traits, and returned. The trailing `where` was left unconsumed, so
+the signature parser demanded the closing paren and the declaration failed with
+`Confused. expected statement: expected ')'`.
+
+The failure was worse than it looked in real code. A parse error inside a
+parameter list backtracks out of the whole enclosing package body, so
+`AccessorFacade`'s
+
+```raku
+multi trait_mod:<is> (Method $r, :$accessor-facade! (*@a) where { any($_.list) !~~ Code }) is export {
+```
+
+surfaced as `X::Undeclared::Symbols: Undeclared routine: AccessorFacade:ver` —
+the `module` declarator re-read as a call. An "undeclared routine" naming a
+package declarator is a symptom of a parse failure somewhere inside its body,
+not of the declarator itself.
+
+The four branches now share one `parse_subsig_tail` helper
+(`src/parser/stmt/sub_param/helpers.rs`) that parses everything a parameter may
+carry after its sub-signature: `is` traits, a `where` constraint, and a default
+value. Sharing it is what keeps the branches in step — three of the four had
+already drifted apart on which of the three they accepted, and `$x ($a, $b) =
+(1, 2)` (a default after a sub-signature, which rakudo accepts) worked in none
+of them.
+
+The constraint is enforced, not merely parsed: a value failing it raises the
+same `Constraint type check failed in binding to parameter '$x'; expected
+anonymous constraint to be met but got List ((1, 2, 3))` rakudo raises, and a
+`multi` candidate carrying one falls through to the next candidate when the
+constraint fails.
+
+`t/routines/signature/sub-signature-with-where.t` pins all eight rows of the
+issue's matrix — positional and named, slurpy and plain — so the four that
+already worked cannot be traded for the four that did not, plus the anonymous
+and bracketed spellings, the enforcement and multi-dispatch behavior, and the
+trait/default tail.
+
+The named rows are pinned only at the level this change is about — the
+signature parses and the call binds — because a separate, pre-existing gap sits
+under them: mutsu still reads a `$`-sigil named parameter's sub-signature
+(`:$x! ($a, $b)`) as the *rename* form `:min(:$minutes)`, so its inner variables
+do not destructure. That is the `$`-sigil twin of the `:@a [...]` bug fixed in
+#7758, and is filed as #7865.
+
+Closes #7864.

--- a/src/parser/stmt/sub_param/helpers.rs
+++ b/src/parser/stmt/sub_param/helpers.rs
@@ -71,6 +71,61 @@ pub(crate) fn starts_with_sigil_param(input: &str) -> bool {
     matches!(input.as_bytes().first(), Some(b'$' | b'@' | b'%' | b'&'))
 }
 
+/// The optional tail a parameter may carry after a destructuring sub-signature:
+/// `is` traits, a `where` post-constraint, and a default value.
+pub(crate) struct SubsigTail {
+    pub(crate) traits: Vec<String>,
+    pub(crate) where_constraint: Option<Box<Expr>>,
+    pub(crate) default: Option<Expr>,
+}
+
+/// Parse whatever follows a parameter's sub-signature.
+///
+/// A parameter may carry a sub-signature *and* a post-constraint at once —
+/// `sub f($x ($a, $b) where { ... })`, `:$x! (*@a) where { ... }` — with the
+/// `where` testing the parameter's own value while the sub-signature unpacks it.
+/// Each sub-signature branch in `param_inner` used to stop after its `is` trait
+/// loop, so the `where` was left unconsumed and the signature failed to parse at
+/// the closing paren. Sharing one tail parser keeps the four branches (bare
+/// `(...)`, `$x (...)`, `&cb (...)`, `@a [...]`) in step.
+pub(crate) fn parse_subsig_tail(input: &str) -> PResult<'_, SubsigTail> {
+    use crate::parser::helpers::{ws, ws1};
+
+    let (mut rest, _) = ws(input)?;
+    let mut traits = Vec::new();
+    while let Some(r) = super::super::keyword("is", rest) {
+        let (r, _) = ws1(r)?;
+        let (r, trait_name) = super::super::ident(r)?;
+        let (r, _) = super::super::sub::validate_param_trait(&trait_name, &traits, r)?;
+        traits.push(trait_name);
+        let (r, _) = ws(r)?;
+        rest = r;
+    }
+    let (rest, where_constraint) = if let Some(r) = super::super::keyword("where", rest) {
+        let (r, _) = ws1(r)?;
+        let (r, constraint) = super::where_constraint::parse_where_constraint_expr(r)?;
+        (r, Some(Box::new(constraint)))
+    } else {
+        (rest, None)
+    };
+    let (rest, _) = ws(rest)?;
+    let (rest, default) = if rest.starts_with('=') && !rest.starts_with("==") {
+        let (r, _) = ws(&rest[1..])?;
+        let (r, expr) = crate::parser::expr::expression(r)?;
+        (r, Some(expr))
+    } else {
+        (rest, None)
+    };
+    Ok((
+        rest,
+        SubsigTail {
+            traits,
+            where_constraint,
+            default,
+        },
+    ))
+}
+
 /// Returns (rest, required, optional_marker).
 /// `!` → required=true, optional_marker=false
 /// `?` → required=false, optional_marker=true

--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -748,6 +748,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         let (r, _) = parse_char(r, ')')?;
         let (r, _) = ws(r)?;
         let (r, required, opt_marker) = super::helpers::parse_required_suffix(r);
+        let (r, tail) = super::helpers::parse_subsig_tail(r)?;
         let mut p = super::helpers::make_param("__subsig__".to_string());
         p.sub_signature = Some(sub_params);
         p.named = named;
@@ -757,6 +758,9 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         p.type_constraint = type_constraint;
         p.required = required;
         p.optional_marker = opt_marker;
+        p.traits = tail.traits;
+        p.where_constraint = tail.where_constraint;
+        p.default = tail.default;
         return Ok((r, p));
     }
 
@@ -1152,18 +1156,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             let (r, _) = parse_char(r, ')')?;
             let (r, _) = ws(r)?;
             let (r, post_required, post_opt_marker) = super::helpers::parse_required_suffix(r);
-            let (r, _) = ws(r)?;
-            let mut param_traits = Vec::new();
-            let (mut r, _) = ws(r)?;
-            while let Some(r2) = super::super::keyword("is", r) {
-                let (r2, _) = ws1(r2)?;
-                let (r2, trait_name) = super::super::ident(r2)?;
-                let (r2, _) =
-                    super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
-                param_traits.push(trait_name);
-                let (r2, _) = ws(r2)?;
-                r = r2;
-            }
+            let (r, tail) = super::helpers::parse_subsig_tail(r)?;
             let mut p = super::helpers::make_param(format!("&{name}"));
             p.required = required || post_required;
             p.optional_marker = opt_marker || post_opt_marker;
@@ -1174,7 +1167,9 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             p.type_constraint = type_constraint;
             p.sub_signature = Some(sig_params.clone());
             p.code_signature = Some((sig_params, sig_ret));
-            p.traits = param_traits;
+            p.traits = tail.traits;
+            p.where_constraint = tail.where_constraint;
+            p.default = tail.default;
             return Ok((r, p));
         }
         let (r, sub_params) = super::super::sub::parse_param_list(r)?;
@@ -1183,17 +1178,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         let (r, _) = ws(r)?;
         // Handle optional (?) / required (!) suffix after sub-signature
         let (r, post_required, post_opt_marker) = super::helpers::parse_required_suffix(r);
-        let (r, _) = ws(r)?;
-        let mut param_traits = Vec::new();
-        let (mut r, _) = ws(r)?;
-        while let Some(r2) = super::super::keyword("is", r) {
-            let (r2, _) = ws1(r2)?;
-            let (r2, trait_name) = super::super::ident(r2)?;
-            let (r2, _) = super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
-            param_traits.push(trait_name);
-            let (r2, _) = ws(r2)?;
-            r = r2;
-        }
+        let (r, tail) = super::helpers::parse_subsig_tail(r)?;
         let param_name = if slurpy {
             match slurpy_sigil {
                 Some('%') => format!("%{}", name),
@@ -1217,7 +1202,9 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         p.onearg = onearg;
         p.type_constraint = type_constraint;
         p.sub_signature = Some(sub_params);
-        p.traits = param_traits;
+        p.traits = tail.traits;
+        p.where_constraint = tail.where_constraint;
+        p.default = tail.default;
         return Ok((r, p));
     }
 
@@ -1231,17 +1218,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         let (r, _) = ws(r)?;
         // Handle optional (?) / required (!) suffix after sub-signature
         let (r, post_required, post_opt_marker) = super::helpers::parse_required_suffix(r);
-        let (r, _) = ws(r)?;
-        let mut param_traits = Vec::new();
-        let (mut r, _) = ws(r)?;
-        while let Some(r2) = super::super::keyword("is", r) {
-            let (r2, _) = ws1(r2)?;
-            let (r2, trait_name) = super::super::ident(r2)?;
-            let (r2, _) = super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
-            param_traits.push(trait_name);
-            let (r2, _) = ws(r2)?;
-            r = r2;
-        }
+        let (r, tail) = super::helpers::parse_subsig_tail(r)?;
         let param_name = if slurpy {
             match slurpy_sigil {
                 Some('%') => format!("%{}", name),
@@ -1265,7 +1242,9 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         p.onearg = onearg;
         p.type_constraint = type_constraint;
         p.sub_signature = Some(sub_params);
-        p.traits = param_traits;
+        p.traits = tail.traits;
+        p.where_constraint = tail.where_constraint;
+        p.default = tail.default;
         return Ok((r, p));
     }
 

--- a/t/routines/signature/sub-signature-with-where.t
+++ b/t/routines/signature/sub-signature-with-where.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# A parameter may carry a destructuring sub-signature AND a `where`
+# post-constraint at the same time: `sub f($x ($a, $b) where { ... })`.
+# The two are independent — the `where` tests the parameter's own value
+# (as `$_`), the sub-signature unpacks it — but the parameter parser used
+# to stop as soon as it had consumed the sub-signature, so the trailing
+# `where` was left unconsumed and the whole signature failed to parse.
+#
+# The four spellings that already parsed (sub-signature alone, `where`
+# alone, positional and named) are pinned here alongside the four that did
+# not, so a future change cannot fix one half by breaking the other.
+
+plan 16;
+
+# --- the four spellings that always worked ---------------------------------
+
+sub sig-only($x ($a, $b)) { "$a/$b" }
+is sig-only((1, 2)), '1/2', 'sub-signature alone';
+
+sub where-only($x where { $_ > 10 }) { "$x" }
+is where-only(42), '42', 'where alone';
+
+sub named-sig-only(:$x! ($a, $b)) { 'called' }
+is named-sig-only(x => (1, 2)), 'called', 'named parameter, sub-signature alone';
+
+sub named-where-only(:$x! where { $_ > 10 }) { "$x" }
+is named-where-only(x => 42), '42', 'named parameter, where alone';
+
+# --- the four that used to fail to parse -----------------------------------
+
+sub pos-sig-where($x ($a, $b) where { $_.elems == 2 }) { "$a/$b" }
+is pos-sig-where((3, 4)), '3/4', 'positional: sub-signature then where';
+
+sub pos-slurpy-where($x (*@a) where { $_.elems == 2 }) { 'called' }
+is pos-slurpy-where((5, 6)), 'called', 'positional: slurpy sub-signature then where';
+
+# The named spellings are pinned at the level this ticket is about -- the
+# signature parses and the call binds. What the constraint's topic is for a
+# named parameter carrying a sub-signature is a separate, pre-existing gap:
+# mutsu still reads `:$x! ($a, $b)` as the RENAME form `:x(:$a)` rather than
+# as destructuring, so neither `$x` nor the inner variables bind the way
+# rakudo binds them -- tracked as #7865. Do not pin that behavior here.
+sub named-sig-where(:$x! ($a, $b) where { True }) { 'called' }
+is named-sig-where(x => (7, 8)), 'called', 'named: sub-signature then where';
+
+sub named-slurpy-where(:$x! (*@a) where { True }) { 'called' }
+is named-slurpy-where(x => (9, 10)), 'called', 'named: slurpy sub-signature then where';
+
+# --- the other two sub-signature spellings ---------------------------------
+
+sub anon-sig-where(($a, $b) where { $_.elems == 2 }) { "$a/$b" }
+is anon-sig-where((11, 12)), '11/12', 'anonymous sub-signature then where';
+
+sub bracket-sig-where(@a [$x, $y] where { $_.elems == 2 }) { "$x/$y" }
+is bracket-sig-where([13, 14]), '13/14', 'bracketed sub-signature then where';
+
+# --- the constraint is enforced, not merely parsed --------------------------
+
+sub enforced($x ($a, $b) where { $_.elems == 2 }) { "$a/$b" }
+is enforced((15, 16)), '15/16', 'a value meeting the constraint binds';
+dies-ok { enforced((1, 2, 3)) }, 'a value failing the constraint does not bind';
+
+multi picky($x ($a, $b) where { $_.elems == 2 }) { 'two' }
+multi picky($x) { 'other' }
+is picky((1, 2)), 'two', 'multi dispatch picks the constrained candidate';
+is picky((1, 2, 3)), 'other', 'multi dispatch falls through when the where fails';
+
+# --- traits and a default value still work alongside the sub-signature ------
+
+sub with-trait($x ($a, $b) is copy where { $_.elems == 2 }) { "$a/$b" }
+is with-trait((17, 18)), '17/18', 'is-trait between the sub-signature and the where';
+
+sub with-default($x ($a, $b) = (19, 20)) { "$a/$b" }
+is with-default(), '19/20', 'default value after a sub-signature';
+
+# vim: ft=raku


### PR DESCRIPTION
A parameter may carry a destructuring sub-signature **and** a `where` post-constraint at once — the sub-signature unpacks the argument, the `where` tests the argument's own value as `$_`:

```raku
sub f($x ($a, $b) where { $_.elems == 2 }) { ... }
```

mutsu parsed either half alone but not the two together. Each of the four sub-signature branches in `src/parser/stmt/sub_param/param_inner.rs` — the bare `(...)`, `$x (...)`, `&cb (...)` and `@a [...]` spellings — consumed the group, then its `is` traits, and returned. The trailing `where` was left unconsumed, so the signature parser demanded the closing paren and the declaration failed with `Confused. expected statement: expected ')'`.

The failure was worse than it looked in real code. A parse error inside a parameter list backtracks out of the whole enclosing package body, so `AccessorFacade`'s

```raku
multi trait_mod:<is> (Method $r, :$accessor-facade! (*@a) where { any($_.list) !~~ Code }) is export {
```

surfaced as `X::Undeclared::Symbols: Undeclared routine: AccessorFacade:ver` — the `module` declarator re-read as a call.

## The change

The four branches now share one `parse_subsig_tail` helper (`sub_param/helpers.rs`) that parses everything a parameter may carry after its sub-signature: `is` traits, a `where` constraint, and a default value. Sharing it is what keeps the branches in step — three of the four had already drifted apart on which of the three they accepted, and `$x ($a, $b) = (1, 2)` (a default after a sub-signature, which rakudo accepts) worked in none of them.

The constraint is enforced, not merely parsed. A value failing it raises the same message rakudo raises:

```
Constraint type check failed in binding to parameter '$x'; expected anonymous constraint to be met but got List ((1, 2, 3))
```

and a `multi` candidate carrying one falls through to the next candidate when the constraint fails.

## Tests

`t/routines/signature/sub-signature-with-where.t` (16 tests) pins all eight rows of the issue's matrix — positional and named, slurpy and plain — so the four spellings that already worked cannot be traded for the four that did not, plus the anonymous and bracketed spellings, the enforcement and multi-dispatch behavior, and the trait/default tail.

The named rows are pinned only at the level this change is about — the signature parses and the call binds — because a separate, pre-existing gap sits under them: mutsu still reads a `$`-sigil named parameter's sub-signature (`:$x! ($a, $b)`) as the *rename* form `:min(:$minutes)`, so its inner variables do not destructure. That is the `$`-sigil twin of the `:@a [...]` bug fixed in #7758, and is filed separately as #7865.

## Verification

- `cargo fmt --all`, `make lint` (all four configurations) — clean
- `make test` — 3959 files, 42088 tests, `Result: PASS`
- `make roast` — 1436 files, 218939 tests; the only failure is `roast/S32-io/IO-Socket-Async.t` (exit 124, ran 17), the documented sandboxed-network environment failure in `docs/agent-environments.md`
- Every row of the matrix checked against `raku` v2026.07 as the oracle

Closes #7864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXZsjZtmdRw7A7riJVXsYu

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXZsjZtmdRw7A7riJVXsYu)_