### PR TITLE
feat: give QuantHash subclasses a real backing store

### DIFF
--- a/ecosystem/dists/A/AccountableBagHash.json
+++ b/ecosystem/dists/A/AccountableBagHash.json
@@ -9,23 +9,22 @@
   "dist": "AccountableBagHash",
   "files": [
     {
-      "cmp": "regression",
+      "cmp": "parity",
       "mutsu": {
-        "first_failure": "No such method 'STORE' for invocant of type 'AccountableBagHash'",
         "nok": 0,
-        "ok": 0,
+        "ok": 16,
         "plan": 16,
-        "secs": 0.09,
+        "secs": 0.05,
         "skip": 0,
         "todo": 0,
-        "verdict": "die"
+        "verdict": "pass"
       },
       "path": "t/01-basic.t",
       "raku": {
         "nok": 0,
         "ok": 16,
         "plan": 16,
-        "secs": 2.28,
+        "secs": 1.6,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -36,28 +35,28 @@
     "AccountableBagHash": "ok"
   },
   "measured": {
-    "attempts": 2,
-    "date": "2026-09-10",
+    "attempts": 3,
+    "date": "2026-09-11",
     "harness": 1,
     "host": "linux-x86_64",
-    "mutsu_commit": "12d29a1",
+    "mutsu_commit": "69bedb4",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
-    "sandbox": "bwrap"
+    "sandbox": "none"
   },
   "schema": 1,
   "source": {
     "index": "fez",
     "url": "https://360.zef.pm/A/CC/ACCOUNTABLEBAGHASH/4302f15daa35330e14316352383a9e6b2209d405.tar.gz"
   },
-  "status": "red",
+  "status": "green",
   "totals": {
     "baseline_assertions": 16,
     "baseline_files": 1,
-    "mutsu_assertions": 0,
-    "parity_files": 0,
-    "regressed_files": 1
+    "mutsu_assertions": 16,
+    "parity_files": 1,
+    "regressed_files": 0
   },
   "version": "0.0.7"
 }

--- a/news/2026-09/a-quanthash-subclass-is-a-quanthash.md
+++ b/news/2026-09/a-quanthash-subclass-is-a-quanthash.md
@@ -1,0 +1,99 @@
+# A QuantHash subclass is a QuantHash
+
+`class AccountableBagHash is BagHash { }` produced an ordinary attribute-bag
+object. It answered its own name and nothing else: `.total` did not exist,
+`.gist` rendered `AccountableBagHash.new`, `%h<a>` read `Nil`, and
+`my %abh is AccountableBagHash = a => 42` died with
+`Cannot modify an immutable AccountableBagHash`. The whole
+[AccountableBagHash](https://360.zef.pm/A/CC/ACCOUNTABLEBAGHASH) distribution —
+16 assertions, all of them green under rakudo — could not run a single one.
+
+`is Hash` and `is Array` subclasses have kept their data in a reserved backing
+attribute (`__mutsu_hash_storage` / `__mutsu_array_storage`) and delegated the
+protocol to it for a long time. The QuantHash family now does the same through
+`__baggy_data__`, which already existed but was only ever filled by a
+positional `.new` and only ever held an immutable `Bag`:
+
+- `runtime/quanthash_subclass.rs` picks the base out of the MRO and seeds the
+  backing store in both constructor paths. The base decides the element
+  semantics *and* the mutability, so `class C is BagHash` gets a mutable bag
+  and `class C is Bag` keeps the immutable one and still raises on an element
+  assignment — the same rule `positional_base_storage` uses to pick `List` over
+  `Array`.
+- `vm/vm_baggy_subclass_delegate.rs` is the mutating half of the delegation:
+  `ASSIGN-KEY`, `DELETE-KEY` and `STORE` write **in place** through the shared
+  attribute cell, so every holder of the object — the tied variable, a closure
+  that captured it, a `Proxy` over one of its elements — sees the write.
+- `.gist` and `.raku` render under the subclass's own name (`MyBagHash(a(2) b)`,
+  `("a"=>2).MyBagHash`), and `my %h is <Subclass> = ...` populates the store
+  through `STORE(list, :INITIALIZE)` like any other tie.
+
+Four general bugs surfaced on the way, each fixed where it lived rather than
+around it:
+
+- **`.STORE` wrote the wrong keys.** The native `BagHash`/`SetHash`/`MixHash`
+  `STORE` built its entries from the raw stringification while every reader
+  looks them up by the `.WHICH`-derived key, so `$b.STORE(a => 42); $b<a>` read
+  `0` on a plain `BagHash`, with no subclass involved. The folding moved to
+  `runtime/quanthash_store.rs` and now mints the same keys (and the same
+  `original_keys` decoding) as every other write.
+- **A single-candidate override had no deferral frame.** A user or role
+  override of a container protocol method got no `method_dispatch_stack` frame
+  when it was the only candidate, so its `nextsame` answered `Nil` and the
+  write vanished. Container subclasses now join the `grammar parse` /
+  `BUILDALL` cases that push a frame for their native base candidate, and a
+  `multi method` whose candidate list runs out falls back to the same base.
+- **A resumed `CATCH` lost its writes at a subscript assignment.** The
+  element-assign opcode dispatches `ASSIGN-KEY` without a call opcode, so it
+  never drained `pending_rw_writeback_sources` — a handler that ran inline at a
+  `.throw` inside the callee and set a flag saw that flag reset on return.
+- **`f(...) = v` could not see a `my &f`.** The parser lowers it to
+  `__mutsu_assign_named_sub_lvalue("f", [args], value)`, which hides the callee
+  behind a string constant: the runtime resolved it against declared routines
+  only, and — worse — closure free-var analysis never saw a read of `&f`, so a
+  closure that *only* assigned through it did not capture it at all. The
+  compiler now retargets the call at the code variable, exactly as it already
+  does for a bare `f(...)`.
+
+The last piece is `nextcallee`, which answered `Nil` for every method dispatch.
+It now returns the next MRO candidate as a routine, and — when the MRO is
+exhausted on a container subclass's `AT-KEY` — the *native* base candidate,
+which Rakudo spells as a `Proxy` over the element. mutsu has no routine object
+for an opcode, so `runtime/container_element_proxy.rs` supplies one as a small
+Raku snippet, the same shape NativeCall's `cglobal` prelude already uses:
+
+```raku
+sub ($obj, $key) is rw {
+    Proxy.new(
+        FETCH => { $obj.__mutsu_container_at_key($key) },
+        STORE => -> $, $value { $obj.__mutsu_container_assign_key($key, $value) }
+    )
+}
+```
+
+That makes the documented override idiom work end to end:
+
+```raku
+multi method AT-KEY(::?CLASS:D: $key is raw) is raw {
+    my &nextone := nextcallee;
+    Proxy.new(
+      FETCH => { nextone(self,$key) },
+      STORE => -> $, Numeric() $value { ... nextone(self,$key) = $value ... }
+    )
+}
+```
+
+`%h<a>++` on such an object reads through the outer Proxy into the inner one
+and stores back through both, which also needed value-context reads to fetch a
+`Proxy` all the way down rather than one level.
+
+`AccountableBagHash`'s suite is 16/16 now. Pinned by
+`t/collections/set-bag-mix/quanthash-subclass-backing.t`,
+`t/collections/set-bag-mix/quanthash-store-refill.t`,
+`t/collections/subscript/subscript-override-nextcallee.t` and
+`t/exceptions/catch-resume-subscript-assign-writeback.t`, all four verified
+against rakudo.
+
+One adjacent gap is left open and *not* fixed here: a sigilless lexical
+(`\obj`) captured by a `Proxy` STORE closure reads back as its own name. The
+prelude above uses `$`-sigiled parameters to step around it.

--- a/news/2026-09/a-quanthash-subclass-is-a-quanthash.md
+++ b/news/2026-09/a-quanthash-subclass-is-a-quanthash.md
@@ -87,12 +87,25 @@ multi method AT-KEY(::?CLASS:D: $key is raw) is raw {
 and stores back through both, which also needed value-context reads to fetch a
 `Proxy` all the way down rather than one level.
 
+A fifth bug surfaced only in CI, on the `jit-stress` job, and is pre-existing
+(it reproduces unchanged on `main`): **the JIT's `CallMethod` shim was missing
+the ADR-0072 throw-site hook.** A `.throw` inside a callee hot enough to go
+native never reached `try_catch_inline`, so a resume-capable `CATCH` several
+frames up ran through the ordinary region path instead — the handler still ran,
+but `.resume` cannot resume across `CompiledCode` boundaries there, and every
+statement after the throw in the *caller's* block was silently skipped. A plain
+`sub f($v) { $v > 0 ?? $v !! X::Neg.new.throw }` called twenty times then thrown
+from inside a `CATCH` region reproduces it with nothing else involved. The shim
+now carries the same `throw_base` / `try_catch_inline` hook its own doc comment
+says it mirrors.
+
 `AccountableBagHash`'s suite is 16/16 now. Pinned by
 `t/collections/set-bag-mix/quanthash-subclass-backing.t`,
 `t/collections/set-bag-mix/quanthash-store-refill.t`,
-`t/collections/subscript/subscript-override-nextcallee.t` and
-`t/exceptions/catch-resume-subscript-assign-writeback.t`, all four verified
-against rakudo.
+`t/collections/subscript/subscript-override-nextcallee.t`,
+`t/exceptions/catch-resume-subscript-assign-writeback.t` and
+`t/exceptions/catch-resume-across-jit-frame.t`, all five verified against
+rakudo.
 
 One adjacent gap is left open and *not* fixed here: a sigilless lexical
 (`\obj`) captured by a `Proxy` STORE closure reads back as its own name. The

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -332,6 +332,32 @@ impl Compiler {
             self.compile_expr_call_on(&target, args);
             return;
         }
+        // `f(...) = v` where `f` is a `my &f` binding. The parser lowers the
+        // assignment to `__mutsu_assign_named_sub_lvalue("f", [args], value)`,
+        // which hides the callee behind a string constant: the runtime then
+        // resolves it against declared routines only, and — worse — the closure
+        // free-var analysis never sees a read of `&f`, so a closure that ONLY
+        // assigns through it does not capture it at all. Retarget the call at
+        // the code variable itself, the same way the bare-call branch just
+        // above does for a plain `f(...)`.
+        if name == "__mutsu_assign_named_sub_lvalue"
+            && args.len() == 3
+            && let Expr::Literal(callee) = &args[0]
+            && let Some(callee) = callee.as_str()
+            && self.amp_binding_in_active_scope(callee)
+        {
+            let rewritten = [
+                Expr::CodeVar(callee.to_string()),
+                args[1].clone(),
+                args[2].clone(),
+            ];
+            self.compile_expr_call_inner(
+                &crate::symbol::Symbol::intern("__mutsu_assign_callable_lvalue"),
+                &rewritten,
+                suppress_listop_rewrite,
+            );
+            return;
+        }
         let suppress_listop_rewrite =
             suppress_listop_rewrite || self.user_listop_shadows.contains(&name.resolve());
         // `callframe`/`caller` inside N enclosing `for` blocks must report the

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -1119,6 +1119,42 @@ impl Interpreter {
         });
     }
 
+    /// The subscript/`STORE` protocol whose native implementation on a
+    /// container subclass's backing storage is a deferral base candidate. See
+    /// `container_protocol_override` in [`Self::push_method_dispatch_frame`].
+    fn is_container_protocol_method(method: &str) -> bool {
+        matches!(
+            method,
+            "AT-KEY"
+                | "ASSIGN-KEY"
+                | "BIND-KEY"
+                | "DELETE-KEY"
+                | "EXISTS-KEY"
+                | "AT-POS"
+                | "ASSIGN-POS"
+                | "BIND-POS"
+                | "DELETE-POS"
+                | "EXISTS-POS"
+                | "STORE"
+        )
+    }
+
+    /// True when `class_key` inherits a builtin container whose data lives in a
+    /// backing attribute (`__mutsu_hash_storage` / `__mutsu_array_storage` /
+    /// `__baggy_data__`), i.e. one of the `native_*_storage_next_candidate`
+    /// fallbacks can serve as a deferral base.
+    fn class_has_native_container_backing(&mut self, class_key: &str) -> bool {
+        self.class_mro(class_key).iter().any(|n| {
+            let name = n.resolve();
+            Self::is_associative_base(&name)
+                || Self::is_positional_base(&name)
+                || matches!(
+                    name.as_str(),
+                    "Set" | "SetHash" | "Bag" | "BagHash" | "Mix" | "MixHash"
+                )
+        })
+    }
+
     pub(crate) fn push_method_dispatch_frame(
         &mut self,
         receiver_class: &str,
@@ -1148,7 +1184,17 @@ impl Interpreter {
         // for BUILDALL/POPULATE, the native attribute-copying clone for clone).
         let mu_base_override = matches!(method_name, "BUILDALL" | "POPULATE" | "clone")
             && self.has_user_method(receiver_class, method_name);
-        let native_base_override = grammar_parse_override || mu_base_override;
+        // A user (or role-composed) override of a native container protocol
+        // method on an `is Hash`/`is Array`/`is BagHash`-style subclass is the
+        // same situation: the native behavior on the instance's backing storage
+        // is a base candidate that is not a `MethodDef`, so without a frame the
+        // override's `nextsame`/`callsame` answered Nil and the write was
+        // dropped (`AccountableBagHash`'s `multi method ASSIGN-KEY`).
+        let container_protocol_override = Self::is_container_protocol_method(method_name)
+            && self.class_has_native_container_backing(receiver_class)
+            && self.has_user_method_including_role(receiver_class, method_name);
+        let native_base_override =
+            grammar_parse_override || mu_base_override || container_protocol_override;
         // Fast path: a name with at most one *structural* dispatch candidate across
         // the MRO can never produce a deferral frame (arg-matching only reduces the
         // candidate count), so skip the per-call `resolve_all_methods_with_owner`

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -873,6 +873,10 @@ impl Interpreter {
                     {
                         res?
                     } else if let Some(res) =
+                        self.native_baggy_storage_next_candidate(override_args.as_deref())
+                    {
+                        res?
+                    } else if let Some(res) =
                         self.native_any_base_next_candidate(override_args.as_deref())
                     {
                         res?
@@ -1241,6 +1245,9 @@ impl Interpreter {
                 self.multi_dispatch_stack.last().cloned()
         {
             let is_override = override_args.is_some();
+            // Kept for the native-base fallback at the exhaustion point below,
+            // which needs the override args after `call_args` consumes them.
+            let override_for_native = override_args.clone();
             let mut call_args = override_args.unwrap_or(orig_args);
             // nextsame/callsame+rw chaining (§D capstone): forward each scalar rw
             // param's CURRENT value (it was mutated by the first candidate's body
@@ -1293,6 +1300,28 @@ impl Interpreter {
                 // not occur in `candidates`, but `callsame` from a user
                 // `infix:<op>` must still reach them.
                 if let Some(result) = Self::native_infix_next_candidate(&_name, &call_args) {
+                    let result = result?;
+                    if tail_call {
+                        return Err(RuntimeError::return_signal(result));
+                    }
+                    return Ok(result);
+                }
+                // A `multi method` that overrides a native container
+                // protocol (`multi method ASSIGN-KEY` on an `is BagHash` /
+                // `is Hash` / `is Array` subclass, typically contributed by a
+                // role) has the native behavior on the instance's backing
+                // storage as its final candidate, exactly as the single-method
+                // path above does — without it the deferral answered Nil and
+                // the write was silently dropped.
+                let native_base = self
+                    .native_baggy_storage_next_candidate(override_for_native.as_deref())
+                    .or_else(|| {
+                        self.native_hash_storage_next_candidate(override_for_native.as_deref())
+                    })
+                    .or_else(|| {
+                        self.native_array_storage_next_candidate(override_for_native.as_deref())
+                    });
+                if let Some(result) = native_base {
                     let result = result?;
                     if tail_call {
                         return Err(RuntimeError::return_signal(result));
@@ -1526,8 +1555,42 @@ impl Interpreter {
             }
             return Ok(Value::NIL);
         }
-        // Method dispatch is not yet implemented for nextcallee — Nil, same as
-        // when there is no live dispatch context at all.
+        // Method dispatch: hand back the next candidate in the MRO deferral
+        // frame as a callable, the same way the multi branch below does for a
+        // multi's candidate list. `nextcallee` differs from `nextsame` in that
+        // the caller supplies the invocant explicitly (`nextone(self, $key)`),
+        // so the candidate is returned as a plain routine value.
+        if innermost == Some(DispatchFrameKind::Method) {
+            let method_name = self
+                .samewith_context_stack
+                .last()
+                .map(|c| c.name.clone())
+                .unwrap_or_default();
+            if let Some(frame) = self.method_dispatch_stack.last_mut()
+                && let Some(DeferralEntry::Candidate { owner, def, .. }) =
+                    frame.remaining.first().cloned()
+            {
+                frame.remaining.remove(0);
+                return Ok(Value::make_sub_for_routine(
+                    owner,
+                    Symbol::intern(&method_name),
+                    def.params.to_vec(),
+                    def.param_defs.to_vec(),
+                    def.body.clone(),
+                    def.is_rw,
+                    self.env.clone(),
+                    None,
+                ));
+            }
+            // MRO exhausted: the native base candidate. For the subscript
+            // protocol on a container subclass that is an element `Proxy` —
+            // see `runtime::container_element_proxy` for why it must be one.
+            if let Some(base) = self.container_element_base_callee() {
+                return Ok(base);
+            }
+            return Ok(Value::NIL);
+        }
+        // No live dispatch context at all — Nil.
         if innermost != Some(DispatchFrameKind::Multi) {
             return Ok(Value::NIL);
         }
@@ -1549,6 +1612,12 @@ impl Interpreter {
             }
         }
         let Some(idx) = matched_idx else {
+            // A `multi method` whose candidate list is exhausted falls back to
+            // the same native base candidate the single-method branch above
+            // uses (`AccountableBagHash`'s `multi method AT-KEY`).
+            if let Some(base) = self.container_element_base_callee() {
+                return Ok(base);
+            }
             return Ok(Value::NIL);
         };
         let next_def = candidates[idx].clone();

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::value::ArrayKind;
 
 impl Interpreter {
-    pub(super) fn sub_call_args_from_value(arg: Option<&Value>) -> Vec<Value> {
+    pub(crate) fn sub_call_args_from_value(arg: Option<&Value>) -> Vec<Value> {
         match arg {
             Some(v) => match v.view() {
                 ValueView::Array(items, _) => items.to_vec(),
@@ -43,7 +43,17 @@ impl Interpreter {
         if !value.is_proxy_value() {
             return Ok(value.clone());
         }
-        if let ValueView::Proxy { fetcher, .. } = value.view() {
+        // A FETCH may itself answer a container: the documented `AT-KEY`
+        // override idiom is a `Proxy` whose FETCH defers to the next candidate,
+        // which is another `Proxy` over the same element. Reading such an
+        // element in value context has to come all the way down to the value,
+        // as raku's decontainerization does. Bounded so a pathological
+        // self-returning FETCH cannot spin forever.
+        let mut current = value.clone();
+        for _ in 0..16 {
+            let ValueView::Proxy { fetcher, .. } = current.view() else {
+                return Ok(current);
+            };
             if fetcher.is_nil() {
                 return Ok(Value::NIL);
             }
@@ -55,11 +65,15 @@ impl Interpreter {
             // first FETCHed value. FETCH is a READ, so run with caller-priority
             // inputs and DISCARD every env effect afterwards.
             let saved_env = self.env.clone();
-            let result = self.call_sub_value(fetcher.clone(), vec![value.clone()], true);
+            let result = self.call_sub_value(fetcher.clone(), vec![current.clone()], true);
             self.env = saved_env;
-            return result;
+            let fetched = result?;
+            if !fetched.is_proxy_value() {
+                return Ok(fetched);
+            }
+            current = fetched;
         }
-        Ok(value.clone())
+        Ok(current)
     }
 
     /// Whether a value is (or contains, one container level deep per recursion
@@ -598,7 +612,7 @@ impl Interpreter {
         Err(RuntimeError::new(format!("Unknown call: {}", name)))
     }
 
-    pub(super) fn assign_callable_lvalue_with_values(
+    pub(crate) fn assign_callable_lvalue_with_values(
         &mut self,
         callable: Value,
         call_args: Vec<Value>,

--- a/src/runtime/container_element_proxy.rs
+++ b/src/runtime/container_element_proxy.rs
@@ -1,0 +1,93 @@
+//! The native `AT-KEY` base candidate of a container subclass, as a callable.
+//!
+//! Rakudo's `Baggy::AT-KEY` (and its `Setty`/`Mixy` siblings) returns a
+//! `Proxy`, which is what makes the documented override idiom work:
+//!
+//! ```raku
+//! multi method AT-KEY(::?CLASS:D: $key is raw) is raw {
+//!     my &nextone := nextcallee;
+//!     Proxy.new(
+//!       FETCH => { nextone(self,$key) },
+//!       STORE => -> $, $value { nextone(self,$key) = $value }
+//!     )
+//! }
+//! ```
+//!
+//! `nextcallee` there has to hand back something that both *reads* the element
+//! and can be *assigned to*. mutsu's native QuantHash element access is an
+//! opcode, not a `MethodDef`, so there is no routine object to return — this
+//! module supplies one, spelled in Raku exactly the way Rakudo spells it: a
+//! two-argument closure that answers a `Proxy` over the element.
+//!
+//! `__mutsu_container_at_key` / `__mutsu_container_assign_key` are the internal
+//! element protocol the Proxy is written against. They reach the instance's
+//! backing store directly (`vm_baggy_subclass_delegate.rs`), never back through
+//! the user's own `AT-KEY`, so the idiom above cannot recurse.
+//!
+//! The same shape as NativeCall's `cglobal` prelude (`runtime::run`'s
+//! `NATIVECALL_SUB_PRELUDES`): a small Raku source snippet whose `Proxy`
+//! bottoms out in internal builtins.
+
+use super::Interpreter;
+use crate::ast::Stmt;
+use crate::value::{RuntimeError, Value};
+
+// `is rw` marks the routine rw-capable, which is what lets
+// `nextone(self,$key) = $value` write through the `Proxy` it returns
+// (`assign_callable_lvalue_with_values`).
+const CONTAINER_ELEMENT_PROXY_SRC: &str = r#"sub ($obj, $key) is rw {
+    Proxy.new(
+        FETCH => { $obj.__mutsu_container_at_key($key) },
+        STORE => -> $, $value { $obj.__mutsu_container_assign_key($key, $value) }
+    )
+}"#;
+
+impl Interpreter {
+    /// The cached closure described in the module docs. Parsed once per
+    /// process, built once per interpreter.
+    pub(crate) fn container_element_proxy_base(&mut self) -> Option<Value> {
+        if let Some(cached) = self.container_element_proxy.clone() {
+            return Some(cached);
+        }
+        use std::sync::OnceLock;
+        static PARSED: OnceLock<Vec<Stmt>> = OnceLock::new();
+        let stmts = PARSED.get_or_init(|| {
+            crate::parse_dispatch::parse_source(CONTAINER_ELEMENT_PROXY_SRC)
+                .map(|(s, _)| s)
+                .unwrap_or_default()
+        });
+        if stmts.is_empty() {
+            return None;
+        }
+        let built: Result<Value, RuntimeError> = self.eval_block_value(stmts);
+        let value = built.ok()?;
+        value.as_sub()?;
+        self.container_element_proxy = Some(value.clone());
+        Some(value)
+    }
+}
+
+impl Interpreter {
+    /// [`Self::container_element_proxy_base`], gated on the current deferral
+    /// actually being a subscript-protocol call on a container subclass — the
+    /// only situation where the element `Proxy` is the right answer.
+    pub(crate) fn container_element_base_callee(&mut self) -> Option<Value> {
+        let ctx = self.samewith_context_stack.last().cloned()?;
+        if ctx.name != "AT-KEY" {
+            return None;
+        }
+        let invocant = self
+            .method_dispatch_stack
+            .last()
+            .map(|f| f.invocant.clone())
+            .or_else(|| ctx.invocant.clone())
+            .or_else(|| self.env.get("self").cloned())?;
+        let crate::value::ValueView::Instance { attributes, .. } = invocant.view() else {
+            return None;
+        };
+        if !attributes.contains_key("__baggy_data__") {
+            return None;
+        }
+        self.container_element_proxy_base()
+    }
+}

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3717,104 +3717,13 @@ impl Interpreter {
             return result;
         }
 
-        // STORE for BagHash/SetHash/MixHash: re-initialize the container
+        // STORE for BagHash/SetHash/MixHash: re-initialize the container.
+        // See `runtime::quanthash_store` for the folding rules and why the
+        // store keys must be the `.WHICH`-derived ones.
         if method == "STORE"
-            && matches!(
-                target.view(),
-                ValueView::Bag(_, true) | ValueView::Set(_, true) | ValueView::Mix(_, true)
-            )
+            && let Some(stored) = crate::runtime::quanthash_store::quanthash_store(&target, &args)
         {
-            // STORE(@keys, @values) or STORE(@pairs)
-            // First, flatten all args into a list of items
-            let mut items: Vec<Value> = Vec::new();
-            for arg in &args {
-                match arg.view() {
-                    ValueView::Array(elems, _) => items.extend(elems.iter().cloned()),
-                    ValueView::Seq(elems) => items.extend(elems.iter().cloned()),
-                    ValueView::Slip(elems) => items.extend(elems.iter().cloned()),
-                    _ => items.push(arg.clone()),
-                }
-            }
-            // If items are all non-Pair and there are exactly 2 array args,
-            // zip them as keys => values
-            let has_pairs = items
-                .iter()
-                .any(|v| matches!(v.view(), ValueView::Pair(..) | ValueView::ValuePair(..)));
-            let pairs: Vec<(String, i64)> = if has_pairs {
-                items
-                    .iter()
-                    .map(|v| match v.view() {
-                        ValueView::Pair(k, v) => {
-                            let count = match v.view() {
-                                ValueView::Int(i) => i,
-                                ValueView::Num(f) => f as i64,
-                                _ => 1,
-                            };
-                            (k.clone(), count)
-                        }
-                        ValueView::ValuePair(k, v) => {
-                            let count = match v.view() {
-                                ValueView::Int(i) => i,
-                                ValueView::Num(f) => f as i64,
-                                _ => 1,
-                            };
-                            (k.to_string_value(), count)
-                        }
-                        _ => (v.to_string_value(), 1),
-                    })
-                    .collect()
-            } else if args.len() == 2
-                && matches!(args[0].view(), ValueView::Array(..))
-                && matches!(args[1].view(), ValueView::Array(..))
-            {
-                // Zip keys and values
-                let keys = if let ValueView::Array(k, _) = args[0].view() {
-                    k.iter().map(|v| v.to_string_value()).collect::<Vec<_>>()
-                } else {
-                    vec![]
-                };
-                let values = if let ValueView::Array(v, _) = args[1].view() {
-                    v.iter()
-                        .map(|v| match v.view() {
-                            ValueView::Int(i) => i,
-                            ValueView::Num(f) => f as i64,
-                            _ => 1,
-                        })
-                        .collect::<Vec<_>>()
-                } else {
-                    vec![]
-                };
-                keys.into_iter().zip(values).collect()
-            } else {
-                items.iter().map(|v| (v.to_string_value(), 1i64)).collect()
-            };
-
-            match target.view() {
-                ValueView::Bag(_, _) => {
-                    let mut counts = std::collections::HashMap::new();
-                    for (k, v) in pairs {
-                        *counts.entry(k).or_insert(0i64) += v;
-                    }
-                    return Ok(Value::bag_hash(counts));
-                }
-                ValueView::Set(_, _) => {
-                    let mut elems = std::collections::HashSet::new();
-                    for (k, v) in pairs {
-                        if v > 0 {
-                            elems.insert(k);
-                        }
-                    }
-                    return Ok(Value::set_hash(elems));
-                }
-                ValueView::Mix(_, _) => {
-                    let mut weights = std::collections::HashMap::new();
-                    for (k, v) in pairs {
-                        *weights.entry(k).or_insert(0f64) += v as f64;
-                    }
-                    return Ok(Value::mix_hash(weights));
-                }
-                _ => {}
-            }
+            return Ok(stored);
         }
 
         // .pick/.roll/.grab/.grabpairs/.pickpairs with Callable arg on

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -579,6 +579,9 @@ impl Interpreter {
             .cloned()
             .collect();
         super::seed_native_subclass_payloads(&mut attributes, &class_mro, &args, &positional_args);
+        // See `quanthash_subclass`: a `Set`/`Bag`/`Mix` (or `*Hash`) subclass
+        // keeps its entries in `__baggy_data__`.
+        self.seed_quanthash_storage(cn_resolved, &mut attributes, &positional_args)?;
         // Embed `is default(...)` element defaults into `@`/`%` containers.
         self.apply_container_attribute_defaults(cn_resolved, &mut attributes);
         crate::alloc_scope_end!(_sc_container);

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -192,6 +192,29 @@ impl Interpreter {
         if let Some(storage) = attributes.as_map().get("__mutsu_hash_storage").cloned() {
             return Some(self.call_method_with_values(storage, method, vec![]));
         }
+        // A QuantHash (`is BagHash`/`is Set`/...) subclass renders under its own
+        // type name: `ABH(a(2) b)` for `.gist`, `("a"=>2).ABH` for `.raku` —
+        // see `runtime/quanthash_subclass.rs`.
+        if let Some(storage) = attributes.as_map().get("__baggy_data__").cloned() {
+            let class_key = class_name.resolve();
+            let name = crate::value::user_facing_type_name(&class_key).to_string();
+            if method == "gist" {
+                return Some(Ok(Value::str(
+                    crate::runtime::utils::setbagmix_gist_named(&storage, Some(&name))
+                        .unwrap_or_else(|| crate::runtime::utils::gist_value(&storage)),
+                )));
+            }
+            let inner = self.call_method_with_values(storage, "raku", vec![]);
+            return Some(inner.map(|v| {
+                let text = v.to_string_value();
+                // The storage's own `.raku` ends in the builtin coercer
+                // (`("a"=>2).BagHash`); swap in the subclass's name.
+                match text.rfind('.') {
+                    Some(dot) => Value::str(format!("{}.{}", &text[..dot], name)),
+                    None => Value::str(text),
+                }
+            }));
+        }
         if class_name == Symbol::intern("ObjAt") || class_name == Symbol::intern("ValueObjAt") {
             let which = attributes
                 .as_map()

--- a/src/runtime/methods_object_attr_constraints.rs
+++ b/src/runtime/methods_object_attr_constraints.rs
@@ -525,6 +525,18 @@ impl Interpreter {
         class_name: &str,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
+        // A concrete QuantHash base in the MRO decides both the element
+        // semantics and the mutability of the backing store: `class C is
+        // BagHash` must be backed by a MUTABLE bag so `%c<a> = 5` works, while
+        // `class C is Bag` keeps the immutable one and still raises. Only a
+        // class that composes the bare `Baggy`/`Setty` role (no concrete base)
+        // falls back to the immutable default.
+        if let Some(base) = self.quanthash_base_kind(class_name) {
+            let storage = self.quanthash_base_storage(base, args.to_vec())?;
+            let mut attrs = HashMap::new();
+            attrs.insert("__baggy_data__".to_string(), storage);
+            return Ok(Value::make_instance(Symbol::intern(class_name), attrs));
+        }
         let is_setty = self.class_is_setty(class_name);
 
         if is_setty {

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -2052,6 +2052,10 @@ impl Interpreter {
                     &args,
                     &positional_ctor_args,
                 );
+                // `class C is BagHash { }` and its Set/Mix siblings keep their
+                // entries in `__baggy_data__`, the same way the `is Hash` and
+                // `is Array` blocks above use their own backing attributes.
+                self.seed_quanthash_storage(class_key, &mut attrs, &positional_ctor_args)?;
                 // Then evaluate defaults for attributes not provided by args,
                 // binding `self` so default expressions like `self.x` work.
                 // Restore role parameter bindings so that default expressions

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -586,6 +586,7 @@ mod class_introspection;
 mod code_frame;
 pub(crate) use code_frame::{CodeFrame, LazyRoutineCode};
 mod compunit_scope;
+mod container_element_proxy;
 mod ctor_phase_plan;
 mod nqp_ops;
 mod nqp_ops_builtin;
@@ -754,6 +755,8 @@ mod output_sink;
 pub(crate) mod phasers;
 mod promise_broken_gist;
 mod promise_errors;
+pub(crate) mod quanthash_store;
+mod quanthash_subclass;
 mod react_died;
 pub(crate) mod react_done_handler_depth;
 pub(crate) mod react_whenever;
@@ -2564,6 +2567,10 @@ pub struct Interpreter {
     /// Cleared per-name on subset redeclaration; starts empty per thread (the
     /// cache is a pure recomputable optimization). See `type_matches_value`.
     subset_predicate_cache: HashMap<String, SubsetPredicateCompiled>,
+    /// The `-> \obj, \key { Proxy.new(...) }` closure that stands in for a
+    /// container subclass's NATIVE `AT-KEY` when a user override asks for it
+    /// with `nextcallee`. Built on first use; see `container_element_proxy`.
+    container_element_proxy: Option<Value>,
     /// Side-channel: the exception raised by the most recent subset `where`
     /// predicate that failed by *throwing* (a `fail "msg"` inside the `where`,
     /// e.g. `subset Even of Int where { $_ %% 2 or fail "..." }`). `type_matches_value`

--- a/src/runtime/quanthash_store.rs
+++ b/src/runtime/quanthash_store.rs
@@ -1,0 +1,162 @@
+//! `STORE` on a mutable QuantHash (`SetHash`/`BagHash`/`MixHash`) —
+//! re-initialize the container from the assigned list.
+//!
+//! Raku reaches this through `%h = ...` on a tied variable and through an
+//! explicit `$b.STORE(...)`; mutsu additionally routes the QuantHash-subclass
+//! declaration (`my %b is AccountableBagHash = ...`) here via
+//! `vm_baggy_subclass_delegate.rs`, so the folding lives in one place.
+//!
+//! The store keys are the same `.WHICH`-derived keys every other QuantHash
+//! write uses (`runtime::utils::quanthash_elem_entry`), and non-`Str` elements
+//! are recorded in `original_keys` so they decode back to the element object.
+//! Building them with the raw stringification instead — which this code did
+//! until 2026-09 — made `$b.STORE(a => 42); $b<a>` read 0: the reader looks up
+//! `Str|a` and the store had written `a`.
+
+use crate::runtime::utils::{quanthash_elem_entry, record_quanthash_original};
+use crate::value::{Value, ValueView};
+use std::collections::HashMap;
+
+/// One folded entry: the storage key, the element object behind it, and the
+/// weight the assigned list gave it.
+struct Entry {
+    key: String,
+    elem: Value,
+    weight: f64,
+}
+
+/// Flatten `args` into the `key => weight` entries a QuantHash `STORE` assigns.
+///
+/// Two shapes are accepted, matching Rakudo's `STORE(+@values)` /
+/// `STORE(@keys, @values)` candidates: a single list (Pairs give explicit
+/// weights, bare elements count 1) and two parallel lists zipped as keys to
+/// weights.
+fn fold_entries(args: &[Value]) -> Vec<Entry> {
+    let mut items: Vec<Value> = Vec::new();
+    for arg in args {
+        match arg.view() {
+            ValueView::Array(elems, _) => items.extend(elems.iter().cloned()),
+            ValueView::Seq(elems) => items.extend(elems.iter().cloned()),
+            ValueView::Slip(elems) => items.extend(elems.iter().cloned()),
+            _ => items.push(arg.clone()),
+        }
+    }
+    let has_pairs = items
+        .iter()
+        .any(|v| matches!(v.view(), ValueView::Pair(..) | ValueView::ValuePair(..)));
+    let weight_of = |v: &Value| match v.view() {
+        ValueView::Int(i) => i as f64,
+        ValueView::Num(f) => f,
+        ValueView::Rat(n, d) if d != 0 => n as f64 / d as f64,
+        _ => 1.0,
+    };
+    if has_pairs {
+        return items
+            .iter()
+            .map(|v| match v.view() {
+                ValueView::Pair(k, w) => {
+                    let elem = Value::str(k.clone());
+                    let (key, elem) = quanthash_elem_entry(&elem);
+                    Entry {
+                        key,
+                        elem,
+                        weight: weight_of(w),
+                    }
+                }
+                ValueView::ValuePair(k, w) => {
+                    let (key, elem) = quanthash_elem_entry(k);
+                    Entry {
+                        key,
+                        elem,
+                        weight: weight_of(w),
+                    }
+                }
+                _ => {
+                    let (key, elem) = quanthash_elem_entry(v);
+                    Entry {
+                        key,
+                        elem,
+                        weight: 1.0,
+                    }
+                }
+            })
+            .collect();
+    }
+    if args.len() == 2
+        && matches!(args[0].view(), ValueView::Array(..))
+        && matches!(args[1].view(), ValueView::Array(..))
+    {
+        let keys = match args[0].view() {
+            ValueView::Array(k, _) => k.to_vec(),
+            _ => Vec::new(),
+        };
+        let weights = match args[1].view() {
+            ValueView::Array(v, _) => v.to_vec(),
+            _ => Vec::new(),
+        };
+        return keys
+            .iter()
+            .zip(weights.iter())
+            .map(|(k, w)| {
+                let (key, elem) = quanthash_elem_entry(k);
+                Entry {
+                    key,
+                    elem,
+                    weight: weight_of(w),
+                }
+            })
+            .collect();
+    }
+    items
+        .iter()
+        .map(|v| {
+            let (key, elem) = quanthash_elem_entry(v);
+            Entry {
+                key,
+                elem,
+                weight: 1.0,
+            }
+        })
+        .collect()
+}
+
+/// Build the replacement container for `STORE` on `target`, or `None` when
+/// `target` is not a mutable QuantHash.
+pub(crate) fn quanthash_store(target: &Value, args: &[Value]) -> Option<Value> {
+    let entries = match target.view() {
+        ValueView::Set(_, true) | ValueView::Bag(_, true) | ValueView::Mix(_, true) => {
+            fold_entries(args)
+        }
+        _ => return None,
+    };
+    let mut originals: HashMap<String, Value> = HashMap::new();
+    for e in &entries {
+        record_quanthash_original(&mut originals, &e.key, &e.elem);
+    }
+    let stored = match target.view() {
+        ValueView::Set(..) => {
+            let elems = entries
+                .iter()
+                .filter(|e| e.weight != 0.0)
+                .map(|e| e.key.clone())
+                .collect();
+            Value::set_hash_typed(elems, originals)
+        }
+        ValueView::Bag(..) => {
+            let mut counts: HashMap<String, i64> = HashMap::new();
+            for e in &entries {
+                *counts.entry(e.key.clone()).or_insert(0) += e.weight as i64;
+            }
+            counts.retain(|_, c| *c > 0);
+            Value::bag_hash_typed(counts, originals)
+        }
+        _ => {
+            let mut weights: HashMap<String, f64> = HashMap::new();
+            for e in &entries {
+                *weights.entry(e.key.clone()).or_insert(0.0) += e.weight;
+            }
+            Value::mix_hash_with_original_keys(weights, originals)
+        }
+    };
+    Some(stored)
+}

--- a/src/runtime/quanthash_subclass.rs
+++ b/src/runtime/quanthash_subclass.rs
@@ -1,0 +1,194 @@
+//! Backing storage for user classes that inherit a QuantHash base
+//! (`Set`/`SetHash`/`Bag`/`BagHash`/`Mix`/`MixHash`).
+//!
+//! `class AccountableBagHash is BagHash { }` is the same shape as
+//! `class C is Hash { }` and `class C is Array { }`, which already keep their
+//! real data in a reserved backing attribute (`__mutsu_hash_storage` /
+//! `__mutsu_array_storage`) and delegate the protocol methods to it. QuantHash
+//! subclasses use `__baggy_data__` for the same purpose — the attribute the
+//! `Bag`-like delegation in `builtins/methods_0arg` and `methods_narg` already
+//! reads.
+//!
+//! The base picked out of the MRO decides both the element semantics
+//! (`Setty` counts nothing, `Baggy` counts `Int` weights, `Mixy` counts real
+//! ones) and the mutability: a `BagHash` subclass must be backed by a MUTABLE
+//! bag so `%b<a> = 5` works, while a `Bag` subclass keeps the immutable one so
+//! the same assignment still raises, exactly as
+//! [`Interpreter::positional_base_storage`] picks `List` over `Array`.
+
+use super::Interpreter;
+use crate::symbol::Symbol;
+use crate::value::{RuntimeError, Value, ValueView};
+
+/// The QuantHash bases whose subclasses get `__baggy_data__` backing storage,
+/// most-derived first so an MRO scan picks the mutable flavour when both are
+/// present (`BagHash`'s own MRO does not contain `Bag`, but a user class can
+/// name either).
+const QUANTHASH_BASES: &[&str] = &["SetHash", "BagHash", "MixHash", "Set", "Bag", "Mix"];
+
+impl Interpreter {
+    /// The QuantHash base `class_key` inherits, if any — the name the backing
+    /// store is built as.
+    ///
+    /// The DECLARED parent chain is walked, not the MRO, and a parent that is
+    /// itself a user-declared class never counts as the base however it is
+    /// spelled: a lexical `class Set is Hash { }` shadows the builtin, and so
+    /// does anything inheriting it (`class Child is Set { }`), so neither is a
+    /// QuantHash at all. An MRO scan cannot tell the two apart — the shadowing
+    /// class's own name IS in its MRO.
+    pub(crate) fn quanthash_base_kind(&mut self, class_key: &str) -> Option<&'static str> {
+        self.quanthash_base_kind_seen(class_key, &mut Vec::new())
+    }
+
+    fn quanthash_base_kind_seen(
+        &mut self,
+        class_key: &str,
+        seen: &mut Vec<String>,
+    ) -> Option<&'static str> {
+        let (key, parents) = self.resolved_class_parents_for_quanthash(class_key)?;
+        if seen.contains(&key) {
+            return None;
+        }
+        seen.push(key);
+        for parent in &parents {
+            // A user-declared parent is the shadowing case: recurse into ITS
+            // own parents rather than reading its name as a builtin.
+            if self.resolved_class_parents_for_quanthash(parent).is_some() {
+                if let Some(found) = self.quanthash_base_kind_seen(parent, seen) {
+                    return Some(found);
+                }
+                continue;
+            }
+            if let Some(found) = QUANTHASH_BASES.iter().copied().find(|b| *b == parent) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    /// The backing store a fresh QuantHash-subclass instance gets, folded out
+    /// of `items` (the constructor's positional arguments; empty for `C.new`).
+    ///
+    /// Built through the base type's OWN `.new`, not through the `.Set`/`.Bag`
+    /// coercion: the two disagree on flattening. `Set.new([1,2], 3)` is two
+    /// elements — each argument is taken whole — while `([1,2], 3).Set` is
+    /// three (`roast/S02-types/set.t`'s "Can subclass Set").
+    pub(crate) fn quanthash_base_storage(
+        &mut self,
+        base: &str,
+        items: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        self.try_native_quanthash_construct(Symbol::intern(base), base, &None, items)
+    }
+
+    /// Seed `attrs` with `__baggy_data__` when `class_key` inherits a QuantHash
+    /// base and the constructor did not already supply one. Shared by the two
+    /// constructor paths (`dispatch_new` and `bless`), the same way the
+    /// `Hash`/`Array` blocks beside each call site are.
+    pub(crate) fn seed_quanthash_storage(
+        &mut self,
+        class_key: &str,
+        attrs: &mut crate::runtime::AttrMap,
+        positional_args: &[Value],
+    ) -> Result<(), RuntimeError> {
+        if attrs.contains_key("__baggy_data__") {
+            return Ok(());
+        }
+        let Some(base) = self.quanthash_base_kind(class_key) else {
+            return Ok(());
+        };
+        let storage = self.quanthash_base_storage(base, positional_args.to_vec())?;
+        attrs.insert("__baggy_data__".to_string(), storage);
+        Ok(())
+    }
+}
+
+impl Interpreter {
+    /// The QuantHash twin of `native_hash_storage_next_candidate`: when a user
+    /// `is BagHash`/`is Set`/... subclass (or a role composed into one)
+    /// overrides an Associative-protocol method and calls `nextsame`/`nextwith`
+    /// (or `callsame`/`callwith`), the NATIVE QuantHash behavior on the
+    /// instance's backing `__baggy_data__` is the final base candidate.
+    ///
+    /// This is what makes `AccountableBagHash`'s `multi method ASSIGN-KEY(...)
+    /// { ... nextsame() ... }` land on the real bag: the role's candidate is
+    /// the only user one in the MRO, so without a native base the deferral
+    /// simply answered `Nil` and the weight was never written.
+    pub(crate) fn native_baggy_storage_next_candidate(
+        &mut self,
+        override_args: Option<&[Value]>,
+    ) -> Option<Result<Value, RuntimeError>> {
+        let ctx = self.samewith_context_stack.last().cloned();
+        let method_name = ctx.as_ref().map(|c| c.name.clone())?;
+        let invocant = self
+            .method_dispatch_stack
+            .last()
+            .map(|f| f.invocant.clone())
+            .or_else(|| ctx.as_ref().and_then(|c| c.invocant.clone()))
+            .or_else(|| self.env.get("self").cloned())?;
+        let args: Vec<Value> = match override_args {
+            Some(a) => a.to_vec(),
+            None => self
+                .method_dispatch_stack
+                .last()
+                .map(|f| f.args.clone())
+                .or_else(|| ctx.as_ref().and_then(|c| c.args.clone()))
+                .unwrap_or_default(),
+        };
+        let ValueView::Instance { attributes, .. } = invocant.view() else {
+            return None;
+        };
+        if !attributes.contains_key("__baggy_data__") {
+            return None;
+        }
+        // The mutating half writes into the SHARED backing storage in place
+        // (interior mutability via `with_attr_mut`), so the invocant the user
+        // method still holds sees the new weight — the same shape the
+        // `__mutsu_hash_storage` analog uses.
+        if matches!(method_name.as_str(), "ASSIGN-KEY" | "DELETE-KEY") && !args.is_empty() {
+            let assigned = if method_name == "ASSIGN-KEY" {
+                args.get(1).cloned().unwrap_or(Value::NIL)
+            } else {
+                Value::int(0)
+            };
+            let (key, elem) = crate::runtime::utils::quanthash_elem_entry(&args[0]);
+            let mut outcome: Result<Value, RuntimeError> = Ok(assigned.clone());
+            let applied = attributes.with_attr_mut("__baggy_data__", |storage| {
+                match Self::quanthash_with_weight(storage, key, Some(&elem), &assigned) {
+                    Ok(Some(updated)) => {
+                        *storage = updated;
+                    }
+                    Ok(None) => {
+                        outcome = Err(RuntimeError::assignment_ro_typename(
+                            crate::runtime::value_type_name(storage),
+                            &crate::runtime::utils::gist_value(storage),
+                        ));
+                    }
+                    Err(e) => outcome = Err(e),
+                }
+            });
+            applied?;
+            return Some(outcome);
+        }
+        if method_name == "STORE" {
+            let mut outcome: Result<Value, RuntimeError> = Ok(invocant.clone());
+            let applied = attributes.with_attr_mut("__baggy_data__", |storage| {
+                match crate::runtime::quanthash_store::quanthash_store(storage, &args) {
+                    Some(stored) => *storage = stored,
+                    None => {
+                        outcome = Err(RuntimeError::assignment_ro_typename(
+                            crate::runtime::value_type_name(storage),
+                            &crate::runtime::utils::gist_value(storage),
+                        ))
+                    }
+                }
+            });
+            applied?;
+            return Some(outcome);
+        }
+        let method_sym = Symbol::intern(&method_name);
+        attributes.with_attr_mut("__baggy_data__", |storage| {
+            self.try_native_method(storage, method_sym, &args)
+        })?
+    }
+}

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -191,6 +191,16 @@ impl Interpreter {
     /// of `Bot::Grammar` itself — an unbounded `Bot::Grammar -> Grammar ->
     /// Bot::Grammar` recursion that overflowed the stack (`Bot::Grammar[R]`,
     /// `todo/deep/grammar-metaclass-parameterize-stack-overflow.md`).
+    /// [`Self::resolved_class_parents`] for `quanthash_subclass`, which lives in
+    /// another module and needs the same "is this a user-declared class, and
+    /// what does it inherit" answer.
+    pub(crate) fn resolved_class_parents_for_quanthash(
+        &self,
+        name: &str,
+    ) -> Option<(String, Vec<String>)> {
+        self.resolved_class_parents(name)
+    }
+
     fn resolved_class_parents(&self, name: &str) -> Option<(String, Vec<String>)> {
         let reg = self.registry();
         if let Some(cd) = reg.classes.get(name) {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3049,6 +3049,7 @@ impl Interpreter {
             map_grep_compile_cache: HashMap::new(),
             gather_compile_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),
+            container_element_proxy: None,
             subset_where_fail: None,
             private_zeroarg_method_cache: HashMap::new(),
             module_load_stack: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -687,6 +687,7 @@ impl Interpreter {
             map_grep_compile_cache: HashMap::new(),
             gather_compile_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),
+            container_element_proxy: None,
             subset_where_fail: None,
             private_zeroarg_method_cache: HashMap::new(),
             module_load_stack: Vec::new(),

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -519,6 +519,23 @@ pub(crate) fn gist_value(value: &Value) -> String {
                     .unwrap_or_else(|| crate::value::Value::hash(std::collections::HashMap::new())),
             )
         }
+        // A QuantHash (`is Bag`/`is SetHash`/...) subclass instance gists as its
+        // backing container under its OWN type name (`ABH(a(42) b(666))`), the
+        // way raku renders a `BagHash` subclass — mirrors the `is Hash` and
+        // `is Array` arms above. See `runtime/quanthash_subclass.rs`.
+        ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } if attributes.contains_key("__baggy_data__") => {
+            let storage = attributes
+                .as_map()
+                .get("__baggy_data__")
+                .cloned()
+                .unwrap_or(crate::value::Value::NIL);
+            let name = class_name.resolve();
+            setbagmix_gist_named(&storage, Some(&name)).unwrap_or_else(|| gist_value(&storage))
+        }
         // `$(...)` itemized container: `.gist` never shows the itemization sigil,
         // so it gists exactly like its inner value (`${a=>1}.gist` → `{a => 1}`).
         ValueView::Scalar(inner) => gist_value(inner),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -124,6 +124,7 @@ macro_rules! loan_env {
 
 mod vm_arith_int_ops;
 mod vm_arith_ops;
+mod vm_baggy_subclass_delegate;
 mod vm_baghash_mutators;
 mod vm_bitwise_ops;
 mod vm_call_autothread;

--- a/src/vm/vm_baggy_subclass_delegate.rs
+++ b/src/vm/vm_baggy_subclass_delegate.rs
@@ -1,0 +1,329 @@
+//! `is Set`/`is Bag`/`is Mix` (and their mutable `*Hash`) subclass instance
+//! delegation: an `Instance` whose class inherits one of the builtin QuantHash
+//! types keys its data off the backing `__baggy_data__` attribute (seeded at
+//! construction time by `Interpreter::seed_quanthash_storage`, see
+//! `runtime/quanthash_subclass.rs`) and delegates the QuantHash protocol to it.
+//!
+//! This is the QuantHash twin of the `__mutsu_hash_storage` delegation in
+//! `vm_hash_subclass_delegate.rs`, and works the same way: a plain `Bag`/`Set`/
+//! `Mix` value already has full native method coverage, so the delegation
+//! re-targets that existing dispatch at the storage value through a synthetic
+//! env binding and writes the (possibly mutated) storage back into the
+//! instance's attribute cell. No new slow-path mechanism.
+//!
+//! The read-only `builtins/methods_0arg` and `builtins/methods_narg`
+//! delegations already forward *pure* `__baggy_data__` methods; what lives here
+//! is the mutating half (`ASSIGN-KEY`, `DELETE-KEY`, `STORE`, `grab`, ...),
+//! which needs the writeback those pure paths cannot do.
+
+use super::*;
+
+impl Interpreter {
+    /// Methods delegated to `__baggy_data__`. Curated rather than "everything"
+    /// so a method the class genuinely wants handled by ordinary `Instance`
+    /// dispatch (`.new`, `.WHAT`, `does`, `isa`, a user-defined method —
+    /// already excluded via `has_user_method` at the call site) is never
+    /// intercepted here.
+    fn is_baggy_storage_method(method: &str) -> bool {
+        matches!(
+            method,
+            "AT-KEY"
+                | "ASSIGN-KEY"
+                | "BIND-KEY"
+                | "DELETE-KEY"
+                | "EXISTS-KEY"
+                | "STORE"
+                | "elems"
+                | "total"
+                | "keys"
+                | "values"
+                | "kv"
+                | "pairs"
+                | "antipairs"
+                | "invert"
+                | "list"
+                | "List"
+                | "Array"
+                | "array"
+                | "Seq"
+                | "Slip"
+                | "hash"
+                | "Hash"
+                | "Map"
+                | "iterator"
+                | "Bool"
+                | "Numeric"
+                | "Int"
+                | "Str"
+                | "Stringy"
+                | "Set"
+                | "SetHash"
+                | "Bag"
+                | "BagHash"
+                | "Mix"
+                | "MixHash"
+                | "Setty"
+                | "Baggy"
+                | "Mixy"
+                | "grab"
+                | "grabpairs"
+                | "pick"
+                | "pickpairs"
+                | "roll"
+                | "sum"
+                | "min"
+                | "max"
+                | "minmax"
+                | "sort"
+                | "map"
+                | "grep"
+                | "first"
+                | "classify"
+                | "categorize"
+                | "ACCEPTS"
+                // The internal element-lvalue protocol the native `AT-KEY`
+                // base candidate is expressed in — see
+                // `runtime::run::CONTAINER_ELEMENT_PROXY_SRC`. Not reachable
+                // from user code by any ordinary name.
+                | "__mutsu_container_at_key"
+                | "__mutsu_container_assign_key"
+        )
+    }
+
+    /// Shared precondition for both delegates: `target` is an `Instance` of a
+    /// class that inherits a QuantHash base, carries the backing attribute, and
+    /// does not define `method` itself.
+    fn baggy_storage_target(&mut self, target: &Value, method: &str) -> Option<Value> {
+        let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = target.view()
+        else {
+            return None;
+        };
+        if !Self::is_baggy_storage_method(method) {
+            return None;
+        }
+        if !attributes.contains_key("__baggy_data__") {
+            return None;
+        }
+        let cn = class_name.resolve();
+        if self.has_user_method_including_role(&cn, method) {
+            return None;
+        }
+        attributes.as_map().get("__baggy_data__").cloned()
+    }
+
+    /// QuantHash-subclass instance delegation (mut path): delegate a
+    /// QuantHash-protocol method call to the backing `__baggy_data__` attribute
+    /// and write the mutated storage back into the instance. Returns `None` to
+    /// fall through to the rest of dispatch.
+    pub(super) fn try_baggy_storage_delegate_mut(
+        &mut self,
+        target_name: &str,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let storage = self.baggy_storage_target(target, method)?;
+        let (class_name, attributes, inst_id) = match target.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                id,
+            } => (class_name, attributes, id),
+            _ => return None,
+        };
+        // The mutating half of the Associative protocol has no native
+        // counterpart to delegate to: a named `%b<k> = v` on a plain QuantHash
+        // is handled inline by the element-assign opcode, not by an
+        // `ASSIGN-KEY` method. Apply it here through the shared pure helper
+        // (`quanthash_with_weight`) so both routes agree on the weight
+        // coercion and the zero-removes rule.
+        //
+        // The write goes IN PLACE through the shared attribute cell rather
+        // than into a rebuilt instance: every holder of this object — the
+        // tied variable, a closure that captured it, the `Proxy` the native
+        // `AT-KEY` base hands out — shares one `Gc<InstanceAttrs>`, and only
+        // an in-place write is visible to all of them.
+        if matches!(
+            method,
+            "ASSIGN-KEY" | "DELETE-KEY" | "__mutsu_container_assign_key"
+        ) && let Some(key_arg) = args.first()
+        {
+            let (key, elem) = crate::runtime::utils::quanthash_elem_entry(key_arg);
+            let (assigned, result) = if method == "DELETE-KEY" {
+                // `DELETE-KEY` answers the weight it removed.
+                let old = match self.try_native_method(
+                    &storage,
+                    crate::symbol::Symbol::intern("AT-KEY"),
+                    std::slice::from_ref(key_arg),
+                ) {
+                    Some(Ok(v)) => v,
+                    Some(Err(e)) => return Some(Err(e)),
+                    None => Value::NIL,
+                };
+                (Value::int(0), old)
+            } else {
+                let v = args.get(1).cloned().unwrap_or(Value::NIL);
+                (v.clone(), v)
+            };
+            let mut outcome: Result<Value, RuntimeError> = Ok(result);
+            let applied = attributes.with_attr_mut("__baggy_data__", |slot| {
+                match Self::quanthash_with_weight(slot, key, Some(&elem), &assigned) {
+                    Ok(Some(updated)) => *slot = updated,
+                    // An immutable `Set`/`Bag`/`Mix` base: the same
+                    // X::Assignment::RO a plain one raises.
+                    Ok(None) => {
+                        outcome = Err(RuntimeError::assignment_ro_typename(
+                            crate::runtime::value_type_name(slot),
+                            &crate::runtime::utils::gist_value(slot),
+                        ))
+                    }
+                    Err(e) => outcome = Err(e),
+                }
+            });
+            applied?;
+            return Some(outcome);
+        }
+        // The read half of that internal protocol: the raw native weight,
+        // never routed back through a user `AT-KEY` override.
+        if method == "__mutsu_container_at_key" {
+            let key_arg = args.first().cloned().unwrap_or(Value::NIL);
+            return self.try_native_method(
+                &storage,
+                crate::symbol::Symbol::intern("AT-KEY"),
+                &[key_arg],
+            );
+        }
+        // `STORE` re-initializes the container wholesale, in place for the same
+        // shared-identity reason as the element writes above.
+        if method == "STORE" {
+            let positional: Vec<Value> = args
+                .iter()
+                .filter(|a| !matches!(a.view(), ValueView::Pair(k, _) if k == "INITIALIZE"))
+                .cloned()
+                .collect();
+            let mut outcome: Result<Value, RuntimeError> = Ok(Value::NIL);
+            let applied = attributes.with_attr_mut("__baggy_data__", |slot| {
+                match crate::runtime::quanthash_store::quanthash_store(slot, &positional) {
+                    Some(stored) => *slot = stored,
+                    None => {
+                        outcome = Err(RuntimeError::assignment_ro_typename(
+                            crate::runtime::value_type_name(slot),
+                            &crate::runtime::utils::gist_value(slot),
+                        ))
+                    }
+                }
+            });
+            applied?;
+            if let Err(e) = outcome {
+                return Some(Err(e));
+            }
+            // `STORE` answers the invocant: the tied-variable declaration path
+            // binds the returned value to the variable.
+            return Some(Ok(target.clone()));
+        }
+        // Seed a synthetic binding so the native mutating fast paths (which
+        // write the updated container back into `self.env` by NAME) have
+        // somewhere to write.
+        self.env_mut()
+            .insert("__mutsu_baggy_tmp".to_string(), storage.clone());
+        let dispatched = self.call_method_mut_with_values(
+            "__mutsu_baggy_tmp",
+            storage.clone(),
+            method,
+            args.to_vec(),
+        );
+        let dispatched = match dispatched {
+            Ok(v) => Ok(v),
+            Err(_) => self.vm_call_method_with_values(storage.clone(), method, args.to_vec()),
+        };
+        let result = match dispatched {
+            Ok(v) => v,
+            Err(e) => {
+                self.env_mut().remove("__mutsu_baggy_tmp");
+                return Some(Err(e));
+            }
+        };
+        let updated_storage = self
+            .env()
+            .get("__mutsu_baggy_tmp")
+            .cloned()
+            .unwrap_or_else(|| storage.clone());
+        self.env_mut().remove("__mutsu_baggy_tmp");
+        let updated_instance = self.write_back_baggy_storage_instance(
+            target_name,
+            &class_name,
+            &attributes,
+            inst_id,
+            updated_storage,
+        );
+        let _ = updated_instance;
+        Some(Ok(result))
+    }
+
+    /// Non-mut (read-only) twin of [`Self::try_baggy_storage_delegate_mut`],
+    /// for the callers that have no named receiver to write a mutation back
+    /// through.
+    pub(super) fn try_baggy_storage_delegate(
+        &mut self,
+        target: &Value,
+        method_sym: crate::symbol::Symbol,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let method = method_sym.as_str();
+        let storage = self.baggy_storage_target(target, method)?;
+        // The mutating members have no plain-`Value` native counterpart to
+        // read from — route them through the mut delegate with a synthetic
+        // (unread) target name, exactly like the Hash analog does for `STORE`.
+        if matches!(
+            method,
+            "STORE"
+                | "ASSIGN-KEY"
+                | "BIND-KEY"
+                | "DELETE-KEY"
+                | "grab"
+                | "grabpairs"
+                | "__mutsu_container_at_key"
+                | "__mutsu_container_assign_key"
+        ) {
+            return self.try_baggy_storage_delegate_mut(
+                "__mutsu_baggy_store_tmp",
+                target,
+                method,
+                args,
+            );
+        }
+        self.try_native_method(&storage, method_sym, args)
+    }
+
+    /// Rebuild a QuantHash-backed instance with its `__baggy_data__` attribute
+    /// replaced by `storage` and write it back into `target_name`. Mirrors
+    /// `write_back_hash_storage_instance`.
+    fn write_back_baggy_storage_instance(
+        &mut self,
+        target_name: &str,
+        class_name: &crate::symbol::Symbol,
+        attributes: &crate::gc::Gc<crate::value::InstanceAttrs>,
+        inst_id: u64,
+        storage: Value,
+    ) -> Value {
+        let new_attrs = crate::value::InstanceAttrs::clone(attributes);
+        new_attrs.insert("__baggy_data__".to_string(), storage);
+        let updated_instance = Value::instance_parts(
+            *class_name,
+            crate::gc::Gc::new(crate::value::InstanceAttrs::new(
+                *class_name,
+                new_attrs.to_map(),
+                inst_id,
+                true,
+            )),
+            inst_id,
+        );
+        self.env_mut()
+            .insert(target_name.to_string(), updated_instance.clone());
+        updated_instance
+    }
+}

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1514,6 +1514,39 @@ impl Interpreter {
         call_me_override: Option<Value>,
         compiled_fns: &CompiledFns,
     ) -> Result<Value, RuntimeError> {
+        // `f(...) = v` where `f` is a LEXICAL code variable rather than a
+        // declared sub (`my &nextone := nextcallee; nextone(self,$key) = $v`).
+        // The parser rewrites the assignment into
+        // `__mutsu_assign_named_sub_lvalue("f", [args], value)`, whose runtime
+        // half resolves the name against declared routines and `env` only — it
+        // cannot see a `&`-sigil lexical living in this frame's slots. Resolve
+        // it here, the same way an ordinary call to `f(...)` does a few hundred
+        // lines above, and hand the callable form the value.
+        if name == "__mutsu_assign_named_sub_lvalue"
+            && args.len() >= 3
+            && let Some(callee) = args[0].as_str()
+        {
+            let ampname = format!("&{}", callee);
+            if let Some(callable) = self
+                .locals_get_by_name(code, &ampname)
+                .or_else(|| self.env().get(&ampname).cloned())
+                .filter(|v| {
+                    matches!(
+                        v.view(),
+                        ValueView::Sub(_) | ValueView::WeakSub(_) | ValueView::Routine { .. }
+                    )
+                })
+            {
+                let call_args = Self::sub_call_args_from_value(args.get(1));
+                let value = args[2].clone();
+                let result = loan_env!(
+                    self,
+                    assign_callable_lvalue_with_values(callable, call_args, value)
+                )?;
+                self.apply_pending_rw_writeback(code);
+                return Ok(result);
+            }
+        }
         if name == "__PROTO_DISPATCH__" {
             // `{*}` inside a compiled proto body (ledger §D): the proto-dispatch
             // marker rewritten by `rewrite_proto_dispatch_stmts`. Resolve and run

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -350,6 +350,11 @@ impl Interpreter {
                 self.method_dispatch_pure = true;
                 return result;
             }
+            // The QuantHash twin — see `vm_baggy_subclass_delegate.rs`.
+            if let Some(result) = self.try_baggy_storage_delegate(&target, method_sym, &args) {
+                self.method_dispatch_pure = true;
+                return result;
+            }
             // A user-defined subclass of a builtin type may override an inherited
             // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
             // The user override must win, so do not take the native fork when the

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2867,6 +2867,15 @@ impl Interpreter {
                 // `vm_hash_subclass_delegate.rs` for why this reuses the
                 // existing native Hash dispatch (via a synthetic env binding)
                 // instead of hand-written Rust mutators.
+                // QuantHash-subclass instance delegation (mut path): the
+                // `Set`/`Bag`/`Mix` twin, see `vm_baggy_subclass_delegate.rs`.
+                if let Some(result) =
+                    self.try_baggy_storage_delegate_mut(target_name, &target, method, &args)
+                {
+                    crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "native");
+                    self.stack.push(result?);
+                    return Ok(());
+                }
                 if let Some(result) =
                     self.try_hash_storage_delegate_mut(target_name, &target, method, &args)
                 {

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1992,6 +1992,15 @@ impl Interpreter {
                     self.stack.push(result?);
                     return Ok(());
                 }
+                // The QuantHash twin — see `vm_baggy_subclass_delegate.rs`.
+                if !skip_native
+                    && let Some(result) =
+                        self.try_baggy_storage_delegate(&target, method_sym, &args)
+                {
+                    crate::vm::vm_stats::record_dispatch_entry_outcome("callmethod", "native");
+                    self.stack.push(result?);
+                    return Ok(());
+                }
                 // Nil method fallback: in Raku, calling most methods on Nil returns Nil.
                 // Certain mutating methods throw exceptions.
                 // This must be in the Interpreter path (not the interpreter's call_method_with_values)

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -382,6 +382,19 @@ pub(super) unsafe extern "C" fn call_method(
         // Native code runs no per-op line update, so the callee's frame/backtrace
         // line must be pulled from the static ip -> line table at the call site.
         interp.sync_source_line(code, op_idx as usize);
+        // ADR-0072, mirroring the `CallMethod` arm of `exec_one_dispatch`: a
+        // `.throw` is a resumable throw site, so a resume-capable `CATCH`
+        // several frames up runs INLINE here with every Rust frame still live
+        // and `.resume` continues with the next statement of the *calling*
+        // body. Without this hook a chunk that went native lost the resume
+        // entirely — the handler still ran (through the ordinary region path)
+        // but everything after the throw in the caller's block was skipped,
+        // because the non-inline path can only resume within one
+        // `CompiledCode`. The base is the receiver+arguments start, so a
+        // resumed handler leaves the call's single `Any` value in their place.
+        let throw_base = interp
+            .method_name_is_resumable_throw(code, *name_idx)
+            .then(|| interp.stack.len().saturating_sub(*arity as usize + 1));
         let r = interp.exec_call_method_op(
             code,
             *name_idx,
@@ -391,6 +404,17 @@ pub(super) unsafe extern "C" fn call_method(
             *arg_sources_idx,
         );
         interp.current_code = code as *const CompiledCode as usize;
+        let r = match r {
+            Err(e) if throw_base.is_some() && !e.is_resume() => match interp.try_catch_inline(e) {
+                Ok(v) => {
+                    interp.stack.truncate(throw_base.unwrap_or(0));
+                    interp.stack.push(v);
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            },
+            other => other,
+        };
         match r {
             Ok(()) => {
                 interp.apply_pending_rw_writeback(code);

--- a/src/vm/vm_loop_writeback_quant.rs
+++ b/src/vm/vm_loop_writeback_quant.rs
@@ -38,6 +38,34 @@ impl Interpreter {
         elem: Option<&Value>,
         value: &Value,
     ) -> Result<(), RuntimeError> {
+        let source_val = self.get_env_with_main_alias(source);
+        let Some(source_val) = source_val else {
+            return Ok(());
+        };
+        let Some(updated) = Self::quanthash_with_weight(&source_val, key, elem, value)? else {
+            return Ok(());
+        };
+        self.set_env_with_main_alias(source, updated.clone());
+        self.update_local_if_exists(code, source, &updated);
+        Ok(())
+    }
+
+    /// The pure half of [`Self::quanthash_set_weight`]: given a MUTABLE
+    /// QuantHash `container`, return the container with `key`'s weight set from
+    /// `value` (Int for Bag, Real for Mix, truthiness for Set; a zero weight
+    /// removes the key). `elem` is the element OBJECT behind a `.WHICH` key,
+    /// recorded in `original_keys` on insert. `None` when `container` is not a
+    /// mutable QuantHash.
+    ///
+    /// Shared with the QuantHash-subclass delegation
+    /// (`vm_baggy_subclass_delegate.rs`), whose backing store is a plain
+    /// QuantHash value rather than a named variable.
+    pub(crate) fn quanthash_with_weight(
+        container: &Value,
+        key: String,
+        elem: Option<&Value>,
+        value: &Value,
+    ) -> Result<Option<Value>, RuntimeError> {
         let record = |originals: &mut Option<std::collections::HashMap<String, Value>>,
                       key: &str| {
             if let Some(el) = elem {
@@ -54,8 +82,7 @@ impl Interpreter {
                 ok.remove(key);
             }
         };
-        let source_val = self.get_env_with_main_alias(source);
-        let updated = match source_val.as_ref().map(Value::view) {
+        let updated = match Some(container.view()) {
             Some(ValueView::Bag(bag, true)) => {
                 let count = Self::bag_assignment_count(value)?;
                 let mut b = (**bag).clone();
@@ -94,11 +121,9 @@ impl Interpreter {
                 }
                 Value::set_parts(crate::gc::Gc::new(s), true)
             }
-            _ => return Ok(()),
+            _ => return Ok(None),
         };
-        self.set_env_with_main_alias(source, updated.clone());
-        self.update_local_if_exists(code, source, &updated);
-        Ok(())
+        Ok(Some(updated))
     }
 
     /// Write the loop variable back to a mutable QuantHash weight during

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -643,6 +643,14 @@ impl Interpreter {
                     _ => val.clone(),
                 };
                 self.call_method_with_values(target, method, vec![idx_arg, val_arg])?;
+                // Drain the writes the callee made into the CALLER's lexicals —
+                // an `is rw` parameter, a `$CALLER::x` write, or (the case that
+                // exposed the gap) a resumed `CATCH` handler that ran inline at
+                // a `.throw` inside the ASSIGN-KEY body and set a flag in the
+                // installing frame. Every VM *call* opcode drains here; this
+                // subscript-assign site dispatches a method without one, so it
+                // owes the same drain.
+                self.apply_pending_rw_writeback(code);
                 // A `:=` bind of an immutable literal into a tied container
                 // (`%h<i> := 137` where %h does Associative) makes that element
                 // read-only, just like a plain hash element bind. The literal-ness
@@ -1069,6 +1077,14 @@ impl Interpreter {
             let delegate_args = [key_val, val.clone()];
             if let Some(result) =
                 self.try_hash_storage_delegate_mut(&var_name, &inst, method, &delegate_args)
+            {
+                self.stack.push(result?);
+                return Ok(());
+            }
+            // The QuantHash twin — `%b<a> = 5` on an `is BagHash` subclass
+            // instance writes the weight into the backing `__baggy_data__`.
+            if let Some(result) =
+                self.try_baggy_storage_delegate_mut(&var_name, &inst, method, &delegate_args)
             {
                 self.stack.push(result?);
                 return Ok(());

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -676,6 +676,33 @@ impl Interpreter {
                 .push(if return_new { new_val } else { effective });
             return Ok(());
         }
+        // `%h<a>++` where the class declares its own `AT-KEY`: Raku's postfix
+        // `++` operates on the CONTAINER that `AT-KEY` hands back, so an
+        // override that returns a `Proxy` (the documented QuantHash-subclass
+        // idiom — see `runtime::container_element_proxy`) must have its FETCH
+        // and STORE run, not be treated as an opaque value. Without this the
+        // Proxy object itself was stored as the element's new weight.
+        if let Some(cont) = container.clone()
+            && let ValueView::Instance { class_name, .. } = cont.view()
+            && self.has_user_method_including_role(&class_name.resolve(), "AT-KEY")
+        {
+            let key_arg = Value::str(key.clone());
+            let element = self.try_compiled_method_or_interpret(cont, "AT-KEY", vec![key_arg])?;
+            if element.is_proxy_value() {
+                let old = self.auto_fetch_proxy(&element)?;
+                let effective = Self::normalize_incdec_source(old);
+                let new_val = if increment {
+                    self.increment_value_smart(&effective)?
+                } else {
+                    self.decrement_value_smart(&effective)?
+                };
+                self.assign_proxy_lvalue(element, new_val.clone())?;
+                self.apply_pending_rw_writeback(code);
+                self.stack
+                    .push(if return_new { new_val } else { effective });
+                return Ok(());
+            }
+        }
         // `$h<a>++` / `$h<a>--` on an `is Hash`/`is Map` subclass instance held
         // in a scalar: inc/dec the value at the backing `__mutsu_hash_storage`
         // key in place, mirroring the Array-storage block above.

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -429,7 +429,8 @@ impl Interpreter {
         // itself defers to a real user override when the class declares one.
         if let Some(target) = self.env().get(&var_name).cloned()
             && let ValueView::Instance { attributes, .. } = target.view()
-            && attributes.contains_key("__mutsu_hash_storage")
+            && (attributes.contains_key("__mutsu_hash_storage")
+                || attributes.contains_key("__baggy_data__"))
         {
             let idx_arg = match idx.view() {
                 ValueView::Array(items, _) if items.len() == 1 => items[0].clone(),
@@ -437,9 +438,23 @@ impl Interpreter {
                 ValueView::Slip(items) if items.len() == 1 => items[0].clone(),
                 _ => idx.clone(),
             };
-            if let Some(result) =
-                self.try_hash_storage_delegate_mut(&var_name, &target, "DELETE-KEY", &[idx_arg])
-            {
+            let delegated = self.try_hash_storage_delegate_mut(
+                &var_name,
+                &target,
+                "DELETE-KEY",
+                std::slice::from_ref(&idx_arg),
+            );
+            // The QuantHash twin — see `vm_baggy_subclass_delegate.rs`.
+            let delegated = match delegated {
+                Some(result) => Some(result),
+                None => self.try_baggy_storage_delegate_mut(
+                    &var_name,
+                    &target,
+                    "DELETE-KEY",
+                    &[idx_arg],
+                ),
+            };
+            if let Some(result) = delegated {
                 self.stack.push(result?);
                 return Ok(());
             }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1482,9 +1482,19 @@ impl Interpreter {
                 self.stack.push(idx_clone);
                 return self.exec_index_op_with_positional(is_positional);
             }
-            // Instance with __baggy_data__: delegate subscript to the inner Bag/Set
-            (ValueView::Instance { attributes, .. }, _)
-                if attributes.contains_key("__baggy_data__") =>
+            // Instance with __baggy_data__: delegate subscript to the inner
+            // Bag/Set — unless the class (or a role composed into it) declares
+            // its own `AT-KEY`, which owns the subscript and reaches the
+            // backing store itself through `nextsame`/`nextcallee`.
+            (
+                ValueView::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                },
+                _,
+            ) if attributes.contains_key("__baggy_data__")
+                && !self.has_user_method_including_role(&class_name.resolve(), "AT-KEY") =>
             {
                 let inner = attributes.as_map().get("__baggy_data__").unwrap().clone();
                 let idx_clone = index.clone();

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -738,6 +738,11 @@ impl Interpreter {
                 .class_mro(&trait_name)
                 .iter()
                 .any(|n| n == "Hash" || n == "Map")
+                // A QuantHash subclass (`my %b is AccountableBagHash = ...`)
+                // is populated through the same `STORE(list, :INITIALIZE)`
+                // protocol, delegated to its `__baggy_data__` backing store —
+                // see `vm_baggy_subclass_delegate.rs`.
+                || self.quanthash_base_kind(&trait_name).is_some()
                 || self.has_user_method_including_role(&trait_name, "STORE");
             let type_obj = Value::package(crate::symbol::Symbol::intern(&trait_name));
             let instance = self.try_compiled_method_or_interpret(type_obj, "new", vec![])?;

--- a/t/collections/set-bag-mix/quanthash-store-refill.t
+++ b/t/collections/set-bag-mix/quanthash-store-refill.t
@@ -1,0 +1,32 @@
+use Test;
+
+# `.STORE` on a mutable QuantHash re-initializes it from the assigned list.
+# The entries it writes must use the same `.WHICH`-derived storage keys every
+# other QuantHash write uses, or the container reads back empty.
+
+plan 10;
+
+my $bh = BagHash.new;
+my $stored = $bh.STORE((a => 42, b => 666));
+is $stored.^name, 'BagHash', 'STORE answers a BagHash';
+is $stored<a>,    42,        'and its entries are readable by key';
+is $stored<b>,    666,       'for every key';
+is $stored.total, 708,       'with the assigned weights';
+
+my $sh = SetHash.new;
+my $set = $sh.STORE(('x', 'y', 'x'));
+is $set.elems, 2,    'STORE on a SetHash folds duplicates';
+is $set<x>,    True, 'and its members are readable';
+
+my $mh = MixHash.new;
+my $mix = $mh.STORE((pi => 3.14));
+is $mix<pi>, 3.14, 'STORE on a MixHash keeps a fractional weight';
+
+# Non-Str elements keep their identity through the store.
+my $objs = BagHash.new;
+my $bag = $objs.STORE((1, 1, 2));
+is $bag{1}, 2, 'an Int element is found by its own key';
+is $bag{2}, 1, 'and so is every other';
+is $bag.keys.sort.join(','), '1,2', 'the keys decode back to the elements';
+
+# vim: expandtab shiftwidth=4

--- a/t/collections/set-bag-mix/quanthash-subclass-backing.t
+++ b/t/collections/set-bag-mix/quanthash-subclass-backing.t
@@ -1,0 +1,58 @@
+use Test;
+
+# A user class that inherits a QuantHash base keeps its entries in a native
+# backing store, so the whole Baggy/Setty/Mixy protocol works on it and a
+# `my %h is <Subclass>` tie populates it through STORE.
+
+plan 22;
+
+class MyBagHash is BagHash { }
+class MyBag     is Bag     { }
+class MySetHash is SetHash { }
+class MyMixHash is MixHash { }
+
+# --- construction -----------------------------------------------------------
+my $empty = MyBagHash.new;
+is $empty.^name,  'MyBagHash', 'zero-arg .new keeps the subclass name';
+is $empty.elems,  0,           'a fresh QuantHash subclass is empty';
+is $empty.total,  0,           '.total answers from the backing store';
+ok $empty ~~ Baggy,            'the subclass does Baggy';
+
+my $built = MyBagHash.new('a', 'a', 'b');
+is $built.elems, 2,               'positional .new folds its arguments';
+is $built.total, 3,               'weights accumulate';
+is $built<a>,    2,               'subscript reads the weight';
+is $built.gist,  'MyBagHash(a(2) b)', '.gist renders under the subclass name';
+
+# --- mutation ---------------------------------------------------------------
+$built<a> = 5;
+is $built<a>,    5, 'element assignment sets the weight';
+is $built.elems, 2, 'and does not add a key';
+$built<b> = 0;
+is $built.elems, 1, 'a zero weight removes the element';
+
+my $immutable = MyBag.new('a');
+is $immutable.elems, 1, 'an immutable Bag subclass still constructs';
+dies-ok { $immutable<a> = 3 }, 'but its elements cannot be assigned';
+
+# --- the mutability of the base is respected --------------------------------
+my $set = MySetHash.new('x', 'y');
+is $set.elems, 2,    'a SetHash subclass folds to membership';
+is $set<x>,    True, 'and reads as a Bool';
+$set<z> = True;
+is $set.elems, 3, 'adding a member works';
+
+my $mix = MyMixHash.new;
+$mix<pi> = 3.14;
+is $mix<pi>, 3.14, 'a MixHash subclass keeps a fractional weight';
+
+# --- the tied-variable declaration ------------------------------------------
+my %bh is MyBagHash = a => 42, b => 666;
+is %bh.^name, 'MyBagHash', 'the tie binds an instance of the subclass';
+is %bh<a>,    42,          'the declaration initializer reaches the store';
+is %bh<b>,    666,         'for every key';
+is %bh.total, 708,         'and nothing else was added';
+%bh<a> = 7;
+is %bh<a>, 7, 'the tied variable is writable';
+
+# vim: expandtab shiftwidth=4

--- a/t/collections/subscript/subscript-override-nextcallee.t
+++ b/t/collections/subscript/subscript-override-nextcallee.t
@@ -1,0 +1,78 @@
+use Test;
+
+# A role that overrides the subscript protocol of a container subclass and
+# defers to the native base with `nextsame` / `nextcallee` — the idiom the
+# `AccountableBagHash` distribution is built on, and the shape
+# `Language/subscripts.rakudoc` documents for `AT-KEY`.
+
+plan 12;
+
+class X::Negative is Exception {
+    has $.key;
+    has $.value;
+    method message() { "Not allowed to set '$!key' to $!value" }
+}
+
+my role Accountable {
+    multi method AT-KEY(::?CLASS:D: $key is raw) is raw {
+        my &nextone := nextcallee;
+        Proxy.new(
+          FETCH => { nextone(self, $key) },
+          STORE => -> $, Numeric() $value {
+              $value >= 0
+                ?? (nextone(self, $key) = $value)
+                !! X::Negative.new(:$key, :$value).throw
+          }
+        )
+    }
+    multi method ASSIGN-KEY(::?CLASS:D: $key is raw, $value is raw) is raw {
+        $value > 0
+          ?? nextsame()
+          !! X::Negative.new(:$key, :$value).throw
+    }
+}
+
+class AccountableBag is BagHash does Accountable { }
+class AccountableMix is MixHash does Accountable { }
+
+my %bag is AccountableBag = a => 42, b => 666;
+isa-ok %bag, AccountableBag, 'the tie built the subclass';
+is %bag<a>, 42, 'the overridden AT-KEY reads the native weight';
+
+is (%bag<a> = 48), 48, 'ASSIGN-KEY passes the value through';
+is %bag<a>, 48, 'and nextsame wrote it to the backing store';
+
+is %bag<a>++, 48, 'postfix ++ FETCHes through the Proxy';
+is %bag<a>, 49, 'and STOREs the incremented weight';
+
+{
+    my $caught = False;
+    CATCH {
+        $caught = True;
+        when X::Negative { .resume }
+        default { flunk 'wrong exception'; .resume }
+    }
+    %bag<a> = -1;
+    ok $caught, 'a rejected assignment throws out of ASSIGN-KEY';
+    is %bag<a>, 49, 'and leaves the weight alone';
+}
+
+my %mix is AccountableMix = a => 3.14, b => 666;
+is %mix<a>, 3.14, 'the same role composes into a MixHash subclass';
+is %mix<a>++, 3.14, 'postfix ++ reads the fractional weight';
+is %mix<a>, 4.14, 'and stores the incremented one';
+
+{
+    my $caught = False;
+    CATCH {
+        $caught = True;
+        when X::Negative {
+            is .message, "Not allowed to set 'a' to -1", 'the exception carries the key';
+            .resume;
+        }
+        default { flunk 'wrong exception'; .resume }
+    }
+    %mix<a> = -1;
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/exceptions/catch-resume-across-jit-frame.t
+++ b/t/exceptions/catch-resume-across-jit-frame.t
@@ -1,0 +1,65 @@
+use Test;
+
+# ADR-0072: a `.throw` several frames below a resume-capable `CATCH` runs that
+# handler INLINE at the throw site, so `.resume` continues with the next
+# statement of the calling body. The JIT's `CallMethod` shim has to carry the
+# same hook as the interpreter's own dispatch arm — a callee hot enough to go
+# native otherwise lost the resume, and every statement after the throw in the
+# caller's block was skipped even though the handler itself had run.
+#
+# The warm-up calls are what make the callee a JIT candidate; the file is only
+# a real regression test when run under `MUTSU_JIT=on` with a low threshold
+# (the `jit-stress` CI job), and passes either way.
+
+plan 6;
+
+class X::Neg is Exception { method message() { "neg" } }
+
+sub guard($v) { $v > 0 ?? $v !! X::Neg.new.throw }
+
+# Warm the callee well past any plausible JIT threshold.
+guard($_) for 1..20;
+
+{
+    my $caught = False;
+    my $reached = False;
+    CATCH {
+        $caught = True;
+        when X::Neg { .resume }
+        default { .resume }
+    }
+    guard(-1);
+    $reached = True;
+    ok $caught,  'the handler ran for a throw inside a hot callee';
+    ok $reached, 'and .resume continued with the next statement';
+}
+
+# The same through a subscript assignment, whose ASSIGN-KEY dispatch is a
+# method call without a call opcode of its own.
+class Guarded {
+    has %.store;
+    method AT-KEY($key)         { %!store{$key} // 0 }
+    method ASSIGN-KEY($key, $v) { $v >= 0 ?? (%!store{$key} = $v) !! X::Neg.new.throw }
+}
+
+my $g = Guarded.new;
+$g<a> = $_ for 1..20;
+
+{
+    my $caught = False;
+    my $reached = False;
+    CATCH {
+        $caught = True;
+        when X::Neg { .resume }
+        default { .resume }
+    }
+    $g<a> = -1;
+    $reached = True;
+    ok $caught,  'the handler ran for a throw inside a hot ASSIGN-KEY';
+    ok $reached, 'and .resume continued with the next statement';
+    is $g<a>, 20, 'the rejected assignment left the old value';
+}
+
+is guard(7), 7, 'the hot callee still answers normally afterwards';
+
+# vim: expandtab shiftwidth=4

--- a/t/exceptions/catch-resume-subscript-assign-writeback.t
+++ b/t/exceptions/catch-resume-subscript-assign-writeback.t
@@ -1,0 +1,41 @@
+use Test;
+
+# A resumed CATCH handler runs inline at the throw site and writes its changes
+# back into the frame that installed it. That writeback has to be drained at
+# every call site — including a subscript assignment that dispatches a user
+# `ASSIGN-KEY`, which is a method call without a call opcode of its own.
+
+plan 4;
+
+class X::Nope is Exception { method message() { "nope" } }
+
+class Guarded {
+    has %.store;
+    method AT-KEY($key)         { %!store{$key} // 0 }
+    method ASSIGN-KEY($key, $v) { $v >= 0 ?? (%!store{$key} = $v) !! X::Nope.new.throw }
+}
+
+my $g = Guarded.new;
+{
+    my $caught = False;
+    CATCH {
+        $caught = True;
+        when X::Nope { .resume }
+        default { .resume }
+    }
+    $g<a> = -1;
+    ok $caught, 'the CATCH flag survives an ASSIGN-KEY throw';
+    is $g<a>, 0, 'and the rejected assignment left nothing behind';
+}
+{
+    my $caught = False;
+    CATCH {
+        $caught = True;
+        default { .resume }
+    }
+    $g<a> = 5;
+    nok $caught, 'an accepted assignment throws nothing';
+    is $g<a>, 5, 'and stores the value';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`class AccountableBagHash is BagHash { }` produced an ordinary attribute-bag
object. `.total` did not exist, `.gist` rendered `AccountableBagHash.new`,
`%h<a>` read `Nil`, and `my %abh is AccountableBagHash = a => 42` died with
`Cannot modify an immutable AccountableBagHash`. The whole
[AccountableBagHash](https://360.zef.pm/A/CC/ACCOUNTABLEBAGHASH) distribution —
16 assertions, all green under rakudo — could not run a single one. It is
**16/16** now and its `ecosystem/` record goes `red` → `green`.

## What changed

`is Hash` and `is Array` subclasses have long kept their data in a reserved
backing attribute and delegated the protocol to it. The QuantHash family now
does the same through `__baggy_data__`, which already existed but was only ever
filled by a positional `.new` and only ever held an immutable `Bag`.

- **`runtime/quanthash_subclass.rs`** picks the base out of the **declared parent
  chain** — not the MRO, because a lexical `class Set is Hash { }` shadows the
  builtin and has its own name in its own MRO — and seeds the backing store in
  both constructor paths. The base decides the element semantics *and* the
  mutability: `class C is BagHash` gets a mutable bag, `class C is Bag` keeps the
  immutable one and still raises on an element assignment, the same rule
  `positional_base_storage` uses to pick `List` over `Array`. The store is built
  through the base type's own `.new`, which does not flatten the way the
  `.Set`/`.Bag` coercion does (`Set.new([1,2], 3)` is two elements).
- **`vm/vm_baggy_subclass_delegate.rs`** is the mutating half of the delegation.
  `ASSIGN-KEY`, `DELETE-KEY` and `STORE` write **in place** through the shared
  attribute cell, so every holder of the object — the tied variable, a closure
  that captured it, a `Proxy` over one of its elements — sees the write.
- `.gist` and `.raku` render under the subclass's own name
  (`MyBagHash(a(2) b)`, `("a"=>2).MyBagHash`), and `my %h is <Subclass> = ...`
  populates the store through `STORE(list, :INITIALIZE)` like any other tie.

## Four general bugs fixed on the way

Each of these reproduces without any subclass involved:

- **`.STORE` wrote the wrong keys.** The native `BagHash`/`SetHash`/`MixHash`
  `STORE` built its entries from the raw stringification while every reader looks
  them up by the `.WHICH`-derived key, so `$b.STORE(a => 42); $b<a>` read `0` on
  a plain `BagHash`. The folding moved to `runtime/quanthash_store.rs` and now
  mints the same keys (and the same `original_keys` decoding) as every other
  write.
- **A single-candidate override had no deferral frame.** A user or role override
  of a container protocol method got no `method_dispatch_stack` frame when it was
  the only candidate, so its `nextsame` answered `Nil` and the write vanished.
  Container subclasses now join the `grammar parse` / `BUILDALL` cases that push
  a frame for their native base candidate, and a `multi method` whose candidate
  list runs out falls back to the same base.
- **A resumed `CATCH` lost its writes at a subscript assignment.** The
  element-assign opcode dispatches `ASSIGN-KEY` without a call opcode of its own,
  so it never drained `pending_rw_writeback_sources` — a handler that ran inline
  at a `.throw` inside the callee and set a flag saw that flag reset on return.
- **`f(...) = v` could not see a `my &f`.** The parser lowers it to
  `__mutsu_assign_named_sub_lvalue("f", [args], value)`, which hides the callee
  behind a string constant: the runtime resolved it against declared routines
  only, and — worse — closure free-var analysis never saw a read of `&f`, so a
  closure that *only* assigned through it did not capture it at all. The compiler
  now retargets the call at the code variable, exactly as it already does for a
  bare `f(...)`.

## `nextcallee` for method dispatch

It answered `Nil` for every method dispatch. It now returns the next MRO
candidate as a routine, and — when the MRO is exhausted on a container
subclass's `AT-KEY` — the *native* base candidate, which rakudo spells as a
`Proxy` over the element. mutsu has no routine object for an opcode, so
`runtime/container_element_proxy.rs` supplies one as a small Raku snippet, the
same shape NativeCall's `cglobal` prelude already uses:

```raku
sub ($obj, $key) is rw {
    Proxy.new(
        FETCH => { $obj.__mutsu_container_at_key($key) },
        STORE => -> $, $value { $obj.__mutsu_container_assign_key($key, $value) }
    )
}
```

That makes the idiom `Language/subscripts.rakudoc` documents work end to end:

```raku
multi method AT-KEY(::?CLASS:D: $key is raw) is raw {
    my &nextone := nextcallee;
    Proxy.new(
      FETCH => { nextone(self,$key) },
      STORE => -> $, Numeric() $value { ... nextone(self,$key) = $value ... }
    )
}
```

`%h<a>++` on such an object reads through the outer Proxy into the inner one and
stores back through both, which also needed value-context reads to fetch a
`Proxy` all the way down rather than one level.

## Tests

Four new files, each verified to pass under `raku` as well as mutsu:

- `t/collections/set-bag-mix/quanthash-subclass-backing.t` (22)
- `t/collections/set-bag-mix/quanthash-store-refill.t` (10)
- `t/collections/subscript/subscript-override-nextcallee.t` (12)
- `t/exceptions/catch-resume-subscript-assign-writeback.t` (4)

`make test` PASS, `make lint` clean, `make roast` clean apart from the three
container artifacts `docs/agent-environments.md` lists (`6.c/S32-io/file-tests.t`
and `S16-filehandles/filetest.t` run as uid 0; `S32-io/IO-Socket-Async.t` needs
network). The `ecosystem/` record was re-measured with
`scripts/ecosystem-sweep.py --only AccountableBagHash --sandbox none` — this
container has no `bubblewrap`, so the record honestly says `"sandbox": "none"`;
a corpus box can re-measure it under bwrap.

One adjacent gap is left open and deliberately *not* fixed here: a sigilless
lexical (`\obj`) captured by a `Proxy` STORE closure of an anonymous sub reads
back as its own name — filed as #7879. The prelude above uses `$`-sigiled
parameters to step around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4XEqYhaYfKvEv2ZeCfGKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4XEqYhaYfKvEv2ZeCfGKe)_