### PR TITLE
perf: resolve const_sym from an eager table instead of two OnceLocks

### DIFF
--- a/news/2026-09/const-sym-eager-table.md
+++ b/news/2026-09/const-sym-eager-table.md
@@ -1,0 +1,71 @@
+# `const_sym` reads an eager table instead of probing two OnceLocks
+
+`CompiledCode::const_sym` answers "what `Symbol` is the string constant at this
+pool index" — the question every `CallFunc`, `CallMethod` and variable-access
+opcode asks about its name. ADR-0037 Slice 1 made it a memo because the call
+path had been re-interning routine names per call, and `Symbol::intern` is a
+thread-local string-keyed hash: five of them per call had been ~26% of
+`bench-fib`. The memo worked.
+
+But the memo was reached lazily, through an outer `OnceLock` holding the side
+table and a second `OnceLock` per slot holding the symbol. Once ADR-0037 and
+ADR-0066 had cleared the interns and hash probes either side of it, the cost of
+*reaching* the memo was what was left, and it was not small: 55.9M of
+`bench-fib`'s 1,292.0M retired instructions, 4.33%.
+
+That is the same lesson ADR-0066 records from the other direction — a
+per-callsite inline cache reached through `OnceLock` → side table → index array
+→ slot retired no fewer instructions than the two hash probes it replaced,
+because five dependent loads cost what two hash probes cost. A shorter pointer
+chase is not the fix; one load is.
+
+## What changed
+
+A chunk is finalized before it executes, so the table never needed to be lazy.
+`compute_needs_env_sync` — which already walks the constant pool to decide
+`reads_topic` — now interns every string constant in one pass and stores the
+result in a plain `Box<[Option<Symbol>]>`. `const_sym` is an indexed load out of
+that, marked `#[inline]` so each dispatch site gets the load itself rather than
+a call; the intern fallback is `#[cold] #[inline(never)]` so the hash probe
+stays behind a call.
+
+`None` marks a non-string constant and an empty table marks a chunk that never
+finalized — the hand-built `CompiledCode::new()` chunks in `runtime/`, whose
+constant pools are empty or trivial. Both fall through to interning directly,
+which is exactly what `const_sym` did before ADR-0037, so nothing regresses to
+worse than the pre-memo behaviour.
+
+## Measurement
+
+callgrind, `--profile profiling`, at the merge of `69bedb4`. Retired
+instructions are deterministic, so these are exact rather than sampled.
+
+| | `bench-fib` total | vs base | `const_sym` | `bench-startup` |
+| --- | ---: | ---: | ---: | ---: |
+| base (`69bedb4`) | 1,291,994,518 | — | 55.9M (4.33%) | 8,737,119 |
+| eager table | 1,264,035,861 | −2.16% | 28.0M (2.21%) | 8,744,395 |
+| + `#[inline]` | **1,248,131,156** | **−3.40%** | **10.5M (0.84%)** | **8,737,168** |
+
+The eager variant's risk was startup: it interns every string constant of every
+chunk up front, including ones never called, and #7579 records `bench-startup`
+as flat over the regression window. It is flat here too — 49 instructions above
+base, 0.0006%. The intermediate row shows where that came from: the eager pass
+itself costs ~7.3k instructions at startup, and inlining `const_sym` gives them
+back.
+
+The middle row is also why `#[inline]` is part of the fix rather than a
+flourish. With the table eager but the function out of line, `bench-fib` paid a
+call, a prologue and an epilogue 2.54M times — 11 retired instructions per call
+for a read that is about six.
+
+## Left on the table
+
+`const_sym` is now ~0.84% of `bench-fib`, and roughly four fifths of that is
+redundancy rather than cost per read: `exec_call_func_op_inner` calls
+`const_sym(name_idx)` four times per dispatch (the `nqp::` flag check, the
+unit-scoped-routine check, the light-cache key, and the argument to
+`call_compiled_function_positional_light_at`) where one hoisted local would do.
+That is worth about 0.7% and is a call-site cleanup, not a `const_sym` fix, so
+it is left for whoever next picks up #7579.
+
+Closes #7739.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2809,6 +2809,44 @@ mod const_pool_dedup {
     }
 
     #[test]
+    fn const_sym_agrees_with_intern_whether_or_not_the_chunk_finalized() {
+        let mut code = CompiledCode::new();
+        let a = code.add_constant(Value::str("fib".to_string()));
+        let b = code.add_constant(Value::str("$n".to_string()));
+
+        // Before finalize the table is empty, so `const_sym` falls back to
+        // interning directly -- a hand-built chunk must still resolve.
+        assert!(code.const_syms.is_empty());
+        assert_eq!(code.const_sym(a), Symbol::intern("fib"));
+        assert_eq!(code.const_sym(b), Symbol::intern("$n"));
+
+        // After finalize the same answers come out of the eager table.
+        code.compute_needs_env_sync();
+        assert_eq!(code.const_syms.len(), code.constants.len());
+        assert_eq!(code.const_sym(a), Symbol::intern("fib"));
+        assert_eq!(code.const_sym(b), Symbol::intern("$n"));
+
+        // A constant appended after finalize is past the table's end and takes
+        // the fallback again.
+        let c = code.add_constant(Value::str("late".to_string()));
+        assert!(c as usize >= code.const_syms.len());
+        assert_eq!(code.const_sym(c), Symbol::intern("late"));
+    }
+
+    #[test]
+    fn finalize_leaves_non_string_constant_slots_unresolved() {
+        let mut code = CompiledCode::new();
+        let n = code.add_constant(Value::int(7));
+        let s = code.add_constant(Value::str("name".to_string()));
+        code.compute_needs_env_sync();
+        // `const_sym` is only ever called on a name slot; a non-string slot
+        // stays `None` so it keeps falling through to the assertion rather than
+        // handing out a bogus symbol.
+        assert_eq!(code.const_syms[n as usize], None);
+        assert_eq!(code.const_syms[s as usize], Some(Symbol::intern("name")));
+    }
+
+    #[test]
     fn env_consumers_publish_only_their_selected_slots() {
         let mut code = CompiledCode::new();
         code.locals.push("x".to_string());

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -5592,6 +5592,7 @@ impl CompiledCode {
     /// thread-local hash lookup) off the per-call dispatch path: method names
     /// are string constants that would otherwise be re-interned on every
     /// `CallMethod`.
+    #[inline]
     pub(crate) fn const_sym(&self, idx: u32) -> Symbol {
         if let Some(Some(sym)) = self.const_syms.get(idx as usize) {
             return *sym;
@@ -5602,7 +5603,11 @@ impl CompiledCode {
         self.intern_const_sym(idx as usize)
     }
 
-    /// Intern the string constant at `i` without consulting `const_syms`.
+    /// Intern the string constant at `i` without consulting `const_syms`. Kept
+    /// out of line so that inlining `const_sym` into a dispatch site copies only
+    /// the indexed load, not `Symbol::intern`'s hash probe.
+    #[cold]
+    #[inline(never)]
     fn intern_const_sym(&self, i: usize) -> Symbol {
         match self.constants[i].view() {
             ValueView::Str(s) => Symbol::intern(s.as_str()),

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2826,11 +2826,19 @@ mod const_pool_dedup {
         assert_eq!(code.const_sym(a), Symbol::intern("fib"));
         assert_eq!(code.const_sym(b), Symbol::intern("$n"));
 
-        // A constant appended after finalize is past the table's end and takes
-        // the fallback again.
+        // A constant appended after finalize extends the table rather than
+        // falling off its end, so a runtime-patched chunk keeps the memo.
         let c = code.add_constant(Value::str("late".to_string()));
-        assert!(c as usize >= code.const_syms.len());
+        assert_eq!(code.const_syms.len(), code.constants.len());
+        assert_eq!(code.const_syms[c as usize], Some(Symbol::intern("late")));
         assert_eq!(code.const_sym(c), Symbol::intern("late"));
+
+        // A chunk that never finalized has no table to extend, and still
+        // resolves through the intern fallback.
+        let mut fresh = CompiledCode::new();
+        let f = fresh.add_constant(Value::str("unfinalized".to_string()));
+        assert!(fresh.const_syms.is_empty());
+        assert_eq!(fresh.const_sym(f), Symbol::intern("unfinalized"));
     }
 
     #[test]
@@ -5047,7 +5055,9 @@ pub(crate) struct CompiledCode {
     /// of `bench-fib` once ADR-0037 had removed the interns either side of it
     /// (#7739). A chunk that never finalizes keeps an empty table and falls
     /// back to interning, which is what it did before ADR-0037 Slice 1.
-    pub(crate) const_syms: Box<[Option<Symbol>]>,
+    /// `add_constant` keeps it index-aligned past finalize, so a chunk patched
+    /// at runtime does not lose the memo for its new slots.
+    pub(crate) const_syms: Vec<Option<Symbol>>,
     /// Lazily-built attribute-cell key per local slot (see `local_attr_key`):
     /// `Some((bare attribute Symbol, is_private))` when the slot's name is an
     /// attribute twigil (`!x`, `$.x`, `@!a`, …), `None` otherwise. Resolving it
@@ -5489,7 +5499,7 @@ impl CompiledCode {
             has_calls: false,
             upvalue_syms: Vec::new(),
             env_only_decls: Vec::new(),
-            const_syms: Box::default(),
+            const_syms: Vec::new(),
             local_attr_keys: std::sync::OnceLock::new(),
             free_var_sym_set: std::sync::OnceLock::new(),
             local_sym_set: std::sync::OnceLock::new(),
@@ -8255,6 +8265,7 @@ impl CompiledCode {
         }
         let Some(key) = ConstKey::of(&value) else {
             let idx = self.constants.len() as u32;
+            self.push_const_sym(&value);
             self.constants.push(value);
             crate::vm::vm_stats::record_const_add(false);
             return idx;
@@ -8264,10 +8275,29 @@ impl CompiledCode {
             return idx;
         }
         let idx = self.constants.len() as u32;
+        self.push_const_sym(&value);
         self.constants.push(value);
         self.const_index.insert(key, idx);
         crate::vm::vm_stats::record_const_add(false);
         idx
+    }
+
+    /// Extend `const_syms` for a constant about to be appended, so the table
+    /// stays index-aligned with `constants`.
+    ///
+    /// Only a chunk that has already finalized has a table to extend; before
+    /// then it is empty and `compute_const_syms` will fill it in one pass. This
+    /// matters for a chunk patched after finalize (a runtime-built body gaining
+    /// a constant): without it that slot would sit past the table's end and
+    /// re-intern on every access, which is the cost the table exists to avoid.
+    fn push_const_sym(&mut self, value: &Value) {
+        if self.const_syms.is_empty() {
+            return;
+        }
+        self.const_syms.push(match value.view() {
+            ValueView::Str(s) => Some(Symbol::intern(s.as_str())),
+            _ => None,
+        });
     }
 
     /// Register a `CallFuncNamed` site's out-of-band named-arg spec, returning

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -5001,10 +5001,15 @@ pub(crate) struct CompiledCode {
     /// avoid leaking a callee's env-only `my` back into a same-named caller
     /// lexical across (self-)recursion. Populated by `compute_needs_env_sync`.
     pub(crate) env_only_decls: Vec<String>,
-    /// Lazily-built `Symbol` per constant-pool slot (see `const_sym`). Sized on
-    /// first use; each slot interns on first access. Cloning a chunk clones the
-    /// already-resolved entries (cheap: `Symbol` is a `u32`).
-    pub(crate) const_syms: std::sync::OnceLock<Box<[std::sync::OnceLock<Symbol>]>>,
+    /// `Symbol` per constant-pool slot (see `const_sym`), interned eagerly when
+    /// the chunk is finalized (`compute_needs_env_sync`); `None` for a constant
+    /// that is not a string. Reading it is a single indexed load, which is the
+    /// point: the lazy predecessor (`OnceLock<Box<[OnceLock<Symbol>]>>`) cost
+    /// two `OnceLock` acquires plus a pointer chase on every call, and was 3.5%
+    /// of `bench-fib` once ADR-0037 had removed the interns either side of it
+    /// (#7739). A chunk that never finalizes keeps an empty table and falls
+    /// back to interning, which is what it did before ADR-0037 Slice 1.
+    pub(crate) const_syms: Box<[Option<Symbol>]>,
     /// Lazily-built attribute-cell key per local slot (see `local_attr_key`):
     /// `Some((bare attribute Symbol, is_private))` when the slot's name is an
     /// attribute twigil (`!x`, `$.x`, `@!a`, …), `None` otherwise. Resolving it
@@ -5446,7 +5451,7 @@ impl CompiledCode {
             has_calls: false,
             upvalue_syms: Vec::new(),
             env_only_decls: Vec::new(),
-            const_syms: std::sync::OnceLock::new(),
+            const_syms: Box::default(),
             local_attr_keys: std::sync::OnceLock::new(),
             free_var_sym_set: std::sync::OnceLock::new(),
             local_sym_set: std::sync::OnceLock::new(),
@@ -5582,27 +5587,41 @@ impl CompiledCode {
         })
     }
 
-    /// The `Symbol` for the string constant at `idx`, interned once per slot
-    /// via a lazily-built side table. Keeps `Symbol::intern` (a thread-local
-    /// hash lookup) off the per-call dispatch path: method names are string
-    /// constants that would otherwise be re-interned on every `CallMethod`.
+    /// The `Symbol` for the string constant at `idx`, read out of the
+    /// `const_syms` table built at finalize time. Keeps `Symbol::intern` (a
+    /// thread-local hash lookup) off the per-call dispatch path: method names
+    /// are string constants that would otherwise be re-interned on every
+    /// `CallMethod`.
     pub(crate) fn const_sym(&self, idx: u32) -> Symbol {
-        let resolve = |i: usize| match self.constants[i].view() {
+        if let Some(Some(sym)) = self.const_syms.get(idx as usize) {
+            return *sym;
+        }
+        // The table is empty (a hand-built chunk that never finalized), or the
+        // constant was appended after finalize. Intern directly; this also
+        // carries the "not a string constant" assertion.
+        self.intern_const_sym(idx as usize)
+    }
+
+    /// Intern the string constant at `i` without consulting `const_syms`.
+    fn intern_const_sym(&self, i: usize) -> Symbol {
+        match self.constants[i].view() {
             ValueView::Str(s) => Symbol::intern(s.as_str()),
             _ => unreachable!("expected string constant"),
-        };
-        let slots = self.const_syms.get_or_init(|| {
-            (0..self.constants.len())
-                .map(|_| std::sync::OnceLock::new())
-                .collect()
-        });
-        match slots.get(idx as usize) {
-            Some(slot) => *slot.get_or_init(|| resolve(idx as usize)),
-            // A constant appended after the table was sized (compile-time
-            // chunks are finalized before execution, so this is defensive):
-            // fall back to a plain intern.
-            None => resolve(idx as usize),
         }
+    }
+
+    /// Build [`CompiledCode::const_syms`]. Called from `compute_needs_env_sync`,
+    /// which is where a chunk is finalized, so the per-call read below never has
+    /// to check whether the table exists.
+    fn compute_const_syms(&mut self) {
+        self.const_syms = self
+            .constants
+            .iter()
+            .map(|c| match c.view() {
+                ValueView::Str(s) => Some(Symbol::intern(s.as_str())),
+                _ => None,
+            })
+            .collect();
     }
 
     /// Scan opcodes to detect if this code references outer-scope variables
@@ -5774,6 +5793,7 @@ impl CompiledCode {
             .constants
             .iter()
             .any(|c| matches!(c.view(), crate::value::ValueView::Str(s) if s.as_str() == "_"));
+        self.compute_const_syms();
         self.compute_locals_sym();
         self.compute_free_vars();
         // Collect env-only `my` declarations so the method-dispatch return merge


### PR DESCRIPTION
## What

`CompiledCode::const_sym` reached its memoized `Symbol` through an outer
`OnceLock` holding a side table and a second `OnceLock` per slot. ADR-0037
Slice 1 built that to keep `Symbol::intern` off the call path, and it worked —
but once ADR-0037 and ADR-0066 had cleared the interns and hash probes either
side of it, the cost of *reaching* the memo was what was left.

A chunk is finalized before it executes, so the table never needed to be lazy.
`compute_needs_env_sync` — which already walks the constant pool to decide
`reads_topic` — now interns every string constant in one pass into a plain
`Vec<Option<Symbol>>`, and `const_sym` is an indexed load out of it. That is
the bar ADR-0066 records: a shorter pointer chase retires no fewer
instructions, only one load does.

`#[inline]` is part of the fix, not a flourish — see the measurement below.
The `intern_const_sym` fallback is `#[cold] #[inline(never)]` so inlining
copies only the load into each dispatch site.

`None` marks a non-string constant; an empty table marks a chunk that never
finalized (the hand-built `CompiledCode::new()` chunks in `runtime/`, whose
constant pools are empty or trivial). Both fall through to interning directly —
what `const_sym` did before ADR-0037 — so nothing regresses below the pre-memo
behaviour.

`add_constant` extends the table past finalize. Sizing it once at finalize
would otherwise have left a gap the lazy predecessor did not have: that one
sized its table on first *use*, i.e. at runtime, so it covered a chunk patched
with a new constant afterwards, where a finalize-sized table would let that slot
fall off the end and re-intern on every access.

## Measurement

callgrind, `--profile profiling`, base `69bedb4`. Retired instructions are
deterministic, so these are exact rather than sampled, and the A/B is
same-benchmark across three separately-built binaries.

| | `bench-fib` total | vs base | `const_sym` | `bench-startup` |
| --- | ---: | ---: | ---: | ---: |
| base (`69bedb4`) | 1,291,994,518 | — | 55.9M (4.33%) | 8,737,119 |
| eager table | 1,264,035,861 | −2.16% | 28.0M (2.21%) | 8,744,395 |
| + `#[inline]` | **1,248,131,156** | **−3.40%** | **10.5M (0.84%)** | **8,737,168** |

Two notes on the numbers:

- **The ticket recorded `const_sym` at 3.55%; it was 4.33%.** The
  `slice/index.rs` and `core/sync/atomic.rs` lines attributed to `const_sym`
  were not counted in the ticket's table.
- **The startup trade-off the ticket worried about did not materialise.** The
  eager variant interns every string constant of every chunk up front,
  including ones never called, and #7579 records `bench-startup` as flat over
  the regression window. It is flat here too: 49 instructions above base,
  0.0006%. The middle row shows why — the eager pass costs ~7.3k instructions
  at startup, and inlining `const_sym` gives them back.

The middle row is also why the `#[inline]` commit exists. With the table eager
but the function out of line, `bench-fib` paid a call, a prologue and an
epilogue 2.54M times: 11 retired instructions per call for a read that is
about six.

The later `add_constant` commit does not move these numbers: it adds a branch to
constant-pool insertion (compile time) and none to `const_sym`, whose read stays
the single indexed load the table records. `Vec` and `Box<[T]>` both index
through an inline pointer+len.

I did not take the ticket's other suggested direction (resolving into the
`OpCode` payload at finalize). It touches the compiler, `OpCode`'s 48-byte size
guard and the JIT `call_func` shim, and this gets the read to one load without
any of that.

## Left on the table

`const_sym` is now ~0.84% of `bench-fib`, and about four fifths of that is
call-site redundancy rather than cost per read: `exec_call_func_op_inner` calls
`const_sym(name_idx)` four times per dispatch where one hoisted local would do.
That is worth roughly 0.7%, but it is a call-site cleanup rather than a
`const_sym` fix, so I left it for whoever next picks up #7579 rather than widen
this PR. It is written up in the news entry.

## Testing

Run from scratch on the final head:

- `make lint` — green in all four configurations.
- `make test` — PASS, 3963 files / 42,149 tests.
- `make roast` — 1436 files / 218,939 tests. Failures are the three documented
  container artefacts, matching `docs/agent-environments.md` down to the counts:
  `6.c/S32-io/file-tests.t` (Failed 4) and `S16-filehandles/filetest.t`
  (Failed 25), both because this container runs as `uid 0` and root bypasses the
  permission bits these tests `chmod`; and `S32-io/IO-Socket-Async.t` (exit 124,
  planned 40 ran 17) on the sandboxed network. `id -u` confirms 0.

Unit tests pin every state a `const_sym` caller can land in: an unfinalized
chunk with an empty table, an index inside the table, a constant appended after
finalize, and a non-string slot staying `None` — all agreeing with interning
the constant directly.

CI's first run went red on `roast/S17-procasync/kill.t` test 7 while `test` and
`gc-stress` passed the same file on the same commit. That is a pre-existing
load-dependent flake, not this diff: it passes **32/32** in isolation under the
jit-stress environment with four CPU burners, and fails only as one of 1436
files under `prove -r -j4`. It is now filed with its evidence as #7892, and the
re-run on the current head is green including `jit-stress`.

Closes #7739

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9eneyfyR623qcZ5JuhUeY