### PR TITLE
feat(ci): dispatch the ecosystem parity sweep from GitHub Actions

### DIFF
--- a/.github/workflows/ecosystem-sweep.yml
+++ b/.github/workflows/ecosystem-sweep.yml
@@ -1,0 +1,573 @@
+name: Ecosystem sweep
+
+# Re-measure the ecosystem parity KPI (issue #7785) on hosted runners and land
+# the result as a pull request. This is the CI entry point to
+# `scripts/ecosystem-sweep.py`, whose numbers live in `ecosystem/` and are
+# published to `site/ecosystem.html`.
+#
+# Method and metric definitions: docs/ecosystem-parity.md
+# Decisions: docs/adr/0085-ecosystem-testsuite-parity-measurement.md (D9 + its
+# 2026-09-10 amendment, which is what allows this workflow to exist).
+#
+# Deliberately `workflow_dispatch` ONLY -- there is no `schedule:`. ADR-0085 D9
+# rejected a periodic sweep and that still stands: a full corpus run is ~20
+# CPU-hours to track a number that moves at the speed of interpreter fixes, so
+# it happens when someone decides the numbers are worth refreshing. What the
+# amendment adds is that "someone" no longer needs a 12-core box and a local
+# `bwrap` -- one dispatch does it.
+#
+# Three things it does NOT compromise on, because they are what make the number
+# mean anything (ADR-0085 D8):
+#   * One binary for the whole run. `build` compiles once and every shard
+#     downloads that artifact, so no shard can measure a different mutsu.
+#   * One rakudo for the whole run. `build` resolves the prebuilt version and
+#     every shard installs that exact release, not "the newest at the time this
+#     job started".
+#   * `bwrap` or nothing. The sweep runs unaudited third-party test suites; if
+#     the sandbox does not work on the runner the job fails instead of quietly
+#     continuing unsandboxed.
+#
+# Each record carries its own provenance, and `measured.host` says `gha-*` for
+# anything measured here, so a CI-measured number is never silently mixed with
+# one from the maintainer's box (docs/ecosystem-parity.md section 8). A run
+# whose records do not share one (mutsu commit, rakudo, host) triple still
+# lands its records but is refused a `history.tsv` row.
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: 'What to measure'
+        type: choice
+        default: stale
+        options:
+          - stale        # records measured at another mutsu commit / rakudo -- "refresh the numbers"
+          - all          # the whole corpus (~20 CPU-hours; fans out to 27 shards)
+          - prefix       # one shard, e.g. every distribution starting with A
+          - only         # named distributions
+          - status       # every record currently at a given status
+      prefix:
+        description: 'scope=prefix: one letter A-Z, or _ for non-letter names'
+        type: string
+        default: ''
+      only:
+        description: 'scope=only: distribution names, comma or space separated'
+        type: string
+        default: ''
+      status:
+        description: 'scope=status: which record status to re-measure'
+        type: choice
+        default: partial
+        options: [partial, red, blocked_load, blocked_dep, no_baseline, green, skipped]
+      shards:
+        description: 'Fan out across the 27 letter shards? auto = only for scope=all'
+        type: choice
+        default: auto
+        options: [auto, letters, single]
+      jobs:
+        description: 'Parallel test processes per runner (hosted runners have 4 vCPU)'
+        type: string
+        default: '4'
+      attempts:
+        description: 'Attempts for a file that did not pass (both sides get the same budget)'
+        type: string
+        default: '3'
+      file_timeout:
+        description: 'Per-test-file timeout in seconds, both sides'
+        type: string
+        default: '120'
+      raku_version:
+        description: 'Pin the rakudo release (e.g. 2026.07); empty = newest prebuilt'
+        type: string
+        default: ''
+      rollup:
+        description: 'Regenerate ecosystem/summary.json + summary.md (skipped for a partial sweep that would create the FIRST one)'
+        type: boolean
+        default: true
+      history:
+        description: 'Append a history.tsv row + redraw the chart (full-corpus runs only)'
+        type: boolean
+        default: false
+      publish:
+        description: 'What to do with the updated records'
+        type: choice
+        default: pull-request
+        options: [pull-request, branch, none]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Never run two sweeps at once: they would race the same records, and the second
+# one to finish would land a mixture. Queue instead of cancelling -- a cancelled
+# sweep throws away hours of measurement.
+concurrency:
+  group: ecosystem-sweep
+  cancel-in-progress: false
+
+jobs:
+  # Plan the matrix and produce the two things every shard must share: one mutsu
+  # binary and one pinned rakudo release.
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      chunks: ${{ steps.plan.outputs.chunks }}
+      count: ${{ steps.plan.outputs.count }}
+      full-corpus: ${{ steps.plan.outputs.full-corpus }}
+      raku-version: ${{ steps.raku.outputs.version }}
+      mutsu-commit: ${{ steps.plan.outputs.mutsu-commit }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The planner validates every dispatch input, so this catches a typo in
+      # ~1s instead of after a release build and 27 rakudo installs.
+      - name: Planner self-test
+        run: python3 scripts/ecosystem-ci.py --self-test
+
+      - name: Plan the matrix
+        id: plan
+        env:
+          # Inputs go through the environment, never through ${{ }} inside a
+          # `run:` body: the planner is what decides they are safe to word-split
+          # into an argv, and it can only do that if the shell never sees them
+          # first.
+          SCOPE: ${{ inputs.scope }}
+          PREFIX: ${{ inputs.prefix }}
+          ONLY: ${{ inputs.only }}
+          STATUS: ${{ inputs.status }}
+          SHARDS: ${{ inputs.shards }}
+          JOBS: ${{ inputs.jobs }}
+          ATTEMPTS: ${{ inputs.attempts }}
+          FILE_TIMEOUT: ${{ inputs.file_timeout }}
+        run: |
+          set -euo pipefail
+          for pair in "jobs:$JOBS" "attempts:$ATTEMPTS" "file_timeout:$FILE_TIMEOUT"; do
+            name=${pair%%:*}; value=${pair#*:}
+            case "$value" in
+              ''|*[!0-9]*) echo "::error::$name must be a positive integer, got '$value'"; exit 1 ;;
+              0) echo "::error::$name must be greater than zero"; exit 1 ;;
+            esac
+          done
+          python3 scripts/ecosystem-ci.py plan \
+            --scope "$SCOPE" --prefix "$PREFIX" --only "$ONLY" \
+            --status "$STATUS" --shards "$SHARDS"
+          echo "mutsu-commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e # 1.96.0
+
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: "ci-ecosystem"
+
+      # Every shard measures THIS binary. Building per shard would let 27
+      # slightly different compilations produce one KPI number.
+      - name: Build (release)
+        run: cargo build --release
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: "false"
+
+      - name: Upload the mutsu binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutsu-release-binary
+          path: target/release/mutsu
+          retention-days: 1
+          if-no-files-found: error
+
+      # Fetch the fez + REA indexes ONCE, for the same reason the binary is
+      # built once: the sweep resolves each distribution's version and
+      # dependency closure from them, and `load_index()` reuses whatever is in
+      # the cache. Without this, a shard that starts three hours later can
+      # measure a different version of the same distribution, and
+      # `index-snapshot.json` would then describe only whichever shard wrote it
+      # last.
+      - name: Fetch and pin the ecosystem index
+        run: |
+          set -euo pipefail
+          python3 -c "import sys; sys.path.insert(0, 'scripts'); import ecosystem_common as eco; \
+            i = eco.load_index(refresh=True); print(len(i.targets), 'distributions')"
+          # Staged outside the cache directory because an action input is not
+          # shell-expanded: `~/.cache/...` in a `with:` would create a directory
+          # literally named `~`.
+          cp -a "$HOME/.cache/mutsu-ecosystem/index" /tmp/eco-index
+
+      - name: Upload the pinned index
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ecosystem-index
+          path: /tmp/eco-index
+          retention-days: 1
+          if-no-files-found: error
+
+      # Resolve the rakudo release ONCE. `install-raku.sh` otherwise picks "the
+      # newest prebuilt right now", which for a multi-hour sweep can differ
+      # between the first shard and the last -- a moving denominator inside one
+      # measurement.
+      - name: Resolve the rakudo release to pin
+        id: raku
+        env:
+          RAKU_VERSION: ${{ inputs.raku_version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$RAKU_VERSION" ]; then
+            url=$(.agents/skills/install-raku/install-raku.sh --print-url --version "$RAKU_VERSION")
+          else
+            url=$(.agents/skills/install-raku/install-raku.sh --print-url)
+          fi
+          version=$(printf '%s\n' "$url" | sed -nE 's#.*/rakudo-moar-([0-9]{4}\.[0-9]+(\.[0-9]+)?)-.*#\1#p')
+          if [ -z "$version" ]; then
+            echo "::error::could not read a rakudo version out of $url"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "pinned rakudo $version ($url)"
+
+      - name: Summary
+        env:
+          SCOPE: ${{ inputs.scope }}
+        run: |
+          {
+            echo "## Ecosystem sweep plan"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| scope | \`$SCOPE\` |"
+            echo "| shard jobs | ${{ steps.plan.outputs.count }} |"
+            echo "| mutsu | \`${{ steps.plan.outputs.mutsu-commit }}\` |"
+            echo "| rakudo | ${{ steps.raku.outputs.version }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  sweep:
+    needs: build
+    runs-on: ubuntu-latest
+    # A shard of the corpus can legitimately run for hours (its own suites, on
+    # both interpreters, with retries). Well under the 6h job ceiling, which is
+    # why the corpus fans out across 27 jobs instead of running as one.
+    timeout-minutes: 330
+    strategy:
+      fail-fast: false
+      # Hosted-runner concurrency is shared with CI on every open PR. 8 keeps a
+      # full sweep from starving the thing that gates merges.
+      max-parallel: 8
+      matrix:
+        chunk: ${{ fromJSON(needs.build.outputs.chunks) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download the mutsu binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mutsu-release-binary
+          path: target/release
+
+      # Into the cache `ecosystem_common.load_index()` reads, so this shard
+      # resolves versions from the same index snapshot as every other shard.
+      - name: Download the pinned index
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ecosystem-index
+          path: /tmp/eco-index
+
+      # The path matters: bundled batteries (the vendored Test.rakumod among
+      # them) are found relative to the executable, `target/<profile>/../../modules`.
+      # Artifacts do not carry the executable bit.
+      - name: Restore the binary layout and the index cache
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.cache/mutsu-ecosystem"
+          cp -a /tmp/eco-index "$HOME/.cache/mutsu-ecosystem/index"
+          chmod +x target/release/mutsu
+          target/release/mutsu --version
+          target/release/mutsu -e 'use Test; plan 1; is MONKEY-SEE-NO-EVAL(), 1, "vendored Test"'
+
+      # See ci.yml's "Use canonical apt mirror": the default runner mirror
+      # (azure.archive.ubuntu.com) has been observed hanging indefinitely.
+      - name: Use canonical apt mirror
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            echo 'http://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list 2>/dev/null || true
+
+      # Loading a distribution runs its BEGIN phasers; running its suite runs
+      # arbitrary unaudited code. The sweep refuses a corpus without bwrap and
+      # so does this job -- there is no unsandboxed fallback, deliberately.
+      - name: Install and verify the sandbox
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq bubblewrap
+          probe() { bwrap --unshare-all --ro-bind / / --dev /dev --proc /proc \
+                      --die-with-parent true; }
+          if ! probe; then
+            # Ubuntu 24.04 restricts unprivileged user namespaces via AppArmor,
+            # which is exactly what --unshare-all needs. The runner gives us
+            # sudo, so lift it rather than dropping the sandbox.
+            echo "bwrap probe failed; relaxing kernel.apparmor_restrict_unprivileged_userns"
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+            probe || { echo "::error::bwrap does not work on this runner; refusing to measure unsandboxed"; exit 1; }
+          fi
+          echo "bwrap ok: $(bwrap --version)"
+
+      - name: Install the pinned rakudo
+        env:
+          RAKU_VERSION: ${{ needs.build.outputs.raku-version }}
+        run: |
+          set -euo pipefail
+          .agents/skills/install-raku/install-raku.sh --version "$RAKU_VERSION"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Measure
+        env:
+          SWEEP_ARGS: ${{ matrix.chunk.args }}
+          JOBS: ${{ inputs.jobs }}
+          ATTEMPTS: ${{ inputs.attempts }}
+          FILE_TIMEOUT: ${{ inputs.file_timeout }}
+          MUTSU_BIN: target/release/mutsu
+        run: |
+          set -euo pipefail
+          raku --version
+          # `measured.host` has to distinguish this from the maintainer's box:
+          # both are linux-x86_64, and a history row that mixes them reports one
+          # triple for two machines.
+          export MUTSU_ECO_HOST="gha-${ImageOS:-ubuntu}-$(nproc)c"
+          # $SWEEP_ARGS is word-split on purpose. Every token in it was
+          # generated and validated by scripts/ecosystem-ci.py plan.
+          # shellcheck disable=SC2086
+          scripts/ecosystem-sweep.py $SWEEP_ARGS \
+            --jobs "$JOBS" --attempts "$ATTEMPTS" --timeout "$FILE_TIMEOUT"
+
+      # Only the records this shard actually changed. Shards are disjoint by
+      # distribution name, so the collect job can merge every artifact into one
+      # tree with no conflicts -- and an untouched record is never re-uploaded
+      # from a stale checkout on top of a fresher measurement.
+      - name: Stage the changed records
+        id: stage
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/eco-staging
+          git status --porcelain -- ecosystem | awk '{print $NF}' | sort -u > /tmp/eco-changed.txt
+          count=$(grep -c . /tmp/eco-changed.txt || true)
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            cp --parents "$path" /tmp/eco-staging/
+          done < /tmp/eco-changed.txt
+          echo "changed=$count" >> "$GITHUB_OUTPUT"
+          echo "shard ${{ matrix.chunk.id }}: $count record file(s) changed"
+
+      - name: Upload the records
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: eco-records-${{ matrix.chunk.id }}
+          path: /tmp/eco-staging
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "- shard \`${{ matrix.chunk.id }}\` (\`${{ matrix.chunk.args }}\`): ${{ steps.stage.outputs.changed || 0 }} record(s) changed" >> "$GITHUB_STEP_SUMMARY"
+
+  # Merge every shard's records into one tree, roll the numbers up, and land it.
+  # Runs even when a shard failed: 26 measured shards are worth landing, and the
+  # failed one is simply re-dispatched (`scope: stale` picks up exactly what is
+  # still at an older commit).
+  collect:
+    needs: [build, sweep]
+    if: >-
+      always() && needs.build.result == 'success'
+      && needs.sweep.result != 'cancelled' && needs.sweep.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # A pull request opened with the default GITHUB_TOKEN does not start CI --
+      # GitHub suppresses workflow triggers from it. The repo already has an App
+      # for exactly this problem (tag-release.yml), so use it when configured
+      # and say so in the summary when it is not.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        if: ${{ vars.TAGPR_APP_CLIENT_ID != '' }}
+        with:
+          client-id: ${{ vars.TAGPR_APP_CLIENT_ID }}
+          private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
+          fetch-depth: 0
+
+      # A sweep whose every verdict matched what is already committed uploads no
+      # artifact at all (`if-no-files-found: ignore`), which is a real and
+      # expected outcome -- "the numbers did not move" -- not a download
+      # failure. The next step counts what actually arrived.
+      - name: Download every shard's records
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: eco-records-*
+          merge-multiple: true
+          path: /tmp/incoming
+
+      - name: Apply them to the tree
+        id: apply
+        run: |
+          set -euo pipefail
+          if [ -d /tmp/incoming ] && [ -n "$(find /tmp/incoming -type f -print -quit)" ]; then
+            cp -a /tmp/incoming/. .
+          fi
+          git status --porcelain -- ecosystem | awk '{print $NF}' | sort -u > /tmp/changed.txt
+          count=$(grep -c . /tmp/changed.txt || true)
+          echo "changed=$count" >> "$GITHUB_OUTPUT"
+          echo "$count record file(s) differ from main"
+
+      - name: Check the provenance
+        id: provenance
+        if: steps.apply.outputs.changed != '0'
+        run: |
+          set -euo pipefail
+          # Only the per-distribution records carry a `measured` block;
+          # index-snapshot.json and the generated summaries do not, and feeding
+          # them in would read as an unreadable record and veto the history row.
+          grep -E '^ecosystem/dists/.*\.json$' /tmp/changed.txt > /tmp/records.txt || true
+          python3 scripts/ecosystem-ci.py provenance --markdown /tmp/provenance.md < /tmp/records.txt
+
+      # `--history` is the one thing a partial or mixed run may not do: a
+      # history row reports a single (mutsu commit, rakudo, host) triple and a
+      # single corpus-wide rate, so appending one for a subset -- or for a run
+      # whose shards disagree about what measured them -- puts a point on the
+      # KPI chart that is not comparable with its neighbours.
+      - name: Roll the numbers up
+        id: rollup
+        if: ${{ inputs.rollup && steps.apply.outputs.changed != '0' }}
+        env:
+          FULL_CORPUS: ${{ needs.build.outputs.full-corpus }}
+          WANT_HISTORY: ${{ inputs.history }}
+          ALL_SHARDS_OK: ${{ needs.sweep.result == 'success' }}
+          UNIFORM: ${{ steps.provenance.outputs.uniform }}
+        run: |
+          set -euo pipefail
+          # `ecosystem/` deliberately carries no summary until a full corpus
+          # sweep has produced one: a rollup over a partial ledger reports a
+          # rate that reads as the ecosystem KPI and is not one
+          # (ecosystem/README.md). Refreshing a summary that already exists is
+          # fine -- creating the first one from a subset is not.
+          if [ ! -f ecosystem/summary.json ] && [ "$FULL_CORPUS" != "true" ]; then
+            echo "::notice title=no rollup::this would create the first ecosystem/summary.json from a partial sweep; run scope=all for that"
+            echo "appended-history=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          history=""
+          if [ "$WANT_HISTORY" = "true" ]; then
+            if [ "$FULL_CORPUS" != "true" ]; then
+              echo "::warning title=no history row::--history needs scope=all; this run measured a subset"
+            elif [ "$ALL_SHARDS_OK" != "true" ]; then
+              echo "::warning title=no history row::a shard failed, so this is not a complete corpus sweep"
+            elif [ "$UNIFORM" != "true" ]; then
+              echo "::warning title=no history row::records disagree about what measured them"
+            else
+              history="--history"
+            fi
+          fi
+          echo "appended-history=$([ -n "$history" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          # shellcheck disable=SC2086
+          scripts/ecosystem-sweep.py --rollup $history
+
+      - name: Write the report
+        id: report
+        run: |
+          set -euo pipefail
+          {
+            echo "## Ecosystem sweep"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| scope | \`${{ inputs.scope }}\` |"
+            echo "| mutsu | \`${{ needs.build.outputs.mutsu-commit }}\` |"
+            echo "| rakudo | ${{ needs.build.outputs.raku-version }} |"
+            echo "| shards | ${{ needs.build.outputs.count }} (\`${{ needs.sweep.result }}\`) |"
+            echo "| records changed | ${{ steps.apply.outputs.changed }} |"
+            # These are rates over the WHOLE ledger, not over this run's slice:
+            # that is what the published KPI is, and a per-run rate over a
+            # hand-picked subset is not one.
+            if [ -f ecosystem/summary.json ]; then
+              for metric in dist_parity file_parity assertion_parity; do
+                value=$(python3 -c "import json,sys;print(json.load(open('ecosystem/summary.json'))[sys.argv[1]])" "$metric")
+                echo "| $metric (whole ledger) | ${value}% |"
+              done
+              echo "| distributions in the ledger | $(python3 -c "import json;print(json.load(open('ecosystem/summary.json'))['distributions'])") |"
+            fi
+            echo "| history row appended | ${{ steps.rollup.outputs.appended-history || 'false' }} |"
+            echo ""
+            if [ -f /tmp/provenance.md ]; then
+              echo "### Provenance"
+              echo ""
+              cat /tmp/provenance.md
+              echo ""
+            fi
+            echo "Measured by [\`ecosystem-sweep.yml\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            echo "on a hosted runner, so \`measured.host\` reads \`gha-*\`. Method:"
+            echo "[docs/ecosystem-parity.md](docs/ecosystem-parity.md); decisions:"
+            echo "[ADR-0085](docs/adr/0085-ecosystem-testsuite-parity-measurement.md)."
+            echo ""
+            echo "Refs #7785"
+            echo ""
+            echo "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+          } > /tmp/report.md
+          cat /tmp/report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Push the branch and open the pull request
+        if: ${{ inputs.publish != 'none' && steps.apply.outputs.changed != '0' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          PUBLISH: ${{ inputs.publish }}
+          SCOPE: ${{ inputs.scope }}
+          HAVE_APP_TOKEN: ${{ steps.app-token.outputs.token != '' }}
+        run: |
+          set -euo pipefail
+          branch="ecosystem/sweep-$(date -u +%Y%m%d)-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add ecosystem/
+          git commit -F - <<EOF
+          chore(ecosystem): refresh parity records (scope=${SCOPE})
+
+          Measured by .github/workflows/ecosystem-sweep.yml on a hosted runner:
+          mutsu ${{ needs.build.outputs.mutsu-commit }}, rakudo ${{ needs.build.outputs.raku-version }}.
+
+          Refs #7785
+          EOF
+          for attempt in 1 2 3; do
+            git push -u origin "$branch" && break
+            echo "push failed, retrying ($attempt)"
+            sleep $((attempt * 4))
+          done
+          if [ "$PUBLISH" != "pull-request" ]; then
+            echo "pushed \`$branch\`; open the pull request by hand" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # A sweep dispatched from a feature ref measured that ref's mutsu,
+          # which is a legitimate thing to want -- but a pull request from it
+          # into main would carry every other commit on that ref alongside the
+          # records. Keep the measurement, skip the pull request.
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::warning title=no pull request::dispatched from $GITHUB_REF, not main; the records are pushed to \`$branch\` but a pull request from a feature ref would carry its other commits too"
+            echo "Records pushed to \`$branch\` (measured on \`$GITHUB_REF\`)." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if ! gh pr create --base main --head "$branch" \
+                 --title "chore(ecosystem): refresh parity records (scope=${SCOPE})" \
+                 --body-file /tmp/report.md; then
+            echo "::warning title=could not open the pull request::the branch is pushed; open it from the compare view"
+            echo "Open it here: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/main...${branch}?expand=1" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ "$HAVE_APP_TOKEN" != "true" ]; then
+            echo "::warning title=CI will not start by itself::the pull request was opened with the default GITHUB_TOKEN, which does not trigger workflows. Configure the TAGPR_APP_CLIENT_ID / TAGPR_APP_PRIVATE_KEY App credentials, or push one commit to the branch from a clone."
+          fi
+
+      - name: Nothing changed
+        if: steps.apply.outputs.changed == '0'
+        run: echo "No record changed — every selected distribution measured identically to what is on main." >> "$GITHUB_STEP_SUMMARY"

--- a/PLAN.md
+++ b/PLAN.md
@@ -102,15 +102,16 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 
 - [ ] **★Ecosystem parity KPI** — run every zef distribution's own test suite on **both** rakudo and
       mutsu and publish the difference as the project's headline compatibility number, with
-      per-distribution machine-readable records in `ecosystem/`. **P1 (the harness) has landed**;
-      the next step is **P2, the first corpus sweep** — it needs a many-core box, and it is what
-      produces the first real numbers.
+      per-distribution machine-readable records in `ecosystem/`. **P1 (the harness) and P3 (the site
+      page) have landed, and the sweep can now be dispatched from GitHub Actions** (`Ecosystem
+      sweep`, ADR-0085 D9 amendment); the next step is **P2, the first corpus sweep** — `scope: all`,
+      which is what produces the first real numbers.
       Decisions: [ADR-0085](docs/adr/0085-ecosystem-testsuite-parity-measurement.md);
       operations manual and phases (P1-P5, one PR each):
       [docs/ecosystem-parity.md](docs/ecosystem-parity.md);
       tracking issue [#7785](https://github.com/tokuhirom/mutsu/issues/7785).
-      The sweep is operator-run on a many-core box, not CI-scheduled (ADR-0085 D9), so it does
-      **not** close B1's "working-module regression CI" — that stays a separate item.
+      The sweep is *dispatched*, never scheduled (ADR-0085 D9), so it does **not** close B1's
+      "working-module regression CI" — that stays a separate item.
 - [ ] **★Real-dist compatibility sweep** — run real fez dists under mutsu and fix the general bugs
       they surface. Ledger: [docs/dist-compat-sweep.md](docs/dist-compat-sweep.md). **The `--run-tests`
       axis is the sharper frontier**: running each loading dist's own suite with raku as the baseline.

--- a/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
+++ b/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
@@ -1,6 +1,6 @@
 # ADR-0085 — The ecosystem KPI is per-distribution test-suite parity against rakudo
 
-- Status: Accepted (design confirmed 2026-09-10; P1 implemented — see "Implementation status")
+- Status: Accepted (design confirmed 2026-09-10; P1 implemented — see "Implementation status"; D9 amended 2026-09-10 to allow an operator-dispatched CI sweep)
 - Date: 2026-09-10
 - Issue: [#7785](https://github.com/tokuhirom/mutsu/issues/7785)
 - Operations manual (the "how"): [docs/ecosystem-parity.md](../ecosystem-parity.md)
@@ -259,6 +259,50 @@ Because the sweep is tied to one machine, `measured.host` is part of every
 record (D7) so a number produced elsewhere is identifiable rather than quietly
 mixed in.
 
+#### Amendment, 2026-09-10: operator-dispatched CI is allowed; scheduled is still not
+
+`.github/workflows/ecosystem-sweep.yml` gives the sweep a **`workflow_dispatch`**
+entry point: one dispatch measures a selection (`stale` / `all` / one shard / a
+list of distributions / one status), fans the corpus out across the 27 letter
+shards, and lands the updated records as an ordinary pull request.
+
+What this changes is *who needs the hardware*, not *when the sweep runs*. The
+argument above rejected a **weekly** sweep and that stands — there is no
+`schedule:` in the workflow, and adding one needs a new decision, not an edit
+here. Refreshing the numbers no longer requires a 12-core box with `bwrap`
+configured, so "the KPI updates only when someone runs it" now costs one button
+instead of an afternoon on a specific machine. PLAN.md §1 B1's "working-module
+regression CI" is still a separate item: this workflow is a measurement anyone
+can start, not a gate on anything.
+
+Three properties of D8's fairness contract had to be *engineered* to survive a
+hosted, sharded run, and they are the reason the workflow is shaped the way it
+is rather than being 27 independent sweeps:
+
+- **One binary.** The `build` job compiles once and every shard downloads that
+  artifact. Per-shard builds would let 27 slightly different compilations
+  contribute to one number.
+- **One rakudo.** `build` resolves the prebuilt release and every shard installs
+  that exact version, rather than each asking for "the newest" hours apart.
+- **One ecosystem index.** `build` fetches the fez + REA indexes once and seeds
+  every shard's cache with them, so no two shards resolve different versions of
+  the same distribution.
+
+Two honesty guards come with it. `measured.host` reads `gha-*` for anything
+measured on a runner (`MUTSU_ECO_HOST`), because a runner and the maintainer's
+box are both `linux-x86_64` and D7's identifiability would otherwise be lost;
+and a run whose records do not share one `(mutsu commit, rakudo, host)` triple —
+or that measured only part of the corpus — lands its records but is refused a
+`history.tsv` row, since that row reports one triple and one corpus-wide rate.
+
+The costs are accepted and recorded: hosted runners have ~4 cores, so a corpus
+sweep is wall-clock slower per shard and its `--timeout 120` bites at a
+different point than on a 12-core box (symmetrically for both interpreters, so a
+timing difference lands in `no_baseline` rather than being charged to mutsu); and
+a pull request opened with the default `GITHUB_TOKEN` does not start CI, so the
+workflow uses the repository's GitHub App token when it is configured and says
+so in the run summary when it is not.
+
 ## Consequences
 
 - The project gains a compatibility number that is defensible, reproducible, and
@@ -292,9 +336,9 @@ Phases are listed in [docs/ecosystem-parity.md](../ecosystem-parity.md) §7.
 | phase | state |
 |---|---|
 | **P1** — harness, dependency resolver, sandbox, record store, `--only`/`--prefix`/`--rollup` | **done** — `scripts/ecosystem-sweep.py` + `scripts/ecosystem_common.py`; validated on eight distributions, which surfaced real interpreter findings on the first pass |
-| **P2** — first corpus sweep, the first KPI numbers | open; needs a many-core box (D9) |
+| **P2** — first corpus sweep, the first KPI numbers | open; a many-core box (D9), or the `Ecosystem sweep` workflow with `scope: all` (D9 amendment) |
 | **P3** — `ecosystem/history.svg` in the README, `site/ecosystem.html` | open |
-| **P4** — operator runbook | open |
+| **P4** — operator runbook | partly done — `.github/workflows/ecosystem-sweep.yml` is the dispatch path (D9 amendment) and docs/ecosystem-parity.md §8 documents both it and the local one |
 | **P5** — root-cause grouping of `regression` records into issues | open |
 
 Two decisions were tested by the implementation rather than only argued:

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -19,7 +19,9 @@ sides, and publish the difference.
 > record store, and the public page (`site/ecosystem.html`) all exist. **P2, the
 > corpus sweep, is what produces the first real KPI numbers**, and until it runs
 > `ecosystem/` holds a partial set rather than a survey; see
-> [ecosystem/README.md](../ecosystem/README.md).
+> [ecosystem/README.md](../ecosystem/README.md). A sweep can be run either
+> locally (§8) or from GitHub Actions (§8.1) — the numbers no longer depend on
+> having a many-core box to hand.
 
 ## 1. What gets measured
 
@@ -247,8 +249,9 @@ scripts/ecosystem-sweep.py --only String::Utils
 # one shard — "all modules that start with A"
 scripts/ecosystem-sweep.py --prefix A --jobs 8
 
-# everything currently red, after a fix lands
-scripts/ecosystem-sweep.py --status regression
+# everything currently red, after a fix lands (a record `status`, so `red` /
+# `partial` — `regression` is a per-FILE verdict, not a selectable status)
+scripts/ecosystem-sweep.py --status partial
 
 # records measured at an older mutsu commit or an older rakudo
 scripts/ecosystem-sweep.py --stale
@@ -266,7 +269,16 @@ dist, to bound a pathological suite), `--include-xt`, `--sandbox {bwrap,none}`,
 plan without executing), `--json -` (emit records to stdout instead of the tree).
 
 Environment: `MUTSU_BIN` (default `target/release/mutsu`), `RAKU_BIN` (default
-`raku`).
+`raku`), `MUTSU_ECO_HOST` (what `measured.host` records; default
+`<uname>-<machine>`, which cannot tell a hosted runner from the maintainer's box
+— §8.1 sets it to `gha-*`).
+
+`scripts/ecosystem-ci.py` is the CI-side companion: `plan` turns
+`.github/workflows/ecosystem-sweep.yml`'s dispatch inputs into a validated job
+matrix, and `provenance` groups a set of records by the
+`(mutsu commit, rakudo, host)` triple that measured them. Both are useful
+locally too — `--self-test` covers them, so a change to either is checked without
+dispatching a run.
 
 ### Cost model
 
@@ -350,25 +362,34 @@ dark README; browsers that ignore it get the light palette.
 | ~~**P1**~~ | ~~`scripts/ecosystem_common.py` extracted from `dist-compat-sweep.py`; `scripts/ecosystem-sweep.py` with the dep resolver, sandbox, TAP compare, `--only` / `--prefix` / `--rollup`; schema v1~~ | **done** — records round-trip, `--rollup` produces summary + history + chart, and the first eight distributions surfaced real findings |
 | **P2** | first full-corpus sweep; `ecosystem/` populated; `summary.*` + the first `history.tsv` row | `file_parity` / `assertion_parity` / `dist_parity` exist as real numbers |
 | ~~**P3**~~ | ~~`ecosystem/history.svg` linked from `README.md`; `site/ecosystem.html` + manifest generator + `pages.yml` wiring~~ | **done** — `site/ecosystem.html` is generated from the ledger by `scripts/gen-ecosystem-manifest.py`, wired into `pages.yml` and the nav, and covered by `site/e2e.test.mjs`. The README link waits on P2, which is what produces the chart |
-| **P4** | the operator runbook (§8) — one `make`-level entry point for a full sweep and for a shard, plus the `--rollup` + `history.tsv` append and the PR it lands as | a maintainer can go from a clean checkout to a merged sweep by following one page |
+| **P4** | the operator runbook (§8) — one entry point for a full sweep and for a shard, plus the `--rollup` + `history.tsv` append and the PR it lands as | **partly done** — `.github/workflows/ecosystem-sweep.yml` (§8.1) is that entry point for anyone with dispatch rights: it plans, builds once, measures, rolls up and opens the PR. What is left is the local `make`-level convenience wrapper |
 | **P5** | root-cause grouping of `regression` records into `todo:ticket` issues, in the shape `scripts/dist-compat-tickets.py` already produces; `docs/triage.md` picks them up | the KPI feeds the work queue |
 
 P1 and P2 are the campaign; P3-P5 make it repeatable. Do not start P2 before
 P1's `--only` round-trips a record.
 
-**There is deliberately no scheduled CI phase** (ADR-0085 D9): a full sweep is
-~20 CPU-hours, which a 12-core box does in ~2.5 h for nothing and a hosted
-runner would charge for weekly, on fewer cores, to track a number that moves at
-the speed of interpreter fixes. The cost is that the headline updates only when
-someone runs it — a documented state, since D7 makes staleness computable — and
-that PLAN.md §1 B1's "working-module regression CI" stays a separate, unstarted
-item rather than being closed by this campaign.
+**There is deliberately no *scheduled* CI sweep** (ADR-0085 D9): a full sweep is
+~20 CPU-hours, and paying a hosted runner for it weekly, on fewer cores, to
+track a number that moves at the speed of interpreter fixes, buys nothing. The
+headline updates when someone decides to refresh it — a documented state, since
+D7 makes staleness computable — and PLAN.md §1 B1's "working-module regression
+CI" stays a separate, unstarted item rather than being closed by this campaign.
+
+**Operator-*dispatched* CI is supported**, though, and is now the ordinary way to
+refresh the numbers: §8.1. That is the D9 amendment — it removes the
+"you need a 12-core box with `bwrap`" precondition without adding a schedule.
 
 ## 8. Operator runbook
 
-The sweep is run by hand on a machine with the cores to spare (ADR-0085 D9) —
-the maintainer's 12-core box, not a CI runner and not an ephemeral remote
-container (4 cores, a fixed disk allowance, and no `bwrap`).
+Two ways to refresh the numbers: **locally** (below) when a many-core box is at
+hand, or **from GitHub Actions** (§8.1) otherwise. They produce the same records
+and differ only in `measured.host`, so pick either — but do not run both at once
+on overlapping selections, or the second to finish overwrites the first.
+
+### 8.0 Locally
+
+A machine with the cores to spare — the maintainer's 12-core box, not an
+ephemeral remote container (4 cores, a fixed disk allowance, and no `bwrap`).
 
 ```sh
 apt-get install bubblewrap          # required; the sweep refuses to run a corpus without it
@@ -382,10 +403,77 @@ git checkout -b ecosystem/sweep-YYYY-MM-DD && git add ecosystem/ && …   # land
 Before landing a sweep, check that `measured.host` is uniform across what
 changed: a shard measured on a different machine is identifiable by design, but
 mixing hosts inside one `history.tsv` row makes the row mean less than it looks.
+`scripts/ecosystem-ci.py provenance` answers that in one command:
+
+```sh
+git status --porcelain -- ecosystem | awk '{print $NF}' \
+  | grep -E '^ecosystem/dists/.*\.json$' \
+  | scripts/ecosystem-ci.py provenance
+```
 
 After a **rakudo upgrade**, every baseline is invalid at once (§5) — run a full
 sweep rather than a shard, and say so in the PR, because the denominator moved
 and the KPI is not comparable across that boundary.
+
+### 8.1 From GitHub Actions
+
+`.github/workflows/ecosystem-sweep.yml`, **Run workflow** (or
+`gh workflow run ecosystem-sweep.yml -f scope=…`). One dispatch does the whole
+runbook: plan, build, measure, roll up, open the pull request.
+
+| input | what it selects | maps to |
+|---|---|---|
+| `scope: stale` (default) | records measured at another mutsu commit or rakudo — "refresh the numbers" | `--stale` |
+| `scope: all` | the whole corpus, fanned out across the 27 letter shards | `--prefix A` … `--prefix _` |
+| `scope: prefix` + `prefix: A` | one shard | `--prefix A` |
+| `scope: only` + `only: BTree, Trie` | named distributions | `--only …` |
+| `scope: status` + `status: partial` | every record currently at that status | `--status partial` |
+
+`shards` controls the fan-out (`auto` = letters for `scope: all`, one job
+otherwise; `letters` forces it, which is what a large `stale` selection wants);
+`jobs` / `attempts` / `file_timeout` are the harness flags; `raku_version` pins
+the oracle; `rollup` regenerates `summary.*`; `history` asks for a `history.tsv`
+row; `publish` chooses `pull-request` (default), `branch`, or `none`.
+
+`rollup` is on by default but will not *create* the first `summary.json` from a
+partial sweep — until a `scope: all` run has produced one, a subset run skips the
+rollup and says so, for the same reason `ecosystem/` has carried no summary since
+P1 ([ecosystem/README.md](../ecosystem/README.md)). Once a full sweep has
+established it, every later run keeps it in step with the records.
+
+What the workflow guarantees, and why it is not simply 27 independent sweeps —
+one mutsu binary, one rakudo release and one ecosystem index snapshot are
+produced by the `build` job and handed to every shard, so nothing inside a single
+KPI number was measured against a different denominator. `bwrap` is verified on
+each runner and the job fails rather than measuring unsandboxed.
+
+Dispatch it **from `main`**. Measuring a feature ref is supported and sometimes
+what you want (it measures that ref's mutsu), but the records are then only
+pushed to a branch: a pull request from a feature ref into `main` would carry
+that ref's other commits alongside the records, so the workflow declines to open
+one and says so.
+
+Two things it will refuse to do:
+
+- **Append a `history.tsv` row for anything but a complete, uniform sweep.** Not
+  a subset (`scope` other than `all`), not a run where a shard failed, not a run
+  whose records disagree about the `(mutsu commit, rakudo, host)` triple that the
+  row would claim. The records still land in all three cases; only the chart
+  point is withheld, and the run summary says which guard fired.
+- **Measure without a sandbox.** There is no fallback flag.
+
+Reading the result: records measured on a runner carry `measured.host` of the
+form `gha-ubuntu24-4c`, so they are never silently mixed with locally-measured
+ones. A hosted runner has ~4 cores, so `--timeout 120` bites earlier in
+wall-clock terms than on a 12-core box — symmetrically for both interpreters, so
+such a file lands in `no_baseline` rather than being charged to mutsu, but it
+does make the measurable baseline slightly smaller than a local sweep's.
+
+If the pull request opens with no CI running on it, the repository's GitHub App
+credentials (`TAGPR_APP_CLIENT_ID` / `TAGPR_APP_PRIVATE_KEY`) are not configured
+and it was opened with the default `GITHUB_TOKEN`, which GitHub does not let
+trigger workflows; the run summary says so. Push one commit to the branch from a
+clone to start CI.
 
 ## 9. Known limits and follow-ups
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -63,12 +63,22 @@ these records stay the authority.
 ```sh
 scripts/ecosystem-sweep.py --only BTree          # one distribution
 scripts/ecosystem-sweep.py --prefix A --jobs 8   # everything starting with A
-scripts/ecosystem-sweep.py --status regression   # everything currently red
+scripts/ecosystem-sweep.py --status partial      # everything currently red
 scripts/ecosystem-sweep.py --rollup              # regenerate summary.* and the chart
 ```
 
 Requires `bubblewrap` (the sweep runs unaudited test suites and refuses to run a
-corpus without a sandbox) and a `raku` on PATH. Full runbook:
+corpus without a sandbox) and a `raku` on PATH.
+
+**Or from GitHub Actions**, when no many-core box with `bwrap` is at hand: run
+the [`Ecosystem sweep`](../.github/workflows/ecosystem-sweep.yml) workflow
+(`gh workflow run ecosystem-sweep.yml -f scope=stale`). It builds mutsu once,
+pins one rakudo and one index snapshot for the whole run, fans `scope: all` out
+across the 27 shards, and opens the pull request itself. Records it measures
+carry a `gha-*` `measured.host`, so a CI number is never silently mixed with a
+locally-measured one.
+
+Full runbook, and what the workflow refuses to do:
 [docs/ecosystem-parity.md](../docs/ecosystem-parity.md) §8.
 
 ## Current state — a partial sweep, not the corpus

--- a/news/2026-09/ecosystem-sweep-from-github-actions.md
+++ b/news/2026-09/ecosystem-sweep-from-github-actions.md
@@ -1,0 +1,84 @@
+# The ecosystem parity numbers can now be refreshed from GitHub Actions
+
+The ecosystem parity KPI ([#7785](https://github.com/tokuhirom/mutsu/issues/7785),
+[ADR-0085](../../docs/adr/0085-ecosystem-testsuite-parity-measurement.md)) had one
+practical problem: refreshing it required a specific machine. The harness needs
+`bubblewrap`, a rakudo oracle, a release build and cores — so in practice only the
+maintainer's 12-core box could produce a number, and a remote container (4 cores,
+no `bwrap`) could not. `.github/workflows/ecosystem-sweep.yml` removes that
+precondition: one **Run workflow** click measures a selection and opens the pull
+request with the updated records.
+
+```sh
+gh workflow run ecosystem-sweep.yml -f scope=stale     # refresh what is out of date
+gh workflow run ecosystem-sweep.yml -f scope=all -f history=true   # the corpus sweep, P2
+gh workflow run ecosystem-sweep.yml -f scope=only -f only='BTree, Trie'
+```
+
+`scope` maps onto the harness's own selectors (`--stale`, `--all`, `--prefix`,
+`--only`, `--status`), so the workflow adds no measurement semantics of its own —
+it is an entry point, not a second implementation.
+
+## What had to be engineered, not just wired up
+
+A sweep fanned out across 27 hosted runners is not 27 independent sweeps. The
+whole value of the KPI is that mutsu and rakudo ran against the same denominator
+(ADR-0085 D2/D8), and three things would have quietly broken that:
+
+- **One binary for the run.** The `build` job compiles `--release` once and every
+  shard downloads that artifact. Building per shard would let 27 slightly
+  different compilations feed one number.
+- **One rakudo for the run.** `build` resolves the prebuilt release once and each
+  shard installs *that* version. `install-raku.sh` otherwise picks "the newest
+  right now", which for a multi-hour sweep can differ between the first shard and
+  the last — a denominator moving inside a single measurement.
+- **One ecosystem index for the run.** `build` fetches the fez + REA indexes once
+  and seeds every shard's cache, so no two shards resolve different versions of
+  the same distribution. Without this, `index-snapshot.json` would also describe
+  only whichever shard happened to write it last.
+
+`bwrap` is verified on each runner (Ubuntu 24.04's AppArmor restriction on
+unprivileged user namespaces is lifted if it blocks the probe) and the job
+**fails** rather than measuring unsandboxed — the sweep runs unaudited
+third-party test suites, so there is deliberately no fallback.
+
+## Two honesty guards
+
+- **`measured.host` now distinguishes the machine.** It was `<uname>-<machine>`,
+  which is `linux-x86_64` for both a runner and the maintainer's box — so D7's
+  "a number produced elsewhere is identifiable" did not actually hold across
+  those two. `MUTSU_ECO_HOST` overrides it and the workflow sets `gha-<image>-<n>c`.
+- **A `history.tsv` row is refused unless the sweep earns it.** That row reports
+  one `(mutsu commit, rakudo, host)` triple and one corpus-wide rate, so the
+  workflow will not append one for a subset (`scope` other than `all`), for a run
+  where a shard failed, or for a run whose records disagree about what measured
+  them. The records still land in all three cases; only the chart point is
+  withheld, and the run summary names the guard that fired.
+
+## What this does not change
+
+ADR-0085 D9 rejected a *scheduled* sweep, and that still stands — the workflow
+has no `schedule:`, only `workflow_dispatch`. A full corpus run is ~20 CPU-hours
+to track a number that moves at the speed of interpreter fixes; paying for it
+weekly buys nothing. It is also not a gate: PLAN.md §1 B1's "working-module
+regression CI" remains a separate, unstarted item. The ADR records this as a
+dated amendment to D9 rather than a rewrite, because the decision was extended
+(who needs the hardware), not reversed (when it runs).
+
+## Also in this change
+
+`scripts/ecosystem-ci.py` holds the two decisions the workflow has to make —
+`plan` (dispatch inputs → job matrix) and `provenance` (group records by the
+triple that measured them) — with a `--self-test` covering both, so they are
+debugged locally instead of one dispatched run at a time. It validates every
+input at plan time, which is also what makes it safe for the workflow to
+word-split the generated selector.
+
+`provenance` doubles as the local runbook's answer to "is what I am about to land
+uniform?", which §8 previously asked the operator to eyeball.
+
+One documentation bug fell out of writing it: both `docs/ecosystem-parity.md` and
+`ecosystem/README.md` suggested `--status regression`, but `regression` is a
+per-*file* verdict — a record's `status` is `green` / `partial` / `red` /
+`no_baseline` / `blocked_load` / `blocked_dep` / `skipped`, so that command
+selected nothing. The examples now say `--status partial`.

--- a/scripts/ecosystem-ci.py
+++ b/scripts/ecosystem-ci.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""ecosystem-ci.py — the two decisions .github/workflows/ecosystem-sweep.yml has to make.
+
+Both live here rather than inline in the workflow so they can be exercised
+locally (`--self-test`) instead of being debugged one dispatched run at a time.
+
+    scripts/ecosystem-ci.py plan --scope all --shards letters
+    scripts/ecosystem-ci.py plan --scope only --only 'BTree, Trie'
+    scripts/ecosystem-ci.py provenance ecosystem/dists/B/BTree.json …
+    scripts/ecosystem-ci.py --self-test
+
+`plan` turns the workflow's dispatch inputs into the job matrix: a list of
+`{id, args}` chunks, each `args` a validated `ecosystem-sweep.py` selector. It
+validates every input here, at plan time, so a typo fails in seconds instead of
+after a build and a rakudo install — and so the workflow can word-split
+`args` without smuggling anything into a shell.
+
+`provenance` answers the question docs/ecosystem-parity.md section 8 makes the
+operator ask before landing a sweep: was all of this measured by ONE mutsu
+commit, on ONE rakudo, on ONE host? Records each carry their own provenance, so
+a mixed set is still honest data and still lands; what it must not do is become
+a `history.tsv` row, because that row reports a single triple for the whole
+sweep. So this prints a table and `uniform=true|false`, and the workflow uses
+that to decide whether `--rollup` may append history.
+
+Anything written to GITHUB_OUTPUT is also printed, so a local run shows exactly
+what the workflow would consume.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import re
+import sys
+
+# One shard per `ecosystem/dists/` directory: A-Z plus `_` for a distribution
+# whose name does not start with an ASCII letter (`shard_of()` in
+# ecosystem-sweep.py). The whole corpus is exactly these 27.
+SHARDS = [chr(c) for c in range(ord("A"), ord("Z") + 1)] + ["_"]
+
+# `status` values a record can carry; see ecosystem/README.md.
+STATUSES = {"green", "partial", "red", "no_baseline", "blocked_load",
+            "blocked_dep", "skipped"}
+
+DIST_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9:_.+-]*$")
+
+
+class PlanError(Exception):
+    pass
+
+
+def emit(name, value):
+    """Set a workflow output, and echo it so a local run is readable."""
+    print(f"{name}={value}")
+    path = os.environ.get("GITHUB_OUTPUT")
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(f"{name}={value}\n")
+
+
+# --- plan --------------------------------------------------------------------
+
+def parse_only(raw):
+    names = [n for n in re.split(r"[,\s]+", (raw or "").strip()) if n]
+    if not names:
+        raise PlanError("scope=only needs at least one distribution in `only`")
+    bad = [n for n in names if not DIST_RE.match(n)]
+    if bad:
+        raise PlanError(f"not distribution names: {', '.join(bad)}")
+    return names
+
+
+def parse_prefix(raw):
+    value = (raw or "").strip()
+    if len(value) != 1 or not (value.isascii() and (value.isalpha() or value == "_")):
+        raise PlanError(f"prefix must be one letter A-Z or `_`, got {value!r}")
+    return value.upper()
+
+
+def parse_status(raw):
+    value = (raw or "").strip()
+    if value not in STATUSES:
+        raise PlanError(f"status must be one of {', '.join(sorted(STATUSES))}, got {value!r}")
+    return value
+
+
+def plan(scope, *, prefix="", only="", status="", shards="auto"):
+    """The dispatch inputs -> the job matrix. Returns a list of {id, args}."""
+    if shards not in ("auto", "letters", "single"):
+        raise PlanError(f"shards must be auto/letters/single, got {shards!r}")
+
+    if scope == "only":
+        # `--only` ignores `--prefix` in the harness, so this is always one job.
+        args = " ".join(f"--only {n}" for n in parse_only(only))
+        return [{"id": "only", "args": args}]
+
+    if scope == "prefix":
+        letter = parse_prefix(prefix)
+        return [{"id": letter, "args": f"--prefix {letter}"}]
+
+    if scope == "all":
+        extra, single_id = "--all", "all"
+    elif scope == "stale":
+        extra, single_id = "--stale", "stale"
+    elif scope == "status":
+        value = parse_status(status)
+        extra, single_id = f"--status {value}", f"status-{value}"
+    else:
+        raise PlanError(f"unknown scope {scope!r}")
+
+    # `auto` fans out only for the whole corpus: that is the run measured in
+    # hours, and it is the one the 6-hour job ceiling actually threatens. A
+    # `--stale` / `--status` run is proportional to how much of the ledger is
+    # already measured, so paying 27 setups (a build download, a rakudo install)
+    # to re-measure a handful of distributions costs more than it saves --
+    # until the ledger is large, at which point `shards: letters` says so
+    # explicitly.
+    fan_out = shards == "letters" or (shards == "auto" and scope == "all")
+    if not fan_out:
+        # `--all` is implied by `--prefix`, and passing both is redundant; every
+        # other scope keeps its selector as-is.
+        return [{"id": single_id, "args": extra}]
+    # The harness composes selectors: `--prefix S --stale` is the stale subset
+    # of one shard. `--all` needs no companion once a prefix narrows it.
+    if scope == "all":
+        return [{"id": s, "args": f"--prefix {s}"} for s in SHARDS]
+    return [{"id": s, "args": f"--prefix {s} {extra}"} for s in SHARDS]
+
+
+def cmd_plan(args):
+    try:
+        chunks = plan(args.scope, prefix=args.prefix, only=args.only,
+                      status=args.status, shards=args.shards)
+    except PlanError as exc:
+        print(f"::error title=ecosystem-sweep plan::{exc}", file=sys.stderr)
+        return 1
+    emit("chunks", json.dumps(chunks, separators=(",", ":")))
+    emit("count", len(chunks))
+    # A full-corpus run is the only one whose numbers may become a history row
+    # (a partial sweep's rollup is not comparable with the rows around it).
+    emit("full-corpus", "true" if args.scope == "all" else "false")
+    for chunk in chunks:
+        print(f"  {chunk['id']:12} {chunk['args']}", file=sys.stderr)
+    return 0
+
+
+# --- provenance --------------------------------------------------------------
+
+def provenance(paths):
+    """Group records by their measurement provenance. Returns (triples, unreadable)."""
+    triples = collections.Counter()
+    unreadable = []
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                measured = json.load(fh)["measured"]
+            triples[(measured["mutsu_commit"], measured["raku_version"],
+                     measured.get("host", "?"))] += 1
+        except (OSError, ValueError, KeyError) as exc:
+            unreadable.append(f"{path}: {exc}")
+    return triples, unreadable
+
+
+def cmd_provenance(args):
+    paths = list(args.paths)
+    if not paths:
+        paths = [line.strip() for line in sys.stdin if line.strip()]
+    triples, unreadable = provenance(paths)
+    lines = ["| mutsu commit | rakudo | host | records |", "|---|---|---|---|"]
+    for (commit, raku, host), count in sorted(triples.items()):
+        lines.append(f"| `{commit}` | {raku} | `{host}` | {count} |")
+    table = "\n".join(lines)
+    print(table, file=sys.stderr)
+    for problem in unreadable:
+        print(f"::warning title=unreadable record::{problem}", file=sys.stderr)
+
+    uniform = len(triples) == 1 and not unreadable
+    if not uniform and triples:
+        print("::warning title=mixed provenance::this sweep was not measured by a "
+              "single (mutsu commit, rakudo, host) triple — the records still land, "
+              "but no history.tsv row will be appended", file=sys.stderr)
+    emit("uniform", "true" if uniform else "false")
+    emit("records", sum(triples.values()))
+    if args.markdown:
+        with open(args.markdown, "w", encoding="utf-8") as fh:
+            fh.write(table + "\n")
+    return 0
+
+
+# --- self-test ---------------------------------------------------------------
+
+def self_test():
+    failures = 0
+
+    def check(label, got, expected):
+        nonlocal failures
+        if got != expected:
+            print(f"not ok - {label}\n     got: {got}\nexpected: {expected}", file=sys.stderr)
+            failures += 1
+        else:
+            print(f"ok - {label}")
+
+    def fails(label, fn):
+        nonlocal failures
+        try:
+            fn()
+        except PlanError:
+            print(f"ok - {label} (rejected)")
+            return
+        print(f"not ok - {label} (should have been rejected)", file=sys.stderr)
+        failures += 1
+
+    check("all fans out to 27 shards", len(plan("all")), 27)
+    check("all shard args", plan("all")[0], {"id": "A", "args": "--prefix A"})
+    check("all last shard is the non-alpha one", plan("all")[-1]["id"], "_")
+    check("all single", plan("all", shards="single"), [{"id": "all", "args": "--all"}])
+    check("stale is one job by default", plan("stale"),
+          [{"id": "stale", "args": "--stale"}])
+    check("stale fans out on request", plan("stale", shards="letters")[3],
+          {"id": "D", "args": "--prefix D --stale"})
+    check("status composes with the shard", plan("status", status="partial",
+                                                 shards="letters")[0],
+          {"id": "A", "args": "--prefix A --status partial"})
+    check("status single", plan("status", status="green"),
+          [{"id": "status-green", "args": "--status green"}])
+    check("prefix is always one job", plan("prefix", prefix="s", shards="letters"),
+          [{"id": "S", "args": "--prefix S"}])
+    check("underscore prefix", plan("prefix", prefix="_"),
+          [{"id": "_", "args": "--prefix _"}])
+    check("only, comma separated", plan("only", only="BTree, Trie"),
+          [{"id": "only", "args": "--only BTree --only Trie"}])
+    check("only, whitespace separated", plan("only", only="A::B\nC-D"),
+          [{"id": "only", "args": "--only A::B --only C-D"}])
+    check("only never fans out", plan("only", only="BTree", shards="letters"),
+          [{"id": "only", "args": "--only BTree"}])
+
+    fails("shell metacharacter in only", lambda: plan("only", only="BTree; rm -rf /"))
+    fails("flag smuggled through only", lambda: plan("only", only="--sandbox"))
+    fails("empty only", lambda: plan("only", only="  "))
+    fails("multi-letter prefix", lambda: plan("prefix", prefix="AB"))
+    fails("digit prefix", lambda: plan("prefix", prefix="4"))
+    fails("unknown status", lambda: plan("status", status="broken"))
+    fails("unknown scope", lambda: plan("everything"))
+    fails("unknown shards mode", lambda: plan("all", shards="many"))
+
+    # Every generated token must be safe to word-split into an argv, since that
+    # is exactly what the workflow does with it.
+    tokens = [t for scope in ("all", "stale") for c in plan(scope, shards="letters")
+              for t in c["args"].split()]
+    check("no shell metacharacters in any generated arg",
+          [t for t in tokens if not re.match(r"^[A-Za-z0-9:_.+-]+$", t.lstrip("-"))], [])
+
+    triples, unreadable = provenance([])
+    check("provenance of nothing is not uniform", (len(triples), unreadable), (0, []))
+
+    print(f"\n{'FAILED' if failures else 'PASS'}: {failures} failure(s)")
+    return 1 if failures else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--self-test", action="store_true", help="verify plan/provenance and exit")
+    sub = ap.add_subparsers(dest="cmd")
+
+    p = sub.add_parser("plan", help="dispatch inputs -> job matrix JSON")
+    p.add_argument("--scope", required=True,
+                   choices=["all", "stale", "status", "prefix", "only"])
+    p.add_argument("--prefix", default="")
+    p.add_argument("--only", default="")
+    p.add_argument("--status", default="")
+    p.add_argument("--shards", default="auto", choices=["auto", "letters", "single"])
+    p.set_defaults(func=cmd_plan)
+
+    q = sub.add_parser("provenance", help="group records by (mutsu commit, rakudo, host)")
+    q.add_argument("paths", nargs="*", help="record paths; read from stdin when absent")
+    q.add_argument("--markdown", help="also write the table to this file")
+    q.set_defaults(func=cmd_provenance)
+
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    if not args.cmd:
+        ap.error("pass a subcommand (plan / provenance) or --self-test")
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ecosystem-sweep.py
+++ b/scripts/ecosystem-sweep.py
@@ -14,7 +14,8 @@ Operations: docs/ecosystem-parity.md   Tracking issue: #7785
     scripts/ecosystem-sweep.py --all --jobs 8
     scripts/ecosystem-sweep.py --rollup
 
-Env: MUTSU_BIN (default target/release/mutsu), RAKU_BIN (default raku).
+Env: MUTSU_BIN (default target/release/mutsu), RAKU_BIN (default raku),
+MUTSU_ECO_HOST (what `measured.host` records; default `<uname>-<machine>`).
 """
 
 from __future__ import annotations
@@ -472,7 +473,13 @@ def preflight(args):
     args.mutsu, args.raku = mutsu, raku
     args.raku_version, args.raku_backend = version, backend
     args.mutsu_commit, args.mutsu_version = commit, mutsu_version
-    args.host = f"{os.uname().sysname.lower()}-{os.uname().machine}"
+    # `measured.host` exists so a number produced on another machine is
+    # identifiable rather than quietly mixed in (ADR-0085 D7/D9). uname alone
+    # cannot do that job -- a hosted runner and the maintainer's box are both
+    # `linux-x86_64` -- so MUTSU_ECO_HOST lets the caller name the machine, and
+    # .github/workflows/ecosystem-sweep.yml sets it to the runner it ran on.
+    args.host = (os.environ.get("MUTSU_ECO_HOST")
+                 or f"{os.uname().sysname.lower()}-{os.uname().machine}")
     args.sandbox = sandbox
     args.tarball_cache = os.path.join(eco.CACHE_DIR, "tarballs")
     args.extract_cache = os.path.join(eco.CACHE_DIR, "deps")


### PR DESCRIPTION
Refreshing the ecosystem parity KPI (#7785) required a specific machine: the harness needs `bubblewrap`, a rakudo oracle, a release build and cores, so in practice only the maintainer's 12-core box could produce a number — a remote container (4 cores, no `bwrap`) could not, which is why P1's own handoff comment said "P2 needs a many-core box".

`.github/workflows/ecosystem-sweep.yml` removes that precondition. One **Run workflow** measures a selection and opens the pull request with the updated records.

```sh
gh workflow run ecosystem-sweep.yml -f scope=stale                  # refresh what is out of date
gh workflow run ecosystem-sweep.yml -f scope=all -f history=true    # the corpus sweep — P2
gh workflow run ecosystem-sweep.yml -f scope=only -f only='BTree, Trie'
```

`scope` maps onto the harness's own selectors (`--stale` / `--all` / `--prefix` / `--only` / `--status`), so the workflow adds **no measurement semantics of its own** — it is an entry point, not a second implementation. `scope: all` fans out across the 27 letter shards, which is what keeps a ~20 CPU-hour sweep under the 6-hour job ceiling.

## What had to be engineered, not just wired up

A sweep spread over 27 runners is not 27 independent sweeps. The KPI means nothing unless both interpreters ran against the same denominator (ADR-0085 D2/D8), and three things would have quietly broken that. Each is produced **once**, by the `build` job, and handed to every shard:

| shared once | what goes wrong otherwise |
|---|---|
| the release binary | 27 slightly different compilations feed one number |
| the rakudo release | `install-raku.sh` picks "the newest right now", which over a multi-hour sweep differs between the first shard and the last — a denominator moving inside one measurement |
| the fez + REA index snapshot | two shards resolve different versions of the same distribution, and `index-snapshot.json` describes only whichever shard wrote it last |

`bwrap` is verified on each runner (Ubuntu 24.04's AppArmor restriction on unprivileged user namespaces is lifted if it blocks the probe) and the job **fails** rather than measuring unsandboxed — the sweep runs unaudited third-party test suites, so there is deliberately no fallback flag.

## Two honesty guards

- **`measured.host` now identifies the machine.** It was `<uname>-<machine>` — `linux-x86_64` for a runner *and* for the maintainer's box — so ADR-0085 D7's "a number produced elsewhere is identifiable rather than quietly mixed in" did not actually hold across those two. `MUTSU_ECO_HOST` overrides it; the workflow sets `gha-<image>-<n>c`.
- **A `history.tsv` row must be earned.** That row reports one `(mutsu commit, rakudo, host)` triple and one corpus-wide rate, so it is refused for a subset run, for a run where a shard failed, and for a run whose records disagree about what measured them. The records still land in all three cases; only the chart point is withheld, and the run summary names the guard that fired. For the same reason a partial sweep will not *create* the first `ecosystem/summary.json` — that is the decision `ecosystem/README.md` has recorded since P1.

## Not a scheduled sweep

ADR-0085 D9 rejected a periodic sweep and that still stands: there is no `schedule:` in the workflow, only `workflow_dispatch`, and PLAN.md §1 B1's "working-module regression CI" remains a separate, unstarted item. Recorded as a **dated amendment** to D9 rather than a rewrite, because the decision was extended (who needs the hardware), not reversed (when it runs).

## Files

- `.github/workflows/ecosystem-sweep.yml` — the workflow (`build` → sharded `sweep` → `collect`).
- `scripts/ecosystem-ci.py` — the two decisions the workflow makes: `plan` (dispatch inputs → job matrix) and `provenance` (group records by the triple that measured them), behind a `--self-test`, so they are debugged locally instead of one dispatched run at a time. Validating inputs there is also what makes it safe for the workflow to word-split the generated selector. `provenance` doubles as the local runbook's answer to "is what I am about to land uniform?", which §8 previously asked the operator to eyeball.
- `scripts/ecosystem-sweep.py` — `MUTSU_ECO_HOST` (the only behavioural change; 7 lines).
- `docs/adr/0085-…md` (D9 amendment), `docs/ecosystem-parity.md` (§8 split into 8.0 local / 8.1 CI), `ecosystem/README.md`, `PLAN.md`, `news/2026-09/ecosystem-sweep-from-github-actions.md`.

**Drive-by fix:** both docs suggested `--status regression`, but `regression` is a per-*file* verdict — a record's `status` is `green`/`partial`/`red`/`no_baseline`/`blocked_load`/`blocked_dep`/`skipped` — so that command selected nothing. Now `--status partial`.

## Verification

- `scripts/ecosystem-ci.py --self-test` — 23 checks, including that every generated selector token is safe to word-split, and that a shell metacharacter or a smuggled flag in `only` is rejected.
- **End-to-end against a real record:** `MUTSU_ECO_HOST=smoke-test-host scripts/ecosystem-sweep.py --only BTree` on a release build with the same rakudo 2026.07 → `measured.host` came back `smoke-test-host`, every per-file verdict reproduced the committed record (only `secs` moved), and piping `git status` through `ecosystem-ci.py provenance` produced the table and `uniform=true` exactly as the collect job does. Also exercised the `uniform=false` path (two records, two commits) and the "unreadable record" path that made filtering `index-snapshot.json` out necessary. The measurement itself was reverted, so this PR changes no records.
- `make test` — **PASS** (3963 files, 42149 tests).
- `make roast` — red **only** on the three documented container artifacts, with the exact documented shapes: `6.c/S32-io/file-tests.t` (`Failed: 4` — 6-8, 10) and `S16-filehandles/filetest.t` (`Failed: 25` — 57-64, 69-72, 77-80, 101…125), both because this container runs as `uid 0`, plus `S32-io/IO-Socket-Async.t` exit 124 (sandboxed network) — see docs/agent-environments.md.
- `cargo fmt --all -- --check` clean. **`make lint` was not run:** this branch changes **zero `.rs` files**, so all four linted configurations compile code identical to `main`, which CI already gates. Everything else here is YAML, Python and Markdown.

## What still can't be verified from here

The workflow itself has never executed — this container has no `bwrap` and cannot dispatch a run against an unmerged workflow file. Its logic is factored into `ecosystem-ci.py` precisely so the parts that *can* be tested are, but the runner-shaped steps (bwrap probe on ubuntu-24.04, artifact round-trip, the App-token PR) are first exercised by the first dispatch. Suggested first run: `scope: prefix`, `prefix: A`, `attempts: 1`, `publish: branch` — a real shard, no pull request, and it times the corpus for P2.

One known limitation, deliberately not fixed here: a pull request opened with the default `GITHUB_TOKEN` does not start CI. The workflow uses the repository's existing App credentials (`TAGPR_APP_CLIENT_ID` / `TAGPR_APP_PRIVATE_KEY`, already used by `tag-release.yml`) when configured, and emits a warning naming the remedy when not.

Refs #7785 — the issue stays open for P2 and P5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164xafjtgmTPhHatdSuMR9a

---
_Generated by [Claude Code](https://claude.ai/code/session_0164xafjtgmTPhHatdSuMR9a)_