### PR TITLE
fix: the nqp text/Unicode op surface, UNIT:: lexical routines, predictive-iterator Seqs

### DIFF
--- a/ecosystem/dists/S/String--Utils.json
+++ b/ecosystem/dists/S/String--Utils.json
@@ -7,32 +7,101 @@
     "unresolved": []
   },
   "dist": "String::Utils",
-  "files": [],
+  "files": [
+    {
+      "cmp": "regression",
+      "mutsu": {
+        "first_failure": "Confused. expected statement: expected expression statement or listop argument expression or expression after infix operator or '.' or digits or ...",
+        "nok": 0,
+        "ok": 0,
+        "plan": null,
+        "secs": 0.04,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "die"
+      },
+      "path": "t/01-basic.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 124,
+        "plan": 124,
+        "secs": 3.68,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "parity",
+      "mutsu": {
+        "nok": 0,
+        "ok": 34,
+        "plan": 34,
+        "secs": 0.15,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      },
+      "path": "t/02-selective-importing.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 34,
+        "plan": 34,
+        "secs": 0.71,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "parity",
+      "mutsu": {
+        "nok": 0,
+        "ok": 7,
+        "plan": 7,
+        "secs": 0.11,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      },
+      "path": "t/03-regexify.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 7,
+        "plan": 7,
+        "secs": 0.74,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    }
+  ],
   "load": {
-    "String::Utils": "An exception occurred while evaluating a CHECK"
+    "String::Utils": "ok"
   },
   "measured": {
-    "date": "2026-09-10",
+    "attempts": 3,
+    "date": "2026-09-11",
     "harness": 1,
     "host": "linux-x86_64",
-    "mutsu_commit": "9c41901",
+    "mutsu_commit": "c9d1846",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
-    "sandbox": "bwrap"
+    "sandbox": "none"
   },
   "schema": 1,
   "source": {
     "index": "fez",
     "url": "https://360.zef.pm/S/TR/STRING_UTILS/dd311482c0621e9465940cbe1786ad03ecdd8ea6.tar.gz"
   },
-  "status": "blocked_load",
+  "status": "partial",
   "totals": {
-    "baseline_assertions": 0,
-    "baseline_files": 0,
-    "mutsu_assertions": 0,
-    "parity_files": 0,
-    "regressed_files": 0
+    "baseline_assertions": 165,
+    "baseline_files": 3,
+    "mutsu_assertions": 41,
+    "parity_files": 2,
+    "regressed_files": 1
   },
   "version": "0.0.40"
 }

--- a/ecosystem/index-snapshot.json
+++ b/ecosystem/index-snapshot.json
@@ -1,11 +1,11 @@
 {
-  "fetched": "2026-09-10",
+  "fetched": "2026-09-11",
   "fez": {
-    "dists": 1623,
-    "sha256": "d56e2bbccc60d1b7c6db98d805252a58a625bebaa0004a0dd83fbc8251886db9",
+    "dists": 1624,
+    "sha256": "94a450a2c3b48b794baab04be55f40401d2ebb95ec5433c318b71917a9186ccc",
     "url": "https://360.zef.pm/"
   },
-  "modules": 12828,
+  "modules": 12832,
   "rea": {
     "dists_added": 921,
     "sha256": "45a2d08b73eadb68abcdd0ff26b7f3c9a65ae5ccca96d55eaa1c5d8a8b04406a",

--- a/news/2026-09/string-utils-nqp-text-ops-and-unit-stash.md
+++ b/news/2026-09/string-utils-nqp-text-ops-and-unit-stash.md
@@ -1,0 +1,98 @@
+# Making String::Utils run: the nqp text surface, `UNIT::`, and predictive Seqs
+
+`String::Utils` is one of the most-depended-on distributions in the zef ecosystem and its
+`ecosystem/` record read `blocked_load`: mutsu could not even `use` it. It is written almost
+entirely in `nqp::` ops, exports through a hand-written `sub EXPORT`, and drives its `ngram`
+sequence from a `PredictiveIterator` — three surfaces that turned out to be missing or wrong in
+mutsu, none of them specific to this distribution.
+
+Following the [`ecosystem-dist-fix`](../../.agents/skills/ecosystem-dist-fix/SKILL.md) loop, each
+failure was reduced to a few lines that live in this repo, measured against rakudo, and then either
+fixed or filed. The distribution went from **0 of 3 test files running** to **2 of 3 green and the
+third at 116 of 124 assertions**.
+
+## The `nqp::` text surface
+
+`runtime/nqp_ops_text.rs` and `runtime/nqp_ops_str.rs` are new links in the pure-value dispatch
+chain, adding the character-class, Unicode-property, codepoint-array and string/hash primitives:
+`iscclass` / `findcclass` / `findnotcclass`, `unipropcode` / `getuniprop_int` / `getuniprop_str`,
+`strtocodes` / `strfromcodes`, `substr` / `concat` / `index` / `rindex` / `eqat` / `flip` / `x` /
+`uc` / `lc`, `bindkey` / `deletekey` / `existskey` / `clone`, `mod_i`, `hllbool`, `box_s`,
+`null_s` / `isnull*`, and the `list_*` / `push_*` / `atpos_s` / `bindpos_s` family. The
+`CCLASS_*` and `NORMALIZE_*` names joined the compiler's `nqp::const::` table, `nqp::create`
+learned to allocate a native array's storage rather than hand back an empty type object, and
+`getattr` / the typed `bindattr_i` / `_n` / `_s` variants were added.
+
+**Every number in there is MoarVM's, read off rakudo rather than invented.** nqp code branches on
+the raw integers — `String::Utils`'s `nomark` compares a `getuniprop_int` result against a bare `6`
+and means "Mn" by it — so a self-consistent numbering of our own would have run such code silently
+wrong instead of loudly unsupported. The General_Category value codes were derived by walking
+codepoints 0..0x2FFFF under rakudo; the `CCLASS_*` membership rules by probing `nqp::iscclass` per
+class. That measurement is worth keeping: `CCLASS_ALPHABETIC` is `gc L*`, **not** the Unicode
+`Alphabetic` property (rakudo answers 0 for U+2160 ROMAN NUMERAL ONE), `CCLASS_UPPERCASE` is `Lu`
+rather than `Uppercase`, `CCLASS_PRINTING` is simply "not `Cc`", and `CCLASS_HEXADECIMAL` is ASCII
+only. `t/vm/nqp-text-unicode-ops.t` pins all of it and passes under **both** interpreters, so the
+oracle travels with the test.
+
+One semantic detail cost a wrong answer before it was measured: `nqp::strtocodes` **replaces** its
+target array rather than appending to it. `root` allocates one buffer and re-fills it once per
+word, so an appending version compared every word after the first against the wrong offsets and
+answered `"abc"` where `root <abcd abce abde>` should give `"ab"`.
+
+## `UNIT::` is a lexical pad, and it now lists the unit's own routines
+
+`UNIT::` resolved as a *package* called "UNIT" and answered an empty stash. It is a lexical
+pseudo-package — the compilation unit's outermost pad — so it now shares the `MY::` path.
+
+That alone was not enough. The lexical pseudo-stash enumerated only routines registered under a
+bare-name package, i.e. `our`/package subs; a `my sub` (and a plain file-scope `sub`, which is also
+lexical) is secluded out of the shared registry into the per-compunit table, and nothing listed
+those. The effect was that a module's own subs appeared in `UNIT::` at its file scope — where they
+are locals of the running frame — but **not** from inside a routine of that module, which is
+precisely where a hand-written `sub EXPORT` reads them. The standard
+`UNIT::.grep: { .key.starts-with('&') }` idiom therefore exported nothing at all.
+
+`Interpreter::visible_unit_private_routines` is the enumerating twin of the existing by-name
+`unit_private_routine`, with the same visibility rule. Asking the env instead would not have done:
+registration deliberately *removes* the `&name` binding when it seclusion-moves a routine, and only
+a call through the name puts one back — which made the stash **order-dependent**, listing a routine
+on the second read and not the first. `t/modules/import-export/unit-stash-lexical-routines.t` pins
+the determinism as well as the contents.
+
+Scoping the registry walk to the pad's own compunit turned out to be part of the fix rather than a
+refinement. The registry is shared across units, so a module's `sub EXPORT` (which runs with the
+module as `current_unit`) saw the *importing script's* file-scope subs in its `UNIT::`, exported
+them straight back, and the script's next `sub` declaration was rejected as a redeclaration of
+itself. A routine declared in another file now belongs in a lexical stash only if this scope can
+actually see it by name.
+
+## A `PredictiveIterator` can drive a Seq
+
+`Seq.new($iterator)` where the iterator does `PredictiveIterator` built an **empty** Seq and kept
+the iterator only in an out-of-band table, so that `.tail` and `.Numeric` could take the
+`count-only` shortcut without draining. The cost was that the Seq had no contents: `.list` was `()`
+where the identical class doing plain `Iterator` produced its elements. It is now an ordinary
+deferred Seq that *also* carries the shortcut, and the guard that used to leave the placeholder
+untouched applies only while the body really is one.
+
+## What was filed instead of fixed
+
+Four findings were too large for this change and are recorded as issues, each with its reduction
+and both interpreters' output:
+
+- [#7880](https://github.com/tokuhirom/mutsu/issues/7880) — `my $x := BEGIN { ... }` binds `Nil`
+  and never runs the body, while `=` works. The compiled bytecode looks right and the opcode
+  provably never executes, so something between compiling and running the mainline substitutes a
+  different instruction sequence for the bind form.
+- [#7881](https://github.com/tokuhirom/mutsu/issues/7881) — a routine exported by a *runtime*
+  `sub EXPORT` is invisible to the parser's static export scan, so `imported-listop <words>` cannot
+  be parsed. This is the one blocker that keeps `t/01-basic.rakutest` from running at all; with its
+  eight affected lines rewritten to the paren form the file reaches 116/124.
+- [#7882](https://github.com/tokuhirom/mutsu/issues/7882) — `my @a is List` declares an `Array`.
+- [#7883](https://github.com/tokuhirom/mutsu/issues/7883) — the regex cursor protocol
+  (`Match.^lookup("!cursor_init")`) is not available to user code, which is how `replace` is
+  written.
+
+The distribution's record is re-measured and its remaining red is now explained by issue number
+rather than by silence — which is the outcome the skill asks for when a distribution does not go
+all the way green in one pass.

--- a/src/compiler/nqp_forms.rs
+++ b/src/compiler/nqp_forms.rs
@@ -15,6 +15,29 @@ pub(crate) fn nqp_const_value(name: &str) -> Option<i64> {
         "BINARY_SIZE_16_BIT" => 4,
         "BINARY_SIZE_32_BIT" => 8,
         "BINARY_SIZE_64_BIT" => 12,
+        // MoarVM's character-class bits, as `nqp::iscclass` / `findcclass` /
+        // `findnotcclass` take them (runtime/nqp_ops_text.rs implements the
+        // membership rules). These are a bit SET: `CCLASS_ANY` is every bit.
+        "CCLASS_UPPERCASE" => 1,
+        "CCLASS_LOWERCASE" => 2,
+        "CCLASS_ALPHABETIC" => 4,
+        "CCLASS_NUMERIC" => 8,
+        "CCLASS_HEXADECIMAL" => 16,
+        "CCLASS_WHITESPACE" => 32,
+        "CCLASS_PRINTING" => 64,
+        "CCLASS_BLANK" => 256,
+        "CCLASS_CONTROL" => 512,
+        "CCLASS_PUNCTUATION" => 1024,
+        "CCLASS_ALPHANUMERIC" => 2048,
+        "CCLASS_NEWLINE" => 4096,
+        "CCLASS_WORD" => 8192,
+        "CCLASS_ANY" => 65535,
+        // Normalization forms for `nqp::strtocodes`.
+        "NORMALIZE_NONE" => 0,
+        "NORMALIZE_NFC" => 1,
+        "NORMALIZE_NFD" => 2,
+        "NORMALIZE_NFKC" => 3,
+        "NORMALIZE_NFKD" => 4,
         _ => return None,
     })
 }

--- a/src/runtime/methods_object_native_ctors_misc.rs
+++ b/src/runtime/methods_object_native_ctors_misc.rs
@@ -174,7 +174,14 @@ impl Interpreter {
             if matches!(iterator.view(), ValueView::Instance { .. })
                 && self.type_matches_value("PredictiveIterator", iterator)
             {
-                let seq = Value::seq(Vec::new());
+                // Deferred like any other iterator — the stash below only
+                // adds the `count-only` shortcut. It used to be an EMPTY
+                // eager Seq, which made a `does PredictiveIterator` class
+                // unusable as a Seq's source: `Seq.new(It.new(3)).list` was
+                // `()` where `does Iterator` gave the three elements, and
+                // `String::Utils`'s `ngram` (whose NGrams iterator does the
+                // predictive role) returned nothing at all.
+                let seq = Value::seq_deferred(crate::value::SeqSource::Iterator(iterator.clone()));
                 if let ValueView::Seq(items) = seq.view() {
                     let seq_id = items.identity();
                     // Store off the scoped env so the association

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -590,6 +590,8 @@ mod ctor_phase_plan;
 mod nqp_ops;
 mod nqp_ops_builtin;
 mod nqp_ops_process;
+mod nqp_ops_str;
+mod nqp_ops_text;
 pub(crate) use class_introspection::UserMethodOrAccessor;
 pub(crate) mod cstruct_layout;
 mod decl_types;

--- a/src/runtime/nqp_ops_builtin.rs
+++ b/src/runtime/nqp_ops_builtin.rs
@@ -115,10 +115,19 @@ impl Interpreter {
             // nqp::bindattr($obj, Type, '$!attr', value): write an attribute
             // cell directly, bypassing accessors (roast's Test::Compile uses it
             // to install a precomp repository into a CUR::FileSystem instance).
-            "bindattr" => {
+            // The typed variants coerce first: an nqp `int`/`num`/`str`
+            // attribute holds a native value, and code that reads it back with
+            // `getattr_i` expects one.
+            "bindattr" | "bindattr_i" | "bindattr_n" | "bindattr_s" => {
                 let obj = args.first().cloned().unwrap_or(Value::NIL);
                 let attr = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
-                let val = args.get(3).cloned().unwrap_or(Value::NIL);
+                let raw = args.get(3).cloned().unwrap_or(Value::NIL);
+                let val = match op {
+                    "bindattr_i" => Value::int(to_int(&raw)),
+                    "bindattr_n" => Value::num(raw.to_f64()),
+                    "bindattr_s" => Value::str(raw.to_string_value()),
+                    _ => raw,
+                };
                 let attr_key = attr
                     .trim_start_matches(['$', '@', '%', '&'])
                     .trim_start_matches(['!', '.']);
@@ -180,6 +189,61 @@ impl Interpreter {
                 }
                 Ok(Value::int(n))
             }
+            // nqp::create($type) — allocate an instance of `$type` with NO
+            // constructor run: attributes stay uninitialized and `BUILD` is
+            // never called, which is exactly Raku's `.CREATE`. nqp code uses
+            // it both for a native array (`nqp::create(array[uint32])`) and to
+            // hand-build an iterator (`nqp::create(self)` followed by
+            // `bindattr`), so it must not go anywhere near `new`.
+            "create" => {
+                let ty = args.first().cloned().unwrap_or(Value::NIL);
+                // A native array / Buf / Blob is allocated with its REPR's
+                // empty storage, which for mutsu means `.new`: `CREATE` hands
+                // back a value with no element storage at all, so the
+                // `nqp::push_i` that invariably follows
+                // (`nqp::strtocodes($s, NFC, nqp::create(array[uint32]))`)
+                // had nothing to push onto. Everything else takes `CREATE`,
+                // whose whole point here is to skip the constructor.
+                let name = match ty.view() {
+                    ValueView::Package(sym) => sym.resolve().to_string(),
+                    _ => crate::runtime::utils::value_type_name(&ty).to_string(),
+                };
+                let method = if name.starts_with("array[")
+                    || name == "array"
+                    || crate::runtime::utils::is_buf_or_blob_class(&name)
+                {
+                    "new"
+                } else {
+                    "CREATE"
+                };
+                Ok(match self.call_method_with_values(ty, method, vec![]) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                })
+            }
+
+            // nqp::getattr($obj, $class, '$!name') and the typed reads —
+            // straight attribute access, with the class operand ignored
+            // because mutsu stores one flat attribute map per instance rather
+            // than a per-class slot table. (A private attribute of the same
+            // name in two classes of one hierarchy would therefore collide;
+            // that is the same limitation `$!name` access already has.)
+            "getattr" | "getattr_i" | "getattr_n" | "getattr_s" => {
+                let obj = args.first().cloned().unwrap_or(Value::NIL);
+                let name = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
+                let value = Self::nqp_attr_value(&obj, &name);
+                Ok(match op {
+                    "getattr_i" => Value::int(value.as_ref().map(to_int).unwrap_or(0)),
+                    "getattr_n" => Value::num(value.as_ref().map(|v| v.to_f64()).unwrap_or(0.0)),
+                    "getattr_s" => Value::str(
+                        value
+                            .as_ref()
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default(),
+                    ),
+                    _ => value.unwrap_or(Value::NIL),
+                })
+            }
             // nqp::setelems($buf, $n): resize a buffer to `$n` elements, the
             // extra ones zero. `NativeHelpers::Blob`'s `blob-allocate` is
             // `blob.new` followed by this, so a `Buf` out-parameter of a native
@@ -225,5 +289,42 @@ impl Interpreter {
             }
             _ => return None,
         })
+    }
+
+    /// The attribute-map key for an nqp `'$!name'` operand. nqp always spells
+    /// the twigil; mutsu's instance maps are keyed by the bare name, so try
+    /// both rather than assuming one (an attribute declared `@!items` is
+    /// asked for as `'@!items'` and stored as `items`).
+    fn nqp_attr_keys(name: &str) -> Vec<String> {
+        let bare = name
+            .strip_prefix("$!")
+            .or_else(|| name.strip_prefix("@!"))
+            .or_else(|| name.strip_prefix("%!"))
+            .or_else(|| name.strip_prefix("&!"))
+            .unwrap_or(name);
+        if bare == name {
+            vec![name.to_string()]
+        } else {
+            vec![bare.to_string(), name.to_string()]
+        }
+    }
+
+    fn nqp_attr_value(obj: &Value, name: &str) -> Option<Value> {
+        // `nqp::getattr($map, Map, '$!storage')` reaches for the hash a Map
+        // wraps, so that nqp's bindkey/deletekey can build it in place. In
+        // mutsu a Map/Hash IS that storage — there is no wrapper object with a
+        // separate `$!storage` slot — so the hash answers for itself, and the
+        // in-place mutations the caller then performs land on the same `Gc`
+        // the Map value holds.
+        if let ValueView::Hash(_) = obj.view() {
+            return Some(obj.clone());
+        }
+        let ValueView::Instance { attributes, .. } = obj.view() else {
+            return None;
+        };
+        let attrs = attributes.to_map();
+        Self::nqp_attr_keys(name)
+            .into_iter()
+            .find_map(|k| attrs.get(&k).cloned())
     }
 }

--- a/src/runtime/nqp_ops_process.rs
+++ b/src/runtime/nqp_ops_process.rs
@@ -107,7 +107,7 @@ impl Interpreter {
                 Ok(Value::array(parts))
             }
 
-            _ => return None,
+            _ => return self.call_nqp_op_text(op, args),
         })
     }
 

--- a/src/runtime/nqp_ops_str.rs
+++ b/src/runtime/nqp_ops_str.rs
@@ -1,0 +1,157 @@
+//! The `nqp::` string and hash primitives.
+//!
+//! Third link in the pure-value chain (`nqp_ops` → `nqp_ops_process` →
+//! `nqp_ops_text` → here), split for the 500-line limit.
+//!
+//! Every string op is **codepoint-indexed**, not byte-indexed: nqp's `substr`,
+//! `index` and `chars` all count the same units, and nqp code mixes them
+//! freely (`nqp::substr($s, 0, nqp::index($s, $needle))`). Indexing by bytes
+//! would agree with rakudo on ASCII and diverge on the first accented
+//! character.
+
+use super::*;
+
+fn sarg(args: &[Value], i: usize) -> String {
+    args.get(i).map(|v| v.to_string_value()).unwrap_or_default()
+}
+
+fn iarg(args: &[Value], i: usize) -> i64 {
+    args.get(i).map(crate::runtime::to_int).unwrap_or(0)
+}
+
+/// The byte offset of codepoint `n` in `s`, or the string's length.
+fn char_offset(s: &str, n: usize) -> usize {
+    s.char_indices().nth(n).map(|(i, _)| i).unwrap_or(s.len())
+}
+
+impl Interpreter {
+    /// Try a string / hash `nqp::` op. `None` means "not an op this table
+    /// knows"; the caller then raises the unsupported-op error.
+    pub(crate) fn call_nqp_op_str(
+        &mut self,
+        op: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        Some(match op {
+            // nqp::substr($s, $from) / ($s, $from, $chars). A negative or
+            // past-the-end `$from` clamps rather than dying, and a `$chars`
+            // that runs past the end truncates — nqp's own behaviour, which
+            // `String::Utils`'s scanners rely on (they walk with an index that
+            // may reach `chars($s)`).
+            "substr" => {
+                let s = sarg(args, 0);
+                let total = s.chars().count();
+                let from = iarg(args, 1).max(0) as usize;
+                let from = from.min(total);
+                let want = if args.len() > 2 {
+                    let n = iarg(args, 2);
+                    if n < 0 { 0 } else { n as usize }
+                } else {
+                    total - from
+                };
+                let start = char_offset(&s, from);
+                let end = char_offset(&s, from.saturating_add(want));
+                Ok(Value::str(s[start..end].to_string()))
+            }
+            "concat" => Ok(Value::str(format!("{}{}", sarg(args, 0), sarg(args, 1)))),
+            // nqp::index / rindex return **-1** when the needle is absent,
+            // where Raku's `index` returns Nil. nqp code branches on exactly
+            // that, so the -1 is the contract, not a placeholder.
+            "index" | "rindex" => {
+                let haystack = sarg(args, 0);
+                let needle = sarg(args, 1);
+                let chars: Vec<char> = haystack.chars().collect();
+                let needle_chars: Vec<char> = needle.chars().collect();
+                let from = if args.len() > 2 {
+                    iarg(args, 2).max(0) as usize
+                } else if op == "index" {
+                    0
+                } else {
+                    chars.len()
+                };
+                let found = if needle_chars.is_empty() {
+                    Some(from.min(chars.len()))
+                } else if op == "index" {
+                    (from..=chars.len().saturating_sub(needle_chars.len()))
+                        .find(|&i| chars[i..i + needle_chars.len()] == needle_chars[..])
+                } else {
+                    let last = from.min(chars.len().saturating_sub(needle_chars.len()));
+                    (0..=last)
+                        .rev()
+                        .find(|&i| chars[i..i + needle_chars.len()] == needle_chars[..])
+                };
+                Ok(Value::int(found.map(|i| i as i64).unwrap_or(-1)))
+            }
+            "flip" => Ok(Value::str(sarg(args, 0).chars().rev().collect::<String>())),
+            "uc" => Ok(Value::str(sarg(args, 0).to_uppercase())),
+            "lc" => Ok(Value::str(sarg(args, 0).to_lowercase())),
+            "x" => {
+                let n = iarg(args, 1);
+                let n = if n < 0 { 0 } else { n as usize };
+                Ok(Value::str(sarg(args, 0).repeat(n)))
+            }
+
+            // -- hash primitives --
+            // These mutate the hash IN PLACE, through the shared `Gc`, because
+            // that is what nqp callers assume: `abbrev` reaches for a Map's
+            // storage once and then builds it with bindkey/deletekey, expecting
+            // the Map it already holds to reflect every write.
+            "bindkey" | "deletekey" => {
+                let target = args.first().cloned().unwrap_or(Value::NIL);
+                let target = crate::runtime::types::unwrap_varref_value(target);
+                let key = sarg(args, 1);
+                let ValueView::Hash(hash) = target.view() else {
+                    return Some(Err(RuntimeError::new(format!(
+                        "nqp::{op}: expected a hash"
+                    ))));
+                };
+                let val = args.get(2).cloned().unwrap_or(Value::NIL);
+                // SAFETY: audited aliased in-place container write (see
+                // value::gc_contents_mut and docs/gc-contents-mut-inventory.md)
+                // — no borrow into the hash is live across the write.
+                let data = unsafe { crate::value::gc_contents_mut(&hash) };
+                if op == "bindkey" {
+                    data.map.insert(key, val.clone());
+                    Ok(val)
+                } else {
+                    Ok(data.map.remove(&key).unwrap_or(Value::NIL))
+                }
+            }
+            "existskey" => {
+                let target = crate::runtime::types::unwrap_varref_value(
+                    args.first().cloned().unwrap_or(Value::NIL),
+                );
+                let key = sarg(args, 1);
+                let yes = match target.view() {
+                    ValueView::Hash(map) => map.get(&key).is_some(),
+                    _ => false,
+                };
+                Ok(Value::int(yes as i64))
+            }
+
+            // nqp::clone($x) — a shallow copy that does not share the
+            // original's container, so mutating the copy leaves the original
+            // alone (nqp's `clone`, not Raku's `.clone` method dispatch).
+            "clone" => {
+                let v = crate::runtime::types::unwrap_varref_value(
+                    args.first().cloned().unwrap_or(Value::NIL),
+                );
+                Ok(match v.view() {
+                    ValueView::Array(items, _) => Value::array(items.to_vec()),
+                    ValueView::Hash(map) => {
+                        let copied: Vec<(String, Value)> =
+                            map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                        let mut fresh = std::collections::HashMap::new();
+                        for (k, v) in copied {
+                            fresh.insert(k, v);
+                        }
+                        Value::hash_with_data(Value::hash_arc(fresh))
+                    }
+                    _ => v.clone(),
+                })
+            }
+
+            _ => return None,
+        })
+    }
+}

--- a/src/runtime/nqp_ops_text.rs
+++ b/src/runtime/nqp_ops_text.rs
@@ -1,0 +1,450 @@
+//! The `nqp::` text ops: character classes, Unicode properties, codepoint
+//! arrays, and the native string/list primitives that go with them.
+//!
+//! Split out of `nqp_ops` for the 500-line limit, and
+//! reached from the same dispatch chain: `call_nqp_op` falls through to
+//! `call_nqp_op_process`, which falls through to `call_nqp_op_text` before the
+//! loud unsupported-op error.
+//!
+//! **The numbers here are MoarVM's, measured against rakudo, not invented.**
+//! nqp code branches on them directly — `String::Utils`'s `nomark` compares a
+//! `getuniprop_int` result against a bare `6` and means "Mn" by it — so a
+//! self-consistent numbering of our own would run such code silently wrong
+//! rather than loudly unsupported. The General_Category value codes below were
+//! read off rakudo by walking codepoints 0..0x2FFFF, and the `CCLASS_*`
+//! membership rules by probing `nqp::iscclass` per class (see
+//! `t/nqp/nqp-cclass-uniprop.t`, which pins both against the same values).
+
+use super::*;
+
+/// MoarVM's General_Category property value codes, in its enumeration order.
+/// The index into this table *is* the value `nqp::getuniprop_int` returns.
+const GENERAL_CATEGORY_CODES: [&str; 30] = [
+    "Cn", "Lu", "Ll", "Lt", "Lm", "Lo", "Mn", "Me", "Mc", "Nd", "Nl", "No", "Zs", "Zl", "Zp", "Cc",
+    "Cf", "Co", "Cs", "Pd", "Ps", "Pe", "Pc", "Po", "Sm", "Sc", "Sk", "So", "Pi", "Pf",
+];
+
+/// MoarVM's property code for `General_Category`, as `nqp::unipropcode`
+/// answers it. Only the properties mutsu can actually answer are listed: an
+/// unknown name is an error rather than a handle that would later produce a
+/// confidently wrong integer.
+const PROP_GENERAL_CATEGORY: i64 = 20;
+
+fn iarg(args: &[Value], i: usize) -> i64 {
+    args.get(i).map(crate::runtime::to_int).unwrap_or(0)
+}
+
+fn sarg(args: &[Value], i: usize) -> String {
+    args.get(i).map(|v| v.to_string_value()).unwrap_or_default()
+}
+
+/// Is `ch` a member of the MoarVM character class `cclass` (a `CCLASS_*` bit)?
+///
+/// Every rule is derived from the General Category, which is what MoarVM's own
+/// classes are defined over — note that `CCLASS_ALPHABETIC` is `L*`, NOT the
+/// Unicode `Alphabetic` property (rakudo answers 0 for U+2160 ROMAN NUMERAL
+/// ONE, which is `Nl` and `Alphabetic=Yes`), and `CCLASS_UPPERCASE` is `Lu`
+/// rather than `Uppercase`, for the same reason.
+fn is_cclass(cclass: i64, ch: char) -> bool {
+    const ANY: i64 = 65535;
+    if cclass == ANY {
+        return true;
+    }
+    let gc = crate::builtins::unicode::unicode_general_category(ch);
+    let gc = gc.as_str();
+    let cp = ch as u32;
+    // The horizontal/vertical space members that are not `Z*` categories.
+    let is_line_break = matches!(cp, 0x0A | 0x0B | 0x0C | 0x0D | 0x85);
+    let alphabetic = matches!(gc, "Lu" | "Ll" | "Lt" | "Lm" | "Lo");
+    let numeric = gc == "Nd";
+
+    let mut matched = false;
+    let mut test = |bit: i64, yes: bool| {
+        if cclass & bit != 0 && yes {
+            matched = true;
+        }
+    };
+    test(1, gc == "Lu"); // CCLASS_UPPERCASE
+    test(2, gc == "Ll"); // CCLASS_LOWERCASE
+    test(4, alphabetic); // CCLASS_ALPHABETIC
+    test(8, numeric); // CCLASS_NUMERIC
+    test(16, ch.is_ascii_hexdigit()); // CCLASS_HEXADECIMAL (ASCII only)
+    test(
+        32,
+        matches!(gc, "Zs" | "Zl" | "Zp") || is_line_break || cp == 0x09,
+    ); // WHITESPACE
+    test(64, gc != "Cc"); // CCLASS_PRINTING
+    test(256, gc == "Zs" || cp == 0x09); // CCLASS_BLANK
+    test(512, gc == "Cc"); // CCLASS_CONTROL
+    test(1024, gc.starts_with('P')); // CCLASS_PUNCTUATION
+    test(2048, alphabetic || numeric); // CCLASS_ALPHANUMERIC
+    test(4096, is_line_break || matches!(gc, "Zl" | "Zp")); // CCLASS_NEWLINE
+    test(8192, alphabetic || numeric || cp == 0x5F); // CCLASS_WORD
+    matched
+}
+
+/// `(chars, offset)` for a cclass scan: nqp indexes strings by codepoint, so
+/// every one of these ops works on a `Vec<char>` rather than on bytes.
+fn scan_bounds(args: &[Value]) -> (Vec<char>, usize, usize) {
+    let chars: Vec<char> = sarg(args, 1).chars().collect();
+    let offset = iarg(args, 2).max(0) as usize;
+    let count = iarg(args, 3).max(0) as usize;
+    let end = offset.saturating_add(count).min(chars.len());
+    (chars, offset.min(end), end)
+}
+
+/// Empty an nqp list / native array in place.
+fn clear_elems(op: &str, target: &Value) -> Result<(), RuntimeError> {
+    match target.view() {
+        ValueView::Array(items, _) => {
+            // SAFETY: audited aliased in-place container write (see
+            // value::aliased_mut); no borrow into the node is live.
+            let data = unsafe { crate::value::gc_contents_mut(&items) };
+            data.items_mut().clear();
+            Ok(())
+        }
+        ValueView::Instance { attributes, .. } => {
+            let done = crate::value::value_buf::with_buf_elems_mut(&attributes, |e| e.clear());
+            if done.is_none() {
+                return Err(RuntimeError::new(format!(
+                    "nqp::{op}: expected a Buf/Blob or array"
+                )));
+            }
+            Ok(())
+        }
+        _ => Err(RuntimeError::new(format!(
+            "nqp::{op}: expected a Buf/Blob or array"
+        ))),
+    }
+}
+
+/// Push a value onto an nqp list / native array in place.
+fn push_elem(op: &str, target: &Value, val: Value) -> Result<Value, RuntimeError> {
+    match target.view() {
+        ValueView::Array(items, _) => {
+            // SAFETY: audited aliased in-place container write (see
+            // value::aliased_mut) — the same pattern `bindpos_i` uses; no
+            // borrow into the node is live.
+            let data = unsafe { crate::value::gc_contents_mut(&items) };
+            data.items_mut().push(val);
+            Ok(target.clone())
+        }
+        ValueView::Instance { attributes, .. } => {
+            let stored = val.clone();
+            let done = crate::value::value_buf::with_buf_elems_mut(&attributes, |elems| {
+                elems.push(stored)
+            });
+            if done.is_none() {
+                return Err(RuntimeError::new(format!(
+                    "nqp::{op}: expected a Buf/Blob or array"
+                )));
+            }
+            Ok(target.clone())
+        }
+        _ => Err(RuntimeError::new(format!(
+            "nqp::{op}: expected a Buf/Blob or array"
+        ))),
+    }
+}
+
+impl Interpreter {
+    /// Try a text / Unicode / native-list `nqp::` op. `None` means "not an op
+    /// this table knows"; the caller then raises the unsupported-op error.
+    pub(crate) fn call_nqp_op_text(
+        &mut self,
+        op: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        Some(match op {
+            // -- character classes --
+            // nqp::iscclass($cclass, $str, $offset) -> 0/1 for ONE character.
+            "iscclass" => {
+                let chars: Vec<char> = sarg(args, 1).chars().collect();
+                let idx = iarg(args, 2).max(0) as usize;
+                let yes = chars
+                    .get(idx)
+                    .map(|&c| is_cclass(iarg(args, 0), c))
+                    .unwrap_or(false);
+                Ok(Value::int(yes as i64))
+            }
+            // nqp::findcclass / findnotcclass($cclass, $str, $offset, $count)
+            // -> the index of the first (non-)member in the window, or the
+            // window's END when there is none. Returning the end rather than
+            // -1 is what lets `findnotcclass(...) == chars($s)` mean "the
+            // whole string is of this class", which is how String::Utils's
+            // `is-CCLASS` is written.
+            "findcclass" | "findnotcclass" => {
+                let want = op == "findcclass";
+                let cclass = iarg(args, 0);
+                let (chars, start, end) = scan_bounds(args);
+                let found = chars[start..end]
+                    .iter()
+                    .position(|&c| is_cclass(cclass, c) == want)
+                    .map(|i| start + i)
+                    .unwrap_or(end);
+                Ok(Value::int(found as i64))
+            }
+
+            // -- Unicode properties --
+            // nqp::unipropcode($name) -> the property handle getuniprop_* takes.
+            "unipropcode" => {
+                let name = sarg(args, 0);
+                if name.eq_ignore_ascii_case("General_Category") || name.eq_ignore_ascii_case("gc")
+                {
+                    Ok(Value::int(PROP_GENERAL_CATEGORY))
+                } else {
+                    Err(RuntimeError::new(format!(
+                        "nqp::unipropcode: unsupported property '{name}' \
+                         (mutsu answers General_Category only)"
+                    )))
+                }
+            }
+            // nqp::getuniprop_int($codepoint, $propcode) -> the property VALUE
+            // code, and nqp::getuniprop_str the same value as its name.
+            "getuniprop_int" | "getuniprop_str" => {
+                let cp = iarg(args, 0);
+                let prop = iarg(args, 1);
+                if prop != PROP_GENERAL_CATEGORY {
+                    return Some(Err(RuntimeError::new(format!(
+                        "nqp::{op}: unsupported property code {prop} \
+                         (mutsu answers General_Category only)"
+                    ))));
+                }
+                let gc = u32::try_from(cp)
+                    .ok()
+                    .and_then(char::from_u32)
+                    .map(crate::builtins::unicode::unicode_general_category)
+                    .unwrap_or_else(|| "Cn".to_string());
+                if op == "getuniprop_str" {
+                    Ok(Value::str(gc))
+                } else {
+                    let code = GENERAL_CATEGORY_CODES
+                        .iter()
+                        .position(|&c| c == gc)
+                        .unwrap_or(0);
+                    Ok(Value::int(code as i64))
+                }
+            }
+
+            // -- codepoint arrays --
+            // nqp::strtocodes($str, $normalization, $target) — decompose or
+            // compose per the NORMALIZE_* mode, put the codepoints in $target,
+            // and return it. The target is REPLACED, not appended to (measured
+            // against rakudo), and mutated in place because nqp callers keep
+            // their own reference to it: `String::Utils`'s `root` allocates one
+            // buffer and re-fills it once per word, and an appending version
+            // silently compared every word after the first against the wrong
+            // offsets (`root <abcd abce abde>` answered "abc", not "ab").
+            "strtocodes" => {
+                let text = sarg(args, 0);
+                let mode = iarg(args, 1);
+                let target = args.get(2).cloned().unwrap_or(Value::NIL);
+                let normalized = match mode {
+                    0 => text.clone(),
+                    1 => normalize(&text, Normalization::Nfc),
+                    2 => normalize(&text, Normalization::Nfd),
+                    3 => normalize(&text, Normalization::Nfkc),
+                    4 => normalize(&text, Normalization::Nfkd),
+                    other => {
+                        return Some(Err(RuntimeError::new(format!(
+                            "nqp::strtocodes: unknown normalization mode {other}"
+                        ))));
+                    }
+                };
+                if let Err(e) = clear_elems(op, &target) {
+                    return Some(Err(e));
+                }
+                for ch in normalized.chars() {
+                    if let Err(e) = push_elem(op, &target, Value::int(ch as i64)) {
+                        return Some(Err(e));
+                    }
+                }
+                Ok(target)
+            }
+            // nqp::strfromcodes($codes) -> the string those codepoints spell.
+            "strfromcodes" => {
+                let codes = args.first().cloned().unwrap_or(Value::NIL);
+                let elems: Vec<Value> = match codes.view() {
+                    ValueView::Array(items, _) => items.to_vec(),
+                    ValueView::Instance { attributes, .. } => {
+                        crate::value::value_buf::with_buf_elems(&attributes, |e| e.to_vec())
+                            .unwrap_or_default()
+                    }
+                    _ => {
+                        return Some(Err(RuntimeError::new(
+                            "nqp::strfromcodes: expected an array of codepoints".to_string(),
+                        )));
+                    }
+                };
+                let mut out = String::with_capacity(elems.len());
+                for v in &elems {
+                    match u32::try_from(crate::runtime::to_int(v))
+                        .ok()
+                        .and_then(char::from_u32)
+                    {
+                        Some(ch) => out.push(ch),
+                        None => {
+                            return Some(Err(RuntimeError::new(format!(
+                                "nqp::strfromcodes: {} is not a codepoint",
+                                v.to_string_value()
+                            ))));
+                        }
+                    }
+                }
+                Ok(Value::str(out))
+            }
+
+            // -- string primitives --
+            // nqp::eqat($haystack, $needle, $pos) -> 1 when $needle occurs at
+            // exactly codepoint offset $pos.
+            "eqat" => {
+                let haystack: Vec<char> = sarg(args, 0).chars().collect();
+                let needle: Vec<char> = sarg(args, 1).chars().collect();
+                let pos = iarg(args, 2);
+                let yes = usize::try_from(pos)
+                    .ok()
+                    .and_then(|p| haystack.get(p..p.saturating_add(needle.len())))
+                    .map(|window| window == needle.as_slice())
+                    .unwrap_or(false);
+                Ok(Value::int(yes as i64))
+            }
+
+            // nqp::mod_i is MoarVM's, i.e. TRUNCATED like Rust's `%`
+            // (`mod_i(-7, 3)` is -1), not Raku's floored `%`.
+            "mod_i" => {
+                let rhs = iarg(args, 1);
+                if rhs == 0 {
+                    return Some(Err(RuntimeError::new(
+                        "nqp::mod_i: division by zero".to_string(),
+                    )));
+                }
+                Ok(Value::int(iarg(args, 0).wrapping_rem(rhs)))
+            }
+
+            // -- boxing / null --
+            // nqp::hllbool($int) -> the HLL's Bool.
+            "hllbool" => Ok(if iarg(args, 0) != 0 {
+                Value::TRUE
+            } else {
+                Value::FALSE
+            }),
+            // nqp::box_s($str, $type) -> a boxed string. mutsu's Str is not a
+            // separate representation, so the type operand only has to be
+            // honoured for a subclass, which `box_s` is never asked for here.
+            "box_s" => Ok(Value::str(sarg(args, 0))),
+            // The VM-level null. mutsu has one absent value, so `null_s` and
+            // `null` are both Nil.
+            "null_s" | "null" => Ok(Value::NIL),
+            // TODO: compile a real null-string sentinel. MoarVM's `null_s` is
+            // DISTINCT from the empty string, and the distinction is load-
+            // bearing for the idiom this exists to serve: a `str` attribute is
+            // set to `nqp::null_s` to mean "nothing buffered" and tested with
+            // `isnull_s` (String::Utils's paragraph iterator). mutsu has no such
+            // sentinel — storing Nil in a `str` attribute yields "" — so
+            // `isnull_s` has to count "" as null here, which makes it answer 1
+            // for a genuinely empty string too. The correct fix is a null-string
+            // value that stays distinguishable through a native `str` slot.
+            "isnull" | "isnull_s" => {
+                let v = args.first().cloned().unwrap_or(Value::NIL);
+                let null = if op == "isnull_s" {
+                    v.is_nil() || matches!(v.view(), ValueView::Str(s) if s.is_empty())
+                } else {
+                    v.is_nil()
+                };
+                Ok(Value::int(null as i64))
+            }
+
+            // -- native string lists --
+            // nqp::list_s(...) -> a VM list of strings; mutsu represents one as
+            // an ordinary array, which is what atpos_s/bindpos_s/push_s below
+            // (and the existing atpos_i/bindpos_i) already operate on.
+            "list_s" | "list_i" | "list_n" => Ok(Value::array(args.to_vec())),
+            "push_s" | "push_i" | "push_n" => {
+                let target = args.first().cloned().unwrap_or(Value::NIL);
+                let val = args.get(1).cloned().unwrap_or(Value::NIL);
+                let val = match op {
+                    "push_s" => Value::str(val.to_string_value()),
+                    "push_n" => Value::num(val.to_f64()),
+                    _ => Value::int(crate::runtime::to_int(&val)),
+                };
+                push_elem(op, &target, val)
+            }
+            "atpos_s" => {
+                let target = args.first().cloned().unwrap_or(Value::NIL);
+                let idx = iarg(args, 1);
+                let elem = match target.view() {
+                    ValueView::Array(items, _) => usize::try_from(idx)
+                        .ok()
+                        .and_then(|i| items.get(i).cloned()),
+                    ValueView::Instance { attributes, .. } => {
+                        usize::try_from(idx).ok().and_then(|i| {
+                            crate::value::value_buf::with_buf_elems(&attributes, |e| {
+                                e.get(i).cloned()
+                            })
+                            .flatten()
+                        })
+                    }
+                    _ => None,
+                };
+                Ok(Value::str(
+                    elem.map(|v| v.to_string_value()).unwrap_or_default(),
+                ))
+            }
+            "bindpos_s" => {
+                let target = args.first().cloned().unwrap_or(Value::NIL);
+                let idx = iarg(args, 1).max(0) as usize;
+                let val = Value::str(sarg(args, 2));
+                match target.view() {
+                    ValueView::Array(items, _) => {
+                        // SAFETY: audited aliased in-place container write (see
+                        // value::aliased_mut); no borrow into the node is live.
+                        let data = unsafe { crate::value::gc_contents_mut(&items) };
+                        if data.items().len() <= idx {
+                            data.items_mut().resize(idx + 1, Value::str(String::new()));
+                        }
+                        data.items_mut()[idx] = val.clone();
+                        Ok(val)
+                    }
+                    ValueView::Instance { attributes, .. } => {
+                        let stored = val.clone();
+                        let done =
+                            crate::value::value_buf::with_buf_elems_mut(&attributes, |elems| {
+                                if elems.len() <= idx {
+                                    elems.resize(idx + 1, Value::str(String::new()));
+                                }
+                                elems[idx] = stored;
+                            });
+                        if done.is_none() {
+                            return Some(Err(RuntimeError::new(
+                                "nqp::bindpos_s: expected a Buf/Blob or array".to_string(),
+                            )));
+                        }
+                        Ok(val)
+                    }
+                    _ => Err(RuntimeError::new(
+                        "nqp::bindpos_s: expected a Buf/Blob or array".to_string(),
+                    )),
+                }
+            }
+
+            _ => return self.call_nqp_op_str(op, args),
+        })
+    }
+}
+
+enum Normalization {
+    Nfc,
+    Nfd,
+    Nfkc,
+    Nfkd,
+}
+
+fn normalize(text: &str, form: Normalization) -> String {
+    use unicode_normalization::UnicodeNormalization;
+    match form {
+        Normalization::Nfc => text.nfc().collect(),
+        Normalization::Nfd => text.nfd().collect(),
+        Normalization::Nfkc => text.nfkc().collect(),
+        Normalization::Nfkd => text.nfkd().collect(),
+    }
+}

--- a/src/runtime/unit_private_routines.rs
+++ b/src/runtime/unit_private_routines.rs
@@ -196,6 +196,48 @@ impl Interpreter {
         self.unit_private_routine_from(self.executing_unit_sym(), name_sym)
     }
 
+    /// Every compunit-private routine visible to the code running right now —
+    /// the enumerating twin of [`Self::unit_private_routine`], answering from
+    /// the same unit that one would resolve a name against (see the precedence
+    /// note in the body).
+    ///
+    /// A lexical pseudo-stash (`MY::`, `UNIT::`) needs the whole set rather
+    /// than one name: `sub EXPORT`'s standard "export everything I declared"
+    /// idiom is `UNIT::.grep: { .key.starts-with('&') }`, which can only see
+    /// what the stash enumerates. Asking the env instead would be
+    /// order-dependent — registration deliberately REMOVES the `&name` binding
+    /// when it seclusion-moves a routine here, and only a call through the
+    /// name puts one back.
+    pub(crate) fn visible_unit_private_routines(&self) -> Vec<(Symbol, Arc<FunctionDef>)> {
+        if self.unit_private_names.is_empty() {
+            return Vec::new();
+        }
+        // The SAME precedence `unit_private_routine` applies to one name:
+        // `current_unit` first and, only when that chain holds nothing,
+        // the frame's own unit. Never the union of the two — they can be
+        // different compunits (a module's `sub EXPORT` runs with the module
+        // as `current_unit` while the importing script is still the executing
+        // frame's unit), and unioning them put the IMPORTER's routines into
+        // the module's `UNIT::`. The module then exported them back, and the
+        // importer's next `sub` declaration was rejected as a redeclaration
+        // of itself.
+        for anchor in [self.current_unit, self.executing_unit_sym()] {
+            let mut out: Vec<(Symbol, Arc<FunctionDef>)> = Vec::new();
+            let mut unit = Some(anchor);
+            for _ in 0..64 {
+                let Some(sym) = unit else { break };
+                if let Some(table) = self.unit_private_routines.get(&sym) {
+                    out.extend(table.iter().map(|(name, def)| (*name, def.clone())));
+                }
+                unit = crate::runtime::eval_unit_parent(sym);
+            }
+            if !out.is_empty() {
+                return out;
+            }
+        }
+        Vec::new()
+    }
+
     /// A private routine named `name_sym` declared by `unit`, or by a unit
     /// `unit` is an `EVAL` of (an `EVAL` compiles in its caller's lexical
     /// scope).

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -612,7 +612,19 @@ impl Interpreter {
         // matches anything). Leave it completely untouched here; the
         // specific dispatch handlers (`dispatch_tail`, `.Numeric`) do their
         // own `predictive_seq_iter_for` lookup against the UNCHANGED body.
-        if body.is_empty() && self.predictive_seq_iter_for(body.identity()).is_some() {
+        // ... but only for the two methods that actually TAKE the shortcut.
+        // A predictive-iterator Seq is an ordinary deferred body now (so that
+        // consuming it pulls — `Seq.new($predictive).list` used to answer `()`),
+        // and the out-of-band association is a count-only shortcut on top of
+        // that rather than the body's only contents. Skipping the touch for
+        // every method would make every consumption answer empty; not skipping
+        // it for these two lets the touch rebuild the body under a new
+        // identity and orphan the association, which is what the paragraph
+        // above describes.
+        if body.is_empty()
+            && matches!(method, "tail" | "Numeric")
+            && self.predictive_seq_iter_for(body.identity()).is_some()
+        {
             return Ok(target);
         }
         if method == "sink" {

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -502,6 +502,19 @@ impl Interpreter {
         if let Some(package) = name.strip_suffix("::")
             && package != "MY"
             && package != "LEXICAL"
+            // `UNIT::` is a LEXICAL pseudo-package — the compilation unit's
+            // outermost pad — not a package called "UNIT". Reading it as one
+            // handed back an empty stash, so `UNIT::.grep: { .key.starts-with('&') }`
+            // (the shape a module's `sub EXPORT` uses to export everything it
+            // declared: String::Utils, Array::Sorted::Util, ...) iterated the
+            // stash object itself and died on `.key`.
+            //
+            // TODO: this shares the `MY::` pad below, which inside a routine
+            // over-reports — it adds that routine's own locals, where rakudo's
+            // `UNIT::` shows only the unit's. Answering it exactly needs the
+            // compiler to keep a per-unit symbol table rather than deriving the
+            // pad from the running frame.
+            && package != "UNIT"
             && !package.is_empty()
         {
             // A lexical bound to a *type object* names that package:
@@ -604,19 +617,33 @@ impl Interpreter {
 
     fn add_visible_routines_to_pseudo_stash(&self, entries: &mut HashMap<String, Value>) {
         let packages = self.bare_name_packages();
+        // The pad this stash represents belongs to ONE compunit, and the
+        // registry is shared across all of them. A routine declared in another
+        // file therefore only belongs here if this scope can actually see it by
+        // name — i.e. it was imported (an `&name` env binding) or it is a
+        // builtin/prelude routine with no declaring file of its own.
+        //
+        // Without the check, a module's `sub EXPORT` (which runs with the
+        // module as `current_unit`) saw the IMPORTING script's own file-scope
+        // subs in its `UNIT::`, exported them straight back, and the script's
+        // next `sub` declaration was rejected as a redeclaration of itself.
+        let anchor = self.current_unit;
         let names: std::collections::HashSet<String> = {
             let registry = self.registry();
             registry
                 .functions
-                .keys()
-                .filter_map(|key| {
+                .iter()
+                .filter_map(|(key, def)| {
                     let key = key.resolve();
-                    packages.iter().find_map(|package| {
+                    let name = packages.iter().find_map(|package| {
                         let prefix = format!("{package}::");
                         let rest = key.strip_prefix(&prefix)?;
                         let name = rest.split('/').next().unwrap_or(rest);
                         (!name.contains("::") && !name.is_empty()).then(|| name.to_string())
-                    })
+                    })?;
+                    let declared_here = def.source_file.is_none()
+                        || self.unit_of_declaring_file(def.source_file.as_deref()) == anchor;
+                    (declared_here || self.env().get(&format!("&{name}")).is_some()).then_some(name)
                 })
                 .collect()
         };
@@ -624,6 +651,26 @@ impl Interpreter {
             let value = self.resolve_code_var(&name);
             if !value.is_nil() {
                 entries.entry(format!("&{name}")).or_insert(value);
+            }
+        }
+        // The registry walk above only reaches routines registered under a
+        // bare-name *package*, i.e. `our`/package subs. A `my sub` (or a plain
+        // `sub` at file scope, which is lexical too) is secluded out of the
+        // registry into the per-compunit table instead, so it needs its own
+        // enumeration — see `runtime/unit_private_routines.rs`.
+        //
+        // Without this, `MY::`/`UNIT::` answered a module's own lexical subs at
+        // its file scope (they are locals of that frame) but NOT from inside a
+        // routine of that module — which is precisely where `sub EXPORT` reads
+        // them, so the standard `UNIT::.grep: { .key.starts-with('&') }`
+        // idiom exported nothing at all (String::Utils, Array::Sorted::Util,
+        // and every other module that exports by enumerating its own unit).
+        for (name, def) in self.visible_unit_private_routines() {
+            let value = self.sub_value_from_function_def((*def).clone());
+            if !value.is_nil() {
+                entries
+                    .entry(format!("&{}", name.resolve()))
+                    .or_insert(value);
             }
         }
     }

--- a/t/collections/lazy-seq/seq-predictive-iterator-source.t
+++ b/t/collections/lazy-seq/seq-predictive-iterator-source.t
@@ -1,0 +1,46 @@
+use Test;
+
+# `Seq.new($iterator)` where the iterator `does PredictiveIterator`.
+#
+# mutsu used to answer an EMPTY Seq for this and keep the iterator only in an
+# out-of-band table, so that `.tail`/`.Numeric` could take the `count-only`
+# shortcut without draining. The cost was that the Seq had no contents at all:
+# `.list` was `()` where the identical class doing plain `Iterator` produced its
+# elements. A predictive Seq is now an ordinary deferred Seq that ALSO carries
+# the shortcut. Found via String::Utils's `ngram`, whose NGrams iterator does
+# the predictive role, so `ngram("foobar", 3)` returned nothing.
+
+plan 6;
+
+my class Plain does Iterator {
+    has int $!n;
+    method new($n) { my $s = self.CREATE; $s.set($n); $s }
+    method set($n) { $!n = $n }
+    method pull-one() { $!n-- ?? "x$!n" !! IterationEnd }
+}
+
+my class Predictive does PredictiveIterator {
+    has int $!n;
+    method new($n) { my $s = self.CREATE; $s.set($n); $s }
+    method set($n) { $!n = $n }
+    method pull-one() { $!n-- ?? "y$!n" !! IterationEnd }
+    method count-only(--> Int:D) { $!n }
+}
+
+is-deeply Seq.new(Plain.new(3)).list.List, ("x2", "x1", "x0"),
+  'a plain Iterator drives a Seq';
+is-deeply Seq.new(Predictive.new(3)).list.List, ("y2", "y1", "y0"),
+  'a PredictiveIterator drives a Seq the same way';
+
+is Seq.new(Predictive.new(3)).elems, 3, 'its elems is the element count';
+is Seq.new(Predictive.new(3)).iterator.count-only, 3,
+  'the count-only shortcut still reaches the iterator';
+
+# Consumption must still be single-use, and pulling must not be duplicated by
+# the shortcut being present.
+my $seq = Seq.new(Predictive.new(2));
+is-deeply $seq.list.List, ("y1", "y0"), 'consumed once';
+is-deeply Seq.new(Predictive.new(0)).list.List, (),
+  'an immediately-exhausted predictive iterator gives an empty Seq';
+
+# vim: expandtab shiftwidth=4

--- a/t/lib/UnitStashExport.rakumod
+++ b/t/lib/UnitStashExport.rakumod
@@ -1,0 +1,13 @@
+# A module that exports by enumerating its OWN compilation unit, which is the
+# standard shape of a hand-written `sub EXPORT` (String::Utils, Array::Sorted::Util,
+# ... all use it verbatim). It works only if `UNIT::` lists the unit's lexical
+# routines while EXPORT is running -- see t/modules/unit-stash-lexical-routines.t.
+
+my sub alpha() { "A" }
+my sub beta()  { "B" }
+
+my sub EXPORT(*@names) {
+    Map.new: @names
+      ?? @names.map({ UNIT::{"&$_"}:p })
+      !! UNIT::.grep({ .key.starts-with('&') && .key ne '&EXPORT' })
+}

--- a/t/modules/import-export/unit-stash-lexical-routines.t
+++ b/t/modules/import-export/unit-stash-lexical-routines.t
@@ -1,0 +1,41 @@
+use lib 't/lib';
+use Test;
+use UnitStashExport;
+
+# `UNIT::` is the compilation unit's outermost LEXICAL pad, not a package called
+# "UNIT", and it must list the unit's own `my sub`s from inside a routine of that
+# unit -- which is exactly where a hand-written `sub EXPORT` reads them.
+#
+# Two bugs met here before: `UNIT::` resolved as a package and answered an empty
+# stash, and the lexical pseudo-stash enumerated only `our`/package routines, so
+# the standard `UNIT::.grep: { .key.starts-with('&') }` export idiom (which
+# `t/lib/UnitStashExport.rakumod` uses verbatim, as String::Utils does) exported
+# nothing at all. The second one was also ORDER-DEPENDENT -- a routine appeared
+# only once something had already called through its name -- which is why the
+# repeated reads below are part of the test.
+
+plan 7;
+
+my sub local-helper() { 42 }
+
+sub probe() {
+    UNIT::.keys.grep(*.starts-with('&')).sort.join(",")
+}
+
+ok probe().contains('&local-helper'),
+  'UNIT:: lists a unit-level `my sub` from inside a routine';
+is probe(), probe(),
+  'UNIT:: answers the same set on a second read (no call-warmed entries)';
+ok probe().contains('&probe'),
+  'a plain file-scope `sub` (also lexical) is listed too';
+
+isa-ok UNIT::, PseudoStash, 'UNIT:: is a PseudoStash, not a package stash';
+ok UNIT::.elems > 0, 'UNIT:: is not empty';
+
+is UNIT::<&local-helper>(), 42,
+  'the routine UNIT:: lists is the callable one';
+
+is-deeply (alpha(), beta()), ("A", "B"),
+  'a module whose sub EXPORT enumerates UNIT:: exports its lexical subs';
+
+# vim: expandtab shiftwidth=4

--- a/t/vm/nqp-text-unicode-ops.t
+++ b/t/vm/nqp-text-unicode-ops.t
@@ -1,0 +1,94 @@
+use Test;
+use nqp;
+
+# The `nqp::` text surface: character classes, Unicode properties, codepoint
+# arrays and the string/hash primitives (runtime/nqp_ops_text.rs and
+# runtime/nqp_ops_str.rs). Every number asserted here is MoarVM's, measured
+# against rakudo -- nqp code branches on the raw integers, so a self-consistent
+# numbering of our own would run such code silently wrong. Found by making
+# String::Utils's test suite run, which is written almost entirely in these ops.
+
+plan 46;
+
+#- character classes -----------------------------------------------------------
+
+is nqp::iscclass(nqp::const::CCLASS_UPPERCASE, "A", 0), 1, 'A is uppercase';
+is nqp::iscclass(nqp::const::CCLASS_UPPERCASE, "a", 0), 0, 'a is not uppercase';
+is nqp::iscclass(nqp::const::CCLASS_LOWERCASE, "a", 0), 1, 'a is lowercase';
+is nqp::iscclass(nqp::const::CCLASS_NUMERIC, "7", 0),   1, '7 is numeric';
+is nqp::iscclass(nqp::const::CCLASS_NUMERIC, "\xBC", 0), 0,
+  'VULGAR FRACTION ONE QUARTER is No, not numeric (gc Nd, not the Numeric property)';
+is nqp::iscclass(nqp::const::CCLASS_ALPHABETIC, "\x2160", 0), 0,
+  'ROMAN NUMERAL ONE is Nl, so not CCLASS_ALPHABETIC (gc L*, not the Alphabetic property)';
+is nqp::iscclass(nqp::const::CCLASS_HEXADECIMAL, "f", 0), 1, 'f is a hex digit';
+is nqp::iscclass(nqp::const::CCLASS_HEXADECIMAL, "g", 0), 0, 'g is not a hex digit';
+is nqp::iscclass(nqp::const::CCLASS_WHITESPACE, "\xA0", 0), 1, 'NBSP is whitespace';
+is nqp::iscclass(nqp::const::CCLASS_BLANK, "\t", 0),    1, 'tab is blank';
+is nqp::iscclass(nqp::const::CCLASS_BLANK, "\n", 0),    0, 'newline is not blank';
+is nqp::iscclass(nqp::const::CCLASS_NEWLINE, "\n", 0),  1, 'newline is a newline';
+is nqp::iscclass(nqp::const::CCLASS_CONTROL, "\t", 0),  1, 'tab is a control character';
+is nqp::iscclass(nqp::const::CCLASS_PRINTING, "\t", 0), 0, 'tab does not print';
+is nqp::iscclass(nqp::const::CCLASS_PRINTING, "\xAD", 0), 1,
+  'SOFT HYPHEN is Cf, and everything that is not Cc prints';
+is nqp::iscclass(nqp::const::CCLASS_PUNCTUATION, "_", 0), 1, 'underscore is punctuation (Pc)';
+is nqp::iscclass(nqp::const::CCLASS_PUNCTUATION, "+", 0), 0, 'plus is a symbol, not punctuation';
+is nqp::iscclass(nqp::const::CCLASS_WORD, "_", 0),      1, 'underscore is a word character';
+is nqp::iscclass(nqp::const::CCLASS_WORD, "-", 0),      0, 'hyphen is not a word character';
+
+# findcclass / findnotcclass answer the END of the window when there is no
+# match, not -1 -- which is what lets `findnotcclass(...) == chars($s)` mean
+# "the whole string is of this class".
+is nqp::findnotcclass(nqp::const::CCLASS_NUMERIC, "123", 0, 3), 3,
+  'findnotcclass runs off the end of an all-numeric string';
+is nqp::findnotcclass(nqp::const::CCLASS_NUMERIC, "12a", 0, 3), 2,
+  'findnotcclass finds the first non-member';
+is nqp::findcclass(nqp::const::CCLASS_WORD, "  ab", 0, 4), 2,
+  'findcclass finds the first member';
+is nqp::findcclass(nqp::const::CCLASS_WORD, "    ", 0, 4), 4,
+  'findcclass runs off the end when there is no member';
+
+#- Unicode properties ----------------------------------------------------------
+
+my $gc = nqp::unipropcode("General_Category");
+is $gc, 20, 'the General_Category property code is MoarVM\'s 20';
+is nqp::getuniprop_int("a".ord, $gc), 2,  'Ll is value code 2';
+is nqp::getuniprop_int("A".ord, $gc), 1,  'Lu is value code 1';
+is nqp::getuniprop_int(0x301,   $gc), 6,  'Mn is value code 6 (what "is a mark" tests compare against)';
+is nqp::getuniprop_int("0".ord, $gc), 9,  'Nd is value code 9';
+is nqp::getuniprop_int(" ".ord, $gc), 12, 'Zs is value code 12';
+
+#- codepoint arrays ------------------------------------------------------------
+
+my $codes := nqp::strtocodes("a\c[COMBINING ACUTE ACCENT]", nqp::const::NORMALIZE_NFC,
+                             nqp::create(array[uint32]));
+is nqp::elems($codes), 1, 'NFC composes the decomposed pair into one codepoint';
+is nqp::atpos_i($codes, 0), 0xE1, '... and it is LATIN SMALL LETTER A WITH ACUTE';
+
+my $nfd := nqp::strtocodes("\xE9", nqp::const::NORMALIZE_NFD, nqp::create(array[uint32]));
+is nqp::elems($nfd), 2, 'NFD decomposes it back into two';
+
+# The target is REPLACED, not appended to: nqp code allocates one buffer and
+# re-fills it per item (String::Utils's `root` does exactly this).
+my $reused := nqp::create(array[uint32]);
+nqp::strtocodes("ab", nqp::const::NORMALIZE_NFC, $reused);
+nqp::strtocodes("xyz", nqp::const::NORMALIZE_NFC, $reused);
+is nqp::elems($reused), 3, 'strtocodes replaces the target rather than appending to it';
+is nqp::strfromcodes($reused), "xyz", 'strfromcodes turns codepoints back into a string';
+
+#- string primitives -----------------------------------------------------------
+
+is nqp::substr("hello", 2),      "llo", 'substr from an offset';
+is nqp::substr("hello", 1, 3),   "ell", 'substr with a length';
+is nqp::substr("hello", 3, 99),  "lo",  'substr past the end truncates';
+is nqp::substr("h\xE9llo", 1, 2), "\xE9l",
+  'substr counts codepoints, not bytes';
+is nqp::concat("foo", "bar"), "foobar", 'concat';
+is nqp::index("hello", "ll"), 2,  'index finds a substring';
+is nqp::index("hello", "zz"), -1, 'index answers -1 when absent, where Raku index answers Nil';
+is nqp::eqat("hello", "ell", 1), 1, 'eqat at the right position';
+is nqp::eqat("hello", "ell", 2), 0, 'eqat at the wrong position';
+is nqp::flip("abc"), "cba", 'flip';
+is nqp::x("ab", 3), "ababab", 'x repeats';
+is nqp::mod_i(-7, 3), -1, 'mod_i truncates like MoarVM, it does not floor like Raku %';
+
+# vim: expandtab shiftwidth=4

--- a/t/vm/nqp-unimplemented-op-errors.t
+++ b/t/vm/nqp-unimplemented-op-errors.t
@@ -20,18 +20,24 @@ plan 7;
     is nqp::ordat("abc", 1), 98, 'an implemented nqp op still works';
 }
 
-throws-like 'use nqp; nqp::index("hello", "z")', X::AdHoc,
-    message => /'Unsupported nqp:: op' .* 'nqp::index'/,
+# (`nqp::index` was the example here until the String::Utils slice implemented
+# it -- like the two below, the example must stay an op mutsu does NOT provide.
+# `nqp::reverse` keeps the point intact: Raku's `reverse("abc")` is the
+# one-element list `("abc")`, nqp's is the string `"cba"`.)
+throws-like 'use nqp; nqp::reverse("abc")', X::AdHoc,
+    message => /'Unsupported nqp:: op' .* 'nqp::reverse'/,
     'an unimplemented nqp op fails instead of aliasing to the Raku builtin';
 
 # (`nqp::chars` was the example here until the CBOR::Simple slice implemented
-# it — the example must stay an op mutsu does NOT provide.)
+# it -- the example must stay an op mutsu does NOT provide.)
 throws-like 'use nqp; nqp::objectid($_)', X::AdHoc,
     message => /'nqp::objectid'/,
     'and names the op it could not provide';
 
-throws-like 'use nqp; nqp::substr("hello", 1, 3)', X::AdHoc,
-    message => /'nqp::substr'/,
+# (`nqp::substr` was the example here until the String::Utils slice implemented
+# it.)
+throws-like 'use nqp; nqp::chr(65)', X::AdHoc,
+    message => /'nqp::chr'/,
     'including ops whose Raku namesake would have produced a plausible answer';
 
 # Regression guard: this must stay scoped to `nqp::`. An ordinary qualified


### PR DESCRIPTION
Three unrelated interpreter gaps, found by running **`String::Utils`**'s own test suite under both interpreters (`ecosystem/dists/S/String--Utils.json`, which read `blocked_load` — mutsu could not even `use` it). None of them is specific to that distribution.

| | before | after |
|---|---|---|
| record status | `blocked_load` | `partial` |
| baseline files passing | 0 of 0 (nothing ran) | **2 of 3** |
| `t/01-basic.rakutest` | does not parse | 116 of 124 assertions, blocked by one parse gap (#7881) |

## 1. The `nqp::` text surface

`runtime/nqp_ops_text.rs` and `runtime/nqp_ops_str.rs` are new links in the pure-value dispatch chain: `iscclass` / `findcclass` / `findnotcclass`, `unipropcode` / `getuniprop_int` / `getuniprop_str`, `strtocodes` / `strfromcodes`, `substr` / `concat` / `index` / `rindex` / `eqat` / `flip` / `x` / `uc` / `lc`, `bindkey` / `deletekey` / `existskey` / `clone`, `mod_i`, `hllbool`, `box_s`, `null_s` / `isnull*`, and the `list_*` / `push_*` / `atpos_s` / `bindpos_s` family. The `CCLASS_*` and `NORMALIZE_*` names join the compiler's `nqp::const::` table, `nqp::create` allocates a native array's storage rather than handing back an empty type object, and `getattr` plus the typed `bindattr_i` / `_n` / `_s` variants are added.

**Every number is MoarVM's, read off rakudo rather than invented.** nqp code branches on the raw integers — `String::Utils`'s `nomark` compares a `getuniprop_int` result against a bare `6` and means "Mn" by it — so a self-consistent numbering of our own would run such code *silently wrong* instead of loudly unsupported. The General_Category value codes came from walking codepoints 0..0x2FFFF under rakudo, the `CCLASS_*` rules from probing `nqp::iscclass` per class. Worth keeping from that measurement:

- `CCLASS_ALPHABETIC` is `gc L*`, **not** the Unicode `Alphabetic` property (rakudo answers 0 for U+2160 ROMAN NUMERAL ONE, which is `Nl` and `Alphabetic=Yes`);
- `CCLASS_UPPERCASE` is `Lu` rather than `Uppercase`, for the same reason;
- `CCLASS_PRINTING` is simply "not `Cc`"; `CCLASS_HEXADECIMAL` is ASCII only;
- `nqp::strtocodes` **replaces** its target array rather than appending — `root` allocates one buffer and re-fills it per word, so an appending version compared every word after the first against the wrong offsets and answered `"abc"` where `root <abcd abce abde>` should give `"ab"`.

## 2. `UNIT::` is a lexical pad, and it lists the unit's own routines

`UNIT::` resolved as a *package* called "UNIT" and answered an empty stash; it is a lexical pseudo-package, so it now shares the `MY::` path.

That alone was not enough. The lexical pseudo-stash enumerated only routines registered under a bare-name package (`our`/package subs), while a `my sub` — and a plain file-scope `sub`, which is also lexical — is secluded out of the shared registry into the per-compunit table. So a module's own subs appeared in `UNIT::` at its file scope (where they are locals of the running frame) but **not** from inside a routine of that module, which is precisely where a hand-written `sub EXPORT` reads them. The standard `UNIT::.grep: { .key.starts-with('&') }` idiom therefore exported nothing at all.

`Interpreter::visible_unit_private_routines` is the enumerating twin of the by-name `unit_private_routine`, with the same unit precedence. Asking the env instead would not do: registration deliberately *removes* the `&name` binding when it seclusion-moves a routine, and only a call through the name puts one back — which made the stash **order-dependent**, listing a routine on the second read and not the first.

Scoping the registry walk to the pad's own compunit is part of the fix rather than a refinement. The registry is shared across units, so a module's `sub EXPORT` (which runs with the module as `current_unit`) saw the *importing script's* file-scope subs in its `UNIT::`, exported them straight back, and the script's next `sub` declaration was rejected as a redeclaration of itself.

## 3. A `PredictiveIterator` can drive a Seq

`Seq.new($iterator)` where the iterator does `PredictiveIterator` built an **empty** Seq and kept the iterator only in an out-of-band table, so `.tail` / `.Numeric` could take the `count-only` shortcut without draining. The cost was that the Seq had no contents: `.list` was `()` where the identical class doing plain `Iterator` produced its elements (this is why `ngram("foobar", 3)` returned nothing). It is now an ordinary deferred Seq that *also* carries the shortcut, and the guard that skips the touch applies only to the two methods that actually take it.

## Tests

- `t/vm/nqp-text-unicode-ops.t` — passes under **both** interpreters, so rakudo is the oracle for every number it asserts.
- `t/modules/import-export/unit-stash-lexical-routines.t` + `t/lib/UnitStashExport.rakumod`, which uses the export idiom verbatim; it pins the determinism as well as the contents.
- `t/collections/lazy-seq/seq-predictive-iterator-source.t`.
- `t/vm/nqp-unimplemented-op-errors.t` moves its examples to ops that are still unimplemented, as that file's own comment instructs (`nqp::index` / `nqp::substr` → `nqp::reverse` / `nqp::chr`).

## Filed instead of fixed

Four findings were too large for this change, each with its reduction and both interpreters' output:

- **#7880** — `my $x := BEGIN { ... }` binds `Nil` and never runs the body, while `=` works. The bytecode looks right and the opcode provably never executes.
- **#7881** — a routine exported by a *runtime* `sub EXPORT` is invisible to the parser's static export scan, so `imported-listop <words>` cannot be parsed. This is the only thing left standing between `t/01-basic.rakutest` and running.
- **#7882** — `my @a is List` declares an `Array`.
- **#7883** — the regex cursor protocol behind `Match.^lookup("!cursor_init")`, which is how `replace` is written.

## Verification

`cargo fmt --all`, `make lint` (all four configurations), `make test` (**Result: PASS**, 3966 files / 42208 tests) and `make roast` all run locally. `make roast` is red only on the three environment-only files documented in `docs/agent-environments.md`, matching by name *and* by failing-test numbers: `roast/6.c/S32-io/file-tests.t` (tests 6-8, 10 — `uid 0`), `roast/S16-filehandles/filetest.t` (Failed: 25 — `uid 0`) and `roast/S32-io/IO-Socket-Async.t` (exit 124 — sandboxed network).

The ledger record was re-measured with `scripts/ecosystem-sweep.py --only String::Utils --sandbox none` and is committed alongside the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pjz7KrxpkCarqUMgej9GED

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pjz7KrxpkCarqUMgej9GED)_