### PR TITLE
fix: distinguish native multi-dispatch candidates

### DIFF
--- a/news/2026-09/native-multi-dispatch.md
+++ b/news/2026-09/native-multi-dispatch.md
@@ -1,0 +1,4 @@
+Native and boxed numeric multi-dispatch candidates now distinguish their
+argument provenance. Boxed values no longer match native-only candidates, and
+native candidates with different widths in the same family correctly report
+an ambiguous dispatch.

--- a/src/compiler/control_for.rs
+++ b/src/compiler/control_for.rs
@@ -281,6 +281,36 @@ impl Compiler {
         let param_local = param
             .as_ref()
             .and_then(|p| self.local_map.get(p.as_str()).copied());
+        // The VM carries a loop parameter's type in `ForLoopSpec` for bind-time
+        // checking, but the compiler's call-site provenance mask also needs to
+        // know that a native loop parameter is native when it is passed to a
+        // multi candidate inside the body. Keep this temporary compiler-side
+        // entry scoped to the loop body so an untyped shadow cannot inherit the
+        // enclosing parameter's native shape.
+        let loop_param_types: Vec<(String, Option<String>)> = if let Some(def) = param_def
+            .as_ref()
+            .filter(|def| def.type_constraint.is_some())
+        {
+            let name = param.clone().unwrap_or_else(|| def.name.clone());
+            let old = self.local_types.insert(
+                name.clone(),
+                def.type_constraint.clone().unwrap_or_default(),
+            );
+            vec![(name, old)]
+        } else {
+            params
+                .iter()
+                .zip(params_def.iter())
+                .filter_map(|(name, def)| {
+                    let type_constraint = def.type_constraint.as_ref()?;
+                    let name = name.strip_prefix('\\').unwrap_or(name).to_string();
+                    let old = self
+                        .local_types
+                        .insert(name.clone(), type_constraint.clone());
+                    Some((name, old))
+                })
+                .collect()
+        };
         // A single scalar for-loop param is this compiled code's OWN
         // declaration, not something it could ever need to capture from an
         // enclosing scope -- record it so `compute_free_vars` (opcode.rs)
@@ -505,6 +535,13 @@ impl Compiler {
             }
         } else {
             self.compile_scope_restored_loop_body(&loop_body);
+        }
+        for (name, old) in loop_param_types {
+            if let Some(old) = old {
+                self.local_types.insert(name, old);
+            } else {
+                self.local_types.remove(&name);
+            }
         }
         self.callframe_block_depth -= 1;
         for n in &newly_registered {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2663,8 +2663,9 @@ impl Compiler {
         }
     }
 
-    /// Bitmask of the argument positions written as a LITERAL of a type that
-    /// has a native counterpart (`Int`, `Num`, `Str`), for
+    /// Bitmask of the argument positions written as a literal, or as an
+    /// anonymous native scalar declaration, of a type that has a native
+    /// counterpart (`Int`, `Num`, `Str`), for
     /// `OpCode::CallFunc`'s `literal_native_args`. A literal carries no source
     /// variable, so multi dispatch had no `var_type` to rank a native candidate
     /// with and `multi d(int)` / `multi d(Int)` called as `d(5)` answered `Int`
@@ -2685,7 +2686,12 @@ impl Compiler {
         mask
     }
 
-    /// One position's test for `literal_native_args_mask`. A NEGATED numeric
+    /// One position's test for `literal_native_args_mask`. An anonymous native
+    /// scalar declaration is included as well: `my uint32 $ = 1` has no named
+    /// lexical metadata for the runtime matcher to inspect, but its call-site
+    /// shape still identifies it as a native argument.
+    ///
+    /// A NEGATED numeric
     /// literal counts: `-3` parses as `Unary { Minus, Literal(3) }` rather than
     /// a negative literal, and rakudo ranks `d(-3)` on `int` exactly as it ranks
     /// `d(3)`.
@@ -2708,6 +2714,24 @@ impl Compiler {
                     | crate::value::ValueView::Str(_)
             )
         };
+        if let Expr::DoStmt(stmt) = arg
+            && let Stmt::VarDecl {
+                name,
+                type_constraint: Some(type_constraint),
+                ..
+            } = stmt.as_ref()
+            && name == "__ANON_STATE__"
+            && crate::runtime::native_types::is_native_array_element_type(type_constraint)
+        {
+            return true;
+        }
+        if let Expr::Var(name) = arg
+            && self.local_types.get(name).is_some_and(|type_constraint| {
+                crate::runtime::native_types::is_native_array_element_type(type_constraint)
+            })
+        {
+            return true;
+        }
         // The literal shapes are recognised without folding, so they still
         // rank native in a unit that declares an operator (which turns folding
         // off entirely).

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -1283,7 +1283,7 @@ impl Interpreter {
             // Find the first candidate whose signature matches the (possibly new) args.
             let mut matched_idx = None;
             for (i, cand) in candidates.iter().enumerate() {
-                if self.args_match_param_types(&call_args, &cand.param_defs) {
+                if self.args_match_multi_candidate(&call_args, &cand.param_defs) {
                     matched_idx = Some(i);
                     break;
                 }
@@ -1543,7 +1543,7 @@ impl Interpreter {
         // have dispatched to, skipping non-matching candidates.
         let mut matched_idx = None;
         for (i, cand) in candidates.iter().enumerate() {
-            if self.args_match_param_types(&orig_args, &cand.param_defs) {
+            if self.args_match_multi_candidate(&orig_args, &cand.param_defs) {
                 matched_idx = Some(i);
                 break;
             }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -83,11 +83,19 @@ impl Interpreter {
                     // that `Int() $` and `Str() $` (both `(Any)`) are seen as
                     // the same shape and can be reported as ambiguous once
                     // ranking has tied them.
-                    Some(
-                        crate::runtime::types::parse_coercion_type(tc)
-                            .map(|(_, source)| source.unwrap_or("Any").to_string())
-                            .unwrap_or_else(|| tc.to_string()),
+                    let shape = crate::runtime::types::parse_coercion_type(tc)
+                        .map(|(_, source)| source.unwrap_or("Any").to_string())
+                        .unwrap_or_else(|| tc.to_string());
+                    // Rakudo ignores the width within a native family when
+                    // deciding whether equally-ranked candidates are
+                    // ambiguous: `int`, `int8`, and `int32` all describe the
+                    // same dispatch shape.
+                    let shape = crate::runtime::native_types::native_family(
+                        Self::constraint_base_name(&shape),
                     )
+                    .map(|family| format!("__native_{family}__"))
+                    .unwrap_or(shape);
+                    Some(shape)
                 } else if !p.slurpy && p.name.starts_with('@') {
                     Some("__sigil_@__".to_string())
                 } else if !p.slurpy && p.name.starts_with('%') {

--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -139,7 +139,7 @@ impl Interpreter {
                     .count();
                 positional_arg_count == def.params.len()
             } else {
-                self.args_match_param_types(args, &def.param_defs)
+                self.args_match_multi_candidate(args, &def.param_defs)
             };
             if let Some(e) = self.take_where_exception() {
                 if threw.is_none() {
@@ -1078,24 +1078,7 @@ impl Interpreter {
 
     /// Check if a type name is a native type.
     fn is_native_type_name(name: &str) -> bool {
-        matches!(
-            name,
-            "int"
-                | "int8"
-                | "int16"
-                | "int32"
-                | "int64"
-                | "uint"
-                | "uint8"
-                | "uint16"
-                | "uint32"
-                | "uint64"
-                | "byte"
-                | "num"
-                | "num32"
-                | "num64"
-                | "str"
-        )
+        crate::runtime::native_types::native_family(name).is_some()
     }
 
     /// Map native type names to their boxed equivalents.
@@ -1109,14 +1092,6 @@ impl Interpreter {
     /// `Int`, and an integer literal against `byte`/`Int` answers `Int`), and so
     /// is int-vs-num (`my int $n` against `num`/`Int` answers `Int`).
     fn native_family(name: &str) -> Option<&'static str> {
-        match name {
-            "int" | "int8" | "int16" | "int32" | "int64" | "atomicint" | "long" | "longlong"
-            | "ssize_t" | "bool" => Some("int"),
-            "uint" | "uint8" | "uint16" | "uint32" | "uint64" | "byte" | "ulong" | "ulonglong"
-            | "size_t" => Some("uint"),
-            "num" | "num32" | "num64" => Some("num"),
-            "str" => Some("str"),
-            _ => None,
-        }
+        crate::runtime::native_types::native_family(name)
     }
 }

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -308,7 +308,7 @@ impl Interpreter {
             if !seen_fps.insert(fp) {
                 continue; // duplicate
             }
-            if !self.args_match_param_types(args, &cand.param_defs) {
+            if !self.args_match_multi_candidate(args, &cand.param_defs) {
                 continue; // doesn't match
             }
             if !found_current {

--- a/src/runtime/dispatch_resolve.rs
+++ b/src/runtime/dispatch_resolve.rs
@@ -659,7 +659,7 @@ impl Interpreter {
                 .map(|(_, def)| (**def).clone())
                 .collect();
             for def in candidates {
-                if self.args_match_param_types(arg_values, &def.param_defs) {
+                if self.args_match_multi_candidate(arg_values, &def.param_defs) {
                     all_matches.push(def);
                 }
             }
@@ -686,7 +686,7 @@ impl Interpreter {
                 b_has_subsig.cmp(&a_has_subsig).then(a.0.cmp(&b.0))
             });
             for (_, def) in candidates {
-                if self.args_match_param_types(arg_values, &def.param_defs) {
+                if self.args_match_multi_candidate(arg_values, &def.param_defs) {
                     let fp = crate::ast::function_body_fingerprint(
                         &def.params,
                         &def.param_defs,
@@ -723,7 +723,7 @@ impl Interpreter {
             .collect();
         slurpy_candidates.sort_by(|a, b| a.0.cmp(&b.0));
         for (_, def) in slurpy_candidates {
-            if self.args_match_param_types(arg_values, &def.param_defs) {
+            if self.args_match_multi_candidate(arg_values, &def.param_defs) {
                 let fp = def.body_fingerprint();
                 if !all_matches.iter().any(|m: &FunctionDef| {
                     crate::ast::function_body_fingerprint(&m.params, &m.param_defs, &m.body) == fp

--- a/src/runtime/native_types.rs
+++ b/src/runtime/native_types.rs
@@ -106,6 +106,23 @@ pub(crate) fn native_family_name(name: &str) -> &'static str {
     }
 }
 
+/// Return the dispatch family for a native type, or `None` for boxed and
+/// ordinary user-defined types.  Native widths within one family are equally
+/// specific during multi dispatch: `int`, `int8`, and `int32` are all the
+/// signed-integer family, while `uint*`, `num*`, and `str` form their own
+/// families.
+pub(crate) fn native_family(name: &str) -> Option<&'static str> {
+    match name {
+        "int" | "int8" | "int16" | "int32" | "int64" | "atomicint" | "long" | "longlong"
+        | "ssize_t" | "bool" => Some("int"),
+        "uint" | "uint8" | "uint16" | "uint32" | "uint64" | "byte" | "ulong" | "ulonglong"
+        | "size_t" => Some("uint"),
+        "num" | "num32" | "num64" => Some("num"),
+        "str" => Some("str"),
+        _ => None,
+    }
+}
+
 /// Returns (min, max) bounds for a native integer type as BigInt values.
 /// `byte` is an alias for `uint8`.
 /// `int` is an alias for `int64`, `uint` is an alias for `uint64`.

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -1063,7 +1063,11 @@ impl Interpreter {
         let Some(def) = def else {
             return false;
         };
-        self.args_match_param_types(args, &def.param_defs)
+        if self.has_multi_function(name) {
+            self.args_match_multi_candidate(args, &def.param_defs)
+        } else {
+            self.args_match_param_types(args, &def.param_defs)
+        }
     }
 
     /// A routine whose signature already pins the return value (`--> Nil`,

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -113,6 +113,27 @@ impl Interpreter {
         args: &[Value],
         param_defs: &[ParamDef],
     ) -> bool {
+        self.args_match_param_types_inner(args, param_defs, false)
+    }
+
+    /// Match a signature while selecting among multi candidates.  Native type
+    /// constraints are deliberately stricter in this context: a boxed value
+    /// does not make a native-only candidate applicable, although ordinary
+    /// single-candidate binding still accepts and unboxes it.
+    pub(crate) fn args_match_multi_candidate(
+        &mut self,
+        args: &[Value],
+        param_defs: &[ParamDef],
+    ) -> bool {
+        self.args_match_param_types_inner(args, param_defs, true)
+    }
+
+    fn args_match_param_types_inner(
+        &mut self,
+        args: &[Value],
+        param_defs: &[ParamDef],
+        multi_dispatch: bool,
+    ) -> bool {
         let saved_env = self.env.clone();
         // The outer per-arg `bind_param_value` below only exists so that a
         // *later* param's `where {...}` / sub-signature / code-signature can
@@ -453,7 +474,15 @@ impl Interpreter {
                         {
                             return false;
                         }
-                    } else if !self.type_matches_value(&resolved_constraint, &dispatch_arg) {
+                    } else if (multi_dispatch
+                        && !self.native_dispatch_arg_matches(
+                            &resolved_constraint,
+                            args,
+                            arg_idx,
+                            &dispatch_arg,
+                        ))
+                        || !self.type_matches_value(&resolved_constraint, &dispatch_arg)
+                    {
                         return false;
                     }
                     if is_coercion_constraint(&resolved_constraint) {
@@ -814,6 +843,58 @@ impl Interpreter {
             self.env = saved_env;
         }
         result
+    }
+
+    /// Whether a native constraint is applicable during multi dispatch.  The
+    /// value itself is boxed by the time this matcher runs, so provenance must
+    /// come from the source VarRef metadata or the call-site literal mask.
+    fn native_dispatch_arg_matches(
+        &self,
+        constraint: &str,
+        args: &[Value],
+        arg_idx: Option<usize>,
+        value: &Value,
+    ) -> bool {
+        let base = Self::constraint_base_name(constraint);
+        if crate::runtime::native_types::native_family(base).is_none() {
+            return true;
+        }
+
+        let source_name = arg_idx
+            .and_then(|idx| args.get(idx))
+            .and_then(varref_from_value)
+            .map(|(name, _)| name)
+            .or_else(|| {
+                arg_idx.and_then(|idx| {
+                    self.pending_call_arg_sources
+                        .as_ref()
+                        .and_then(|sources| sources.get(idx))
+                        .and_then(|name| name.as_ref())
+                        .cloned()
+                })
+            });
+        if let Some(source_name) = source_name {
+            let source_constraint = self.var_type_constraint(&source_name).or_else(|| {
+                self.var_type_constraint(source_name.trim_start_matches(['$', '@', '%', '&']))
+            });
+            if source_constraint.is_some_and(|source| {
+                crate::runtime::native_types::native_family(Self::constraint_base_name(&source))
+                    .is_some()
+            }) {
+                return true;
+            }
+        }
+
+        // A literal has no VarRef, but the compiler records its source shape
+        // separately so `multi f(int)` can outrank `multi f(Int)` for `f(5)`.
+        arg_idx.is_some_and(|idx| {
+            idx < 32
+                && self.literal_native_args & (1 << idx) != 0
+                && matches!(
+                    value.view(),
+                    ValueView::Int(_) | ValueView::Num(_) | ValueView::Str(_)
+                )
+        })
     }
 
     pub(crate) fn method_args_match(&mut self, args: &[Value], param_defs: &[ParamDef]) -> bool {

--- a/t/nativecall/native-multi-candidates.t
+++ b/t/nativecall/native-multi-candidates.t
@@ -1,0 +1,39 @@
+use Test;
+
+# Native type names are dispatch constraints, not aliases for their boxed
+# counterparts.  A boxed lexical must not make a native-only candidate match,
+# while a native lexical can still fall back to a boxed candidate.
+
+plan 7;
+
+multi sub native-only-int(int $value) { $value }
+
+my Int $boxed = 2;
+my int $native = 2;
+
+throws-like { native-only-int($boxed) }, X::Multi::NoMatch,
+    'a boxed Int does not match a native-only candidate';
+is native-only-int($native), 2,
+    'a native lexical matches a native candidate';
+
+multi sub native-widths(int $value) { 'int' }
+multi sub native-widths(int32 $value) { 'int32' }
+
+throws-like { native-widths($native) }, X::Multi::Ambiguous,
+    'native widths in one family are ambiguous';
+
+multi sub native-or-boxed(int $value) { 'native' }
+multi sub native-or-boxed(Int $value) { 'boxed' }
+
+is native-or-boxed($boxed), 'boxed',
+    'a boxed lexical selects the boxed candidate';
+is native-or-boxed($native), 'native',
+    'a native lexical selects the native candidate';
+is native-or-boxed(42), 'native',
+    'a native-shaped literal selects the native candidate';
+
+my Int $boxed-again = 3;
+throws-like { native-only-int($boxed-again) }, X::Multi::NoMatch,
+    'boxed values stay boxed across repeated dispatches';
+
+done-testing;


### PR DESCRIPTION
## Summary

- distinguish boxed arguments from native arguments when matching multi candidates
- treat native widths within one family as equally specific, reporting ambiguity
- cover native multi dispatch with focused regression tests

Closes #7778

## Validation

- `make lint`
- `make test`
- `make roast`
