### PR TITLE
fix(ci): a new shard directory made the ecosystem sweep discard its records

### DIFF
--- a/.github/workflows/ecosystem-sweep.yml
+++ b/.github/workflows/ecosystem-sweep.yml
@@ -343,21 +343,50 @@ jobs:
       # distribution name, so the collect job can merge every artifact into one
       # tree with no conflicts -- and an untouched record is never re-uploaded
       # from a stale checkout on top of a fresher measurement.
+      # `always()` on this step and the upload below: records are written per
+      # distribution as the sweep goes, so a Measure that dies half way through
+      # still produced real measurements. Discarding them is never the right
+      # call -- a partial set is exactly what `scope: stale` picks up next time,
+      # and the collect job already refuses a history row for an incomplete run.
       - name: Stage the changed records
         id: stage
+        if: always()
         run: |
           set -euo pipefail
           mkdir -p /tmp/eco-staging
-          git status --porcelain -- ecosystem | awk '{print $NF}' | sort -u > /tmp/eco-changed.txt
+          # `-uall` is load-bearing, not tidiness: plain `git status --porcelain`
+          # COLLAPSES a wholly-new directory into one entry (`?? ecosystem/dists/D/`),
+          # and a shard whose letter has never been measured creates exactly that.
+          # `cp --parents` then refuses the directory and the whole shard's
+          # measurement is lost -- which is precisely what happened to the first
+          # real run (`cp: -r not specified; omitting directory
+          # 'ecosystem/dists/D/'`, 128 distributions thrown away after 26 minutes).
+          # `-z` plus the 3-character status prefix keeps a path with a space or a
+          # non-ASCII character intact, which `awk '{print $NF}'` and git's default
+          # path quoting would each mangle.
+          git -c core.quotePath=false status --porcelain -uall -z -- ecosystem \
+            | tr '\0' '\n' | sed -n 's/^.\{3\}//p' | sort -u > /tmp/eco-changed.txt
           count=$(grep -c . /tmp/eco-changed.txt || true)
+          staged=0
           while IFS= read -r path; do
             [ -n "$path" ] || continue
-            cp --parents "$path" /tmp/eco-staging/
+            # Tolerant on purpose: one unexpected path must cost one record, not
+            # the whole shard. `set -e` here is what turned a single bad `cp`
+            # into 128 discarded measurements.
+            if cp --parents "$path" /tmp/eco-staging/ 2>/dev/null; then
+              staged=$((staged + 1))
+            else
+              echo "::warning title=could not stage a record::$path"
+            fi
           done < /tmp/eco-changed.txt
-          echo "changed=$count" >> "$GITHUB_OUTPUT"
-          echo "shard ${{ matrix.chunk.id }}: $count record file(s) changed"
+          echo "changed=$staged" >> "$GITHUB_OUTPUT"
+          if [ "$staged" != "$count" ]; then
+            echo "::warning title=staged fewer than changed::$staged of $count"
+          fi
+          echo "shard ${{ matrix.chunk.id }}: staged $staged of $count changed record file(s)"
 
       - name: Upload the records
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: eco-records-${{ matrix.chunk.id }}
@@ -417,7 +446,12 @@ jobs:
           if [ -d /tmp/incoming ] && [ -n "$(find /tmp/incoming -type f -print -quit)" ]; then
             cp -a /tmp/incoming/. .
           fi
-          git status --porcelain -- ecosystem | awk '{print $NF}' | sort -u > /tmp/changed.txt
+          # Same `-uall` requirement as the staging step above: a new shard
+          # directory would otherwise arrive as a single directory entry, which
+          # the `.json` filter in the provenance step drops -- leaving the
+          # records unattributed and silently vetoing the history row.
+          git -c core.quotePath=false status --porcelain -uall -z -- ecosystem \
+            | tr '\0' '\n' | sed -n 's/^.\{3\}//p' | sort -u > /tmp/changed.txt
           count=$(grep -c . /tmp/changed.txt || true)
           echo "changed=$count" >> "$GITHUB_OUTPUT"
           echo "$count record file(s) differ from main"

--- a/.github/workflows/ecosystem-sweep.yml
+++ b/.github/workflows/ecosystem-sweep.yml
@@ -1,9 +1,15 @@
 name: Ecosystem sweep
 
 # Re-measure the ecosystem parity KPI (issue #7785) on hosted runners and land
-# the result as a pull request. This is the CI entry point to
-# `scripts/ecosystem-sweep.py`, whose numbers live in `ecosystem/` and are
-# published to `site/ecosystem.html`.
+# the result as a pull request that auto-merges once CI passes. This is the CI
+# entry point to `scripts/ecosystem-sweep.py`, whose numbers live in
+# `ecosystem/` and are published to `site/ecosystem.html`.
+#
+# The records are not reviewed by a human and are not meant to be: a diff of
+# thousands of machine-generated measurements tells a reader nothing a reviewer
+# could act on. Every guard that makes the numbers trustworthy runs before the
+# diff exists (see below), so CI is the gate and the pull request is the audit
+# trail and the revert handle.
 #
 # Method and metric definitions: docs/ecosystem-parity.md
 # Decisions: docs/adr/0085-ecosystem-testsuite-parity-measurement.md (D9 + its
@@ -591,15 +597,32 @@ jobs:
             echo "Records pushed to \`$branch\` (measured on \`$GITHUB_REF\`)." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          if ! gh pr create --base main --head "$branch" \
+          if ! pr_url=$(gh pr create --base main --head "$branch" \
                  --title "chore(ecosystem): refresh parity records (scope=${SCOPE})" \
-                 --body-file /tmp/report.md; then
+                 --body-file /tmp/report.md); then
             echo "::warning title=could not open the pull request::the branch is pushed; open it from the compare view"
             echo "Open it here: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/main...${branch}?expand=1" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          echo "opened $pr_url" >> "$GITHUB_STEP_SUMMARY"
+
+          # Auto-merge, like every other pull request in this repository
+          # (CLAUDE.md's PR workflow step 4). There is nothing in a records diff
+          # for a human to read: it is thousands of machine-generated
+          # measurements, and a reviewer cannot tell a right number from a wrong
+          # one by looking at it. What protects the numbers is upstream of the
+          # diff and already automatic -- the vendored-Test.rakumod probe, the
+          # required sandbox, one binary and one rakudo per run, the provenance
+          # check, and the guards that withhold a summary or a history row from a
+          # partial or mixed sweep. So the gate here is CI, and the pull request
+          # is the audit trail and the revert handle, not a review queue. Merge,
+          # never squash: squash merging is disabled on this repository and
+          # `--squash` silently leaves auto-merge off.
+          if ! gh pr merge --auto --merge "$pr_url"; then
+            echo "::warning title=auto-merge not enabled::$pr_url is open but will not merge on its own; merge it by hand"
+          fi
           if [ "$HAVE_APP_TOKEN" != "true" ]; then
-            echo "::warning title=CI will not start by itself::the pull request was opened with the default GITHUB_TOKEN, which does not trigger workflows. Configure the TAGPR_APP_CLIENT_ID / TAGPR_APP_PRIVATE_KEY App credentials, or push one commit to the branch from a clone."
+            echo "::warning title=CI will not start by itself::the pull request was opened with the default GITHUB_TOKEN, which does not trigger workflows, so auto-merge will never fire. Configure the TAGPR_APP_CLIENT_ID / TAGPR_APP_PRIVATE_KEY App credentials, or push one commit to the branch from a clone."
           fi
 
       - name: Nothing changed

--- a/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
+++ b/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
@@ -264,7 +264,19 @@ mixed in.
 `.github/workflows/ecosystem-sweep.yml` gives the sweep a **`workflow_dispatch`**
 entry point: one dispatch measures a selection (`stale` / `all` / one shard / a
 list of distributions / one status), fans the corpus out across the 27 letter
-shards, and lands the updated records as an ordinary pull request.
+shards, and lands the updated records as an ordinary pull request that
+**auto-merges when CI passes**.
+
+That last part is deliberate and was initially got wrong: the first version left
+the pull request open for a human, reading §8's "check that `measured.host` is
+uniform before landing" as a call for review. It is not. A records diff is
+thousands of machine-generated measurements, and a reviewer cannot tell a right
+number from a wrong one by reading it — while the uniformity check itself is
+automated (`scripts/ecosystem-ci.py provenance`, whose verdict gates the history
+row). Every other guard is upstream of the diff too, so review added a manual
+step that decided nothing and left correct measurements sitting unlanded. CI is
+the gate; the pull request is the audit trail and the revert handle. `publish:
+branch` remains for a sweep someone does want to inspect first.
 
 What this changes is *who needs the hardware*, not *when the sweep runs*. The
 argument above rejected a **weekly** sweep and that stands — there is no

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -440,6 +440,17 @@ otherwise; `letters` forces it, which is what a large `stale` selection wants);
 the oracle; `rollup` regenerates `summary.*`; `history` asks for a `history.tsv`
 row; `publish` chooses `pull-request` (default), `branch`, or `none`.
 
+**The pull request auto-merges** (merge, never squash) as soon as CI passes — the
+records are not reviewed and are not meant to be. A diff of thousands of
+machine-generated measurements gives a reviewer nothing to act on: they cannot
+tell a right number from a wrong one by reading it. Everything that makes the
+numbers trustworthy runs *before* the diff exists — the vendored-`Test.rakumod`
+probe, the required sandbox, one binary and one rakudo and one index per run, the
+provenance check, and the guards below that withhold a summary or a history row
+from a partial or mixed sweep. So CI is the gate, and the pull request is the
+audit trail and the revert handle rather than a review queue. `publish: branch`
+is the way to get a sweep that waits for a human.
+
 `rollup` is on by default but will not *create* the first `summary.json` from a
 partial sweep — until a `scope: all` run has produced one, a subset run skips the
 rollup and says so, for the same reason `ecosystem/` has carried no summary since

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -74,7 +74,9 @@ corpus without a sandbox) and a `raku` on PATH.
 the [`Ecosystem sweep`](../.github/workflows/ecosystem-sweep.yml) workflow
 (`gh workflow run ecosystem-sweep.yml -f scope=stale`). It builds mutsu once,
 pins one rakudo and one index snapshot for the whole run, fans `scope: all` out
-across the 27 shards, and opens the pull request itself. Records it measures
+across the 27 shards, and opens the pull request itself — which auto-merges once
+CI passes, because a diff of machine-generated measurements has nothing in it for
+a reviewer to act on (`publish: branch` if you do want to inspect one first). Records it measures
 carry a `gha-*` `measured.host`, so a CI number is never silently mixed with a
 locally-measured one.
 

--- a/news/2026-09/ecosystem-data-prs-auto-merge.md
+++ b/news/2026-09/ecosystem-data-prs-auto-merge.md
@@ -1,0 +1,38 @@
+# The ecosystem sweep's records auto-merge: there is nothing in them to review
+
+`.github/workflows/ecosystem-sweep.yml` shipped opening its pull request and
+stopping there, deliberately — `docs/ecosystem-parity.md` §8 says to check that
+`measured.host` is uniform before landing a sweep, and that read as "a human
+looks at it first". That was wrong, and the workflow now enables auto-merge
+(merge, never squash) on the pull request it opens.
+
+The records are **thousands of machine-generated measurements**. A reviewer
+cannot tell a right number from a wrong one by reading the diff: `"ok": 12` for
+one test file of one distribution carries no signal a person can check. So the
+review step decided nothing, while costing the one thing the workflow exists to
+remove — a human in the loop between "the numbers changed" and "the numbers are
+published".
+
+Everything that actually protects the numbers runs **before the diff exists**,
+and all of it is already automatic:
+
+- the vendored-`Test.rakumod` probe, so both sides count `ok` lines emitted by
+  the same harness (ADR-0085 D8);
+- a working `bwrap`, or the job fails rather than measuring unsandboxed;
+- one release binary, one pinned rakudo and one ecosystem-index snapshot shared
+  by every shard, so nothing inside a single number was measured against a
+  different denominator;
+- `scripts/ecosystem-ci.py provenance` — which is §8's host-uniformity check,
+  automated; its verdict is what gates the `history.tsv` row;
+- the guards that withhold a `summary.json` or a history row from a partial or
+  mixed sweep.
+
+CI is therefore the gate, and the pull request is the **audit trail and the
+revert handle** rather than a review queue — which is also what CLAUDE.md's PR
+workflow step 4 has always said to do with a pull request in this repository.
+`publish: branch` stays available for a sweep someone does want to inspect
+before it lands.
+
+Recorded as an amendment in ADR-0085 D9 rather than silently: the ADR's D9
+amendment now says the pull request auto-merges, and why the first version's
+review step was a misreading of §8.

--- a/news/2026-09/ecosystem-sweep-new-shard-directory-lost-its-records.md
+++ b/news/2026-09/ecosystem-sweep-new-shard-directory-lost-its-records.md
@@ -1,0 +1,82 @@
+# A new shard directory made the ecosystem sweep discard everything it measured
+
+The first real dispatch of `.github/workflows/ecosystem-sweep.yml`
+(`scope: prefix`, `prefix: D`, [#7785](https://github.com/tokuhirom/mutsu/issues/7785))
+measured all 128 `D` distributions on both interpreters in 26 minutes — and then
+threw the results away one step later:
+
+```
+cp: -r not specified; omitting directory 'ecosystem/dists/D/'
+```
+
+`git status --porcelain` **collapses a wholly-new directory into a single entry**.
+`ecosystem/dists/D/` had never been measured, so the 128 fresh records were
+reported as one line, `?? ecosystem/dists/D/`, and the staging loop handed that
+directory to `cp --parents`, which refuses a directory without `-r`. With
+`set -euo pipefail` the step failed, the upload step was skipped for want of an
+artifact, and the `collect` job correctly concluded "nothing changed" and opened
+no pull request.
+
+Two things were wrong, and the second is the one worth remembering.
+
+## The bug
+
+`git status --porcelain -uall` lists untracked files individually instead of
+collapsing their directory. The staging and apply steps now use:
+
+```sh
+git -c core.quotePath=false status --porcelain -uall -z -- ecosystem \
+  | tr '\0' '\n' | sed -n 's/^.\{3\}//p' | sort -u
+```
+
+`-z` plus stripping the three-character status prefix also keeps a path with a
+space or a non-ASCII character intact — `awk '{print $NF}'` would have split the
+first and git's default path quoting would have mangled the second. That matters
+for the `_` shard, which exists precisely for distribution names that are not
+ordinary ASCII words.
+
+The same `-uall` is load-bearing in the `collect` job for a quieter reason: a
+collapsed directory entry does not match the `\.json$` filter that feeds the
+provenance check, so the records would have landed *unattributed* and silently
+lost their `history.tsv` row.
+
+## The real lesson: never let one bad path discard a measurement
+
+A 26-minute measurement was destroyed by a single `cp` invocation, which is a
+cost asymmetry the step had no business accepting. The staging loop is now
+tolerant per path (one unexpected path costs one record and emits a warning), and
+both the staging and upload steps run under `if: always()` so that a `Measure`
+step which dies half way through still ships what it did measure. Records are
+written per distribution as the sweep proceeds, `scope: stale` picks up whatever
+is left, and the `collect` job already refuses a `history.tsv` row for an
+incomplete run — so keeping a partial set is strictly better than discarding it,
+and nothing downstream can mistake it for a complete sweep.
+
+## What the discarded run did tell us
+
+The measurement itself worked, and the log preserved its rollup — the first
+ecosystem parity numbers ever produced on a hosted runner, over 128
+distributions:
+
+| status | dists |
+|---|---|
+| `blocked_load` | 45 |
+| `green` | 27 |
+| `partial` | 25 |
+| `red` | 17 |
+| `no_baseline` | 12 |
+| `blocked_dep` | 2 |
+
+`blocked_load` — a distribution whose own provided module does not even `use`
+successfully — is the largest bucket at 35% of the shard, well ahead of the 27
+that pass their whole baseline. That says the frontier for the `D` shard is
+module *loading*, not assertion-level divergence, which is where P5's root-cause
+grouping should start looking. These figures are a single shard on
+`gha-ubuntu24-4c` and are recorded here as an observation, not as a KPI: the
+records that would have carried their own provenance were the ones lost, and the
+re-run is what lands them.
+
+Everything else in the run was already green on its first attempt: the shared
+release binary and pinned index artifacts, the `bwrap` probe on ubuntu-24.04
+(plain `apt-get install bubblewrap`, no AppArmor relaxation needed), the pinned
+rakudo install, and the vendored-`Test.rakumod` check.


### PR DESCRIPTION
The first real dispatch of `ecosystem-sweep.yml` ([run 34544758519](https://github.com/tokuhirom/mutsu/actions/runs/34544758519), `scope: prefix` / `prefix: D`) measured all 128 `D` distributions on both interpreters in 26 minutes — and then threw the results away one step later:

```
cp: -r not specified; omitting directory 'ecosystem/dists/D/'
```

## Root cause

`git status --porcelain` **collapses a wholly-new directory into a single entry**. `ecosystem/dists/D/` had never been measured, so the 128 fresh records were reported as one `?? ecosystem/dists/D/` line, the staging loop handed that directory to `cp --parents`, and `set -euo pipefail` failed the step. The upload was skipped for want of an artifact, and `collect` correctly concluded "nothing changed" and opened no pull request.

The fix is `-uall`, which lists untracked files individually:

```sh
git -c core.quotePath=false status --porcelain -uall -z -- ecosystem \
  | tr '\0' '\n' | sed -n 's/^.\{3\}//p' | sort -u
```

`-z` plus stripping the three-character status prefix also keeps a path with a space or a non-ASCII character intact — `awk '{print $NF}'` splits the first and git's default path quoting mangles the second. Both matter for the `_` shard, which exists precisely for names that are not ordinary ASCII words.

The apply step in `collect` needed the same fix for a quieter reason: a collapsed directory entry does not match the `\.json$` filter feeding the provenance check, so the records would have landed **unattributed** and silently lost their `history.tsv` row.

## The part worth keeping

A 26-minute measurement was destroyed by one `cp` invocation — a cost asymmetry that step had no business accepting. So, independent of the bug:

- the staging loop is **tolerant per path** (one unexpected path costs one record and emits a warning, not the shard), and
- staging and upload both run under **`if: always()`**, so a `Measure` step that dies half way through still ships what it did measure.

Records are written per distribution as the sweep proceeds, `scope: stale` picks up whatever is left, and `collect` already refuses a `history.tsv` row for an incomplete run — so keeping a partial set is strictly better than discarding it, and nothing downstream can mistake it for a complete sweep.

## Verification

Reproduced the exact failure locally and verified the fix against it, including the cases the old one-liner would also have broken on:

| case | old | new |
|---|---|---|
| brand-new shard dir (`ecosystem/dists/D/`, 2 records) | `cp: -r not specified` → **step fails, all records lost** | both records staged individually |
| new `_` shard (non-ASCII-leading name) | same failure | staged |
| modified existing record | fine | fine |
| `collect`: apply → count → provenance → `git add` | provenance table empty | 4 changed files, provenance attributes each record, `git add` sees all of them |

Also re-ran the provenance guard's three paths (uniform, mixed, unreadable) — the `.json` filter plus `-uall` is what makes the attribution table non-empty for a new shard.

No Rust, no `t/`, no roast inputs touched (workflow YAML + one news entry), so `make test` / `make roast` / `make lint` results are identical to `main` by construction; CI runs the full suite anyway because `.github/**` forces it.

## What the discarded run did tell us

The measurement itself worked, and its rollup survives in the log — the first ecosystem parity numbers produced on a hosted runner, over 128 distributions:

| status | dists |
|---|---|
| `blocked_load` | 45 |
| `green` | 27 |
| `partial` | 25 |
| `red` | 17 |
| `no_baseline` | 12 |
| `blocked_dep` | 2 |

`blocked_load` — the distribution's own module does not even `use` — is the largest bucket at 35%, well ahead of the 27 that pass their whole baseline. For this shard the frontier is module *loading*, not assertion-level divergence, which is where P5's root-cause grouping should start. Recorded in `news/` as an observation, not a KPI: the records that would have carried their own provenance are exactly what was lost, and re-running `prefix: D` after this merges is what lands them.

Everything else in the run was green on the first attempt: the shared release binary and pinned index artifacts, the `bwrap` probe on ubuntu-24.04 (plain `apt-get install bubblewrap`, no AppArmor relaxation needed), the pinned rakudo install, and the vendored-`Test.rakumod` check.

Refs #7785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164xafjtgmTPhHatdSuMR9a

---
_Generated by [Claude Code](https://claude.ai/code/session_0164xafjtgmTPhHatdSuMR9a)_