### PR TITLE
fix: compose unit grammar also-is parents

### DIFF
--- a/news/2026-09/unit-grammar-also-is.md
+++ b/news/2026-09/unit-grammar-also-is.md
@@ -1,0 +1,3 @@
+`also is Parent` now replaces a `unit grammar` declaration's implicit `Grammar`
+parent, matching Rakudo and allowing the named grammar parent to compose
+without an inconsistent class hierarchy.

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -352,11 +352,21 @@ pub(crate) fn stmt_list_with_mode(
                     // statements here, so apply the same extraction — otherwise an
                     // `also is Parent` (a bare `is(also, Parent)` infix expression)
                     // would execute as a runtime "two terms in a row".
+                    // A grammar has an implicit `Grammar` parent when it has no
+                    // explicit `is` clause. `also is Parent` supplies that direct
+                    // parent in Raku; retaining both `Grammar` and a grammar that
+                    // already inherits it makes the C3 merge inconsistent.
+                    let has_implicit_grammar_parent = parents.len() == 1 && parents[0] == "Grammar";
+                    let mut replaced_implicit_grammar_parent = false;
                     tail_stmts.retain(|stmt| {
                         if class::stmt_is_also_is_rw(stmt) {
                             *class_is_rw = true;
                             false
                         } else if let Some(parent_name) = class::stmt_also_is_parent(stmt) {
+                            if has_implicit_grammar_parent && !replaced_implicit_grammar_parent {
+                                parents.clear();
+                                replaced_implicit_grammar_parent = true;
+                            }
                             parents.push(parent_name);
                             false
                         } else {

--- a/t/grammar/unit-grammar-also-is.t
+++ b/t/grammar/unit-grammar-also-is.t
@@ -1,0 +1,20 @@
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+grammar BaseG {
+    token ws { \s* }
+    rule TOP { ^ 'x' $ }
+}
+
+my $derived = EVAL q:to/CODE/;
+    unit grammar DerivedG;
+    also is BaseG;
+    rule TOP { ^ 'y' $ }
+    CODE
+
+plan 3;
+ok $derived.parse('y'), 'unit grammar also is parent parses its own rule';
+ok $derived.parse('x') ~~ Nil,
+    'unit grammar also is parent does not use the inherited grammar TOP';
+ok $derived.^mro.map(*.^name).grep('BaseG'),
+    'also is parent appears in the grammar MRO';


### PR DESCRIPTION
Summary:

- Replace a unit grammar declaration’s implicit `Grammar` parent when a trailing `also is Parent` supplies the direct parent.
- Add a dual-oracle regression test for unit grammar inheritance and a release note.

Closes #7867

Validation:

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
- `raku t/grammar/unit-grammar-also-is.t`
- `target/debug/mutsu t/grammar/unit-grammar-also-is.t`
