### PR TITLE
perf: stop multi dispatch at the first candidate that binds

### DIFF
--- a/news/2026-09/multi-dispatch-narrowest-first-where.md
+++ b/news/2026-09/multi-dispatch-narrowest-first-where.md
@@ -1,0 +1,99 @@
+# Multi dispatch stops at the first candidate that binds
+
+`Config::TOML` v0.1.3's `t/special-cases/03-txn.rakutest` parses a single
+350-line TOML ledger. It produced the right answer but took **69.8s** where
+`raku` took 2.0s on the same box ([#7858](https://github.com/tokuhirom/mutsu/issues/7858)).
+It now takes **16.9s** — 4.1x faster — and the dist's whole suite went from 91s
+to 31s with an identical pass/fail set.
+
+## What was slow
+
+The issue named three suspects; measurement ruled out two of them straight
+away. Timing `Config::TOML::Parser::Grammar.parse` with **no** `:actions`
+showed the grammar is linear and cheap (0.58s for the four-entry input, the
+whole of which takes 26s with actions), and truncating the input to 1..7
+ledger entries produced a **linear** curve, not the quadratic one a
+document-copying `Crane.set` would give. What was left was a large constant
+factor per keypair, and a `Crane.exists` microbenchmark isolated it: 200 calls
+cost mutsu 2.09s against rakudo's 0.008s.
+
+`Crane`'s API is built out of `where`-constrained protos — `in` has 17
+candidates, `exists-key` 7, and their constraints recurse back into `Crane`
+(`@path where { .elems > 1 and exists-key($container, [@path[0]]) }`). A
+callgrind run put `choose_best_matching_candidate` at 64% of the whole program,
+which is the shape the issue predicted.
+
+## Three fixes, in the order they matter
+
+**Dispatch walks narrowest-first and stops.** `choose_best_matching_candidate`
+used to bind-test *every* candidate and only then rank the ones that matched.
+But `candidate_rank_key` reads nothing but the declared signature and the
+argument types — it never runs user code, and in particular never evaluates a
+`where` clause (it only counts how many params carry one). So the whole
+candidate list can be ordered up front, and the bind attempts can stop as soon
+as the remaining candidates are strictly wider than the best match: a wider
+candidate can neither win nor join the tie set that decides
+`X::Multi::Ambiguous`, so testing it cannot change the answer. Raku dispatches
+this way too, and the difference is observable, because a `where` clause is
+user code:
+
+```raku
+my @log;
+multi sub f(Int:D $x where { @log.push('int'); True }) { 'int' }
+multi sub f($x       where { @log.push('any'); True }) { 'any' }
+f(1);   # rakudo: @log is ['int']. mutsu used to run 'any' too.
+```
+
+A wider candidate whose `where` *dies* is likewise never reached now, which is
+what rakudo does and what the `where`-throws rule in
+[#7539](https://github.com/tokuhirom/mutsu/issues/7539) was approximating by
+comparing ranks after the fact. Because the scan breaks at the first strictly
+wider candidate, every collected match ties with `matches[0]` on all five
+narrowness components by construction — so the post-scan re-sort and the `tied`
+re-filter, which recomputed `candidate_specificity_rank_for_args` and
+`candidate_type_distance` per match, are gone too.
+
+**Candidates are deduplicated before they are tested, not after.** One `multi`
+is registered under several registry keys (the arity key `Pkg::f/1`, the typed
+key `Pkg::f/1:Int`, the `__m<n>` multi suffixes) and the gathers collect by key,
+so the same `Arc<FunctionDef>` arrived two or three times over. The `seen`
+fingerprint filter ran *after* matching, so each copy's `where` clause was
+actually run. Moving the filter ahead of the bind test cut a two-candidate
+`multi`'s constraint evaluations from 10 per call to 4.
+
+**The bind snapshot no longer copies the whole env.** `args_match_param_types_inner`
+cloned the flat env and wrote the parameter bindings into it, which
+`make_mut`-deep-copied every entry on the first write; the rollback
+(`restore_env_preserving_dynamics`) then walked every entry again looking for
+dynamic-variable writes, resolving each key to a `&str` through a thread-local
+to test its sigils. Binding into a `Env::scoped_child` overlay instead — the
+same treatment `method_args_match_for_invocant` already had — makes the bind
+O(binds) and leaves the rollback walking only what the match wrote, and the
+dynamic-name test now reads the memoized `DYNAMIC_VAR_ENV_KEY` symbol flag.
+That flag mirrors `is_dynamic_var_env_key`, which trims *every* sigil before
+looking for the `*` twigil, so `@*x` / `%*x` / `&*x` writes from a `where`
+clause now survive the rollback alongside `$*x`; the older hand-rolled test
+(`*` or `$*` prefix) simply missed them.
+
+## Measured
+
+Release builds, same box, `main` at 69bedb4 against the branch:
+
+| | main | after | raku |
+| --- | --- | --- | --- |
+| `Crane.exists` x200 | 2.093s | 0.408s | 0.008s |
+| `Crane.set` x200 | 1.737s | 0.405s | 0.035s |
+| `03-txn.rakutest` | 69.8s | 16.9s | 2.0s |
+| whole `Config-TOML` suite | 91s | 31s | — |
+
+## What is still slow
+
+The gap to rakudo on that file is now ~8x rather than ~35x, and the profile has
+moved off dispatch. Two findings from the same callgrind run are filed
+separately rather than stretched into this change: `dispatch_func_call_inner`
+resolves the same call **three** times (`find_compiled_function_memo`, then
+`resolve_function_multi_cached`, then `push_multi_dispatch_frame`), which is
+why a `where` constraint still runs 4x per call where rakudo runs it once; and
+`eval_block_value_inner` clones the entire registry `functions` map on every
+block evaluation to be able to restore it, even though the restore itself is
+already skipped when `registry_write_gen` says nothing was declared.

--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -104,14 +104,77 @@ impl Interpreter {
             .then(a.5.cmp(&b.5))
     }
 
+    /// `key` with its declaration-order component cleared, so two candidates
+    /// that are equally narrow compare `Equal` instead of by declaration
+    /// stamp. This is the comparison that decides *ties* — which candidates
+    /// join the `X::Multi::Ambiguous` set, and where the narrowest-first scan
+    /// in [`Interpreter::choose_best_matching_candidate`] may stop — as
+    /// opposed to `candidate_rank_cmp` on the full key, which is the total
+    /// order the winner is picked by.
+    fn rank_key_ignoring_decl_order(mut key: CandidateRankKey) -> CandidateRankKey {
+        key.5 = 0;
+        key
+    }
+
     pub(super) fn choose_best_matching_candidate(
         &mut self,
         name: &str,
         args: &[Value],
         candidates: Vec<(String, Arc<FunctionDef>)>,
     ) -> Option<Arc<FunctionDef>> {
-        let mut matches = Vec::new();
-        let mut seen = std::collections::HashSet::new();
+        // Rank every candidate BEFORE trying to bind any of them.
+        //
+        // [`Self::candidate_rank_key`] reads only the declared signature and
+        // the argument *types* — it never runs user code, and in particular
+        // never evaluates a `where` clause (it merely counts how many params
+        // carry one). So the whole candidate list can be put in
+        // narrowest-first order up front, and the bind attempts below can then
+        // stop as soon as the remaining candidates are strictly wider than the
+        // best match found so far: a wider candidate can neither win nor join
+        // the tie set that decides `X::Multi::Ambiguous`, so testing it cannot
+        // change the answer.
+        //
+        // Raku dispatches this way too — narrowest-first, stopping at the
+        // first candidate that binds — and the difference matters because a
+        // bind attempt is not cheap here: every `where` clause is a compiled
+        // block run against a snapshot of the env. `Crane`'s protos are the
+        // pathological case, with 17 (`in`) and 7 (`exists-key`) candidates
+        // whose `where` clauses recurse back into `Crane`; running all of them
+        // on every call is what made `Config::TOML` 12x slower than rakudo
+        // ([#7858](https://github.com/tokuhirom/mutsu/issues/7858)).
+        //
+        // The sort is stable, so candidates the caller already ordered by
+        // `sort_candidates_by_specificity` keep that order within a rank group
+        // — which is what makes the final "first declared wins" tie-break come
+        // out the same as it did when every candidate was tried.
+        let mut ranked: Vec<(CandidateRankKey, Arc<FunctionDef>)> =
+            Vec::with_capacity(candidates.len());
+        for (_, def) in candidates {
+            let key = self.candidate_rank_key(&def, args);
+            ranked.push((key, def));
+        }
+        ranked.sort_by(|a, b| Self::candidate_rank_cmp(a.0, b.0));
+        // One `multi` is registered under SEVERAL registry keys — the arity key
+        // `Pkg::f/1`, the typed key `Pkg::f/1:Int`, the `__m<n>` multi suffixes
+        // — and the gathers above collect by key, so the same `Arc<FunctionDef>`
+        // arrives two or three times over. Dropping the repeats here, rather
+        // than after matching (where the `seen` set below used to be the only
+        // filter), is what stops one candidate's `where` clause from being RUN
+        // once per key it happens to be registered under: `multi f(Int:D $x
+        // where {...})` evaluated its constraint 3x per resolution before this.
+        // Identical fingerprints mean identical `params`/`param_defs`/`body`, so
+        // the dropped copies would have matched and ranked exactly the same;
+        // the sort above is stable, so the survivor is the one that already won
+        // the caller's declaration-order tie-break.
+        {
+            let mut seen_keys = std::collections::HashSet::new();
+            ranked.retain(|(_, def)| seen_keys.insert(def.body_fingerprint()));
+        }
+
+        let mut matches: Vec<Arc<FunctionDef>> = Vec::new();
+        // The rank key of `matches[0]`, i.e. of the narrowest candidate that
+        // actually bound. `None` until the first match.
+        let mut best_key: Option<CandidateRankKey> = None;
         // The first candidate whose `where` constraint THREW, together with
         // the exception. Raku walks the candidates narrowest-first and stops at
         // the first that binds, so such an exception escapes only when that
@@ -123,7 +186,17 @@ impl Interpreter {
         // earlier in the same instruction, say) must not be mistaken for one of
         // these candidates': park it and put it back below.
         let outer_where_exception = self.pending_where_exception.take();
-        for (_, def) in candidates {
+        for (key, def) in ranked {
+            // Strictly wider than the narrowest candidate that already bound:
+            // every candidate from here on is too, since the list is sorted.
+            if let Some(best) = best_key
+                && Self::candidate_rank_cmp(
+                    Self::rank_key_ignoring_decl_order(key),
+                    Self::rank_key_ignoring_decl_order(best),
+                ) == std::cmp::Ordering::Greater
+            {
+                break;
+            }
             // For auto-param subs ($^a, $^b) with empty param_defs but
             // non-empty params, check arity against params.len() since
             // args_match_param_types cannot handle this case.
@@ -150,10 +223,10 @@ impl Interpreter {
                 continue;
             }
             if type_ok {
-                let fingerprint = def.body_fingerprint();
-                if !seen.insert(fingerprint) {
-                    continue;
-                }
+                // No fingerprint filter here: `ranked` is already unique by
+                // fingerprint (see the `retain` above), so every match is a
+                // distinct declaration.
+                best_key.get_or_insert(key);
                 matches.push(def);
             }
         }
@@ -200,42 +273,19 @@ impl Interpreter {
             return matches.into_iter().next();
         }
 
-        // Sort matches by specificity rank (primary, DESC), type hierarchy
-        // distance (secondary, ASC), whether the candidate declares any named
-        // parameter at all (DESC), then fewer optional positionals, then
-        // required named count (DESC), then declaration order — so that subset
-        // types win over plain types, more specific types (e.g. Str:D) beat
-        // less specific ones (e.g. Any), and among equally-specific candidates,
-        // those with required named params win.
-        {
-            let mut ranked: Vec<(usize, _)> = matches
-                .iter()
-                .enumerate()
-                .map(|(i, def)| (i, self.candidate_rank_key(def, args)))
-                .collect();
-            ranked.sort_by(|a, b| Self::candidate_rank_cmp(a.1, b.1));
-            let sorted_matches: Vec<Arc<FunctionDef>> =
-                ranked.iter().map(|(i, _)| matches[*i].clone()).collect();
-            matches = sorted_matches;
-        }
-
-        let best_rank = self.candidate_specificity_rank_for_args(&matches[0], args);
+        // `matches` is ALREADY in narrowest-first order — the scan walked the
+        // pre-ranked list and broke at the first candidate strictly wider than
+        // `matches[0]`. So `matches[0]` is the winner, and every entry ties
+        // with it on all five narrowness components (specificity rank, type
+        // distance, declares-a-named, optional-positional count, required-named
+        // count) by construction: the loop's break condition is exactly "that
+        // five-component key compares Greater". The separate re-sort and the
+        // `tied` re-filter this used to do — both of which recomputed
+        // `candidate_specificity_rank_for_args` and `candidate_type_distance`
+        // per match — are therefore redundant.
         let best_shape = self.candidate_dispatch_shape(&matches[0]);
-        let best_distance = self.candidate_type_distance(args, &matches[0]);
         let best_has_named = Self::candidate_declares_named(&matches[0]);
-        let best_opt = Self::candidate_optional_positional_count(&matches[0]);
-        let best_req_named = Self::candidate_required_named_count(&matches[0]);
-        let tied: Vec<Arc<FunctionDef>> = matches
-            .iter()
-            .filter(|def| {
-                self.candidate_specificity_rank_for_args(def, args) == best_rank
-                    && self.candidate_type_distance(args, def) == best_distance
-                    && Self::candidate_declares_named(def) == best_has_named
-                    && Self::candidate_optional_positional_count(def) == best_opt
-                    && Self::candidate_required_named_count(def) == best_req_named
-            })
-            .cloned()
-            .collect();
+        let tied: Vec<Arc<FunctionDef>> = matches.clone();
         // Compare dispatch shapes as sorted multisets so that candidates with
         // the same set of typed parameters in a different order are still
         // detected as tied (e.g. `foo(S $a, T $b)` vs `foo(T $a, S $b)`).

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -132,14 +132,29 @@ impl Interpreter {
     /// (`$*name`) writes made since — the observable side effects of user code
     /// (e.g. a `where` clause) run during a speculative dispatch match whose
     /// bindings are otherwise rolled back.
+    ///
+    /// The dynamic-name test reads the symbol's memoized
+    /// [`crate::symbol::flags::DYNAMIC_VAR_ENV_KEY`] bit rather than resolving
+    /// each key to a `&str` and rescanning its sigils. This scan runs over
+    /// every env key TWICE per multi candidate whose signature carries a
+    /// `where` clause (once for the clause, once for the signature match), so
+    /// the per-key thread-local round trip `with_str` costs dominated a
+    /// `where`-heavy dispatch: a callgrind run of `Crane.exists` (17 candidates,
+    /// every one `where`-constrained) put this function at 25.8% of the whole
+    /// program with `LocalKey::with` as its top leaf
+    /// ([#7858](https://github.com/tokuhirom/mutsu/issues/7858)). The memoized
+    /// bit answers it with one relaxed atomic load.
+    ///
+    /// The bit mirrors [`crate::env::is_dynamic_var_env_key`], which trims
+    /// *every* sigil before looking for the `*` twigil — so `@*x` / `%*x` /
+    /// `&*x` writes now survive the rollback alongside `$*x` and the sigil-less
+    /// `*x`. They are dynamic variables in Raku too; the older hand-rolled test
+    /// (`*` or `$*` prefix) simply missed them.
     pub(crate) fn restore_env_preserving_dynamics(&mut self, saved: crate::env::Env) {
         let dyn_writes: Vec<(crate::symbol::Symbol, Value)> = self
             .env
             .iter()
-            .filter(|(k, v)| {
-                k.with_str(|name| name.starts_with('*') || name.starts_with("$*"))
-                    && saved.get_sym(**k) != Some(*v)
-            })
+            .filter(|(k, v)| k.is_dynamic_var_env_key() && saved.get_sym(**k) != Some(*v))
             .map(|(k, v)| (*k, v.clone()))
             .collect();
         self.env = saved;

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -150,6 +150,24 @@ impl Interpreter {
                 || pd.outer_sub_signature.is_some()
                 || pd.code_signature.is_some()
         });
+        // When binds DO happen, do them in a *scoped child* overlay rather than
+        // in the flat env. Both costs the flat env charges are proportional to
+        // the whole env: the first `insert` `make_mut`-deep-copies every entry,
+        // and the rollback below (`restore_env_preserving_dynamics`) then walks
+        // every entry again looking for dynamic-variable writes. A child overlay
+        // starts empty and shares the parent by `Arc`, so the bind is O(binds)
+        // and the rollback walks only what this match actually wrote — and the
+        // per-`where`-clause snapshot/restore pairs nested inside inherit the
+        // same small overlay for free.
+        //
+        // This is the shape a `where`-constrained multi pays for on EVERY
+        // candidate: `Crane`'s 17-candidate `in()` / 7-candidate `exists-key()`
+        // protos re-ran both O(env) scans per candidate per call, which is what
+        // made `Config::TOML` 12x slower than rakudo
+        // ([#7858](https://github.com/tokuhirom/mutsu/issues/7858)).
+        if needs_outer_bind {
+            self.env = crate::env::Env::scoped_child(saved_env.clone());
+        }
         let result = (|| {
             // A slurpy hash (`*%o`) collects *named* arguments, so it is neither
             // a positional parameter nor a positional variadic: `sub f(Str $a,

--- a/t/routines/dispatch/multi-where-narrowest-first.t
+++ b/t/routines/dispatch/multi-where-narrowest-first.t
@@ -1,0 +1,45 @@
+use Test;
+
+# A `where` constraint is USER CODE, so when it runs is observable. Raku walks
+# the candidates narrowest-first and stops at the first one that binds, which
+# means a wider candidate's `where` never runs once a narrower one has matched.
+# mutsu used to evaluate every candidate's constraint before ranking them,
+# which both ran side effects raku never runs and made a `where`-heavy proto
+# (Crane's 17-candidate `in`) cost a full constraint evaluation per candidate
+# per call -- issue #7858.
+#
+# Every expectation below was verified against rakudo v2026.07.
+
+plan 6;
+
+# --- the narrower candidate binds: the wider one's `where` must not run ------
+
+my @log;
+multi sub f(Int:D $x where { @log.push('int'); True }) { 'int' }
+multi sub f($x       where { @log.push('any'); True }) { 'any' }
+
+is f(1), 'int', 'narrowest candidate wins';
+is @log.grep('any').elems, 0,
+   "a wider candidate's where does not run once a narrower one binds";
+
+# --- the narrower candidate REJECTS: the wider one must still be reached -----
+
+my @log2;
+multi sub g(Int:D $x where { @log2.push('int'); False }) { 'int' }
+multi sub g($x       where { @log2.push('any'); True })  { 'any' }
+
+is g(1), 'any', 'a rejecting narrow candidate falls through to the wider one';
+ok @log2.grep('any').elems > 0,
+   "the wider candidate's where IS reached when the narrow one rejects";
+
+# --- a `where` that dies is only reached if raku would have reached it -------
+
+multi sub h(Int:D $x)                { 'int' }
+multi sub h($x where { die 'boom' }) { 'any' }
+
+is h(1), 'int',
+   'a wider candidate whose where dies is never reached past a narrower match';
+
+# The same constraint on the only applicable candidate still propagates.
+multi sub i(Int:D $x where { die 'boom' }) { 'int' }
+dies-ok { i(1) }, 'a where that dies on the reached candidate still throws';


### PR DESCRIPTION
`Config::TOML`'s `t/special-cases/03-txn.rakutest` parses a 350-line TOML ledger in **69.8s** where `raku` takes **2.0s** on the same box (#7858). It now takes **16.9s**, and the dist's whole suite went from 91s to 31s with an identical pass/fail set.

## Ruling out the other two suspects first

The issue named three. Timing `Config::TOML::Parser::Grammar.parse` with **no** `:actions` showed the grammar is linear and cheap (0.58s for the four-entry input, the whole of which takes 26s with actions), and truncating the input to 1..7 ledger entries produced a **linear** curve, not the quadratic one a document-copying `Crane.set` would give. What was left was a large constant factor per keypair, and a `Crane.exists` microbenchmark isolated it: 200 calls cost mutsu 2.09s against rakudo's 0.008s. A callgrind run then put `choose_best_matching_candidate` at 64% of the whole program — the shape suspect 1 predicted.

## Changes

**Rank the candidates before binding any of them, then stop.** `candidate_rank_key` reads only the declared signature and the argument types — it never runs user code, and in particular never evaluates a `where` clause (it only counts how many params carry one). So the whole list can be put in narrowest-first order up front, and the bind attempts can break at the first candidate strictly wider than the best match: a wider candidate can neither win nor join the tie set that decides `X::Multi::Ambiguous`. Raku dispatches this way too, and the difference is observable because a `where` clause is user code:

```raku
my @log;
multi sub f(Int:D $x where { @log.push('int'); True }) { 'int' }
multi sub f($x       where { @log.push('any'); True }) { 'any' }
f(1);   # rakudo: @log is ['int']. mutsu used to run 'any' too.
```

A wider candidate whose `where` *dies* is likewise no longer reached, which is what rakudo does and what the `where`-throws rule in #7539 was approximating by comparing ranks after the fact. Because the scan breaks at the first strictly wider candidate, every collected match ties with `matches[0]` on all five narrowness components by construction — so the post-scan re-sort and the `tied` re-filter, which recomputed `candidate_specificity_rank_for_args` and `candidate_type_distance` per match, are gone too.

**Deduplicate candidates before the bind test, not after.** One `multi` is registered under several registry keys (the arity key `Pkg::f/1`, the typed key `Pkg::f/1:Int`, the `__m<n>` suffixes) and the gathers collect by key, so the same `Arc<FunctionDef>` arrived two or three times over. The `seen` fingerprint filter ran *after* matching, so each copy's `where` clause was actually run. A two-candidate `multi` went from 10 constraint evaluations per call to 4.

**The bind snapshot no longer copies the whole env.** `args_match_param_types_inner` cloned the flat env and wrote the bindings into it, which `make_mut`-deep-copied every entry on the first write; the rollback then walked every entry again looking for dynamic-variable writes, resolving each key to a `&str` through a thread-local to test its sigils. Binding into an `Env::scoped_child` overlay — the treatment `method_args_match_for_invocant` already had — makes the bind O(binds) and leaves the rollback walking only what the match wrote, and the dynamic-name test now reads the memoized `DYNAMIC_VAR_ENV_KEY` symbol flag. That flag mirrors `is_dynamic_var_env_key`, which trims *every* sigil, so `@*x` / `%*x` / `&*x` writes from a `where` clause now survive the rollback alongside `$*x`; the older hand-rolled test (`*` or `$*` prefix) simply missed them.

## Measured

Release builds, same box, `main` at 69bedb4 against this branch:

| | main | after | raku |
| --- | --- | --- | --- |
| `Crane.exists` x200 | 2.093s | 0.408s | 0.008s |
| `Crane.set` x200 | 1.737s | 0.405s | 0.035s |
| `03-txn.rakutest` | 69.8s | 16.9s | 2.0s |
| whole `Config-TOML` suite | 91s | 31s | — |

(The issue quotes 58.4s vs 4.9s from the maintainer's box; this container is slower for mutsu and faster for raku, hence the different absolute numbers. The ratio moves from ~35x to ~8.5x here.)

## Verification

- New pin `t/routines/dispatch/multi-where-narrowest-first.t`: 6 assertions on when a `where` clause runs during dispatch. Every expectation was checked against rakudo v2026.07 first; the file passes under `raku`, fails on `main`, passes on this branch.
- Narrowness/ambiguity edge cases (`X::Multi::Ambiguous` on a genuine tie, subset-beats-plain, `is default` tie-break, named-parameter first-binds-wins) re-checked against rakudo and unchanged.
- `callsame`/`nextcallee` are unaffected — `resolve_all_matching_candidates` is a separate walk and still collects every matching candidate.
- `make lint` clean.
- `prove -r t/` on the release binary: 3964 files, 42155 tests, PASS.
- `make roast`: 1436 files, 218939 tests. The only failures are the three `docs/agent-environments.md` records as container-specific — `6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` (both `chmod`-based, meaningless as `uid 0`, and the failing-test lists match that document exactly) and `S32-io/IO-Socket-Async.t` (sandboxed network).

## What is still slow

The profile has moved off dispatch. Two findings from the same callgrind run are filed separately rather than stretched into this change: `dispatch_func_call_inner` resolves the same call **three** times (`find_compiled_function_memo`, then `resolve_function_multi_cached`, then `push_multi_dispatch_frame`), which is why a `where` constraint still runs 4x per call where rakudo runs it once; and `eval_block_value_inner` clones the entire registry `functions` map on every block evaluation to be able to restore it, even though the restore is already skipped when `registry_write_gen` says nothing was declared.

Closes #7858

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RN8EmqVKpJDVyZ5fZ4Rjb

---
_Generated by [Claude Code](https://claude.ai/code/session_012RN8EmqVKpJDVyZ5fZ4Rjb)_