### PR TITLE
perf(jit): make the inline local read 25 instructions instead of 48

### DIFF
--- a/docs/jit-codegen-inspection.md
+++ b/docs/jit-codegen-inspection.md
@@ -1,0 +1,124 @@
+# Reading what the JIT actually emitted
+
+The Tier A/B JIT (ADR-0004) writes its bodies into anonymous memory at runtime,
+so nothing on disk carries a symbol for them. A profiler therefore reports the
+generated code as a single unnamed `???:0x…` entry — on `bench-fib` that entry
+was **13.3% of the whole run**, the second-largest symbol in the benchmark, with
+no way to see inside it
+([#7737](https://github.com/tokuhirom/mutsu/issues/7737)). Two rounds of
+guessing at its cost from the interpreter side produced nothing; both this
+document and the tooling it describes exist so the next session measures
+instead.
+
+Everything here is off unless an environment variable asks for it. With the
+variables unset the only cost is one `OnceLock` read per compiled chunk.
+
+## `MUTSU_JIT_DUMP` — the emitted code
+
+| value | what you get |
+| --- | --- |
+| `ops` | the accepted opcode range, the chunk's locals, the emitted code size and the finalized entry address |
+| `clif` | the above plus the Cranelift IR handed to the backend |
+| `asm` | the above plus the backend's disassembly, with each helper-shim call address annotated by name (`; -> call_func`) |
+| `all` / `1` | `clif` and `asm` together |
+
+Two companions:
+
+- `MUTSU_JIT_DUMP_FILE=<path>` — append the dump there instead of stderr.
+- `MUTSU_JIT_DUMP_BIN=<dir>` — also write each chunk's finalized bytes to
+  `<dir>/<name>.bin`, so the body can be disassembled at its real load address
+  and lined up with a profile.
+
+Pair it with `MUTSU_JIT_THRESHOLD=2` to make a small script compile its hot
+chunk immediately:
+
+```
+cargo build
+MUTSU_JIT_THRESHOLD=2 MUTSU_JIT_DUMP=asm MUTSU_JIT_DUMP_FILE=tmp/jit.txt \
+  ./target/debug/mutsu tmp/fib.raku
+```
+
+The Rust optimization level does **not** affect what the JIT emits — Cranelift
+compiles the same bytecode either way — so a `cargo build` (debug) dump is
+byte-for-byte the dump a release binary would produce, modulo helper addresses
+and `Interpreter` field displacements. Use the debug build to read codegen; the
+`profiling` profile is only needed when the *profile* must include symbolized
+interpreter frames.
+
+### Per-opcode byte spans
+
+When a dump is on, every emitted instruction is tagged with the index of the
+opcode it came from, and the `asm` dump prints the resulting map:
+
+```
+  span 0x0021..0x005e op 0
+  span 0x0066..0x0084 op 0
+  ...
+  span 0x0154..0x0175 op 1
+```
+
+`op 4294967295` is code with no source opcode: the prologue, the epilogue and
+the register moves the register allocator inserted between opcodes. The spans
+are what turn a flat profile of the body into a per-opcode cost table.
+
+## Per-opcode instruction profile
+
+`perf` cannot help here (and is absent from remote containers entirely), but
+`callgrind` counts retired instructions deterministically and
+layout-insensitively — the right oracle at this effect size, per
+[#7579](https://github.com/tokuhirom/mutsu/issues/7579)'s method notes.
+
+```
+cargo build --profile profiling
+MUTSU_JIT_DUMP=asm MUTSU_JIT_DUMP_FILE=tmp/jit.txt MUTSU_JIT_DUMP_BIN=tmp/jitbin \
+  valgrind --tool=callgrind --dump-instr=yes \
+           --callgrind-out-file=tmp/cg.out \
+           ./target/profiling/mutsu benchmarks/bench-fib.raku
+scripts/jit-instr-profile.py tmp/cg.out tmp/jit.txt tmp/jitbin
+```
+
+`--dump-instr=yes` is what makes callgrind record per-address counts; the script
+joins those to the disassembly through the entry address and spans the dump
+printed in the same run (the address is a fresh `mmap` each run, so both halves
+must come from one invocation). Output:
+
+```
+=== mutsu_jit_1  0x4847000..0x4847ce0 (3296 bytes)  self Ir=178254096 (13.28% of run) ===
+
+op               Ir   share     runs instr/run  opcode
+0          30503712  17.11%   635494      48.0  GetLocal(0)
+4          15252288   8.56%   317756      48.0  GetLocal(0)
+2          13980868   7.84%   635494      22.0  NumLe
+16         11120830   6.24%   317738      35.0  Add
+...
+glue       15569451   8.73%                     prologue / regalloc moves
+```
+
+followed by the whole body annotated instruction-by-instruction with its Ir
+count and owning opcode. `instr/run` is the number that matters: it says what
+one execution of that opcode costs in native instructions, independent of how
+often the benchmark runs it.
+
+## Comparing two revisions
+
+To answer "did codegen change between commit A and commit B", build both and
+diff the dumps rather than bisecting — per-commit code-layout noise is ~5% and
+swamps the effects being chased ([#7579](https://github.com/tokuhirom/mutsu/issues/7579)).
+
+```
+git worktree add /tmp/old <commit>          # outside the repo, or add `[workspace]`
+                                            # to the worktree's Cargo.toml
+# copy src/vm/vm_jit_dump.rs and its two call sites in if the old tree predates them
+cargo build && MUTSU_JIT_THRESHOLD=2 MUTSU_JIT_DUMP=asm ... > old.txt
+```
+
+Normalize before diffing: helper-shim addresses, `Interpreter` field
+displacements and Cranelift's block numbering all move for reasons unrelated to
+the shape of the code.
+
+That comparison is what settled #7737: the 2026-08-20 and 2026-09-10 bodies for
+`fib` are the same code, four instructions per `GetLocal` apart (ADR-0077 Slice
+2 made a slot address `base + idx` in a shared stack instead of a direct index
+into a per-frame `Vec`). There was no codegen regression to find — the body is
+simply expensive in absolute terms, which is a different problem with a
+different fix.

--- a/news/2026-09/jit-inline-local-read-was-48-instructions.md
+++ b/news/2026-09/jit-inline-local-read-was-48-instructions.md
@@ -1,0 +1,118 @@
+# The JIT's inline local read was 48 native instructions; now it is 25
+
+`bench-fib`'s second-largest symbol was the JIT-generated body itself — 13.3% of
+the run, reported by every profiler as a bare unnamed `???:0x…` because the code
+is written into anonymous memory at runtime. [#7737](https://github.com/tokuhirom/mutsu/issues/7737)
+had been open on the premise that the body got 50% slower over late August and
+that the first step was to dump the generated code and diff two builds, which
+nobody had done. This does that, and then fixes what the dump showed.
+
+## Seeing inside the body
+
+`MUTSU_JIT_DUMP` (`ops` / `clif` / `asm` / `all`) prints the accepted opcode
+range, the Cranelift IR, and the backend's disassembly with every helper-shim
+call address annotated by name. `MUTSU_JIT_DUMP_BIN=<dir>` also writes each
+chunk's finalized bytes, and `MUTSU_JIT_DUMP_FILE` redirects the text. Crucially
+every emitted instruction is tagged with the index of the opcode it came from,
+so the dump carries a per-opcode byte map.
+
+That map is what makes the body measurable. `scripts/jit-instr-profile.py`
+joins a `callgrind --dump-instr=yes` run to the dumped code image — both taken
+from the same invocation, since the entry address is a fresh `mmap` each run —
+and prints a per-source-opcode instruction table. `docs/jit-codegen-inspection.md`
+is the recipe. All of it is off unless asked for; with the variables unset the
+cost is one `OnceLock` read per compiled chunk.
+
+## What the table said
+
+`bench-fib`, `--profile profiling`, at the merge of #7860. The fib body is 18
+opcodes and runs 635,494 times, for **280 native instructions per call**:
+
+| opcode | instr/run | share of body |
+| --- | ---: | ---: |
+| `GetLocal(0)` × 4 sites | **48** | **42.8%** |
+| `Add` | 35 | 6.2% |
+| `Sub` × 2 | 30 | 10.7% |
+| `NumLe` | 22 | 7.8% |
+| `Return` × 2 | 11–13 | 4.3% |
+| `LoadConst` × 3 | 12 | 8.6% |
+| `JumpIfFalse` | 9.5 | 3.4% |
+| `CallFunc` × 2 | 7–8 | 2.7% |
+| `ContainerizePair` × 2 | 4 | 1.4% |
+| prologue / epilogue / regalloc moves | — | 8.7% |
+
+One read of one scalar local cost 48 instructions, split four ways: 12 for the
+spoiler latches, 8 to bounds-check the slot, **19** for the refcount-free tag
+probe, and 9 to push the word.
+
+## The 19-instruction tag probe
+
+The probe asked four independent questions and ORed the answers: `page ==
+INT_PAGE`, `NUM_PAGE_MIN <= page <= NUM_PAGE_MAX`, `word & KIND_MASK ==
+BOOL_PATTERN`, `word & KIND_MASK == PACKAGE_PATTERN` — the last three needing
+64-bit constants the backend had to load from the code's own pool, so three of
+the 19 instructions were memory reads of literals.
+
+The NaN-box layout already orders those cases. Pages `INT_PAGE ..= NUM_PAGE_MAX`
+are *exactly* the small Int and Num words (kind words start at
+`KIND_PAGE_BASE`), so the first two questions collapse into one unsigned range
+test on the page, and it branches straight to the push. Above that range the
+word is a kind, and `word_for_kind` is strictly monotonic in the kind id, so the
+two admissible kinds — adjacent ids — collapse into a second range test,
+`masked - BOOL_PATTERN <= BOOL_PACKAGE_SPAN`. Both facts are now pinned by
+`const _: () = assert!` in `value::nanbox`. The accepted set is unchanged, down
+to page 0 (the unused niche), which is deliberately outside the range rather
+than assumed impossible: it fails the test and takes the shim.
+
+Common path: **5 instructions instead of 19.**
+
+## Four spoiler latches became one
+
+The guard also loaded two process-global counters and two per-interpreter
+`bool`s and ORed them — four loads, three `or`s and a test. Every one of those
+inputs is monotonic and never cleared, so their OR *is* a counter that each
+source bumps: `vm_jit::LOCAL_READ_SPOILERS`, now bumped by `note_container_cell`,
+`note_caller_var_binding`, `mark_atomic_var_seen` and the sigilless-attribute
+alias site. Folding the two per-interpreter flags in makes the latch
+conservative across interpreters — one interpreter using sigilless attributes
+routes every interpreter's inline read through the shim — which can only cost
+speed, exactly like the process-global counters it joins. **4 instructions
+instead of 12**, and `JitLayout` loses two fields.
+
+The bounds check lost two more: `base + idx < len` is the element's own
+in-bounds condition and subsumes the separate `base <= len` guard, and the sum
+is the index the load needs anyway.
+
+## Result
+
+| | before | after |
+| --- | ---: | ---: |
+| `GetLocal` inline read | 48 instr | **25 instr** |
+| JIT body (`bench-fib`) | 178,254,096 Ir (13.28%) | **143,302,124 Ir (10.97%)** |
+| whole `bench-fib` | 1,342,290,714 Ir | **1,306,053,867 Ir (−2.70%)** |
+| emitted body | 3,296 bytes | 3,160 bytes |
+
+Pinned by `t/vm/codegen/jit-getlocal-fastpath.t`, which gains three cases for
+the reduced guard: an atomic variable and a sigilless attribute must still spoil
+the inline read (both had only a per-interpreter flag before), and a `Whatever`
+local — one kind id below `Bool` — must still fall off the range test onto the
+shim.
+
+## And the premise: there was no codegen regression
+
+The other half of #7737 was the claim that the generated body got 50% slower
+between 2026-08-19 and 2026-08-31 while nothing in the interpreter explained it.
+Building the 2026-08-20 tree with the dump facility grafted on and diffing its
+`fib` body against today's answers that directly: it is the same code. The JIT
+emitters (`src/vm/vm_jit_*.rs`) are byte-identical across that window apart from
+two mechanical renames, and the only shape difference against today is four
+instructions per `GetLocal`, from ADR-0077 Slice 2 (2026-09-08, *after* the
+window) making a slot address `base + idx` into a shared stack instead of a
+direct index into a per-frame `Vec`.
+
+So the +50% was not a codegen change, and the ticket's real finding is the one
+above: the generated body is expensive in absolute terms. That is worth
+recording, because it is the second time an interpreter-side hypothesis about
+this benchmark has been disproved by measurement rather than confirmed — #7579's
+own audit closed one of its seven items as "wrong" for the same reason. The
+dump and the profile script exist so the third time is cheaper.

--- a/scripts/jit-instr-profile.py
+++ b/scripts/jit-instr-profile.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Per-opcode instruction profile of a JIT-compiled mutsu chunk.
+
+The JIT emits its bodies into anonymous memory at runtime, so a profiler has no
+symbol for them and reports only a bare `???:0x...` (13.3% of `bench-fib` at
+the time of writing). This joins the two halves back together.
+
+    cargo build --profile profiling
+    MUTSU_JIT_DUMP=asm MUTSU_JIT_DUMP_FILE=tmp/jit.txt MUTSU_JIT_DUMP_BIN=tmp/jitbin \
+      valgrind --tool=callgrind --dump-instr=yes \
+               --callgrind-out-file=tmp/cg.out \
+               ./target/profiling/mutsu benchmarks/bench-fib.raku
+    scripts/jit-instr-profile.py tmp/cg.out tmp/jit.txt tmp/jitbin
+
+Reads the entry address, length and per-opcode byte spans that MUTSU_JIT_DUMP
+printed, disassembles <bin-dir>/<name>.bin at the real load address, and
+reports (a) a per-source-opcode Ir table and (b) the annotated listing.
+Callgrind counts retired instructions deterministically, so the numbers are
+load-insensitive and directly comparable across builds.
+
+See docs/jit-codegen-inspection.md.
+"""
+
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+if len(sys.argv) < 4:
+    sys.exit(__doc__)
+cg_path, dump_path, bin_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+want = sys.argv[4] if len(sys.argv) > 4 else None
+
+# --- chunk headers, per-opcode spans and the opcode listing from the dump ---
+chunks, spans, oplist = [], defaultdict(list), defaultdict(dict)
+cur_name = None
+for line in open(dump_path):
+    m = re.match(r"=== mutsu jit: (\S+) ops\[", line)
+    if m:
+        cur_name = m.group(1)
+        continue
+    m = re.match(r"\s{2,}(\d+)\s\s(\S.*)$", line)
+    if m and cur_name:
+        oplist[cur_name][int(m.group(1))] = m.group(2).strip()
+        continue
+    m = re.match(r"--- (\S+) code \((\d+) bytes\)", line)
+    if m:
+        cur_name = m.group(1)
+        continue
+    m = re.match(r"\s+span 0x([0-9a-f]+)\.\.0x([0-9a-f]+) op (\d+)", line)
+    if m and cur_name:
+        spans[cur_name].append((int(m.group(1), 16), int(m.group(2), 16), int(m.group(3))))
+        continue
+    m = re.match(r"--- (\S+) entry at 0x([0-9a-f]+) len (\d+)", line)
+    if m:
+        chunks.append((m.group(1), int(m.group(2), 16), int(m.group(3))))
+if want:
+    chunks = [c for c in chunks if c[0] == want]
+if not chunks:
+    sys.exit("no chunks found in %s" % dump_path)
+
+# --- per-address Ir from the callgrind file --------------------------------
+POS = r"(0x[0-9a-f]+|[+-]?\d+|\*)"
+counts = defaultdict(int)
+cur = None
+total = 0
+pending_call = False
+for raw in open(cg_path):
+    line = raw.rstrip("\n")
+    if not line:
+        continue
+    if line.startswith("calls="):
+        pending_call = True
+        continue
+    if re.match(r"^(fn|fl|ob|cfn|cfl|cob|fe|fi|jump|jcnd)=", line) or line[0] == "#":
+        if re.match(r"^(fn|fl|ob)=", line):
+            cur = None
+        continue
+    if re.match(r"^(events|positions|summary|totals|cmd|part|desc|version|creator|pid):", line):
+        continue
+    m = re.match(r"^%s\s+%s\s+(\d+)\s*$" % (POS, POS), line)
+    if not m:
+        continue
+    pos, ir = m.group(1), int(m.group(3))
+    if pos.startswith("0x"):
+        cur = int(pos, 16)
+    elif pos == "*":
+        pass
+    elif pos[0] in "+-":
+        cur = (cur or 0) + int(pos)
+    else:
+        cur = int(pos)
+    if pending_call:
+        pending_call = False   # inclusive cost of a call, not a caller instruction
+        continue
+    counts[cur] += ir
+    total += ir
+
+print("callgrind: %d addresses, %d Ir self total\n" % (len(counts), total))
+
+for name, addr, length in chunks:
+    binf = "%s/%s.bin" % (bin_dir, name)
+    dis = subprocess.run(
+        ["objdump", "-D", "-b", "binary", "-m", "i386:x86-64", "-M", "att",
+         "--adjust-vma=%#x" % addr, binf],
+        capture_output=True, text=True).stdout
+    body = sum(v for k, v in counts.items() if addr <= k < addr + length)
+    print("=== %s  %#x..%#x (%d bytes)  self Ir=%d (%.2f%% of run) ===" %
+          (name, addr, addr + length, length, body,
+           100.0 * body / total if total else 0))
+
+    # per-opcode table
+    per_op, per_op_instrs, glue = defaultdict(int), defaultdict(int), 0
+    for lo, hi, op in spans.get(name, []):
+        for a in range(addr + lo, addr + hi):
+            if a in counts:
+                if op == 0xFFFFFFFF:
+                    glue += counts[a]
+                else:
+                    per_op[op] += counts[a]
+                    per_op_instrs[op] += 1
+    if per_op:
+        print("\n%-6s %12s %7s %8s %9s  %s" %
+              ("op", "Ir", "share", "runs", "instr/run", "opcode"))
+        for op in sorted(per_op, key=lambda o: -per_op[o]):
+            runs = max((counts[a] for lo, hi, o in spans[name] if o == op
+                        for a in range(addr + lo, addr + hi) if a in counts), default=0)
+            print("%-6d %12d %6.2f%% %8d %9.1f  %s" %
+                  (op, per_op[op], 100.0 * per_op[op] / body, runs,
+                   per_op[op] / runs if runs else 0, oplist.get(name, {}).get(op, "?")))
+        print("%-6s %12d %6.2f%% %8s %9s  %s" %
+              ("glue", glue, 100.0 * glue / body, "", "", "prologue / regalloc moves"))
+        print("%-6s %12d %6.2f%%" % ("total", body, 100.0))
+
+    print("\n--- annotated listing ---")
+    op_at = {}
+    for lo, hi, op in spans.get(name, []):
+        for a in range(addr + lo, addr + hi):
+            op_at[a] = op
+    for line in dis.splitlines():
+        m = re.match(r"^\s*([0-9a-f]+):\s", line)
+        if not m:
+            continue
+        a = int(m.group(1), 16)
+        op = op_at.get(a)
+        tag = "" if op is None or op == 0xFFFFFFFF else "op%-3d" % op
+        print("%12d %-6s %s" % (counts.get(a, 0), tag, line.strip()))

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -544,10 +544,12 @@ impl Interpreter {
     }
 
     /// Mark that an atomic variable / atomic storage has been registered, both on
-    /// this interpreter (for the read gates) and process-wide (for the reset gate).
+    /// this interpreter (for the read gates) and process-wide (for the reset gate
+    /// and the JIT's `LOCAL_READ_SPOILERS` latch).
     pub(crate) fn mark_atomic_var_seen(&mut self) {
         self.atomic_var_seen = true;
         ATOMIC_VAR_SEEN.store(true, std::sync::atomic::Ordering::Relaxed);
+        crate::vm::vm_jit::note_local_read_spoiler();
     }
 
     /// Whether any variable type constraint has ever been registered in this

--- a/src/value/nanbox/mod.rs
+++ b/src/value/nanbox/mod.rs
@@ -539,6 +539,24 @@ pub(crate) mod jit_words {
     /// duplicate them as raw bits.
     pub(crate) const PACKAGE_PATTERN: u64 = word_for_kind(Kind::Package, 0).get();
 
+    /// `word & KIND_MASK` distance from [`BOOL_PATTERN`] to [`PACKAGE_PATTERN`],
+    /// so "Bool or Package" is one *ordered range* test (`masked -
+    /// BOOL_PATTERN <= BOOL_PACKAGE_SPAN`) instead of two full-word equality
+    /// probes against 64-bit constants. Sound because `word_for_kind` is
+    /// strictly monotonic in the kind id (page = `KIND_PAGE_BASE + k / 8`,
+    /// subkind = `k % 8`) and `Package` is `Bool + 1`, both asserted below: the
+    /// only *kind* words in that closed interval are exactly those two.
+    pub(crate) const BOOL_PACKAGE_SPAN: u64 = PACKAGE_PATTERN - BOOL_PATTERN;
+    const _: () = assert!(Kind::Package as u8 == Kind::Bool as u8 + 1);
+
+    /// Pages `INT_PAGE ..= NUM_PAGE_MAX` are exactly the Int and Num words, so
+    /// "small Int or Num" is likewise one ordered range test on the page rather
+    /// than an equality probe ORed with a second range test. Page 0 is unused
+    /// (the niche) and is deliberately *outside* the range — it is not assumed
+    /// impossible, it simply fails the test and takes the shim.
+    const _: () = assert!(NUM_PAGE_MIN == INT_PAGE + 1);
+    const _: () = assert!(NUM_PAGE_MAX < KIND_PAGE_BASE);
+
     /// True when duplicating/discarding this word needs no refcount or GC
     /// bookkeeping: small Int, Num, or a payload-free inline kind. The Tier B
     /// `LoadConst` emitter inlines the push of such a constant as a raw

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -187,6 +187,8 @@ pub(crate) mod vm_jit;
 #[cfg(feature = "jit")]
 mod vm_jit_compile;
 #[cfg(feature = "jit")]
+mod vm_jit_dump;
+#[cfg(feature = "jit")]
 mod vm_jit_helpers;
 #[cfg(feature = "jit")]
 mod vm_jit_layout;

--- a/src/vm/vm_jit.rs
+++ b/src/vm/vm_jit.rs
@@ -98,6 +98,7 @@ pub(crate) static CONTAINER_CELLS: std::sync::atomic::AtomicU32 =
 #[inline]
 pub(crate) fn note_container_cell() {
     CONTAINER_CELLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    note_local_read_spoiler();
 }
 
 /// Process-wide, monotonic count of `$CALLER::x := ...` variable-binding
@@ -112,6 +113,42 @@ pub(crate) static CALLER_VAR_BINDS: std::sync::atomic::AtomicU32 =
 #[inline]
 pub(crate) fn note_caller_var_binding() {
     CALLER_VAR_BINDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    note_local_read_spoiler();
+}
+
+/// Process-wide, monotonic count of events that spoil the Tier B inline
+/// `GetLocal` fast path (ADR-0004 J4d). Zero proves that every probe the
+/// interpreter's `exec_get_local_op` arm runs *before* it reaches the slot is
+/// a no-op everywhere, so the inline read may go straight from the slot word
+/// to the stack:
+///
+/// - a `ContainerRef` cell was packed ([`CONTAINER_CELLS`]) — the env
+///   cell-adoption probe could find something;
+/// - a `$CALLER::x := ...` alias was registered ([`CALLER_VAR_BINDS`]) —
+///   `resolve_binding` could answer;
+/// - an atomic variable was registered (`Interpreter::mark_atomic_var_seen`) —
+///   the atomic-read branch could fire;
+/// - a sigilless attribute alias was materialized
+///   (`Interpreter::sigilless_attrs_active`) — the alias table must be
+///   consulted.
+///
+/// **One counter, not four latches.** Each input is already monotonic and is
+/// never cleared, so their OR *is* a counter that every source bumps — and the
+/// emitted form is what makes the difference: four loads, three `or`s and a
+/// test were 12 of the 48 instructions one inline local read cost on
+/// `bench-fib` ([#7737](https://github.com/tokuhirom/mutsu/issues/7737)),
+/// against four for a single load and test. Folding in the two
+/// *per-interpreter* flags makes the latch conservative across interpreters —
+/// one interpreter using sigilless attributes routes every interpreter's
+/// inline read through the shim — which can only cost speed, exactly like the
+/// process-global counters above. Never decremented.
+pub(crate) static LOCAL_READ_SPOILERS: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
+/// Record one Tier B local-read spoiler (see [`LOCAL_READ_SPOILERS`]).
+#[inline]
+pub(crate) fn note_local_read_spoiler() {
+    LOCAL_READ_SPOILERS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// Native entry signature: `(interp, code, compiled_fns) -> status`.

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -164,6 +164,11 @@ fn build(
     end: usize,
     targets: &std::collections::HashSet<usize>,
 ) -> Option<JitEntryFn> {
+    // `MUTSU_JIT_DUMP` (#7737): when on, every emitted instruction is tagged
+    // with its source opcode index so the dump can report a per-opcode byte
+    // range (and a profiler a per-opcode cost). Off by default; the only cost
+    // then is this `OnceLock` read.
+    let dump = super::vm_jit_dump::mode();
     let mut guard = ENGINE.lock().unwrap();
     let engine = match guard.as_mut() {
         Some(e) => e,
@@ -260,6 +265,9 @@ fn build(
             // Straight-line code right after a terminator with no incoming
             // jump: unreachable, skip.
             continue;
+        }
+        if dump.on() {
+            b.set_srcloc(cranelift_codegen::ir::SourceLoc::new(i as u32));
         }
         match op {
             OpCode::LoadConst(idx) => {
@@ -626,10 +634,13 @@ fn build(
     let id = module
         .declare_function(&name, Linkage::Local, &ctx.func.signature)
         .ok()?;
+    super::vm_jit_dump::before_define(dump, &name, code, start, end, &mut ctx);
     module.define_function(id, &mut ctx).ok()?;
+    let code_len = super::vm_jit_dump::after_define(dump, &name, &ctx);
     module.clear_context(&mut ctx);
     module.finalize_definitions().ok()?;
     let addr = module.get_finalized_function(id);
+    super::vm_jit_dump::after_finalize(dump, &name, addr, code_len);
     // SAFETY: `addr` is the finalized code for the signature declared above,
     // which matches `JitEntryFn` exactly; the module (and thus the code
     // memory) lives for the process lifetime.

--- a/src/vm/vm_jit_dump.rs
+++ b/src/vm/vm_jit_dump.rs
@@ -1,0 +1,294 @@
+//! Env-gated dump of what the JIT actually emitted (`MUTSU_JIT_DUMP`).
+//!
+//! The generated bodies are written to anonymous JIT memory at runtime, so a
+//! profiler has no symbol for them: on `bench-fib` the largest generated body
+//! shows up in `callgrind` only as `???:0x…` at 13.8% of the run
+//! ([#7737](https://github.com/tokuhirom/mutsu/issues/7737)). Guessing at the
+//! cost from the interpreter side has repeatedly failed; this module makes the
+//! emitted code readable instead.
+//!
+//! Set `MUTSU_JIT_DUMP` to one of:
+//!
+//! - `ops` — the opcode range that was accepted, plus the finalized code
+//!   address and length (enough to correlate a profiler's bare `0x…` symbol
+//!   with a chunk);
+//! - `clif` — the above plus the Cranelift IR handed to the backend;
+//! - `asm` — the above plus the backend's own disassembly of the emitted
+//!   machine code, with every helper-shim call address annotated by name;
+//! - `all` / `1` — `clif` and `asm` together.
+//!
+//! Output goes to stderr, or to the file named by `MUTSU_JIT_DUMP_FILE`.
+//! Everything here runs once per compiled chunk, on the compilation path
+//! only; when the variable is unset the whole module is one `OnceLock` read.
+
+use super::*;
+use std::io::Write as _;
+
+/// What `MUTSU_JIT_DUMP` asked for. `Off` short-circuits every call site.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum DumpMode {
+    Off,
+    Ops,
+    Clif,
+    Asm,
+    All,
+}
+
+impl DumpMode {
+    pub(super) fn on(self) -> bool {
+        self != DumpMode::Off
+    }
+    fn asm(self) -> bool {
+        matches!(self, DumpMode::Asm | DumpMode::All)
+    }
+    fn clif(self) -> bool {
+        matches!(self, DumpMode::Clif | DumpMode::All)
+    }
+}
+
+/// Resolved once from `MUTSU_JIT_DUMP`; an unrecognized value warns and is
+/// treated as `all` (a typo should not silently produce no output when the
+/// user clearly asked for a dump).
+pub(super) fn mode() -> DumpMode {
+    static MODE: std::sync::OnceLock<DumpMode> = std::sync::OnceLock::new();
+    *MODE.get_or_init(|| match std::env::var("MUTSU_JIT_DUMP").ok().as_deref() {
+        None | Some("") | Some("0") | Some("off") => DumpMode::Off,
+        Some("ops") => DumpMode::Ops,
+        Some("clif") => DumpMode::Clif,
+        Some("asm") => DumpMode::Asm,
+        Some("all") | Some("1") => DumpMode::All,
+        Some(other) => {
+            eprintln!("[mutsu jit] warning: unrecognized MUTSU_JIT_DUMP={other:?}, using \"all\"");
+            DumpMode::All
+        }
+    })
+}
+
+/// Append `text` to the dump sink (`MUTSU_JIT_DUMP_FILE`, else stderr).
+fn emit(text: &str) {
+    match std::env::var("MUTSU_JIT_DUMP_FILE").ok() {
+        Some(path) => {
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+            {
+                let _ = f.write_all(text.as_bytes());
+                return;
+            }
+            eprint!("{text}");
+        }
+        None => eprint!("{text}"),
+    }
+}
+
+/// Every shim the emitter can plant as a raw call target, so an address
+/// constant in the disassembly can be shown as a name. Built once; the list
+/// is small enough that a linear scan per address is irrelevant next to the
+/// cost of formatting the disassembly at all.
+fn helper_names() -> &'static [(usize, &'static str)] {
+    use super::vm_jit_helpers as h;
+    static NAMES: std::sync::OnceLock<Vec<(usize, &'static str)>> = std::sync::OnceLock::new();
+    NAMES.get_or_init(|| {
+        macro_rules! addr {
+            ($f:expr) => {
+                $f as *const () as usize
+            };
+        }
+        vec![
+            (addr!(h::load_const), "load_const"),
+            (addr!(h::containerize_pair), "containerize_pair"),
+            (addr!(h::safepoint), "safepoint"),
+            (addr!(h::mark_failure_top), "mark_failure_top"),
+            (addr!(h::get_local), "get_local"),
+            (addr!(h::meta_assign_identity), "meta_assign_identity"),
+            (
+                addr!(h::meta_assign_identity_fallible),
+                "meta_assign_identity_fallible",
+            ),
+            (addr!(h::set_local), "set_local"),
+            (addr!(h::set_local_decl), "set_local_decl"),
+            (addr!(h::step), "step"),
+            (addr!(h::jump_if_false_cond), "jump_if_false_cond"),
+            (addr!(h::jump_if_true_cond), "jump_if_true_cond"),
+            (addr!(h::jump_if_not_nil_cond), "jump_if_not_nil_cond"),
+            (
+                addr!(h::state_var_init_guard_cond),
+                "state_var_init_guard_cond",
+            ),
+            (addr!(h::ret), "ret"),
+            (addr!(h::call_method), "call_method"),
+            (addr!(h::call_method_mut), "call_method_mut"),
+            (addr!(h::call_func), "call_func"),
+            (addr!(h::add), "add"),
+            (addr!(h::sub), "sub"),
+            (addr!(h::mul), "mul"),
+            (addr!(h::div), "div"),
+            (addr!(h::modulo), "modulo"),
+            (addr!(h::int_div), "int_div"),
+            (addr!(h::int_mod), "int_mod"),
+            (addr!(h::pow), "pow"),
+            (addr!(h::negate), "negate"),
+            (addr!(h::num_lt), "num_lt"),
+            (addr!(h::num_le), "num_le"),
+            (addr!(h::num_gt), "num_gt"),
+            (addr!(h::num_ge), "num_ge"),
+            (addr!(h::num_eq), "num_eq"),
+            (addr!(h::num_ne), "num_ne"),
+            (addr!(h::concat), "concat"),
+            (addr!(h::str_eq), "str_eq"),
+            (addr!(h::str_ne), "str_ne"),
+            (addr!(h::bit_and), "bit_and"),
+            (addr!(h::bit_or), "bit_or"),
+            (addr!(h::bit_xor), "bit_xor"),
+            (addr!(h::bit_shift_left), "bit_shift_left"),
+            (addr!(h::bit_shift_right), "bit_shift_right"),
+            (addr!(h::int_bit_neg), "int_bit_neg"),
+        ]
+    })
+}
+
+/// Annotate a disassembly line carrying a raw helper address with the shim's
+/// name, so `movabs $0x5581…, %r10` reads as a call to `call_func`.
+fn annotate(line: &str) -> String {
+    let bytes = line.as_bytes();
+    let mut found: Option<&'static str> = None;
+    let mut i = 0;
+    while i + 2 < bytes.len() {
+        if bytes[i] == b'0' && bytes[i + 1] == b'x' {
+            let start = i + 2;
+            let mut end = start;
+            while end < bytes.len() && (bytes[end] as char).is_ascii_hexdigit() {
+                end += 1;
+            }
+            if end > start
+                && let Ok(v) = usize::from_str_radix(&line[start..end], 16)
+                && let Some((_, name)) = helper_names().iter().find(|(a, _)| *a == v)
+            {
+                found = Some(name);
+                break;
+            }
+            i = end;
+            continue;
+        }
+        i += 1;
+    }
+    match found {
+        Some(name) => format!("{line}    ; -> {name}\n"),
+        None => format!("{line}\n"),
+    }
+}
+
+/// Header + accepted opcode range. Printed before codegen so a chunk that
+/// then fails to compile is still identified.
+fn dump_ops(name: &str, code: &CompiledCode, start: usize, end: usize) {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "\n=== mutsu jit: {name} ops[{start}..{end}] locals={:?} ===\n",
+        code.locals
+    ));
+    for (i, op) in code.ops[start..end].iter().enumerate() {
+        out.push_str(&format!("  {:>4}  {:?}\n", start + i, op));
+    }
+    emit(&out);
+}
+
+/// The Cranelift IR handed to the backend.
+fn dump_clif(name: &str, func: &cranelift_codegen::ir::Function) {
+    if !mode().clif() {
+        return;
+    }
+    emit(&format!("\n--- {name} clif ---\n{}\n", func.display()));
+}
+
+/// The backend's disassembly, the emitted code size, and the per-opcode byte
+/// spans (`start end op_index`, function-relative). The spans are what turns a
+/// flat profile of the body into a per-opcode cost table: every emitted
+/// instruction was tagged with the index of the opcode it came from.
+fn dump_code(name: &str, vcode: Option<&str>, len: usize, spans: &[(u32, u32, u32)]) {
+    let mut out = String::new();
+    out.push_str(&format!("\n--- {name} code ({len} bytes) ---\n"));
+    for (start, end, op) in spans {
+        out.push_str(&format!("  span {start:#06x}..{end:#06x} op {op}\n"));
+    }
+    if let Some(v) = vcode {
+        for line in v.lines() {
+            out.push_str(&annotate(line));
+        }
+    }
+    emit(&out);
+}
+
+/// The finalized entry address — the number that lets a profiler's bare
+/// `???:0x…` symbol be matched back to a chunk. When `MUTSU_JIT_DUMP_BIN`
+/// names a directory, the finalized bytes are also written there as
+/// `<name>.bin`, so the body can be disassembled at its real load address
+/// (`objdump -D -b binary -m i386:x86-64 --adjust-vma=<entry>`) and lined up
+/// with a `callgrind --dump-instr=yes` profile instruction by instruction.
+fn dump_addr(name: &str, addr: *const u8, len: usize) {
+    emit(&format!(
+        "--- {name} entry at {addr:p} len {len} ({:#x}..{:#x}) ---\n",
+        addr as usize,
+        addr as usize + len
+    ));
+    let Some(dir) = std::env::var("MUTSU_JIT_DUMP_BIN").ok() else {
+        return;
+    };
+    // SAFETY: `addr`/`len` describe the finalized, immutable code buffer the
+    // module just published; it lives for the process lifetime.
+    let bytes = unsafe { std::slice::from_raw_parts(addr, len) };
+    let _ = std::fs::create_dir_all(&dir);
+    let _ = std::fs::write(
+        std::path::Path::new(&dir).join(format!("{name}.bin")),
+        bytes,
+    );
+}
+
+// ---- hooks called from the compiler around `Module::define_function` -------
+
+/// Before codegen: the opcode range and the CLIF, and arm the backend's own
+/// disassembler when `asm` was asked for.
+pub(super) fn before_define(
+    mode: DumpMode,
+    name: &str,
+    code: &CompiledCode,
+    start: usize,
+    end: usize,
+    ctx: &mut cranelift_codegen::Context,
+) {
+    if !mode.on() {
+        return;
+    }
+    dump_ops(name, code, start, end);
+    dump_clif(name, &ctx.func);
+    ctx.set_disasm(mode.asm());
+}
+
+/// After codegen, before the context is cleared: the disassembly and the
+/// per-opcode byte spans. Returns the emitted code length, which
+/// [`after_finalize`] needs to bound the code image.
+pub(super) fn after_define(mode: DumpMode, name: &str, ctx: &cranelift_codegen::Context) -> usize {
+    if !mode.on() {
+        return 0;
+    }
+    let Some(cc) = ctx.compiled_code() else {
+        return 0;
+    };
+    let spans: Vec<(u32, u32, u32)> = cc
+        .buffer
+        .get_srclocs_sorted()
+        .iter()
+        .map(|l| (l.start, l.end, l.loc.bits()))
+        .collect();
+    let len = cc.code_buffer().len();
+    dump_code(name, cc.vcode.as_deref(), len, &spans);
+    len
+}
+
+/// After the module publishes the code: the entry address, and the code image
+/// itself when `MUTSU_JIT_DUMP_BIN` asked for it.
+pub(super) fn after_finalize(mode: DumpMode, name: &str, addr: *const u8, len: usize) {
+    if mode.on() {
+        dump_addr(name, addr, len);
+    }
+}

--- a/src/vm/vm_jit_layout.rs
+++ b/src/vm/vm_jit_layout.rs
@@ -22,14 +22,10 @@ pub(super) struct JitLayout {
     /// the current frame is at `locals_base + i`.
     pub(super) locals: i32,
     /// Byte offset of the executing frame's base word (a `usize`) inside
-    /// `Interpreter::locals`. Tier B must add it to every slot index and
-    /// subtract it from the length when bounds-checking; it changes on every
+    /// `Interpreter::locals`. Tier B adds it to every slot index and
+    /// bounds-checks the sum against the stack's length; it changes on every
     /// call, so it is loaded per access exactly like the `Vec` header words.
     pub(super) locals_base: i32,
-    /// Byte offsets of the per-Interpreter gate flags the GetLocal fast path
-    /// loads (both plain `bool` fields).
-    pub(super) atomic_var_seen: i32,
-    pub(super) sigilless_attrs_active: i32,
     /// Byte offsets of the data pointer / length / capacity words inside
     /// `Vec<Value>` (relative to the start of the `Vec`).
     pub(super) vec_ptr: i32,
@@ -79,9 +75,6 @@ pub(super) fn layout() -> Option<&'static JitLayout> {
                     + crate::runtime::Locals::SLOTS_BYTE_OFFSET) as i32,
                 locals_base: (std::mem::offset_of!(Interpreter, locals)
                     + crate::runtime::Locals::BASE_BYTE_OFFSET) as i32,
-                atomic_var_seen: std::mem::offset_of!(Interpreter, atomic_var_seen) as i32,
-                sigilless_attrs_active: std::mem::offset_of!(Interpreter, sigilless_attrs_active)
-                    as i32,
                 vec_ptr,
                 vec_len,
                 vec_cap,

--- a/src/vm/vm_jit_tier_b.rs
+++ b/src/vm/vm_jit_tier_b.rs
@@ -499,10 +499,10 @@ impl TierB {
     }
 
     /// `GetLocal` of a statically-eligible plain local (ADR-0004 J4d): when
-    /// no dynamic spoiler exists — no `ContainerRef` cell anywhere in the
-    /// process, no `$CALLER::x := ...` alias, no atomic variable on this
-    /// interpreter, no sigilless attribute alias — and the slot word is a
-    /// refcount-free scalar (small Int / Num / Bool / Package), the
+    /// no dynamic spoiler exists (`vm_jit::LOCAL_READ_SPOILERS` is zero — no
+    /// `ContainerRef` cell anywhere in the process, no `$CALLER::x := ...`
+    /// alias, no atomic variable, no sigilless attribute alias) and the slot
+    /// word is a refcount-free scalar (small Int / Num / Bool / Package), the
     /// interpreter arm reduces to `stack.push(locals[idx].clone())`, which is
     /// emitted here as two loads and a store. Every other combination calls
     /// the Tier A shim, which re-runs the full `exec_get_local_op` guard
@@ -521,40 +521,26 @@ impl TierB {
         let slow_blk = b.create_block();
         let done = b.create_block();
 
-        // -- process-global spoiler latches (see vm_jit::CONTAINER_CELLS /
-        // CALLER_VAR_BINDS): both zero ⟺ the resolve_binding and env
-        // cell-adoption probes are provably no-ops everywhere.
-        let cells_addr = std::ptr::addr_of!(super::vm_jit::CONTAINER_CELLS) as usize;
-        let cells_addr = b.ins().iconst(self.ptr_ty, cells_addr as i64);
-        let cells = b.ins().load(types::I32, Self::mf(), cells_addr, 0);
-        let binds_addr = std::ptr::addr_of!(super::vm_jit::CALLER_VAR_BINDS) as usize;
-        let binds_addr = b.ins().iconst(self.ptr_ty, binds_addr as i64);
-        let binds = b.ins().load(types::I32, Self::mf(), binds_addr, 0);
-        let global_spoil = b.ins().bor(cells, binds);
-        // -- per-interpreter spoiler flags (plain bool fields, 0 or 1).
-        let atomic = b
-            .ins()
-            .load(types::I8, Self::mf(), self.interp, self.lay.atomic_var_seen);
-        let sigil = b.ins().load(
-            types::I8,
-            Self::mf(),
-            self.interp,
-            self.lay.sigilless_attrs_active,
-        );
-        let interp_spoil = b.ins().bor(atomic, sigil);
-        let interp_spoil = b.ins().uextend(types::I32, interp_spoil);
-        let spoiled = b.ins().bor(global_spoil, interp_spoil);
-        let word_chk = b.create_block();
-        b.ins().brif(spoiled, slow_blk, &[], word_chk, &[]);
+        // -- one process-global spoiler latch (vm_jit::LOCAL_READ_SPOILERS):
+        // zero ⟺ `resolve_binding`, the env cell-adoption probe, the
+        // atomic-variable read and the sigilless-alias lookup are all no-ops
+        // everywhere, so the arm reduces to the slot read below.
+        let spoil_addr = std::ptr::addr_of!(super::vm_jit::LOCAL_READ_SPOILERS) as usize;
+        let spoil_addr = b.ins().iconst(self.ptr_ty, spoil_addr as i64);
+        let spoiled = b.ins().load(types::I32, Self::mf(), spoil_addr, 0);
+        let bounds_chk = b.create_block();
+        b.ins().brif(spoiled, slow_blk, &[], bounds_chk, &[]);
 
         // -- slot word load. Slots live in one shared stack and the executing
         // frame starts at `locals_base` (ADR-0077), so slot `idx` is the
-        // absolute element `base + idx`, and the frame's length is
-        // `len - base`. Both words are loaded per access — a push can
-        // reallocate the stack and every call moves the base, so neither may be
-        // cached across an access. Bounds-checked because a non-standard runner
-        // may have installed a shorter frame; the shim handles that shape.
-        b.switch_to_block(word_chk);
+        // absolute element `base + idx`. All three words are loaded per access
+        // — a push can reallocate the stack and every call moves the base, so
+        // none may be cached across an access. `base + idx < len` is the
+        // element's own in-bounds condition (it subsumes `base <= len`, since
+        // `idx >= 0`), and the sum is the index the load below needs anyway;
+        // bounds-checked at all because a non-standard runner may have
+        // installed a shorter frame, a shape the shim handles.
+        b.switch_to_block(bounds_chk);
         let lptr = b.ins().load(
             self.ptr_ty,
             Self::mf(),
@@ -570,46 +556,47 @@ impl TierB {
         let lbase = b
             .ins()
             .load(types::I64, Self::mf(), self.interp, self.lay.locals_base);
-        // `len - base` is the frame's slot count. An unsigned compare against
-        // it also rejects the (impossible, but not statically provable) case of
-        // a base past the length: the wrapped-around difference is huge, so
-        // guard the subtraction with `base <= len` first.
-        let base_ok = b.ins().icmp(IntCC::UnsignedLessThanOrEqual, lbase, llen);
-        let len_chk = b.create_block();
-        b.ins().brif(base_ok, len_chk, &[], slow_blk, &[]);
-        b.switch_to_block(len_chk);
-        let frame_len = b.ins().isub(llen, lbase);
-        let inbounds = b
-            .ins()
-            .icmp_imm(IntCC::UnsignedGreaterThan, frame_len, idx as i64);
+        let abs = b.ins().iadd_imm(lbase, idx as i64);
+        let inbounds = b.ins().icmp(IntCC::UnsignedLessThan, abs, llen);
         let tag_chk = b.create_block();
         b.ins().brif(inbounds, tag_chk, &[], slow_blk, &[]);
 
         b.switch_to_block(tag_chk);
-        // byte offset = (base + idx) * 8, computed from the base register since
-        // only `idx` is a compile-time constant.
-        let abs = b.ins().iadd_imm(lbase, idx as i64);
         let byte_off = b.ins().imul_imm(abs, 8);
         let slot_addr = b.ins().iadd(lptr, byte_off);
         let word = b.ins().load(types::I64, Self::mf(), slot_addr, 0);
-        // Refcount-free scalar probe: small Int page, encoded-Num page range,
-        // Bool kind, or Package kind. Everything else (Nil included — the arm
-        // has a whole undeclared-check branch for it) goes to the shim.
+        // Refcount-free scalar probe, as two *ordered range tests* rather than
+        // four predicates ORed together (the OR form cost 19 instructions, of
+        // which three were 64-bit constant loads from the code's own pool).
+        // Pages `INT_PAGE ..= NUM_PAGE_MAX` are exactly the small Int and Num
+        // words — the overwhelmingly common case, so it branches straight to
+        // the push. Anything above that page range is a kind word, where only
+        // Bool and Package may be duplicated as raw bits; they are adjacent
+        // kind ids, so `masked - BOOL_PATTERN <= BOOL_PACKAGE_SPAN` admits
+        // exactly those two. Everything else (Nil included — the arm has a
+        // whole undeclared-check branch for it) goes to the shim.
         let page = self.page(b, word);
-        let is_int = self.is_int_page(b, page);
-        let is_num = self.is_num_page(b, page);
-        let masked = b.ins().band_imm(word, w::KIND_MASK as i64);
-        let is_bool = b
-            .ins()
-            .icmp_imm(IntCC::Equal, masked, w::BOOL_PATTERN as i64);
-        let is_pkg = b
-            .ins()
-            .icmp_imm(IntCC::Equal, masked, w::PACKAGE_PATTERN as i64);
-        let num_or_int = b.ins().bor(is_int, is_num);
-        let inline_kind = b.ins().bor(is_bool, is_pkg);
-        let ok = b.ins().bor(num_or_int, inline_kind);
+        let page_rel = b.ins().iadd_imm(page, -(w::INT_PAGE as i64));
+        let int_or_num = b.ins().icmp_imm(
+            IntCC::UnsignedLessThanOrEqual,
+            page_rel,
+            (w::NUM_PAGE_MAX - w::INT_PAGE) as i64,
+        );
+        let kind_chk = b.create_block();
         let push_chk = b.create_block();
-        b.ins().brif(ok, push_chk, &[], slow_blk, &[]);
+        b.ins().brif(int_or_num, push_chk, &[], kind_chk, &[]);
+
+        b.switch_to_block(kind_chk);
+        let masked = b.ins().band_imm(word, w::KIND_MASK as i64);
+        let kind_rel = b
+            .ins()
+            .iadd_imm(masked, (w::BOOL_PATTERN as i64).wrapping_neg());
+        let inline_kind = b.ins().icmp_imm(
+            IntCC::UnsignedLessThanOrEqual,
+            kind_rel,
+            w::BOOL_PACKAGE_SPAN as i64,
+        );
+        b.ins().brif(inline_kind, push_chk, &[], slow_blk, &[]);
 
         // -- push (only a full stack falls back, mirroring emit_load_const).
         b.switch_to_block(push_chk);

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -649,8 +649,11 @@ impl Interpreter {
             if let Some(actual_attr) = attr_name.strip_prefix(ATTR_ALIAS_META_PREFIX) {
                 if let ValueView::Str(source_name) = attr_val.view() {
                     // A sigilless attribute is in play — enable the cell-direct
-                    // routing's alias-table lookup (Phase 3 Stage 2c (ii)).
+                    // routing's alias-table lookup (Phase 3 Stage 2c (ii)), and
+                    // spoil the JIT's inline local read, which skips exactly
+                    // that lookup (`vm_jit::LOCAL_READ_SPOILERS`).
                     self.sigilless_attrs_active = true;
+                    crate::vm::vm_jit::note_local_read_spoiler();
                     // Set up bidirectional alias: !x ↔ alias_name
                     self.env_mut().insert(
                         format!("__mutsu_sigilless_alias::!{}", actual_attr),

--- a/t/vm/codegen/jit-getlocal-fastpath.t
+++ b/t/vm/codegen/jit-getlocal-fastpath.t
@@ -7,8 +7,15 @@ use Test;
 # ContainerRef cells (`:=` / `is rw`), boxed (non-word) values like Str,
 # and Nil-slot declaration checks. Run under the default JIT; CI's
 # jit-stress job re-runs with MUTSU_JIT_THRESHOLD=2.
+#
+# Tests 9-11 pin the two probes the emitted guard was reduced to (#7737):
+# the single `LOCAL_READ_SPOILERS` latch, which every spoiler source must
+# still bump (atomic variables and sigilless attributes had only a
+# per-interpreter flag before), and the ordered page-range test, which must
+# keep admitting exactly Int/Num/Bool/Package -- Whatever sits one kind id
+# below Bool and must still take the shim.
 
-plan 8;
+plan 11;
 
 # 1. Plain Int local, hot recursive body (fast path shape).
 sub sum-to($n) {
@@ -73,3 +80,36 @@ sub niler() {
 my $d = True;
 for ^150 { $d = niler() }
 nok $d, 'Nil slots keep the interpreter declaration semantics';
+
+# 9. Atomic-variable spoiler: registering atomic storage must route every
+#    later inline read through the shim, whichever interpreter saw it.
+my atomicint $counter = 0;
+sub read-through($n) {
+    my $local = $n;
+    return $local + atomic-fetch($counter);
+}
+my $sum = 0;
+for ^150 { atomic-fetch-add($counter, 1); $sum = read-through($_) }
+is $sum, 149 + 150, 'atomic storage spoils the inline read without losing values';
+
+# 10. Sigilless attribute alias: the alias table must still be consulted for
+#     a bare-name read once any `has $x` attribute has been materialized.
+class Holder {
+    has $x = 7;
+    method bump-sum($n) {
+        my $acc = 0;
+        for ^$n { $acc = $acc + $x }
+        return $acc;
+    }
+}
+is Holder.new.bump-sum(150), 7 * 150, 'sigilless attribute reads stay correct in a hot body';
+
+# 11. Whatever local: one kind id below Bool, so the guard's ordered range
+#     must exclude it and let the shim answer.
+sub whatever-kind($n) {
+    my $w = *;
+    return $w.^name ~ $n;
+}
+my $wn = "";
+for ^150 { $wn = whatever-kind($_) }
+is $wn, "Whatever149", 'Whatever locals stay off the inline fast path';


### PR DESCRIPTION
`bench-fib`'s second-largest symbol was the JIT-generated body itself — 13.3% of the run — reported by every profiler as an unnamed `???:0x…` because the code is written into anonymous memory at runtime. #7737 asked for the step nobody had taken: dump the generated code and measure it, rather than guessing from the interpreter side.

## Seeing inside the body

`MUTSU_JIT_DUMP` (`ops` / `clif` / `asm` / `all`) prints the accepted opcode range, the Cranelift IR, and the backend's disassembly with every helper-shim call address annotated by name. `MUTSU_JIT_DUMP_BIN=<dir>` also writes each chunk's finalized bytes; `MUTSU_JIT_DUMP_FILE` redirects the text. Every emitted instruction is tagged with the index of the opcode it came from, so the dump carries a **per-opcode byte map**.

`scripts/jit-instr-profile.py` joins that map to a `callgrind --dump-instr=yes` run (both from the same invocation — the entry address is a fresh `mmap` each run) and prints a per-source-opcode instruction table. `docs/jit-codegen-inspection.md` is the recipe. All of it is off unless asked for; with the variables unset the cost is one `OnceLock` read per compiled chunk.

## What the table said

`bench-fib`, `--profile profiling`. The fib body is 18 opcodes and runs 635,494 times, for **280 native instructions per call**:

| opcode | instr/run | share of body |
| --- | ---: | ---: |
| `GetLocal(0)` × 4 sites | **48** | **42.8%** |
| `Add` | 35 | 6.2% |
| `Sub` × 2 | 30 | 10.7% |
| `NumLe` | 22 | 7.8% |
| `LoadConst` × 3 | 12 | 8.6% |
| `Return` × 2 | 11–13 | 4.3% |
| `JumpIfFalse` | 9.5 | 3.4% |
| `CallFunc` × 2 | 7–8 | 2.7% |
| `ContainerizePair` × 2 | 4 | 1.4% |
| prologue / epilogue / regalloc moves | — | 8.7% |

One read of one scalar local cost 48 instructions: 12 for the spoiler latches, 8 to bounds-check the slot, **19** for the refcount-free tag probe, 9 to push the word.

## The three fixes

**The 19-instruction tag probe → 5.** It asked four questions and ORed them: `page == INT_PAGE`, the Num page range, and two `word & KIND_MASK ==` equality tests against 64-bit constants the backend had to load from the code's own pool. The NaN-box layout already orders those cases — pages `INT_PAGE ..= NUM_PAGE_MAX` are *exactly* the Int and Num words (kind words start at `KIND_PAGE_BASE`), and `word_for_kind` is strictly monotonic in the kind id, so the two admissible kinds, adjacent ids, collapse into a second range test. Both facts are now pinned by `const _: () = assert!` in `value::nanbox`. The accepted set is unchanged, page 0 (the unused niche) included: it is deliberately outside the range rather than assumed impossible, so it fails the test and takes the shim.

**Four spoiler latches → one, 12 instructions → 4.** The guard loaded two process-global counters and two per-interpreter `bool`s and ORed them. Every input is monotonic and never cleared, so their OR *is* a counter each source bumps: `vm_jit::LOCAL_READ_SPOILERS`, now bumped by `note_container_cell`, `note_caller_var_binding`, `mark_atomic_var_seen` and the sigilless-attribute alias site. Folding the two per-interpreter flags in makes the latch conservative across interpreters — one interpreter using sigilless attributes routes every interpreter's inline read through the shim — which can only cost speed, exactly like the process-global counters it joins. `JitLayout` loses two fields.

**The bounds check, 8 → 6.** `base + idx < len` is the element's own in-bounds condition and subsumes the separate `base <= len` guard, and the sum is the index the load needs anyway.

## Result

| | before | after |
| --- | ---: | ---: |
| `GetLocal` inline read | 48 instr | **25 instr** |
| JIT body (`bench-fib`) | 178,254,096 Ir (13.28%) | **143,302,124 Ir (10.97%)** |
| whole `bench-fib` | 1,342,290,714 Ir | **1,306,053,867 Ir (−2.70%)** |
| emitted body | 3,296 bytes | 3,160 bytes |

Callgrind counts retired instructions deterministically, so these are load-insensitive and directly comparable; the bench-CI series remains the source of truth for any number that reaches a repository document.

`t/vm/codegen/jit-getlocal-fastpath.t` gains three cases for the reduced guard, all three checked against Rakudo: an atomic variable and a sigilless attribute must still spoil the inline read (both had only a per-interpreter flag before), and a `Whatever` local — one kind id below `Bool` — must still fall off the range test onto the shim.

## And the ticket's other premise: there was no codegen regression

#7737 also carried the claim that the generated body got 50% slower between 2026-08-19 and 2026-08-31 while nothing in the interpreter explained it. Building the 2026-08-20 tree with the dump facility grafted on and diffing its `fib` body against today's answers that directly: **it is the same code.** The JIT emitters (`src/vm/vm_jit_*.rs`) are byte-identical across that window apart from two mechanical renames, and the only shape difference against today is four instructions per `GetLocal`, from ADR-0077 Slice 2 (2026-09-08 — *after* the window) making a slot address `base + idx` into a shared stack instead of a direct index into a per-frame `Vec`.

So the +50% was not a codegen change, and the ticket's real finding is the one above: the body is expensive in absolute terms. Recorded in `news/2026-09/jit-inline-local-read-was-48-instructions.md`, along with why the dump and the profile script exist — this is the second interpreter-side hypothesis about this benchmark that measurement disproved rather than confirmed.

## Verification

- `make test` — 3959 files, 42091 tests, `Result: PASS`
- `make roast` — 1436 files, 218,939 tests; the only red files are `roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t` and `roast/S32-io/IO-Socket-Async.t`, with exactly the shapes `docs/agent-environments.md` documents as this container's `uid 0` / sandboxed-network artifacts
- `make lint` — all four configurations clean (default clippy, `jit` off, wasm32, rustdoc)
- `cargo fmt --all --check` clean

Closes #7737

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5ssvPJ6smVU43G1DgVGNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5ssvPJ6smVU43G1DgVGNK)_