### PR TITLE
docs: add the ecosystem-dist-fix skill for taking one zef dist from red to green

### DIFF
--- a/.agents/skills/ecosystem-dist-fix/SKILL.md
+++ b/.agents/skills/ecosystem-dist-fix/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: ecosystem-dist-fix
+description: Make one real zef distribution's own test suite pass under mutsu — download the dist and its dependency closure, run every test file under rakudo and mutsu, fix the interpreter where the gap is bounded, file an issue where it needs a complex feature, and land it as a PR that also updates the ecosystem/ ledger record. Use when asked to make a named distribution's tests pass ("String::Utils のテストを通るようにして", "get Trie green", "fix the JSON::Fast suite"), or to work the red/partial/blocked_load records in ecosystem/.
+metadata:
+  short-description: Take one zef distribution from red to green
+---
+
+# Ecosystem distribution fix
+
+One distribution, end to end: from the `ecosystem/` ledger record to a merged PR. The unit of
+success is **a test file rakudo passes and mutsu now passes too** — not "the suite looks better".
+
+The method, the metric definitions and the fairness contract are
+[docs/ecosystem-parity.md](../../../docs/ecosystem-parity.md); the decisions behind them are
+[ADR-0085](../../../docs/adr/0085-ecosystem-testsuite-parity-measurement.md). This file is the
+per-distribution loop that consumes them. Read the parity doc's §1-§3 once before your first
+distribution; after that, this page is enough.
+
+The `gh` commands below are the local-dev-box form. A remote container has no `gh` — translate with
+the mapping table in [docs/agent-environments.md](../../../docs/agent-environments.md).
+
+## Ground rules — these decide whether the result means anything
+
+1. **rakudo is the denominator, and you check it first.** A file rakudo does not pass cleanly is
+   `no_baseline`: it is never charged to mutsu and never worth fixing. Run `raku` on the exact same
+   file with the exact same `-I` list *before* calling anything a mutsu bug. Suites that need the
+   network, a database, or a `zef`-installed repository fail on both sides — that is the expected
+   outcome, not a finding.
+2. **`MUTSU_FUDGE` must be unset.** It is roast-only; a stray `#?rakudo skip` in a distribution
+   would silently drop the next statement and hand you a fake pass.
+3. **Never edit the distribution to make the test pass.** The extracted tree under `tmp/ecosystem/`
+   is a *measurement subject*. Editing it to bisect which construct dies is good debugging; shipping
+   anything from it is not a deliverable, and neither is a patch upstream. The fix goes in mutsu.
+4. **Never special-case the distribution inside mutsu.** No hardcoded outputs, no "if the module is
+   `String::Utils`" branches, no stubs. `CLAUDE.md`'s rule for roast holds here verbatim: every fix
+   is a genuine, general-purpose improvement.
+5. **Do not answer a hard distribution by bundling it.** Vendoring the module into `modules/` or
+   reimplementing it natively is BATTERIES.md rung 3, **banned by user decision** — see `CLAUDE.md`.
+   Grow the interpreter until the real, upstream module runs verbatim, or file the issue.
+6. **Dependencies arrive only as `-I` paths.** Never `mzef install` them into a site repo: mutsu's
+   bundled batteries would then supply something rakudo lacks and the comparison stops being one.
+
+## 1. Read the ledger record before you download anything
+
+```sh
+cat ecosystem/dists/S/String--Utils.json      # <S> = first letter; :: becomes --
+```
+
+`status` tells you what kind of job this is, and it is worth knowing before you spend a build:
+
+| `status` | what it means | first move |
+|---|---|---|
+| `blocked_load` | a provided module does not even `use` | fix the load. Nothing else in the suite can run, and this is usually one concrete parse/compile gap |
+| `red` / `partial` | the suite runs, some baseline files fail | go file by file; `files[].cmp == "regression"` and `"partial"` are the actionable ones |
+| `no_baseline` | rakudo does not pass it either | **stop.** Report that and pick another distribution — there is nothing here to fix |
+| `blocked_dep` | the dependency closure cannot be resolved | usually malformed upstream `depends` metadata. Not a mutsu bug; not worth chasing |
+| `green` | already passing | re-measure to confirm, then stop |
+
+Also read `axis`: `pure` distributions are the ones that reward interpreter work. `guts` (`nqp::`,
+Metamodel, `EXPORTHOW`) and `native` (`NativeCall`) distributions are usually the issue-filing case
+of §5, not the fix case — decide that deliberately rather than discovering it after an hour.
+
+`measured.mutsu_commit` says how old the record is. A record from before a fix you know landed is
+evidence about that commit, not about `main`; re-measure rather than trusting it.
+
+If there is no record at all, that is fine — the corpus sweep is partial (see
+`ecosystem/README.md`). Go to step 2 and create one in step 7.
+
+## 2. Check the distribution out
+
+```sh
+.agents/skills/ecosystem-dist-fix/checkout-dist.py String::Utils
+```
+
+It resolves the same flat dependency closure the sweep does, extracts everything under
+`tmp/ecosystem/<Dist--Name>/` (gitignored, and reused on re-runs), and prints `DIST`, `LIBS`,
+`MUTSU`, `RAKU` plus the test file list. `--json` gives the same as a machine-readable plan;
+`--force` re-extracts. Set `MUTSU_BIN` first if you want a binary other than `target/debug/mutsu`.
+
+It does **not** sandbox — you are about to execute a third-party test suite on this machine. Skim
+the suite before running it, exactly as the sweep's `--sandbox none` escape hatch assumes for a
+single distribution you already trust.
+
+## 3. Load probe, then file by file
+
+Always the load probe first: a module that does not `use` makes every file failure downstream noise.
+
+```sh
+cd "$DIST"
+timeout 60 $RAKU  $LIBS -e 'use String::Utils; exit 0'
+timeout 60 $MUTSU $LIBS -e 'use String::Utils; exit 0'
+```
+
+Then, for each test file, rakudo first and mutsu second:
+
+```sh
+timeout 120 $RAKU  $LIBS t/01-basic.rakutest
+timeout 120 $MUTSU $LIBS t/01-basic.rakutest
+```
+
+Classify each file exactly as the ledger does — `parity`, `partial` (mutsu reaches the plan and
+fails assertions), `regression` (dies, hangs, or never reaches the plan), `no_baseline`. Work
+`regression` before `partial`: a file that dies at line 3 is hiding every gap after it, so one fix
+there often moves more than a careful assertion hunt.
+
+Never run the two sides with different `-I` lists, a different working directory, or a different
+timeout. The distribution root is the working directory because suites reach for fixtures by
+relative path.
+
+## 4. Reduce to a repro that lives in this repo
+
+The distribution is not in mutsu's CI and never will be, so a failure only counts once it exists as
+a few lines you can run from the repo. Write the reduction to `tmp/` with the Write tool, and put
+mutsu's and rakudo's output side by side:
+
+```sh
+timeout 30 target/debug/mutsu ./tmp/repro.p6
+raku ./tmp/repro.p6
+```
+
+That reduction is three things at once: the thing you debug, the regression test you will commit in
+step 6, and the body of the issue you file in step 5. Do not skip it and debug against the
+distribution's 124-assertion test file.
+
+`CLAUDE.md`'s debugging guidance applies unchanged — `--dump-ast`, `MUTSU_TRACE`, and
+`rust-gdb -batch` before any `eprintln!`.
+
+## 5. Decide: fix it now, or file an issue
+
+**This decision is the point of the skill.** Make it per finding, not per distribution — one
+distribution routinely produces two quick fixes and one issue, and that is a complete, successful
+run.
+
+**Fix it in this PR** when the gap is bounded and needs no new architectural decision:
+
+- a missing or wrong method / builtin / operator, or an unhandled edge case in an existing one;
+- a parser gap for syntax that has an obvious home in the existing grammar;
+- a compile/VM slice that follows the existing Parser → Compiler → VM path;
+- anything you can pin with a focused `t/` test and explain in one paragraph.
+
+**File an issue instead** — this is what "複雑な機能が必要なら" means — when the fix needs:
+
+- a new or superseding **ADR**, or a decision `CLAUDE.md` reserves for the user;
+- **deep machinery**: `nqp::` ops, Metamodel/MOP, `EXPORTHOW`, slangs, precompilation, `NativeCall`
+  guts — the `guts` / `native` axis;
+- a **cross-cutting invariant** across execution layers (container semantics, laziness, the
+  `env_dirty` dual store, concurrency ordering);
+- anything that cannot be bounded as one PR, or whose right answer you cannot state confidently.
+
+Label it by `docs/issue-workflow.md`: `todo:ticket` for a small self-contained slice you are simply
+not doing now, `todo:deep` for the design-needed cases above, `todo:perf` only when mutsu is
+*correct but slow* — a wrong answer is never `todo:perf`. Title it after the missing capability, not
+after the distribution ("`EXPORTHOW::DECLARE` … " not "String::Utils fails"), because the next
+distribution to hit it must find the issue. The body carries the §4 reduction with both
+interpreters' output, the distribution and test file it came from, and why it is large. One issue
+per finding; only ever in `tokuhirom/mutsu`.
+
+Then say so in the PR: the distribution's remaining red files each name their issue number. A
+distribution that goes from `red` to `partial` with the residue filed is a good outcome. What is
+**not** acceptable is leaving a finding unrecorded because it was too big to fix — that is the one
+way this loop loses work.
+
+## 6. Fix, and pin it in `t/`
+
+The change goes where `CLAUDE.md` says it goes: implement in `compiler/` and `vm/`, never a new
+`runtime/methods.rs` slow-path fallback. When the spec is unclear, `raku -e` is the oracle and
+`raku-doc/` is the reference.
+
+**Every fix commits a focused regression test under `t/`** — the §4 reduction, placed by
+[docs/t-directory-layout.md](../../../docs/t-directory-layout.md) (by what it would catch, not by
+the syntax it uses). The ecosystem sweep is operator-run and not in CI, so this `t/` file is the
+*only* thing standing between your fix and a silent regression. Name it after the capability, and
+say in a comment which distribution it came from.
+
+Then the standard gate, before publishing: `cargo fmt --all`, `make lint`, `make test`,
+`make roast`, reading `tmp/make-test.log` / `tmp/make-roast.log` with the Grep tool rather than
+re-running a suite. In a remote container, confirm any red `make roast` is a subset **by name** of
+the environment-only failures in
+[docs/agent-environments.md](../../../docs/agent-environments.md).
+
+## 7. Re-measure and update the ledger record
+
+The record is part of the deliverable — a fix that leaves the ledger saying `red` has not been
+reported.
+
+```sh
+touch src/main.rs && cargo build --release        # a stale binary is measured silently
+MUTSU_BIN=target/release/mutsu scripts/ecosystem-sweep.py --only String::Utils --sandbox none
+```
+
+- `--sandbox none` is permitted **only** with `--only`, for a distribution you have read. A shard or
+  corpus sweep needs `bubblewrap`, which a remote container does not have — do not attempt one there.
+- The sweep aborts unless `use Test` reaches the vendored `modules/Rakudo-Core/lib/Test.rakumod` on
+  both sides. That is the fairness precondition, not a nuisance: fix it rather than working around it.
+- Timestamps are date-granular, so an unchanged same-day re-run produces no diff. A record that did
+  not change when you expected it to means the fix did not reach the measured binary.
+- Do **not** run `--rollup --history` for one distribution: `history.tsv` takes one row per *full*
+  sweep, and a row from a single dist is not comparable with the ones around it.
+- `docs/ecosystem-parity.md` §5 lists `--mutsu-only`, `--refresh-baseline` and `--json -`. Those are
+  design, not implementation — the harness does not accept them today. Use the flags in
+  `--help`.
+
+Commit the changed `ecosystem/dists/<S>/<Dist--Name>.json` in the same PR as the fix.
+
+## 8. Publish
+
+Branch off an updated `main`, commit (English, root cause in the message), push, open a
+**non-draft** PR, enable auto-merge with the **merge** method (squash is rejected by this
+repository), then immediately check `mergeStateStatus` is not `DIRTY` — the ledger records are
+one-file-per-dist precisely so parallel PRs do not conflict, but `src/` still can. Watch CI in the
+background and fix forward. The full flow, including the one-branch-per-session case, is
+[`mutsu-ticket-flow`](../mutsu-ticket-flow/SKILL.md).
+
+The PR body states: the distribution and version, baseline files before → after, what was fixed,
+and the issue number for every file still red. Write the accomplishment up as
+`news/YYYY-MM/<slug>.md`, and close any issue the fix resolves with `Closes #NNNN`.
+
+## Done means
+
+Either the distribution's record reads `green`, or every remaining non-`parity` baseline file is
+explained by an open issue named in the PR. "I improved some assertions" is not a finish line;
+"3 of 3 baseline files pass, and `t/02` needs #NNNN" is.

--- a/.agents/skills/ecosystem-dist-fix/SKILL.md
+++ b/.agents/skills/ecosystem-dist-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ecosystem-dist-fix
-description: Make one real zef distribution's own test suite pass under mutsu — download the dist and its dependency closure, run every test file under rakudo and mutsu, fix the interpreter where the gap is bounded, file an issue where it needs a complex feature, and land it as a PR that also updates the ecosystem/ ledger record. Use when asked to make a named distribution's tests pass ("String::Utils のテストを通るようにして", "get Trie green", "fix the JSON::Fast suite"), or to work the red/partial/blocked_load records in ecosystem/.
+description: Make one real zef distribution's own test suite pass under mutsu by fixing mutsu — download the dist and its dependency closure, run every test file under rakudo and mutsu, fix the interpreter where the gap is bounded, file a tokuhirom/mutsu issue where it needs a complex feature, and land it as a PR to tokuhirom/mutsu that also updates the ecosystem/ ledger record. The distribution is the test subject, never the thing being patched, and no PR or issue ever goes to another repository. Use when asked to make a named distribution's tests pass ("String::Utils のテストを通るようにして", "get Trie green", "fix the JSON::Fast suite"), or to work the red/partial/blocked_load records in ecosystem/.
 metadata:
   short-description: Take one zef distribution from red to green
 ---
@@ -9,6 +9,26 @@ metadata:
 
 One distribution, end to end: from the `ecosystem/` ledger record to a merged PR. The unit of
 success is **a test file rakudo passes and mutsu now passes too** — not "the suite looks better".
+
+## The two things this skill is and is not
+
+**The goal is to fix mutsu.** The distribution is a *test subject*, not a client. Its suite is a
+supply of real-world Raku that roast does not cover, and every failure it exposes is a question
+about the interpreter: which language feature does mutsu get wrong? The deliverable is always a
+change under `src/` (or a recorded reason why that change is too large), never a change to the
+distribution. If a suite could be made green by patching the distribution, working around its idiom,
+teaching mutsu the module's name, or bundling the module, **the work has not been done** — you have
+moved the failure rather than fixed it. There is one legitimate exception, and it is not a fix: the
+distribution's own bug, which rakudo also fails, is `no_baseline` and belongs to nobody here.
+
+**Every PR and every issue goes to `tokuhirom/mutsu`, and nowhere else.** Not to the distribution's
+repository, not to `Raku/roast`, `Raku/doc` or `rakudo/rakudo`, not to a dependency's repository —
+no matter how clearly the bug looks like theirs, and no matter how small the patch. This holds for
+issues, pull requests, comments, labels and closes alike. An AI has actually mis-filed a mutsu issue
+into a Raku-org repository before, which is why `CLAUDE.md` states it as an absolute and why it is
+repeated here: this loop reads more third-party repositories than any other, so it is where the
+mistake is easiest to make. If a finding genuinely belongs upstream, record it in a
+`tokuhirom/mutsu` issue and stop — reporting it upstream is the user's call, not yours.
 
 The method, the metric definitions and the fairness contract are
 [docs/ecosystem-parity.md](../../../docs/ecosystem-parity.md); the decisions behind them are
@@ -153,7 +173,9 @@ not doing now, `todo:deep` for the design-needed cases above, `todo:perf` only w
 after the distribution ("`EXPORTHOW::DECLARE` … " not "String::Utils fails"), because the next
 distribution to hit it must find the issue. The body carries the §4 reduction with both
 interpreters' output, the distribution and test file it came from, and why it is large. One issue
-per finding; only ever in `tokuhirom/mutsu`.
+per finding, **filed in `tokuhirom/mutsu`** — the issue records a gap in *mutsu*, so it belongs in
+mutsu's tracker even when the reduction is quoted verbatim from someone else's distribution. Never
+open it, or a comment on it, anywhere else.
 
 Then say so in the PR: the distribution's remaining red files each name their issue number. A
 distribution that goes from `red` to `partial` with the residue filed is a good outcome. What is
@@ -202,11 +224,12 @@ MUTSU_BIN=target/release/mutsu scripts/ecosystem-sweep.py --only String::Utils -
 
 Commit the changed `ecosystem/dists/<S>/<Dist--Name>.json` in the same PR as the fix.
 
-## 8. Publish
+## 8. Publish — to `tokuhirom/mutsu`
 
-Branch off an updated `main`, commit (English, root cause in the message), push, open a
-**non-draft** PR, enable auto-merge with the **merge** method (squash is rejected by this
-repository), then immediately check `mergeStateStatus` is not `DIRTY` — the ledger records are
+Branch off an updated `main` **of `tokuhirom/mutsu`**, commit (English, root cause in the message),
+push, open a **non-draft** PR *against that repository*, enable auto-merge with the **merge** method
+(squash is rejected by this repository), then immediately check `mergeStateStatus` is not
+`DIRTY` — the ledger records are
 one-file-per-dist precisely so parallel PRs do not conflict, but `src/` still can. Watch CI in the
 background and fix forward. The full flow, including the one-branch-per-session case, is
 [`mutsu-ticket-flow`](../mutsu-ticket-flow/SKILL.md).
@@ -218,5 +241,7 @@ and the issue number for every file still red. Write the accomplishment up as
 ## Done means
 
 Either the distribution's record reads `green`, or every remaining non-`parity` baseline file is
-explained by an open issue named in the PR. "I improved some assertions" is not a finish line;
-"3 of 3 baseline files pass, and `t/02` needs #NNNN" is.
+explained by an open `tokuhirom/mutsu` issue named in the PR. "I improved some assertions" is not a
+finish line; "3 of 3 baseline files pass, and `t/02` needs #NNNN" is.
+
+And in both cases the distribution is exactly as you found it: every line that changed is mutsu's.

--- a/.agents/skills/ecosystem-dist-fix/checkout-dist.py
+++ b/.agents/skills/ecosystem-dist-fix/checkout-dist.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""checkout-dist.py — lay one zef distribution and its dependency closure out on
+disk so an agent can iterate on it.
+
+`scripts/ecosystem-sweep.py` extracts into a temporary directory and deletes it,
+which is right for a measurement and useless for debugging: fixing a
+distribution means running the same test file thirty times while rebuilding the
+interpreter in between. This does the same resolution and extraction, keeps the
+tree, and prints the exact commands to run each side.
+
+    .agents/skills/ecosystem-dist-fix/checkout-dist.py String::Utils
+
+Writes to tmp/ecosystem/<Dist--Name>/ (gitignored) and prints a shell snippet
+defining DIST, LIBS, MUTSU and RAKU. Re-running reuses what is already there
+unless --force is given.
+
+Same index, same tarball cache and same flat `-I` closure as the sweep, so a
+green run here means the same thing a green record does. It does NOT sandbox:
+you are running an unaudited third-party test suite on your own machine, so read
+what you are about to run first, exactly as the sweep's `--sandbox none` escape
+hatch expects for a single distribution you already trust.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+sys.path.insert(0, os.path.join(REPO, "scripts"))
+import ecosystem_common as eco  # noqa: E402
+
+OUT_ROOT = os.path.join(REPO, "tmp", "ecosystem")
+
+
+def slug(name: str) -> str:
+    return name.replace("::", "--")
+
+
+def place(name: str, index, dest: str, force: bool) -> str | None:
+    """Extract `name` under `dest` and return its distribution root."""
+    marker = os.path.join(dest, ".root")
+    if os.path.exists(marker) and not force:
+        with open(marker, encoding="utf-8") as fh:
+            root = fh.read().strip()
+        if os.path.isdir(root):
+            return root
+    url = index.url(name)
+    if url is None:
+        return None
+    eco.rmtree(dest)
+    root = eco.extract_dist(eco.fetch_tarball(url, os.path.join(eco.CACHE_DIR, "tarballs")),
+                            dest)
+    if root:
+        with open(marker, "w", encoding="utf-8") as fh:
+            fh.write(root)
+    return root
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("dist", help="distribution name, e.g. String::Utils")
+    ap.add_argument("--force", action="store_true", help="re-extract even if present")
+    ap.add_argument("--refresh-index", action="store_true")
+    ap.add_argument("--json", action="store_true", help="emit the plan as JSON")
+    args = ap.parse_args()
+
+    if os.environ.get("MUTSU_FUDGE"):
+        return err("MUTSU_FUDGE is set; it is roast-only and would drop statements. Unset it.")
+
+    index = eco.load_index(refresh=args.refresh_index)
+    name = args.dist
+    if name not in index.dists:
+        target = index.resolve_name(name)
+        if target is None:
+            return err(f"{name} is in neither the fez nor the REA index. "
+                       "Check the spelling, or pass the distribution name rather than a "
+                       "module name.")
+        print(f"note: {name} is a module provided by {target}; using that distribution",
+              file=sys.stderr)
+        name = target
+
+    resolved, unresolved = index.closure(name)
+    base = os.path.join(OUT_ROOT, slug(name))
+    root = place(name, index, os.path.join(base, "dist"), args.force)
+    if root is None:
+        return err(f"{name} has no usable tarball / META6.json in the index")
+
+    libs = [os.path.join(root, "lib")]
+    dep_roots = {}
+    for dep in resolved:
+        dep_root = place(dep, index, os.path.join(base, "deps", slug(dep)), args.force)
+        if dep_root is None:
+            unresolved.append(dep)
+            continue
+        dep_roots[dep] = dep_root
+        libs.append(os.path.join(dep_root, "lib"))
+
+    meta = eco.read_meta6(root) or {}
+    tests = [os.path.relpath(p, root) for p in eco.find_test_files(root)]
+    lib_args = " ".join(f"-I {shlex.quote(p)}" for p in libs)
+
+    if args.json:
+        print(json.dumps({"dist": name, "version": meta.get("version"), "root": root,
+                          "libs": libs, "tests": tests, "provides": sorted(meta.get("provides") or {}),
+                          "deps": resolved, "unresolved": sorted(set(unresolved)),
+                          "axis": eco.source_axis(root)}, indent=2, sort_keys=True))
+        return 0
+
+    print(f"# {name} {meta.get('version', '?')}   axis={eco.source_axis(root)}")
+    if unresolved:
+        # The sweep records this as blocked_dep and runs neither side. Here it is
+        # only a warning: a suite whose missing dependency none of its test files
+        # touch is still worth running.
+        print(f"# UNRESOLVED dependencies: {', '.join(sorted(set(unresolved)))}")
+        print("#   the sweep would call this blocked_dep; expect the files that use them to die")
+    print(f"# provides: {', '.join(sorted(meta.get('provides') or {})) or '-'}")
+    print(f"# {len(tests)} test file(s): {', '.join(tests) or '-'}")
+    print()
+    print(f"DIST={shlex.quote(root)}")
+    print(f"LIBS={shlex.quote(lib_args)}")
+    print(f"MUTSU={shlex.quote(os.environ.get('MUTSU_BIN', os.path.join(REPO, 'target', 'debug', 'mutsu')))}")
+    print(f"RAKU={shlex.quote(os.environ.get('RAKU_BIN', 'raku'))}")
+    print()
+    print('# cd "$DIST" first: suites reach for fixtures by relative path.')
+    if tests:
+        print(f'# (cd "$DIST" && timeout 120 $RAKU   $LIBS {shlex.quote(tests[0])})')
+        print(f'# (cd "$DIST" && timeout 120 $MUTSU $LIBS {shlex.quote(tests[0])})')
+    return 0
+
+
+def err(msg: str) -> int:
+    print(msg, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ than in this file; read the matching one before starting such a task. Currently:
 `cut-release` (releasing), `install-raku` (installing the Rakudo oracle when
 `raku` is missing), `roast-triage` (choosing and investigating roast work),
 `test-util-workout`, `reclaim-disk` (stale worktrees and cargo caches),
-`mutsu-ticket-flow`, and `rakuast-implementation`.
+`mutsu-ticket-flow`, `rakuast-implementation`, and `ecosystem-dist-fix`
+(taking one zef distribution's own test suite from red to green).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ before starting one of these tasks:
 | [`reclaim-disk`](.agents/skills/reclaim-disk/SKILL.md) | Disk is filling up: stale agent worktrees, `target/` caches |
 | [`mutsu-ticket-flow`](.agents/skills/mutsu-ticket-flow/SKILL.md) | Working `todo:ticket` issues end-to-end through merge |
 | [`rakuast-implementation`](.agents/skills/rakuast-implementation/SKILL.md) | A RakuAST compatibility slice (`src/rakuast/`, `t/rakuast/`) |
+| [`ecosystem-dist-fix`](.agents/skills/ecosystem-dist-fix/SKILL.md) | Making one zef distribution's own test suite pass ("make `String::Utils`'s tests pass"), or working a red/`blocked_load` `ecosystem/` record |
 
 ## Where this session is running — check before following any shell recipe
 

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -9,6 +9,11 @@ sides, and publish the difference.
   one file per distribution, the sandbox and environment contract). Read it
   before changing the method; this file is the *how*.
 - **Tracking issue**: [#7785](https://github.com/tokuhirom/mutsu/issues/7785).
+- **Acting on a record**: this file measures; taking one distribution from red
+  to green is
+  [`.agents/skills/ecosystem-dist-fix/SKILL.md`](../.agents/skills/ecosystem-dist-fix/SKILL.md),
+  which consumes §1-§3 below and adds the per-distribution debugging loop and the
+  fix-versus-file-an-issue rule.
 - **Sibling tools**: [docs/dist-compat-sweep.md](dist-compat-sweep.md) is the
   load-level (`use <module>`) diagnostic sampler that feeds root-cause tickets;
   [BATTERIES.md](../BATTERIES.md) / `scripts/battery-testsuite.sh` is the

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -71,6 +71,13 @@ Requires `bubblewrap` (the sweep runs unaudited test suites and refuses to run a
 corpus without a sandbox) and a `raku` on PATH. Full runbook:
 [docs/ecosystem-parity.md](../docs/ecosystem-parity.md) §8.
 
+## Fixing one
+
+Turning a red record green — check the distribution out, run both sides file by
+file, fix the interpreter where the gap is bounded and file an issue where it
+needs a complex feature — is the
+[`ecosystem-dist-fix`](../.agents/skills/ecosystem-dist-fix/SKILL.md) skill.
+
 ## Current state — a partial sweep, not the corpus
 
 **The corpus sweep (P2) is in progress and these records cover only part of it.**

--- a/news/2026-09/ecosystem-dist-fix-skill.md
+++ b/news/2026-09/ecosystem-dist-fix-skill.md
@@ -1,0 +1,41 @@
+# A skill for taking one zef distribution from red to green
+
+`ecosystem/` measures how mutsu does against rakudo on real zef distributions, and
+`docs/ecosystem-parity.md` says how the measurement is made — but nothing said what to *do* with a
+record that reads `red` or `blocked_load`. Acting on one was reconstructed from scratch each time:
+the sweep extracts into a temporary directory and deletes it, which is exactly right for a
+measurement and useless for the thirty-runs-and-a-rebuild loop that fixing a distribution actually
+is.
+
+`.agents/skills/ecosystem-dist-fix/` is that loop, written down. A request like "make
+`String::Utils`'s tests pass" now has one procedure: read the ledger record to learn what kind of
+job it is, check the distribution out, run every test file under rakudo *first* and mutsu second,
+reduce the failure to a few lines that live in this repo, fix the interpreter or file an issue, pin
+the fix with a `t/` test, re-measure, and land the record change alongside the fix.
+
+Two parts of it are worth calling out.
+
+**The fix-versus-issue rule is explicit.** A distribution routinely yields two bounded fixes and one
+finding that needs an ADR, `nqp::` guts, the MOP or a cross-cutting invariant. The skill makes that
+a per-finding decision rather than a per-distribution one: fix what is bounded, file the rest as
+`todo:ticket` / `todo:deep` with the reduction and both interpreters' output in the body, title it
+after the missing capability rather than the distribution, and name the issue numbers in the PR. A
+distribution that goes from `red` to `partial` with its residue filed is a successful run; a finding
+left unrecorded because it was too big to fix is the one way the loop loses work.
+
+**`checkout-dist.py` gives the loop somewhere to stand.** It resolves the same flat dependency
+closure the sweep does, extracts the distribution and every dependency under `tmp/ecosystem/`
+(gitignored, reused across runs), and prints `DIST` / `LIBS` / `MUTSU` / `RAKU` plus the test file
+list, so both sides are guaranteed to run with the same `-I` list and the same working directory —
+the fairness contract the comparison depends on. It accepts a module name and says which
+distribution provides it, warns when the closure is incomplete instead of silently under-resolving,
+and deliberately does not sandbox: a single distribution you have read is the sweep's own
+`--sandbox none` escape hatch, and a corpus is not this skill's business.
+
+The skill also records the ground rules that make a green run mean something, several of which are
+easy to violate by accident: rakudo is the denominator and gets run first, `MUTSU_FUDGE` stays
+unset, the extracted distribution is never edited into a deliverable, mutsu never learns a
+distribution's name, dependencies arrive only as `-I` paths, and bundling the module instead of
+fixing the interpreter remains banned. One drift was found while writing it and is noted where it
+would otherwise cost an hour: `docs/ecosystem-parity.md` §5 documents `--mutsu-only`,
+`--refresh-baseline` and `--json -`, which the harness does not implement.


### PR DESCRIPTION
`ecosystem/` and `docs/ecosystem-parity.md` say how mutsu is measured against rakudo on real zef distributions, but nothing said what to *do* with a record that reads `red` or `blocked_load`. The sweep extracts into a temporary directory and deletes it — right for a measurement, useless for the iterate-and-rebuild loop that fixing a distribution actually is — so acting on a record was reconstructed from scratch each time.

This adds `.agents/skills/ecosystem-dist-fix/`, so a request like "make `String::Utils`'s tests pass" has one written-down procedure.

## What is in the skill

**`SKILL.md`** — the per-distribution loop: read the ledger record to learn what kind of job it is, check the distribution out, run every test file under rakudo *first* and mutsu second, reduce the failure to something that lives in this repo, decide fix-versus-issue per finding, pin the fix with a `t/` test, re-measure, and land the record change alongside the fix.

Two things are stated outright at the top, because this loop spends its time inside third-party repositories and that is where they are easiest to get wrong:

- **The goal is to fix mutsu.** The distribution is a test subject, not a client. A suite made green by patching the distribution, working around its idiom, teaching mutsu the module's name, or bundling the module has moved the failure rather than fixed it.
- **Every PR and every issue goes to `tokuhirom/mutsu` and nowhere else** — not the distribution's repository, not a dependency's, and above all not a Raku-org one, however clearly the bug looks like theirs. A finding that genuinely belongs upstream is recorded as a mutsu issue and stopped there.

The rest of the ground rules are the ones that make a green run mean something: rakudo is the denominator and gets run first, `MUTSU_FUDGE` stays unset, the extracted distribution is never edited into a deliverable, mutsu never learns a distribution's name, dependencies arrive only as `-I` paths, and bundling instead of fixing stays banned.

**The fix-versus-issue rule is the point of the skill**, and it is a per-finding decision rather than a per-distribution one — a distribution routinely yields two bounded fixes and one finding that needs an ADR, `nqp::` guts, the MOP, or a cross-cutting invariant. Fix what is bounded; file the rest as `todo:ticket` / `todo:deep` with the reduction and both interpreters' output in the body, titled after the missing capability rather than the distribution, so the next distribution to hit it finds the issue. A distribution that goes from `red` to `partial` with its residue filed is a successful run; a finding left unrecorded because it was too big to fix is the one way the loop loses work.

**`checkout-dist.py`** — resolves the same flat dependency closure the sweep does, extracts the distribution and every dependency under `tmp/ecosystem/` (gitignored, reused across runs), and prints `DIST` / `LIBS` / `MUTSU` / `RAKU` plus the test file list, so both sides are guaranteed to run with the same `-I` list and the same working directory. It accepts a module name and reports which distribution provides it, warns on an incomplete closure instead of under-resolving silently, and deliberately does not sandbox — a single distribution you have read is the sweep's own `--sandbox none` escape hatch, and a corpus is not this skill's business.

## Also here

- Registered in `CLAUDE.md`'s and `AGENTS.md`'s skill lists, and pointed at from `ecosystem/README.md` and `docs/ecosystem-parity.md`.
- `news/2026-09/ecosystem-dist-fix-skill.md`.
- One drift found while verifying the recipes and noted where it would otherwise cost an hour: `docs/ecosystem-parity.md` §5 documents `--mutsu-only`, `--refresh-baseline` and `--json -`, which the harness does not implement.

## Verification

The recipes were run, not just written:

- **String::Utils** — reproduces the recorded `blocked_load` and gives the concrete cause the record does not (`Unsupported nqp:: op: nqp::unipropcode`, i.e. the skill's issue-filing case rather than its fix case).
- **Trie** — a one-dependency closure (`OrderedHash`), both `-I` paths correct; its `t/01-basic.rakutest` passes under rakudo with the generated command line.
- **JSON::Fast** — 14 test files enumerated.
- Module-name resolution (`X::Trie::MultipleValues` → `Trie`) and the unknown-name error path.

No `src/`, `t/`, `Makefile` or `scripts/` change, and nothing in the diff is executed by either suite, so `make test` / `make roast` were not run locally — CI runs both in full on this PR (`.agents/**` is deliberately outside `scripts/ci-docs-only.sh`'s allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pjz7KrxpkCarqUMgej9GED

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pjz7KrxpkCarqUMgej9GED)_