### PR TITLE
perf: let the binder read its callee's baked parameter symbols

### DIFF
--- a/news/2026-09/binder-baked-param-symbols-and-no-container-key.md
+++ b/news/2026-09/binder-baked-param-symbols-and-no-container-key.md
@@ -1,0 +1,97 @@
+# The binder reads its callee's baked parameter symbols, and the last scalar-declaration env key gets pre-interned
+
+Two of the three units named in [#7766](https://github.com/tokuhirom/mutsu/issues/7766) — the
+successor to the [#7736](https://github.com/tokuhirom/mutsu/issues/7736) /
+[#7762](https://github.com/tokuhirom/mutsu/pull/7762) campaign that cut the per-`Test`-assertion
+`Symbol::intern` budget from 72 to the mid-30s. Both were the same shape: a name that had *already*
+been interned once, somewhere the hot path could reach, being re-hashed per call anyway.
+
+## The binder's parameter names (#7766 unit 1)
+
+`CompiledFunction::precompute_param_name_syms` interns every `param_defs[i].name` when a routine is
+registered. `bind_function_args_values_inner` did not read it: it kept a per-parameter `OnceCell`
+and interned the name on first use in each call. Once per parameter per call is better than once per
+helper — that was #7762's improvement — but it is not zero, and binding is the single hottest thing
+a `Test` assertion does.
+
+`bind_function_args_values_with_syms` is the new entry point: the two existing ones
+(`bind_function_args_values`, `..._with_argspec`) delegate to it with an empty slice, so none of the
+~16 callers that build `param_defs` by hand — a `FunctionDef`, a `SubData`, a synthesized signature —
+needed touching or lost anything. The one caller that *does* hold a registered routine,
+`call_compiled_function_named_inner`, passes `&cf.param_name_syms`, and that single site covers every
+binder call the benchmark makes.
+
+The slice is index-parallel to `param_defs`, so the interesting failure mode is misalignment: a
+parameter bound, marked readonly or cleared under a *neighbour's* name. Two things guard it. A slice
+whose length does not match `param_defs` is treated as empty rather than trusted, so a vector left
+over from a `param_defs` mutated after the precompute degrades to the old lazy intern instead of
+mis-keying a binding. And each of the two loops that resolves a name `debug_assert_eq!`s the baked
+symbol against a fresh intern of `pd.name`, which makes a genuine index mismatch loud in CI's debug
+runs (`gc-stress` / `jit-stress`).
+
+## `__mutsu_scalar_bind_no_container::` (#7766 unit 3)
+
+`my $i := 42` binds straight to a value, so the name owns no `Scalar` container and
+`$i.self =:= $i` is True where `my $a = 42` answers False. That fact is recorded under
+`__mutsu_scalar_bind_no_container::<name>`, and **every** scalar `my` declaration cleared the key
+speculatively so a redeclaration could not inherit an earlier same-named variable's state.
+
+Each of its four sibling keys — `locals_alias_sym`, `locals_readonly_sym`,
+`locals_deleted_index_sym`, `locals_bound_slice_sym` — already has a per-local pre-interned vector on
+`CompiledCode`; this one was the entry missing from the set, so it paid a `format!` plus a
+`Symbol::intern` per declaration. It now has `locals_scalar_no_container_sym`, filled in
+`compute_locals_sym` like the rest, and the key shape moved next to theirs in `runtime/utils.rs`.
+
+The speculative clear also got the gate the family convention implies: a monotonic
+`scalar_bind_no_container_possible()` latch, armed by the one site that creates the key (through
+`insert_sym_noting`, since a plain `insert_sym` deliberately does not run `note_env_key`). A program
+that never makes such a binding now skips the clear entirely — which matters beyond the intern,
+because it also skips the `env_mut()` that could CoW-deep-clone the frame env on every `my $x`.
+
+## Measured
+
+Release + callgrind, `use Test; plan 2000; for ^2000 { ok 1, "x" }` under `MUTSU_REAL_TEST=1`, warm
+precompilation cache, second run after the rebuild (a cold cache inflates this benchmark by ~60% and
+is not comparable to anything).
+
+| | before | after |
+| --- | --- | --- |
+| whole run | 488.15 M Ir | 481.05 M Ir (−1.45%) |
+| `Symbol::intern` calls | 120,822 | 97,088 (−23,734) |
+
+Per assertion, from the `callgrind_annotate --tree=caller` caller counts (all three are linear in the
+assertion count):
+
+| caller | before | after |
+| --- | --- | --- |
+| `bind_function_args_values_inner` | 7.00 | 2.00 |
+| `OnceCell::try_init` (the binder's per-parameter cell) | 5.00 | 0 |
+| `exec_set_local_op_inner` | 2.01 | 0 |
+
+−11.9 interns per assertion, about a third of #7766's measured 35.4 budget. The `OnceCell::try_init`
+row is the binder's too: #7766's table attributed ~7 interns/assertion to the binder because
+callgrind charges the `get_or_init` closure to `OnceCell`, so the binder's real cost was ~12 and the
+unit was worth more than it looked.
+
+`t/routines/signature/param-bind-symbol-keys.t` — the file #7766 names as the regression cover for
+exactly this class of change, a *name* bound under the wrong key rather than a slowdown — grew 11
+assertions: parameter positions stay aligned across a mixed
+positional/array/named/slurpy signature and across a parameter that follows a destructuring
+sub-signature, only the `is copy` parameter of a pair is marked writable, and the container-identity
+marker is set, cleared by a same-named assigned redeclaration, and set again. All 32 pass under
+rakudo too.
+
+## Still open on #7766
+
+Unit 2 — the dispatch names (`call_compiled_function_named_inner` interning `fn_package`/`fn_name`
+from `&str` parameters, the resolution layers below it re-hashing the callee name, and the
+receiver-class names in `multi_arg_type_keys` / `vm_call_method_compiled_cache`) — is untouched. It
+is ~10 interns/assertion across five call sites whose `&str` APIs are fed by further `&str` APIs, so
+doing it properly means growing a `_sym` variant chain up the call graph, which #7766 itself
+anticipates may want its own split. The measurement is recorded on the issue.
+
+A new residue came out of the re-measurement: 2 interns/assertion still charged to
+`bind_function_args_values_inner` after the parameter names are free (an inlined by-name `Env`
+operation, not the parameter path), and a 16-interns/assertion bucket callgrind attributes to a
+`Vec::from_iter` — an inlining artefact whose real owner needs the per-string histogram #7766
+describes. Neither is named in the issue's original table.

--- a/src/env.rs
+++ b/src/env.rs
@@ -277,6 +277,18 @@ static BOUND_KEY_SEEN: AtomicBool = AtomicBool::new(false);
 /// `distribute_bound_multidim_slice` on every scalar `SetLocal`/assignment.
 static BOUND_SLICE_KEY_SEEN: AtomicBool = AtomicBool::new(false);
 
+/// Monotonic, process-global flag for `__mutsu_scalar_bind_no_container::*`
+/// markers (`my $i := 42`, recording that the name owns no Scalar container).
+///
+/// EVERY scalar `my` declaration used to clear this key speculatively, so that a
+/// redeclaration could not inherit an earlier same-named variable's state — an
+/// `env_mut()` (and so a possible CoW deep clone of the frame env) per `my $x`,
+/// for a key that a program without a single `:=`-to-value bind never holds.
+/// Same soundness argument as [`BOUND_SLICE_KEY_SEEN`]: the only creation site
+/// goes through a noting insert, the flag is monotonic, and an over-set only
+/// makes the (correct) clear run.
+static SCALAR_NO_CONTAINER_KEY_SEEN: AtomicBool = AtomicBool::new(false);
+
 /// Monotonic, process-global flag for the per-element index metadata keys
 /// (`__mutsu_bound_index::*`, `__mutsu_elem_share::*`, `__mutsu_deleted_index::*`).
 /// Their probes run on *every* element write (`@a[i] = x`) and on `:exists`, and
@@ -349,6 +361,13 @@ pub(crate) fn bound_array_slice_possible() -> bool {
     BOUND_SLICE_KEY_SEEN.load(Ordering::Relaxed)
 }
 
+/// True if any `__mutsu_scalar_bind_no_container::*` marker may exist in some
+/// env. See [`SCALAR_NO_CONTAINER_KEY_SEEN`].
+#[inline]
+pub(crate) fn scalar_bind_no_container_possible() -> bool {
+    SCALAR_NO_CONTAINER_KEY_SEEN.load(Ordering::Relaxed)
+}
+
 /// True if any per-element index metadata key may exist in some env. See
 /// [`ELEM_INDEX_META_SEEN`].
 #[inline]
@@ -398,6 +417,8 @@ pub(crate) fn note_env_key(key: &str) {
             BOUND_KEY_SEEN.store(true, Ordering::Relaxed);
         } else if key.starts_with("__mutsu_bound_array_slice::") {
             BOUND_SLICE_KEY_SEEN.store(true, Ordering::Relaxed);
+        } else if key.starts_with("__mutsu_scalar_bind_no_container::") {
+            SCALAR_NO_CONTAINER_KEY_SEEN.store(true, Ordering::Relaxed);
         } else if key.starts_with("__mutsu_bound_index::")
             || key.starts_with("__mutsu_elem_share::")
             || key.starts_with("__mutsu_deleted_index::")

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4254,6 +4254,10 @@ pub(crate) struct CompiledCode {
     /// is once per iteration.
     pub(crate) locals_deleted_index_sym: Vec<Symbol>,
     pub(crate) locals_bound_slice_sym: Vec<Symbol>,
+    /// Pre-interned Symbol of the `__mutsu_scalar_bind_no_container::<name>` env
+    /// key for each local — the one key of that family that still paid a
+    /// `format!` plus a `Symbol::intern` on every scalar `my` declaration.
+    pub(crate) locals_scalar_no_container_sym: Vec<Symbol>,
     /// Bitmap: true if `local[i]` is a *plain lexical* name — the sigil-less form
     /// the compiler stores scalars under (`my $x` -> `"x"`, a scalar param
     /// `$n` -> `"n"`), with no twigil (`*d`, `^a`), no attribute (`.x`, `!x`),
@@ -5369,6 +5373,7 @@ impl CompiledCode {
             locals_readonly_sym: Vec::new(),
             locals_deleted_index_sym: Vec::new(),
             locals_bound_slice_sym: Vec::new(),
+            locals_scalar_no_container_sym: Vec::new(),
             plain_locals: Vec::new(),
             state_locals: Vec::new(),
             our_locals: Vec::new(),
@@ -5697,6 +5702,18 @@ impl CompiledCode {
         }
     }
 
+    /// The interned `__mutsu_scalar_bind_no_container::<name>` env key of local
+    /// `idx`. See [`CompiledCode::alias_sym`].
+    pub(crate) fn scalar_no_container_sym(&self, idx: usize) -> Option<Symbol> {
+        match self.locals_scalar_no_container_sym.get(idx) {
+            Some(sym) => Some(*sym),
+            None => self
+                .locals
+                .get(idx)
+                .map(|n| Symbol::intern(&crate::runtime::scalar_bind_no_container_key(n))),
+        }
+    }
+
     pub(crate) fn compute_locals_sym(&mut self) {
         self.locals_sym = self.locals.iter().map(|s| Symbol::intern(s)).collect();
         self.locals_alias_sym = self
@@ -5718,6 +5735,11 @@ impl CompiledCode {
             .locals
             .iter()
             .map(|s| Symbol::intern(&crate::runtime::bound_array_slice_key(s)))
+            .collect();
+        self.locals_scalar_no_container_sym = self
+            .locals
+            .iter()
+            .map(|s| Symbol::intern(&crate::runtime::scalar_bind_no_container_key(s)))
             .collect();
     }
 

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -32,6 +32,25 @@ fn param_display_name(pd: &crate::ast::ParamDef) -> String {
     }
 }
 
+/// The callee's pre-interned Symbol for parameter `idx`, when it handed one over
+/// (see [`Interpreter::bind_function_args_values_with_syms`]). `None` means no
+/// baked table, and the caller interns `pd.name` itself.
+///
+/// The table is index-parallel to `param_defs`, so the failure this guards
+/// against is a *misalignment*: a parameter bound, marked readonly or cleared
+/// under a neighbour's name. The `debug_assert_eq!` makes that loud in CI's
+/// debug runs; `with_syms` drops a table whose length already disagrees.
+fn baked_param_name_sym(baked: &[Symbol], idx: usize, pd: &ParamDef) -> Option<Symbol> {
+    let sym = *baked.get(idx)?;
+    debug_assert_eq!(
+        sym,
+        Symbol::intern(&pd.name),
+        "param_name_syms[{idx}] is not the symbol of param_defs[{idx}] ({:?})",
+        pd.name,
+    );
+    Some(sym)
+}
+
 fn legacy_has_plain_positional_param(params: &[String]) -> bool {
     params.iter().any(|p| {
         !p.starts_with(':')
@@ -547,7 +566,7 @@ impl Interpreter {
         params: &[String],
         args: &[Value],
     ) -> Result<Vec<(String, String)>, RuntimeError> {
-        self.bind_function_args_values_with_argspec(param_defs, params, args, None)
+        self.bind_function_args_values_with_syms(param_defs, params, args, None, &[])
     }
 
     /// Whether `data`'s body reads the legacy argument array `@_`, or `None`
@@ -582,8 +601,41 @@ impl Interpreter {
         args: &[Value],
         reads_args_array: Option<bool>,
     ) -> Result<Vec<(String, String)>, RuntimeError> {
-        let result =
-            self.bind_function_args_values_inner(param_defs, params, args, reads_args_array);
+        self.bind_function_args_values_with_syms(param_defs, params, args, reads_args_array, &[])
+    }
+
+    /// [`Interpreter::bind_function_args_values_with_argspec`] plus the callee's
+    /// **pre-interned parameter names**.
+    ///
+    /// Binding a parameter names it several times — the value bind, the type
+    /// constraint, the readonly mark — and every one of those wants a `Symbol`.
+    /// A registered routine already has them:
+    /// [`CompiledFunction::precompute_param_name_syms`](crate::opcode::CompiledFunction::precompute_param_name_syms)
+    /// interns `param_defs[i].name` once at registration time. Handing that slice
+    /// over takes the per-call cost to zero; the benchmark behind #7766 spent
+    /// ~12 `Symbol::intern` calls per `Test::ok` assertion here, the single
+    /// largest remaining bucket.
+    ///
+    /// `param_name_syms` is index-parallel to `param_defs`, or empty. A caller
+    /// that builds `param_defs` by hand (a `FunctionDef`/`SubData` path, a
+    /// synthesized signature) passes `&[]` and every name is interned lazily as
+    /// before. A slice whose length does not match `param_defs` is treated as
+    /// empty rather than trusted, so a stale vector cannot mis-key a binding.
+    pub(crate) fn bind_function_args_values_with_syms(
+        &mut self,
+        param_defs: &[ParamDef],
+        params: &[String],
+        args: &[Value],
+        reads_args_array: Option<bool>,
+        param_name_syms: &[Symbol],
+    ) -> Result<Vec<(String, String)>, RuntimeError> {
+        let result = self.bind_function_args_values_inner(
+            param_defs,
+            params,
+            args,
+            reads_args_array,
+            param_name_syms,
+        );
         let declares_self = crate::ast::signature_declares_self_lexical(param_defs)
             // The legacy binding path: a single pointy-block parameter
             // (`-> $self { }`) arrives as a bare name with no `ParamDef`.
@@ -600,7 +652,24 @@ impl Interpreter {
         params: &[String],
         args: &[Value],
         reads_args_array: Option<bool>,
+        param_name_syms: &[Symbol],
     ) -> Result<Vec<(String, String)>, RuntimeError> {
+        // Index-parallel or nothing: a length mismatch means the slice does not
+        // describe THIS signature (a caller that passed a sibling's vector, or a
+        // `param_defs` mutated after the precompute), and indexing it would bind
+        // a parameter under another one's name. Falling back to the lazy intern
+        // keeps such a caller correct at the old cost.
+        let baked_name_syms: &[Symbol] = if param_name_syms.len() == param_defs.len() {
+            param_name_syms
+        } else {
+            debug_assert!(
+                param_name_syms.is_empty(),
+                "param_name_syms ({}) is neither empty nor parallel to param_defs ({})",
+                param_name_syms.len(),
+                param_defs.len(),
+            );
+            &[]
+        };
         let filtered_args: Vec<Value> = args
             .iter()
             .filter(|arg| !is_internal_named_arg(&unwrap_varref_value((*arg).clone())))
@@ -992,13 +1061,18 @@ impl Interpreter {
             })
             .collect();
         let mut positional_idx = 0usize;
-        for pd in param_defs {
-            // One intern per parameter for the whole per-parameter path below
+        for (param_idx, pd) in param_defs.iter().enumerate() {
+            // One Symbol per parameter for the whole per-parameter path below
             // (value bind, type constraint, readonly mark), instead of one per
-            // helper. Lazy, so an arm that never names the parameter still
-            // interns nothing (#7736).
+            // helper (#7736). Served from the callee's registration-time
+            // `param_name_syms` when the caller had one, so a compiled routine
+            // interns nothing at all here (#7766); otherwise interned lazily, so
+            // an arm that never names the parameter still interns nothing.
             let pd_name_cell = std::cell::OnceCell::new();
-            let pd_name_sym = || *pd_name_cell.get_or_init(|| Symbol::intern(&pd.name));
+            let pd_name_sym = || {
+                baked_param_name_sym(baked_name_syms, param_idx, pd)
+                    .unwrap_or_else(|| *pd_name_cell.get_or_init(|| Symbol::intern(&pd.name)))
+            };
             if pd.onearg {
                 // +@ (single-argument rule slurpy): if exactly one remaining positional
                 // arg is Iterable (Array, List, etc.), use its elements directly.
@@ -2864,7 +2938,7 @@ impl Interpreter {
         // Mark parameters as readonly unless they have `is rw`, `is copy`, or `is raw` traits.
         // Sigilless params (\x) are always writable (they are raw aliases).
         // For `is raw` with non-lvalue args, also mark readonly.
-        for pd in param_defs {
+        for (param_idx, pd) in param_defs.iter().enumerate() {
             if pd.name.is_empty() || pd.name == "__type_only__" || pd.name == "__subsig__" {
                 continue;
             }
@@ -2886,8 +2960,10 @@ impl Interpreter {
             // attribute binds, already skipped above.)
             let is_container_param = pd.name.starts_with('@') || pd.name.starts_with('%');
             if !is_container_param {
-                // One intern for both arms below (#7736).
-                let pd_name_sym = Symbol::intern(&pd.name);
+                // One Symbol for both arms below (#7736), from the callee's baked
+                // table when there is one (#7766).
+                let pd_name_sym = baked_param_name_sym(baked_name_syms, param_idx, pd)
+                    .unwrap_or_else(|| Symbol::intern(&pd.name));
                 if !has_mutable_trait || raw_nonlvalue_params.contains(&pd.name) {
                     self.mark_readonly_sym(pd_name_sym);
                 } else {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -65,6 +65,21 @@ pub(crate) fn bound_array_slice_key(name: &str) -> String {
     format!("__mutsu_bound_array_slice::{name}")
 }
 
+/// The env key recording that a `$` name was `:=`-bound straight to a value and
+/// so owns no Scalar container (`my $i := 42`). Written at the declaration's
+/// store and speculatively cleared on every other scalar declaration, so — like
+/// the four keys above — a hot path pre-interns it per local rather than
+/// rebuilding it per store (`CompiledCode::locals_scalar_no_container_sym`).
+///
+/// The `$` is trimmed because the compiler stores scalars under their bare name,
+/// but a caller that still holds the sigiled spelling must land on the same key.
+pub(crate) fn scalar_bind_no_container_key(name: &str) -> String {
+    format!(
+        "__mutsu_scalar_bind_no_container::{}",
+        name.trim_start_matches('$')
+    )
+}
+
 /// True for the per-call-site internal temp names of the Index-argument `is rw`
 /// writeback machinery (`__mutsu_index_rw_arg_N` / `__mutsu_index_rw_orig_N` /
 /// `__mutsu_call_result_N`, see `compile_call_arg_with_escape` /

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -205,7 +205,16 @@ impl Interpreter {
         } else {
             match loan_env!(
                 self,
-                bind_function_args_values(&cf.param_defs, &cf.params, &args)
+                // `cf.param_name_syms` is `cf.param_defs[i].name` interned at
+                // registration time, so the binder names each parameter without
+                // re-hashing it per call (#7766).
+                bind_function_args_values_with_syms(
+                    &cf.param_defs,
+                    &cf.params,
+                    &args,
+                    None,
+                    &cf.param_name_syms
+                )
             ) {
                 Ok(bindings) => bindings,
                 Err(e) => {

--- a/src/vm/vm_comparison_container_ops.rs
+++ b/src/vm/vm_comparison_container_ops.rs
@@ -172,20 +172,25 @@ impl Interpreter {
         // value. A readonly *alias* with a container behind it — a non-`is rw`
         // parameter, a `for @a -> $v` alias — is deliberately not excluded:
         // rakudo reports `Scalar` for those.
-        !self.scalar_name_has_no_container(name)
-            && !self
-                .env()
-                .contains_key(&Self::scalar_bind_no_container_key(name))
+        if self.scalar_name_has_no_container(name) {
+            return false;
+        }
+        // The store-side half of the same decision. Gated on the monotonic
+        // key-family latch, so a program that never made such a binding spends
+        // neither the `format!` nor the env lookup.
+        if !crate::env::scalar_bind_no_container_possible() {
+            return true;
+        }
+        !self
+            .env()
+            .contains_key(&Self::scalar_bind_no_container_key(name))
     }
 
     /// Env key recording that a `$` name was `:=`-bound straight to a value and
     /// so owns no Scalar container. Written at the declaration's store; see
     /// `bind_marks_no_container` in `vm_var_assign_set_local.rs`.
     pub(crate) fn scalar_bind_no_container_key(name: &str) -> String {
-        format!(
-            "__mutsu_scalar_bind_no_container::{}",
-            name.trim_start_matches('$')
-        )
+        crate::runtime::scalar_bind_no_container_key(name)
     }
 
     /// Walk the `__mutsu_sigilless_alias::` chain to find the ultimate

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -854,11 +854,21 @@ impl Interpreter {
         // `bind_marks_no_container`). Set/cleared per declaration so a later
         // `my $o = 5` of the same name goes back to owning a Scalar.
         if is_vardecl && !code.locals[idx].starts_with(['@', '%', '&']) {
-            let key = Self::scalar_bind_no_container_key(&code.locals[idx]);
             if bind_marks_no_container {
-                self.env_mut().insert(key, Value::TRUE);
-            } else {
-                self.env_mut().remove(&key);
+                // `insert_sym_noting`, not `insert_sym`: this is the only site
+                // that creates the key, so it is what arms
+                // `scalar_bind_no_container_possible` for the clear below.
+                if let Some(sym) = code.scalar_no_container_sym(idx) {
+                    self.env_mut().insert_sym_noting(sym, Value::TRUE);
+                }
+            } else if crate::env::scalar_bind_no_container_possible()
+                && let Some(sym) = code.scalar_no_container_sym(idx)
+            {
+                // Speculative clear, so a redeclaration cannot inherit an
+                // earlier same-named variable's "owns no container" state.
+                // Skipped entirely — no `env_mut()`, so no CoW deep clone — in
+                // the common program that never made such a binding.
+                self.env_mut().remove_sym(sym);
             }
         }
 

--- a/t/routines/signature/param-bind-symbol-keys.t
+++ b/t/routines/signature/param-bind-symbol-keys.t
@@ -9,7 +9,7 @@ use Test;
 # share one symbol, so a mix-up would show up as a *wrong name* being bound,
 # marked or cleared rather than as a slowdown.
 
-plan 21;
+plan 32;
 
 # --- the fixed per-call keys -------------------------------------------------
 
@@ -80,3 +80,52 @@ sub untyped-inner($v) { $v }
 my Str $v = "s";
 is untyped-inner(1), 1, "an untyped parameter shadows the caller's typed lexical";
 lives-ok { $v = "t" }, "the caller's own typed lexical keeps its constraint";
+
+# --- #7766: the callee's BAKED parameter symbols ------------------------------
+# A compiled routine now hands the binder its registration-time
+# `param_name_syms` instead of interning each parameter name per call, so the
+# slice is indexed by parameter position. A misalignment would bind, mark or
+# clear a parameter under a *neighbour's* name, which these pin by giving every
+# position a distinguishable value.
+
+sub positional-order($a, $b, $c) { "$a|$b|$c" }
+is positional-order(1, 2, 3), "1|2|3", 'three positionals bind in signature order';
+
+sub mixed-shape($head, @rest, :$opt = "o", *%extra) {
+    "$head/{@rest.join(',')}/$opt/{%extra.keys.sort.join(',')}"
+}
+is mixed-shape("h", [1, 2], :opt<p>, :x, :y), "h/1,2/p/x,y",
+    'a mixed positional/array/named/slurpy signature binds each position to its own name';
+
+sub after-subsig([$p, $q], $tail) { "$p$q$tail" }
+is after-subsig([1, 2], 3), "123",
+    'a parameter following a destructuring sub-signature still binds its own name';
+
+sub invocant-then-params($n, $m) { "$n-$m" }
+is invocant-then-params(4, 5), "4-5", 'positions stay aligned across repeated calls';
+is invocant-then-params(6, 7), "6-7", 'a second call rebinds the same positions';
+
+class Baked {
+    method two($x, $y is copy) { $y = $y + 1; "$x:$y" }
+}
+is Baked.new.two(1, 2), "1:3",
+    'a method marks only the `is copy` parameter writable, by position';
+
+# --- #7766: the `__mutsu_scalar_bind_no_container::` marker -------------------
+# `my $i := 42` records "this name owns no Scalar container" under a per-local
+# pre-interned key, and every other scalar declaration clears it so a
+# same-named redeclaration cannot inherit it. A key mix-up shows up as `.self
+# =:= $name` answering for the wrong variable.
+
+my $bound := 42;
+ok $bound.self =:= $bound, 'a `:=`-to-value scalar owns no Scalar container';
+my $assigned = 42;
+nok $assigned.self =:= $assigned, 'an assigned scalar does own a Scalar container';
+
+sub container-id($bind) {
+    if $bind { my $v := 9; return $v.self =:= $v }
+    else     { my $v = 9;  return $v.self =:= $v }
+}
+ok container-id(True), 'the marker is set for the bound declaration';
+nok container-id(False), 'a later same-named assigned declaration clears it';
+ok container-id(True), 'and the marker is set again on the next bound declaration';


### PR DESCRIPTION
Units **1** and **3** of #7766. Both are the same shape: a name that had *already* been interned somewhere the hot path could reach, being re-hashed per call anyway.

Unit 2 (the dispatch names) is deliberately left on the issue — see *Not in this PR* below.

## Unit 1 — the binder's parameter names

`CompiledFunction::precompute_param_name_syms` interns every `param_defs[i].name` when a routine is registered. `bind_function_args_values_inner` did not read it: it kept a per-parameter `OnceCell` and interned the name on first use in each call. Once per parameter per call is better than once per helper — that was #7762 — but it is not zero, and binding is the hottest thing a `Test` assertion does.

`bind_function_args_values_with_syms` is the new entry point; the two existing ones (`bind_function_args_values`, `..._with_argspec`) delegate to it with an empty slice, so **none of the ~16 callers that build `param_defs` by hand** — a `FunctionDef`, a `SubData`, a synthesized signature — needed touching or lost anything. The one caller that does hold a registered routine, `call_compiled_function_named_inner`, passes `&cf.param_name_syms`, and that single site covers every binder call the benchmark makes.

The slice is index-parallel to `param_defs`, so the interesting failure mode is a **misalignment**: a parameter bound, marked readonly or cleared under a *neighbour's* name. Two guards:

- a slice whose length does not match `param_defs` is treated as empty rather than trusted, so a vector left over from a `param_defs` mutated after the precompute degrades to the old lazy intern instead of mis-keying a binding;
- `baked_param_name_sym` `debug_assert_eq!`s the resolved symbol against a fresh intern of `pd.name`, which makes a genuine index mismatch loud in the `gc-stress` / `jit-stress` jobs' debug runs.

## Unit 3 — the last missing pre-interned key

`my $i := 42` binds straight to a value, so the name owns no `Scalar` container and `$i.self =:= $i` is True where `my $a = 42` answers False. That fact lives under `__mutsu_scalar_bind_no_container::<name>`, and **every** scalar `my` declaration cleared the key speculatively so a redeclaration could not inherit an earlier same-named variable's state.

Each of its four sibling keys already has a per-local pre-interned vector on `CompiledCode` (`locals_alias_sym`, `locals_readonly_sym`, `locals_deleted_index_sym`, `locals_bound_slice_sym`); this was the entry missing from the set, so it paid a `format!` plus a `Symbol::intern` per declaration. It now has `locals_scalar_no_container_sym`, filled in `compute_locals_sym` like the rest, and the key shape moved next to theirs in `runtime/utils.rs`.

The speculative clear also got the gate the family convention implies: a monotonic `scalar_bind_no_container_possible()` latch, armed by the one site that creates the key — through `insert_sym_noting`, since a plain `insert_sym` deliberately does not run `note_env_key`. A program that never makes such a binding now skips the clear entirely, and with it the `env_mut()` that could CoW-deep-clone the frame env on every `my $x`.

## Measured

Release + callgrind, `use Test; plan 2000; for ^2000 { ok 1, "x" }` under `MUTSU_REAL_TEST=1`, warm precompilation cache, second run after the rebuild (a cold cache inflates this benchmark by ~60% and is not comparable to anything).

| | before | after |
| --- | --- | --- |
| whole run | 488.15 M Ir | 481.05 M Ir (−1.45%) |
| `Symbol::intern` calls | 120,822 | 97,088 (−23,734) |

Per assertion, from the `callgrind_annotate --tree=caller` counts (all three are linear in the assertion count):

| caller | before | after |
| --- | --- | --- |
| `bind_function_args_values_inner` | 7.00 | 2.00 |
| `OnceCell::try_init` (the binder's per-parameter cell) | 5.00 | 0 |
| `exec_set_local_op_inner` | 2.01 | 0 |

**−11.9 interns per assertion**, about a third of #7766's measured 35.4 budget. The `OnceCell::try_init` row is the binder's too: #7766's table attributed ~7 to the binder because callgrind charges the `get_or_init` closure to `OnceCell`, so the binder's real cost was ~12 and the unit was worth more than it looked.

These are callgrind instruction counts from this container, for the in-flight decision only — a number for a document still has to come from the bench CI.

## Tests

`t/routines/signature/param-bind-symbol-keys.t` — the file #7766 names as the cover for exactly this class of change, a *name* bound under the wrong key rather than a slowdown — grew 11 assertions rather than starting a new file: parameter positions stay aligned across a mixed positional/array/named/slurpy signature and across a parameter that follows a destructuring sub-signature, only the `is copy` parameter of a pair is marked writable, and the container-identity marker is set, cleared by a same-named assigned redeclaration, and set again. **All 32 pass under rakudo too.**

`cargo fmt --all`, `make lint` (all four configurations), `make test` (3959 files, 42099 tests, PASS) and `make roast` all run locally before publishing. The only roast reds are the three documented container-only files — `6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8/10), `S16-filehandles/filetest.t` (`Failed: 25`, the same 25 subtests) and `S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17) — byte-identical to the shapes `docs/agent-environments.md` records for a `uid 0` container with a sandboxed network.

## Not in this PR

Unit 2 — `call_compiled_function_named_inner` interning `fn_package`/`fn_name` from `&str` parameters, the resolution layers below it (`find_compiled_function_inner`, `resolve_function_multi_cached_keyed`, `user_method_overloads`) re-hashing the callee name, and the receiver-class names in `multi_arg_type_keys` / `vm_call_method_compiled_cache`. That is ~10 interns/assertion across five call sites whose `&str` APIs are fed by further `&str` APIs, so doing it properly means growing a `_sym` variant chain up the call graph — which #7766 itself says "may want to be split again once someone has read the call graph". #7766 stays open for it, with the fresh caller-by-caller measurement posted there.

The re-measurement also surfaced two buckets the issue's table does not name: 2 interns/assertion still charged to `bind_function_args_values_inner` after the parameter names are free (an inlined by-name `Env` operation, not the parameter path), and a 16-interns/assertion bucket callgrind attributes to a `Vec::from_iter` — an inlining artefact whose real owner needs the per-string histogram #7766 describes. Both recorded on the issue.

Refs #7766

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBjNxgtvGbyUQkkCKiK8af

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBjNxgtvGbyUQkkCKiK8af)_