### PR TITLE
fix: resolve qualified role parents in unit modules

### DIFF
--- a/news/2026-09/qualified-role-in-unit-module.md
+++ b/news/2026-09/qualified-role-in-unit-module.md
@@ -1,0 +1,2 @@
+Roles declared in a `unit module` can now compose qualified parent roles and
+remain findable by short name from later sibling role declarations.

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -191,11 +191,38 @@ impl Interpreter {
             && !self.registry().classes.contains_key(&role_name_str)
             && !role_name_str.contains('[')
         {
-            let resolved = self.resolve_declared_type_name(&role_name_str);
-            if self.is_role_type_name(&resolved) {
-                resolved
+            if let Some((declaring_package, _)) = cx.name.rsplit_once("::") {
+                // A unit module's mainline runs with GLOBAL as the current
+                // package, even though the compiler has already qualified
+                // this role's storage name. Resolve a sibling parent from the
+                // role declaration's package in that case. The same relative
+                // probe handles a nested name such as `Q::R` inside the unit
+                // module: first try `M::Q::R`, then leave an unrelated fully
+                // qualified name untouched.
+                let relative = format!("{declaring_package}::{role_name_str}");
+                if self.is_role_type_name(&relative)
+                    || self.registry().classes.contains_key(&relative)
+                {
+                    relative
+                } else {
+                    let resolved = self.resolve_declared_type_name(&role_name_str);
+                    if self.is_role_type_name(&resolved)
+                        || self.registry().classes.contains_key(&resolved)
+                    {
+                        resolved
+                    } else {
+                        role_name_str
+                    }
+                }
             } else {
-                role_name_str
+                let resolved = self.resolve_declared_type_name(&role_name_str);
+                if self.is_role_type_name(&resolved)
+                    || self.registry().classes.contains_key(&resolved)
+                {
+                    resolved
+                } else {
+                    role_name_str
+                }
             }
         } else {
             role_name_str

--- a/t/lib/Issue7861/Parent.rakumod
+++ b/t/lib/Issue7861/Parent.rakumod
@@ -1,0 +1,5 @@
+unit module Issue7861::Parent;
+
+role R {
+    method parent { 'parent' }
+}

--- a/t/lib/Issue7861/Unit.rakumod
+++ b/t/lib/Issue7861/Unit.rakumod
@@ -1,0 +1,24 @@
+use Issue7861::Parent;
+unit module Issue7861::Unit;
+
+role ExternalChild does Issue7861::Parent::R {
+    method external-child { 'external-child' }
+}
+
+role ExternalGrandchild does ExternalChild {
+    method external-grandchild { 'external-grandchild' }
+}
+
+module Nested {
+    role R {
+        method nested-parent { 'nested-parent' }
+    }
+}
+
+role NestedChild does Nested::R {
+    method nested-child { 'nested-child' }
+}
+
+role NestedGrandchild does NestedChild {
+    method nested-grandchild { 'nested-grandchild' }
+}

--- a/t/modules/qualified-role-in-unit-module.t
+++ b/t/modules/qualified-role-in-unit-module.t
@@ -1,0 +1,54 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+plan 11;
+
+# A role declaration inside a unit module is registered under its qualified
+# name. When that declaration composes a qualified parent, a later sibling
+# role must still resolve the child's short name in the enclosing package.
+# Qualified parents declared in a nested package need the same resolution.
+use Issue7861::Unit;
+
+class UsesExternal does Issue7861::Unit::ExternalGrandchild { }
+my $external = UsesExternal.new;
+is $external.parent, 'parent', 'qualified external role is composed';
+is $external.external-child, 'external-child', 'external child role is composed';
+is $external.external-grandchild, 'external-grandchild',
+    'short-name sibling chain after qualified composition works';
+
+class UsesNested does Issue7861::Unit::NestedGrandchild { }
+my $nested = UsesNested.new;
+is $nested.nested-parent, 'nested-parent', 'qualified nested role is composed';
+is $nested.nested-child, 'nested-child', 'nested child role is composed';
+is $nested.nested-grandchild, 'nested-grandchild',
+    'short-name nested sibling chain works';
+
+# Keep the non-unit and module-local paths covered as controls for the fix.
+module LocalRoleControl {
+    role Base { method base { 'base' } }
+    role Child does Base { method child { 'child' } }
+}
+class UsesControl does LocalRoleControl::Child { }
+my $control = UsesControl.new;
+is $control.base, 'base', 'ordinary module short-name composition remains valid';
+
+role TopLevelParent { method top-level-parent { 'top-level-parent' } }
+role TopLevelChild does TopLevelParent { method top-level-child { 'top-level-child' } }
+class UsesTopLevel does TopLevelChild { }
+is UsesTopLevel.new.top-level-parent, 'top-level-parent',
+    'top-level short-name composition remains valid';
+
+role TopLevelQualifiedChild does Issue7861::Parent::R {
+    method top-level-qualified-child { 'top-level-qualified-child' }
+}
+role TopLevelQualifiedGrandchild does TopLevelQualifiedChild {
+    method top-level-qualified-grandchild { 'top-level-qualified-grandchild' }
+}
+class UsesTopLevelQualified does TopLevelQualifiedGrandchild { }
+is UsesTopLevelQualified.new.parent, 'parent',
+    'qualified composition outside a unit module remains valid';
+is UsesTopLevelQualified.new.top-level-qualified-child, 'top-level-qualified-child',
+    'the non-unit qualified child role remains composable';
+is UsesTopLevelQualified.new.top-level-qualified-grandchild, 'top-level-qualified-grandchild',
+    'short-name chain after non-unit qualified composition remains valid';


### PR DESCRIPTION
## Summary

- resolve role parents relative to the declaring package inside `unit module`
- support nested qualified role parents such as `Q::R`
- cover unit-module, nested-package, ordinary-module, and top-level cases

Closes #7861

## Validation

- `make lint`
- `make test`
- `make roast`
