### PR TITLE
fix: preserve enum export tags

### DIFF
--- a/news/2026-09/enum-export-tag.md
+++ b/news/2026-09/enum-export-tag.md
@@ -1,0 +1,2 @@
+`is export(:TAG)` now preserves named export tags on enum declarations, so
+their values can be imported by tag like exported routines.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1362,6 +1362,9 @@ pub(crate) enum Stmt {
         name: Symbol,
         variants: Vec<(String, Option<Expr>)>,
         is_export: bool,
+        /// Export tags declared by `is export`, or empty for an untagged enum.
+        #[serde(default)]
+        export_tags: Vec<String>,
         /// Whether declared with an explicit `my` scope (lexical). A `my enum`
         /// is private to its enclosing scope and, unlike a default our-scoped
         /// enum, is allowed inside a role body.

--- a/src/parser/stmt/decl/enum_decl.rs
+++ b/src/parser/stmt/decl/enum_decl.rs
@@ -2,6 +2,7 @@ use super::super::super::expr::expression;
 use super::super::super::helpers::{skip_balanced_parens, ws, ws1};
 use super::super::super::parse_result::{PError, PResult, parse_char, take_while1};
 use super::super::{ident, keyword, qualified_ident};
+use super::helpers::{has_export_tag_argument, parse_export_trait_tags};
 use super::take_while_opt;
 use crate::ast::{Expr, Stmt};
 use crate::symbol::Symbol;
@@ -111,6 +112,7 @@ fn parse_anon_enum_body(input: &str) -> PResult<'_, Stmt> {
             name: Symbol::intern(""),
             variants,
             is_export: false,
+            export_tags: Vec::new(),
             is_my: false,
             base_type: None,
             roles: Vec::new(),
@@ -301,6 +303,7 @@ pub(super) fn parse_enum_decl_body_with_type(
     // ended up with no values at all.
     let mut rest = rest;
     let mut is_export = false;
+    let mut export_tags: Vec<String> = Vec::new();
     let mut roles: Vec<String> = Vec::new();
     loop {
         if let Some(r) = keyword("is", rest) {
@@ -308,12 +311,28 @@ pub(super) fn parse_enum_decl_body_with_type(
             let (r, trait_name) = ident(r)?;
             if trait_name == "export" {
                 is_export = true;
+                let (r, tags) = if has_export_tag_argument(r) {
+                    parse_export_trait_tags(r)?
+                } else {
+                    (r, Vec::new())
+                };
+                if tags.is_empty() {
+                    if !export_tags.iter().any(|t| t == "DEFAULT") {
+                        export_tags.push("DEFAULT".to_string());
+                    }
+                } else {
+                    for tag in tags {
+                        if !export_tags.iter().any(|t| t == &tag) {
+                            export_tags.push(tag);
+                        }
+                    }
+                }
+                let (r, _) = ws(r)?;
+                rest = r;
+                continue;
             }
-            // Consume an optional parenthesized trait argument, e.g.
-            // `is export(:traits)` — without this, the variant parser mistakes
-            // the `(:traits)` for the enum's `(...)` body and the real
-            // `<values>` list after it is left dangling.
-            let r = super::super::super::helpers::skip_balanced_parens(r);
+            // Consume an optional parenthesized argument for other traits.
+            let r = skip_balanced_parens(r);
             let (r, _) = ws(r)?;
             rest = r;
             continue;
@@ -384,6 +403,7 @@ pub(super) fn parse_enum_decl_body_with_type(
                         name,
                         variants: vec![("__DYNAMIC__".to_string(), Some(body))],
                         is_export,
+                        export_tags,
                         is_my,
                         base_type: base_type.clone(),
                         roles,
@@ -406,6 +426,7 @@ pub(super) fn parse_enum_decl_body_with_type(
             name,
             variants,
             is_export,
+            export_tags,
             is_my,
             base_type,
             roles,

--- a/src/parser/stmt/decl/helpers.rs
+++ b/src/parser/stmt/decl/helpers.rs
@@ -97,6 +97,22 @@ pub(super) fn parse_export_trait_tags(input: &str) -> PResult<'_, Vec<String>> {
     Ok((rest, tags))
 }
 
+/// Return whether the optional parenthesized argument after `is export` is a
+/// tag list rather than a declaration body. Enum pair-list bodies use the same
+/// parentheses, so `is export (A => 1)` must be left for the enum parser.
+pub(super) fn has_export_tag_argument(input: &str) -> bool {
+    let Ok((rest, _)) = ws(input) else {
+        return false;
+    };
+    let Some(inner) = rest.strip_prefix('(') else {
+        return false;
+    };
+    inner
+        .chars()
+        .find(|c| !c.is_whitespace() && *c != ',')
+        .is_some_and(|c| c == ':')
+}
+
 pub(super) fn parse_sigilless_decl_name(input: &str) -> PResult<'_, String> {
     super::super::parse_sub_name_pub(input)
 }

--- a/src/parser/stmt/decl/helpers.rs
+++ b/src/parser/stmt/decl/helpers.rs
@@ -99,18 +99,30 @@ pub(super) fn parse_export_trait_tags(input: &str) -> PResult<'_, Vec<String>> {
 
 /// Return whether the optional parenthesized argument after `is export` is a
 /// tag list rather than a declaration body. Enum pair-list bodies use the same
-/// parentheses, so `is export (A => 1)` must be left for the enum parser.
+/// parentheses, so `is export (A => 1)` and `is export (:A(1))` must be left
+/// for the enum parser.
 pub(super) fn has_export_tag_argument(input: &str) -> bool {
     let Ok((rest, _)) = ws(input) else {
         return false;
     };
-    let Some(inner) = rest.strip_prefix('(') else {
+    let Some(mut inner) = rest.strip_prefix('(') else {
         return false;
     };
-    inner
-        .chars()
-        .find(|c| !c.is_whitespace() && *c != ',')
-        .is_some_and(|c| c == ':')
+    inner = inner.trim_start_matches(|c: char| c.is_whitespace() || c == ',');
+    let Some(after_colon) = inner.strip_prefix(':') else {
+        return false;
+    };
+    let after_colon = after_colon.strip_prefix('!').unwrap_or(after_colon);
+    let name_len = after_colon
+        .char_indices()
+        .take_while(|(_, c)| c.is_alphanumeric() || *c == '_' || *c == '-')
+        .last()
+        .map_or(0, |(i, c)| i + c.len_utf8());
+    if name_len == 0 {
+        return false;
+    }
+    let after_name = after_colon[name_len..].trim_start();
+    !after_name.starts_with('(') && !after_name.starts_with("=>")
 }
 
 pub(super) fn parse_sigilless_decl_name(input: &str) -> PResult<'_, String> {

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -2014,6 +2014,7 @@ impl Interpreter {
         name: &str,
         variants: &[(String, Option<Expr>)],
         is_export: bool,
+        export_tags: &[String],
         base_type: Option<&str>,
         roles: &[String],
     ) -> Result<Value, RuntimeError> {
@@ -2195,7 +2196,7 @@ impl Interpreter {
         if is_export && !is_anonymous {
             let pkg = self.current_package();
             for (key, _) in &enum_variants {
-                self.register_exported_var(pkg.clone(), key.clone(), vec!["DEFAULT".to_string()]);
+                self.register_exported_var(pkg.clone(), key.clone(), export_tags.to_vec());
             }
         }
 

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -67,6 +67,7 @@ impl Interpreter {
             name,
             variants,
             is_export,
+            export_tags,
             is_my,
             base_type,
             roles,
@@ -82,6 +83,7 @@ impl Interpreter {
                     &name.resolve(),
                     variants,
                     *is_export,
+                    export_tags,
                     base_type.as_deref(),
                     roles,
                 )

--- a/t/lib/EnumTaggedExportFixture.rakumod
+++ b/t/lib/EnumTaggedExportFixture.rakumod
@@ -1,0 +1,6 @@
+unit module EnumTaggedExportFixture;
+
+sub tagged-control is export(:SubTag) { 'sub' }
+our enum Plain is export(:PlainTag) <A B>;
+enum Bare is export(:BareTag) <C D>;
+our Str enum Typed is export(:TypedTag) «:E<e> :F<f>»;

--- a/t/modules/import-export/enum-export-tag.t
+++ b/t/modules/import-export/enum-export-tag.t
@@ -1,0 +1,24 @@
+use lib 't/lib';
+use Test;
+
+# `is export(:TAG)` on an enum must register every enum value under the named
+# tag, just like the same trait on a sub. Pin the three declaration forms from
+# the issue and keep the exported sub as the control case.
+use EnumTaggedExportFixture :PlainTag;
+import EnumTaggedExportFixture :BareTag;
+import EnumTaggedExportFixture :TypedTag;
+import EnumTaggedExportFixture :SubTag;
+
+enum PairBody is export (PAIR_FOUND => 100, PAIR_GONE => 410);
+
+plan 9;
+
+is tagged-control(), 'sub', 'a tagged sub remains importable';
+is A.key, 'A', 'an `our` enum value imports through its named tag';
+is B.key, 'B', 'the second `our` enum value imports through its named tag';
+is C.key, 'C', 'a bare enum value imports through its named tag';
+is D.key, 'D', 'the second bare enum value imports through its named tag';
+is E.value, 'e', 'a typed enum value imports through its named tag';
+is F.value, 'f', 'the second typed enum value imports through its named tag';
+is PAIR_FOUND.value, 100, 'an exported pair-list enum keeps its declaration body';
+is PAIR_GONE.value, 410, 'the second exported pair-list enum value is preserved';

--- a/t/modules/import-export/enum-export-tag.t
+++ b/t/modules/import-export/enum-export-tag.t
@@ -10,8 +10,9 @@ import EnumTaggedExportFixture :TypedTag;
 import EnumTaggedExportFixture :SubTag;
 
 enum PairBody is export (PAIR_FOUND => 100, PAIR_GONE => 410);
+enum ColonPairBody is export (:COLON_FOUND(200), :COLON_GONE(420));
 
-plan 9;
+plan 11;
 
 is tagged-control(), 'sub', 'a tagged sub remains importable';
 is A.key, 'A', 'an `our` enum value imports through its named tag';
@@ -22,3 +23,5 @@ is E.value, 'e', 'a typed enum value imports through its named tag';
 is F.value, 'f', 'the second typed enum value imports through its named tag';
 is PAIR_FOUND.value, 100, 'an exported pair-list enum keeps its declaration body';
 is PAIR_GONE.value, 410, 'the second exported pair-list enum value is preserved';
+is COLON_FOUND.value, 200, 'a colon-pair enum body remains intact';
+is COLON_GONE.value, 420, 'the second colon-pair enum value is preserved';


### PR DESCRIPTION
## Summary

- Preserve named export tags on enum declarations.
- Keep bare `is export` enums on the `DEFAULT` export tag.
- Avoid treating an exported pair-list enum body as a trait argument.
- Add regression coverage for the three enum forms and an exported sub control.

Closes #7866

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
