### PR TITLE
docs: add the ecosystem-dist-roulette skill and the distribution lock board (#7884)

### DIFF
--- a/.agents/skills/ecosystem-dist-fix/SKILL.md
+++ b/.agents/skills/ecosystem-dist-fix/SKILL.md
@@ -86,6 +86,28 @@ evidence about that commit, not about `main`; re-measure rather than trusting it
 If there is no record at all, that is fine — the corpus sweep is partial (see
 `ecosystem/README.md`). Go to step 2 and create one in step 7.
 
+## 1b. Take the lock — it may already be somebody's
+
+Agents run in parallel and a distribution has no issue of its own to carry a
+claim, so the claim goes on the **lock board**,
+[#7884](https://github.com/tokuhirom/mutsu/issues/7884) (the single open issue
+labelled `ecosystem:lock`). This holds however you arrived at the distribution —
+a user naming it does not make it unclaimed.
+
+Read its comments, and if no live `Locking:` line holds your distribution, post
+one whose first line is exactly `Locking: <Dist::Name> <your-branch>`. Then read
+the comments again: among live locks for that distribution the **lowest comment
+id** wins, and if you did not win, post `Unlocking: <dist> <your-branch>` and
+take this up with the user rather than racing. Release it when the run ends —
+merged, filed, blocked or abandoned — with
+`Unlocking: <Dist::Name> <your-branch>` plus one line on how it went.
+
+The full protocol, including the evidence rule for breaking a lock whose session
+died, is
+[`ecosystem-dist-roulette`](../ecosystem-dist-roulette/SKILL.md), which is also
+the skill to use when the distribution is to be picked at random rather than
+named.
+
 ## 2. Check the distribution out
 
 ```sh

--- a/.agents/skills/ecosystem-dist-roulette/SKILL.md
+++ b/.agents/skills/ecosystem-dist-roulette/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: ecosystem-dist-roulette
+description: Pick ONE random zef distribution out of the ecosystem/ ledger, lock it on the lock board (issue #7884) so no other agent works the same one, then take it from red to green with the ecosystem-dist-fix loop and release the lock. Use when asked to make some/any module work rather than a named one ("ランダムにモジュールを一個選んで動くようにして", "pick a random dist and make its tests pass", "grab an ecosystem module and fix it"), or when running several such agents in parallel and they must not collide.
+metadata:
+  short-description: Draw a random distribution, lock it, make it green
+---
+
+# Ecosystem distribution roulette
+
+One run = **one distribution, drawn at random, held under a lock, fixed, released**.
+
+This skill is only the *selection and mutual-exclusion* wrapper. The work itself — checkout, rakudo
+baseline, reduction, fix-versus-issue, `t/` pin, re-measure, PR — is
+[`ecosystem-dist-fix`](../ecosystem-dist-fix/SKILL.md) and is not repeated here. Read that skill
+before your first run; this page assumes it.
+
+## Why random, and why a lock
+
+**Random, because the parity number has to mean something.** The ledger's KPI is a claim about the
+ecosystem, and it only holds if the distributions worked are a fair sample of it. An agent that
+picks whichever record looks cheapest moves the count without moving the language — the same way
+cherry-picking easy roast tests games the roast count, which `CLAUDE.md` already bans. A uniform
+draw also surfaces the gaps nobody would have volunteered for, which is where the interesting
+interpreter bugs live.
+
+**A lock, because a distribution is not an issue.** Parallel agents already avoid colliding on
+issues by claiming them in the issue's own comments (`docs/issue-workflow.md`). A distribution has
+no issue to carry that claim, and nothing else in the repo can: a lock file in git conflicts and
+goes stale, and a label is a read-then-write two agents can both win. So the claim lives on one
+long-lived board issue, whose comments are an append-only log GitHub returns in creation order —
+the only thing every agent reads identically.
+
+The board does not prevent a collision. It makes both sides **agree on who lost**, which is all an
+optimistic protocol can do, and all it needs to do.
+
+**The lock board is [tokuhirom/mutsu#7884](https://github.com/tokuhirom/mutsu/issues/7884)** — the
+single open issue labelled `ecosystem:lock`. If that number is ever wrong, the label is the
+authority: `gh issue list --repo tokuhirom/mutsu --label ecosystem:lock` (remote: `list_issues` with
+`labels: ["ecosystem:lock"]`), and there is exactly one.
+
+## 1. Read the board first
+
+```sh
+gh issue view 7884 --repo tokuhirom/mutsu --comments
+```
+
+Remote container: `issue_read` with `method: "get_comments"`, `owner: tokuhirom`, `repo: mutsu`,
+`issue_number: 7884`. Page to the end — the log is oldest-first and the live locks are spread
+through it, not only at the bottom.
+
+Build the held set: a `Locking: <dist> <branch>` line is **live** until a matching
+`Unlocking: <dist> <branch>` (same distribution, same branch) appears after it. Keep the comment id
+of every live lock; you will need it in step 3.
+
+## 2. Draw a shortlist
+
+```sh
+.agents/skills/ecosystem-dist-roulette/pick-dist.py --exclude Held::One --exclude Held::Two
+```
+
+It samples uniformly from `ecosystem/dists/**.json`, default pool `red` / `partial` /
+`blocked_load` on the `pure` axis — the records where fixing the interpreter is what moves them.
+`--count`, `--status`, `--axis any`, `--exclude-file`, `--seed` and `--json` are there; `--pool`
+prints the whole matching set instead of a sample. Pass every held distribution as `--exclude`, so
+the shortlist is already lock-free.
+
+**Take the first candidate. Skipping one because it looks hard is cherry-picking** and defeats the
+reason the draw is random. There are exactly three legitimate reasons to move to the next
+candidate, and all three are facts, not impressions:
+
+- the board holds it (which `--exclude` has already handled);
+- an open PR or a live `working` issue already covers it — check before you spend anything;
+- rakudo does not pass its files either, so the record is `no_baseline` and nothing here is charged
+  to mutsu. You discover this in `ecosystem-dist-fix` step 3, *after* locking; release the lock
+  saying so, then draw again.
+
+`guts` and `native` records are usually the issue-filing case rather than the fix case. That is a
+reason to expect an issue as the outcome, not a reason to re-roll; the default `--axis pure` already
+keeps them out unless you asked for them.
+
+## 3. Lock it
+
+Post one comment to #7884 whose **first line is exactly**:
+
+```
+Locking: String::Utils claude/ecosystem-string-utils-ab12
+```
+
+The distribution as the ledger spells it (`::`, not the filename's `--`), then the branch you will
+push. The branch is what identifies you — every agent posts as the same GitHub user, so a lock that
+names no branch names nobody.
+
+```sh
+gh issue comment 7884 --repo tokuhirom/mutsu --body 'Locking: String::Utils claude/<branch>'
+```
+
+Then **read the comments again** and compare ids. Among the live locks for *that distribution*, the
+**lowest comment id wins** — ids increase, so it is the earliest entry. Compare ids, never
+`created_at`: it has one-second resolution and two agents can tie on it.
+
+If you did not win, you lost. Post `Unlocking: <dist> <your-branch>`, go back to step 2's next
+candidate, and do not argue the point: "my branch is further along", "the other lock has nothing
+pushed", "the user pointed me at this one" do **not** override an earlier live lock. That rule is
+exclusive by design and it is the same one, for the same reason, as
+[`docs/issue-workflow.md`](../../../docs/issue-workflow.md) — a criterion that needs judgement
+reintroduces the race the log exists to settle.
+
+### Breaking a stale lock
+
+Sessions die and leave locks behind. Break one **only** on evidence:
+
+- its comment is more than **24 hours** old, **and**
+- `git ls-remote --heads origin <their-branch>` is empty, or that branch's PR is merged or closed.
+
+Then post, before your own `Locking:` line:
+
+```
+Unlocking: String::Utils claude/their-branch (stale: no origin branch after 26h)
+```
+
+Both conditions are checkable by anyone, which is the point. A lock whose branch is simply not
+pushed *yet* is normal — the 24-hour floor is what protects it, so never break a lock on age alone
+or on "looks abandoned".
+
+## 4. Do the work
+
+Hand over to [`ecosystem-dist-fix`](../ecosystem-dist-fix/SKILL.md) and follow it as written: read
+the record, `checkout-dist.py`, load probe, rakudo first and mutsu second per file, reduce into
+`tmp/`, fix what is bounded and file a `tokuhirom/mutsu` issue for what is not, pin every fix with a
+`t/` test, re-measure the record, and open the PR with auto-merge.
+
+Two things that belong to this wrapper rather than that one:
+
+- **Mention the lock in the PR body** ("locked on #7884"), so a reviewer can see the run was
+  serialized and can find the release.
+- **Re-read the board at `ecosystem-dist-fix`'s own checkpoints** — before the pre-publication
+  `make test` + `make roast` run, and immediately before opening the PR. Steps 1-3 settle only the
+  locks that existed in the first few seconds; they cannot see an agent who locks later and declines
+  to yield, nor a PR that lands while your suites run. If you lost at a checkpoint, follow "Losing a
+  claim late" in `docs/issue-workflow.md`: read what landed, verify your repro against it, close
+  your PR with the comparison written down, and offer the delta rather than pushing it.
+
+## 5. Release, always
+
+The moment the run ends — merged, filed, blocked, `no_baseline`, or you simply stopped:
+
+```sh
+gh issue comment 7884 --repo tokuhirom/mutsu --body 'Unlocking: String::Utils claude/<branch>
+Merged as #7901. t/03 still needs #7902 (nqp::unipropcode).'
+```
+
+The first line is the machine-readable release; the rest is one line on how it ended. A lock that is
+never released removes that distribution from every other agent's pool for good, and the release
+note is what makes the board double as the record of what has actually been *attempted* — which the
+ledger cannot show, because a distribution that was tried and correctly ended in an issue still
+reads `red`.
+
+Releasing is not optional on a bad outcome. **"I found nothing and stopped" is exactly the case
+where the next agent most needs to see the lock gone**, and to read why.
+
+## Done means
+
+One distribution: locked, worked to `ecosystem-dist-fix`'s finish line (record `green`, or every
+remaining non-`parity` baseline file explained by an open `tokuhirom/mutsu` issue named in the PR),
+and unlocked with a one-line outcome.
+
+Then, if you were asked for several: draw again from step 1 with a **fresh** shortlist — the board
+has moved while you worked, and a candidate list from an hour ago is stale.

--- a/.agents/skills/ecosystem-dist-roulette/pick-dist.py
+++ b/.agents/skills/ecosystem-dist-roulette/pick-dist.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""pick-dist.py — draw a random actionable distribution out of the ecosystem ledger.
+
+    .agents/skills/ecosystem-dist-roulette/pick-dist.py
+
+Prints a shortlist (default 5) of distributions sampled *uniformly* from
+`ecosystem/dists/**.json`, so the agent can take the first one the lock board
+does not already hold without re-rolling and without re-reading 251 records.
+
+Uniform is the point. Picking the cheapest-looking record games the parity KPI
+exactly the way cherry-picking easy roast tests games the roast count, and the
+number the ledger publishes is only meaningful if the sample behind it is
+unbiased. The one legitimate reason to skip a candidate is that somebody else
+holds it (the lock board, or an open PR) — never that it looks hard.
+
+Default pool: `status` in red / partial / blocked_load, `axis` == pure. Those
+are the records where fixing the interpreter is what moves them; `guts` and
+`native` are usually the issue-filing case (see the ecosystem-dist-fix skill),
+`green` needs nothing, and `no_baseline` / `blocked_dep` are not charged to
+mutsu at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import random
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+DISTS = os.path.join(REPO, "ecosystem", "dists")
+
+ACTIONABLE = ("red", "partial", "blocked_load")
+ALL_STATUS = ACTIONABLE + ("green", "no_baseline", "blocked_dep", "skipped")
+
+
+def load_records() -> list[dict]:
+    out = []
+    for path in sorted(glob.glob(os.path.join(DISTS, "*", "*.json"))):
+        try:
+            with open(path, encoding="utf-8") as fh:
+                rec = json.load(fh)
+        except (OSError, ValueError) as exc:
+            print(f"warning: skipping {path}: {exc}", file=sys.stderr)
+            continue
+        rec["_path"] = os.path.relpath(path, REPO)
+        out.append(rec)
+    return out
+
+
+def actionable_files(rec: dict) -> int:
+    return sum(1 for f in rec.get("files", [])
+               if f.get("cmp") in ("regression", "partial"))
+
+
+def summarize(rec: dict) -> dict:
+    totals = rec.get("totals", {}) or {}
+    load = rec.get("load", {}) or {}
+    bad_load = {m: v for m, v in load.items() if v != "ok"}
+    return {
+        "dist": rec.get("dist"),
+        "version": rec.get("version"),
+        "status": rec.get("status"),
+        "axis": rec.get("axis"),
+        "record": rec["_path"],
+        "baseline_files": totals.get("baseline_files", 0),
+        "parity_files": totals.get("parity_files", 0),
+        "actionable_files": actionable_files(rec),
+        "load_errors": bad_load,
+        "measured": (rec.get("measured", {}) or {}).get("date"),
+        "mutsu_commit": (rec.get("measured", {}) or {}).get("mutsu_commit"),
+        "deps": len((rec.get("deps", {}) or {}).get("resolved", []) or []),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--count", type=int, default=5,
+                    help="how many candidates to draw (default 5)")
+    ap.add_argument("--status", action="append", choices=ALL_STATUS,
+                    help=f"status to draw from; repeatable (default: {' '.join(ACTIONABLE)})")
+    ap.add_argument("--axis", default="pure", choices=("pure", "guts", "native", "any"),
+                    help="axis to draw from (default pure)")
+    ap.add_argument("--exclude", action="append", default=[], metavar="DIST",
+                    help="distribution to leave out; repeatable (use for held locks)")
+    ap.add_argument("--exclude-file", metavar="PATH",
+                    help="file with one distribution name per line to leave out")
+    ap.add_argument("--seed", help="seed the draw, to make it reproducible")
+    ap.add_argument("--json", action="store_true", help="emit the shortlist as JSON")
+    ap.add_argument("--pool", action="store_true",
+                    help="print the whole matching pool instead of a sample")
+    args = ap.parse_args()
+
+    statuses = tuple(args.status) if args.status else ACTIONABLE
+    excluded = {name.strip() for name in args.exclude if name.strip()}
+    if args.exclude_file:
+        with open(args.exclude_file, encoding="utf-8") as fh:
+            excluded |= {line.strip() for line in fh if line.strip()
+                         and not line.startswith("#")}
+
+    records = load_records()
+    if not records:
+        print(f"error: no records under {DISTS}", file=sys.stderr)
+        return 2
+
+    pool = [r for r in records
+            if r.get("status") in statuses
+            and (args.axis == "any" or r.get("axis") == args.axis)
+            and r.get("dist") not in excluded]
+
+    if not pool:
+        print("error: nothing matches that filter (all excluded?)", file=sys.stderr)
+        return 1
+
+    rng = random.Random(args.seed) if args.seed is not None else random.SystemRandom()
+    picked = sorted(pool, key=lambda r: r.get("dist") or "") if args.pool \
+        else rng.sample(pool, min(args.count, len(pool)))
+    rows = [summarize(r) for r in picked]
+
+    if args.json:
+        json.dump({"pool": len(pool), "excluded": sorted(excluded),
+                   "statuses": list(statuses), "axis": args.axis,
+                   "candidates": rows}, sys.stdout, indent=2, sort_keys=True)
+        print()
+        return 0
+
+    print(f"# pool: {len(pool)} records "
+          f"(status {'/'.join(statuses)}, axis {args.axis}"
+          f"{', %d excluded' % len(excluded) if excluded else ''})")
+    for i, row in enumerate(rows, 1):
+        head = (f"{i}. {row['dist']} {row['version']}  "
+                f"[{row['status']} / {row['axis']}]")
+        print(head)
+        if row["status"] == "blocked_load":
+            for mod, err in list(row["load_errors"].items())[:3]:
+                print(f"     load {mod}: {err}")
+        else:
+            print(f"     files: {row['parity_files']}/{row['baseline_files']} at parity, "
+                  f"{row['actionable_files']} actionable")
+        print(f"     deps: {row['deps']}   measured {row['measured']} "
+              f"@ {row['mutsu_commit']}   {row['record']}")
+    print()
+    print("# take the FIRST candidate the lock board does not hold. Skipping one "
+          "because it looks hard is cherry-picking.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,10 @@ than in this file; read the matching one before starting such a task. Currently:
 `cut-release` (releasing), `install-raku` (installing the Rakudo oracle when
 `raku` is missing), `roast-triage` (choosing and investigating roast work),
 `test-util-workout`, `reclaim-disk` (stale worktrees and cargo caches),
-`mutsu-ticket-flow`, `rakuast-implementation`, and `ecosystem-dist-fix`
-(taking one zef distribution's own test suite from red to green).
+`mutsu-ticket-flow`, `rakuast-implementation`, `ecosystem-dist-fix`
+(taking one zef distribution's own test suite from red to green), and
+`ecosystem-dist-roulette` (drawing a *random* distribution and locking it on
+issue #7884 first, so parallel agents never work the same one).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ before starting one of these tasks:
 | [`mutsu-ticket-flow`](.agents/skills/mutsu-ticket-flow/SKILL.md) | Working `todo:ticket` issues end-to-end through merge |
 | [`rakuast-implementation`](.agents/skills/rakuast-implementation/SKILL.md) | A RakuAST compatibility slice (`src/rakuast/`, `t/rakuast/`) |
 | [`ecosystem-dist-fix`](.agents/skills/ecosystem-dist-fix/SKILL.md) | Making one zef distribution's own test suite pass ("make `String::Utils`'s tests pass"), or working a red/`blocked_load` `ecosystem/` record |
+| [`ecosystem-dist-roulette`](.agents/skills/ecosystem-dist-roulette/SKILL.md) | Picking a *random* distribution instead of a named one, and locking it on the board so parallel agents do not collide |
 
 ## Where this session is running — check before following any shell recipe
 

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -13,7 +13,11 @@ sides, and publish the difference.
   to green is
   [`.agents/skills/ecosystem-dist-fix/SKILL.md`](../.agents/skills/ecosystem-dist-fix/SKILL.md),
   which consumes §1-§3 below and adds the per-distribution debugging loop and the
-  fix-versus-file-an-issue rule.
+  fix-versus-file-an-issue rule;
+  [`.agents/skills/ecosystem-dist-roulette/SKILL.md`](../.agents/skills/ecosystem-dist-roulette/SKILL.md)
+  wraps that in a uniform random draw over the actionable records plus a lock on
+  [#7884](https://github.com/tokuhirom/mutsu/issues/7884), so parallel agents
+  neither collide nor bias the sample by cherry-picking cheap records.
 - **Sibling tools**: [docs/dist-compat-sweep.md](dist-compat-sweep.md) is the
   load-level (`use <module>`) diagnostic sampler that feeds root-cause tickets;
   [BATTERIES.md](../BATTERIES.md) / `scripts/battery-testsuite.sh` is the

--- a/docs/issue-workflow.md
+++ b/docs/issue-workflow.md
@@ -189,6 +189,34 @@ noted the earlier one, judged it forfeit for being unpushed, and proceeded. Both
 agents then ran the full suites and opened a PR for the same work — one of which
 was thrown away.)
 
+### Locking a resource that is not an issue — the lock board
+
+The protocol above needs somewhere to put the claim, and it uses the issue
+itself. Work that is *not* an issue has nowhere: an `ecosystem/` distribution is
+picked out of a ledger of 251 records, and two agents drawing the same one waste
+a build slot exactly as two agents on one issue do.
+
+For those, the claim goes on a **lock board** — one long-lived issue whose
+comments are the append-only log, holding `Locking:` / `Unlocking:` lines that
+name the resource and the claiming branch. The tiebreaker, the exclusivity rule
+and the "re-read before you spend and before you publish" checkpoints are the
+same as above; only the resource differs. Nothing else in the repository can
+carry it: a lock file in git conflicts on every write and outlives the session
+that wrote it, and a label — as the `working` section explains — is a
+read-then-write two agents can both win.
+
+The one addition a board needs is a way to break a lock its session died
+holding, and it is evidence-based rather than a judgement call: 24 hours old
+**and** no such branch on `origin` (or its PR merged/closed). Both halves are
+checkable by anyone, which is what keeps it from reintroducing the race.
+
+The board for `ecosystem/` distributions is
+[#7884](https://github.com/tokuhirom/mutsu/issues/7884) — the single open issue
+labelled `ecosystem:lock`, which is the authority if the number ever drifts — and
+the procedure around it is
+[`.agents/skills/ecosystem-dist-roulette/SKILL.md`](../.agents/skills/ecosystem-dist-roulette/SKILL.md).
+A board issue is infrastructure: it is never worked and never closed.
+
 ### Losing a claim late
 
 Finding out at a checkpoint that someone else's work has landed is not a reason

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -88,6 +88,17 @@ file, fix the interpreter where the gap is bounded and file an issue where it
 needs a complex feature — is the
 [`ecosystem-dist-fix`](../.agents/skills/ecosystem-dist-fix/SKILL.md) skill.
 
+To pick one **at random** rather than by name — and to do so with several agents
+running at once — use
+[`ecosystem-dist-roulette`](../.agents/skills/ecosystem-dist-roulette/SKILL.md)
+instead. It draws uniformly from the actionable records here (a uniform sample is
+what keeps the published figure honest; picking the cheapest-looking record games
+it), takes a lock on
+[#7884](https://github.com/tokuhirom/mutsu/issues/7884) so no two agents work the
+same distribution, and then hands over to `ecosystem-dist-fix`. A distribution
+has no issue of its own to carry a claim, which is why the lock lives on that one
+board issue's comments rather than in this tree.
+
 ## Current state — a partial sweep, not the corpus
 
 **The corpus sweep (P2) is in progress and these records cover only part of it.**

--- a/news/2026-09/ecosystem-dist-roulette-and-lock-board.md
+++ b/news/2026-09/ecosystem-dist-roulette-and-lock-board.md
@@ -1,0 +1,72 @@
+# Picking an ecosystem distribution at random, and locking it so two agents cannot pick the same one
+
+`ecosystem-dist-fix` (added the day before) answers "make `String::Utils`'s tests
+pass". It does not answer the request that actually scales the parity campaign:
+*make some module work* — no name given, several agents at once. That request has
+two problems the per-distribution loop does not have, and neither is about
+Raku.
+
+**The first is sampling.** The ledger publishes a figure about the ecosystem, and
+the figure is only worth reading if the distributions that got worked are a fair
+sample of it. An agent left to choose for itself picks the record with one
+failing assertion over the one that will not load, which moves the count without
+moving the interpreter — the same trade `CLAUDE.md` already bans for roast, where
+cherry-picking easy tests is called out by name. So the draw is uniform over the
+actionable records, and the skill says outright that "it looks hard" is not a
+reason to re-roll. The three legitimate reasons to skip a candidate are all
+facts: somebody holds it, an open PR already covers it, or rakudo fails it too
+(`no_baseline`, which is never charged to mutsu).
+
+**The second is mutual exclusion.** Parallel agents already avoid colliding on
+issues by claiming them in the issue's own comments. A distribution has no issue
+to carry that claim, and nothing in the repository can carry it either: a lock
+file in git conflicts on every write and outlives the session that wrote it, and
+a label is a read-then-write two agents can both win — the same reason
+`docs/issue-workflow.md` demotes the `working` label to a fast filter and makes
+the comment log the record.
+
+So the claim goes on a **lock board**:
+[#7884](https://github.com/tokuhirom/mutsu/issues/7884), one long-lived issue
+labelled `ecosystem:lock`, never worked and never closed. An agent posts
+`Locking: <Dist::Name> <branch>`, re-reads, and yields unless its comment id is
+the lowest among the live locks on that distribution; it posts
+`Unlocking: <Dist::Name> <branch>` plus one line on how the run ended. That is
+deliberately the protocol issue claims already use, pointed at a different
+resource — an append-only log GitHub returns in creation order is the only thing
+every agent reads identically, so the board does not prevent a collision, it
+makes both sides agree on who lost.
+
+Two details are new, because a board has failure modes a per-issue claim does
+not:
+
+- **Breaking a lock its session died holding** is evidence-based, never a
+  judgement call: the comment must be more than 24 hours old **and** the branch
+  must be absent from `origin` (or its PR merged/closed). Both halves are
+  checkable by anyone, which is what stops "looks abandoned" from reintroducing
+  the race. The 24-hour floor is what protects a fresh lock that has nothing
+  pushed yet.
+- **Releasing is mandatory on a bad outcome too.** A distribution that was tried
+  and correctly ended in a filed issue still reads `red` in the ledger, so the
+  release note is the only record that it was attempted at all — and an
+  unreleased lock removes that distribution from every other agent's pool for
+  good.
+
+## What landed
+
+- `.agents/skills/ecosystem-dist-roulette/SKILL.md` — the draw, the lock, the
+  handover to `ecosystem-dist-fix`, and the release.
+- `.agents/skills/ecosystem-dist-roulette/pick-dist.py` — uniform sampler over
+  `ecosystem/dists/**.json`; default pool `red` / `partial` / `blocked_load` on
+  the `pure` axis (104 of the 251 records today), with `--exclude` for held
+  locks, plus `--count`, `--status`, `--axis`, `--exclude-file`, `--seed`,
+  `--json` and `--pool`.
+- Issue #7884, and the `ecosystem:lock` label that identifies it if the number
+  ever drifts.
+- `ecosystem-dist-fix` gained step 1b: take the lock **however** you arrived at
+  the distribution. A user naming one does not make it unclaimed, and a named-dist
+  run that skips the board can still collide with a random one.
+- `docs/issue-workflow.md` records the generalization — locking a resource that
+  is not an issue — next to the claim protocol it reuses; `ecosystem/README.md`
+  and `docs/ecosystem-parity.md` point at the skill.
+
+No `src/`, `t/`, `Makefile` or `scripts/` change.


### PR DESCRIPTION
#7877 gave the campaign `ecosystem-dist-fix`, which answers "make `String::Utils`'s tests pass". It does not answer the request that actually scales the parity campaign — *make some module work*, no name given, several agents at once. That request has two problems the per-distribution loop does not have, and neither of them is about Raku.

## Sampling — why the draw is uniform, and why re-rolling is banned

The ledger publishes a figure about the ecosystem, and the figure is only worth reading if the distributions that got worked are a fair sample of it. An agent left to choose for itself takes the record with one failing assertion over the one that will not load: the count moves, the interpreter does not. That is the same trade `CLAUDE.md` already bans by name for roast.

So `pick-dist.py` draws **uniformly** from the actionable records, and the skill states outright that "it looks hard" is not a reason to re-roll. Exactly three skips are legitimate, and all three are facts rather than impressions: somebody holds the lock, an open PR already covers it, or rakudo fails the files too (`no_baseline`, never charged to mutsu — and discovered legitimately in `ecosystem-dist-fix` step 3, after locking).

## Mutual exclusion — why a board issue, and not a file or a label

Parallel agents already avoid colliding on issues by claiming them in the issue's own comments. A distribution has no issue to carry that claim, and nothing in the repository can carry one either: a lock file in git conflicts on every write and outlives the session that wrote it, and a label is a read-then-write two agents can both win — which is precisely why `docs/issue-workflow.md` demotes `working` to a fast filter and makes the comment log the record.

So the claim goes on a **lock board**: [#7884](https://github.com/tokuhirom/mutsu/issues/7884), one long-lived issue labelled `ecosystem:lock`, never worked and never closed. `Locking: <Dist::Name> <branch>` → re-read → lowest comment id among live locks wins → `Unlocking: <Dist::Name> <branch>` plus one line on how the run ended. Deliberately the protocol issue claims already use, pointed at a different resource, for the same reason: an append-only log GitHub returns in creation order is the only thing every agent reads identically. It does not prevent a collision — it makes both sides agree on who lost.

Two things a board needs that a per-issue claim does not:

- **Breaking a lock its session died holding is evidence-based**, never a judgement call: the comment must be over 24 hours old **and** the branch absent from `origin` (or its PR merged/closed). Both halves are checkable by anyone, which is what stops "looks abandoned" from reintroducing the race the log exists to settle; the 24-hour floor is what protects a fresh lock with nothing pushed yet.
- **Releasing is mandatory on a bad outcome too.** A distribution that was tried and correctly ended in a filed issue still reads `red` in the ledger, so the release note is the only record that it was attempted at all — and an unreleased lock removes that distribution from every other agent's pool for good.

## What is here

- **`.agents/skills/ecosystem-dist-roulette/SKILL.md`** — read the board, draw a shortlist, lock, hand over to `ecosystem-dist-fix`, release. It is only the selection-and-exclusion wrapper; the work itself is not duplicated.
- **`pick-dist.py`** — uniform sampler over `ecosystem/dists/**.json`. Default pool `red` / `partial` / `blocked_load` on the `pure` axis (104 of the 251 records today), `--exclude` for held locks, plus `--count`, `--status`, `--axis`, `--exclude-file`, `--seed`, `--json` and `--pool`.
- **`ecosystem-dist-fix` gains step 1b**: take the lock *however* you arrived at the distribution. A user naming one does not make it unclaimed, and a named-dist run that skips the board still collides with a random one.
- **`docs/issue-workflow.md`** records the generalization — locking a resource that is not an issue — next to the claim protocol it reuses. `ecosystem/README.md`, `docs/ecosystem-parity.md`, `CLAUDE.md` and `AGENTS.md` point at the skill.
- Issue #7884 and the `ecosystem:lock` label exist already, so the skill is usable the moment this merges.

## Verification

- `pick-dist.py` exercised across `--seed` (reproducible draws), `--json`, `--pool`, `--exclude`, a `--count` larger than the pool, and an empty-filter error path; the `blocked_load` rows print their load error and the `red`/`partial` rows their parity counts.
- Every relative link in the eight touched files resolves.
- `scripts/ci-docs-only.sh` classifies this diff as **not** docs-only (`ecosystem/README.md` is a nested README), so the full `test` / `lint-configs` / `wasm-e2e` / `gc-stress` / `jit-stress` set runs on this PR.
- No `src/`, `t/`, `Makefile` or `scripts/` change, and nothing in the diff is executed by either suite, so `make test` / `make roast` were not run locally — CI runs both in full here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9HmXGhvdveop6c4bUtW4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9HmXGhvdveop6c4bUtW4q)_