### PR TITLE
perf: resolve a multi call once, not three times

### DIFF
--- a/news/2026-09/one-call-one-multi-resolution.md
+++ b/news/2026-09/one-call-one-multi-resolution.md
@@ -1,0 +1,90 @@
+# One function call, one multi resolution
+
+`dispatch_func_call_inner` used to run the full `resolve_function_with_types`
+candidate walk **three times** for a single `multi` call. For a `multi` whose
+candidates are type+arity deterministic the second and third walks were served
+from `func_multi_resolve_cache` and merely wasted a few hash lookups. For a
+*value-dependent* one — a `where` clause, a subset, a literal, a coercion —
+`func_multi_dispatch_type_cacheable` correctly refuses to cache the winner, so
+all three walks ran the constraint, i.e. **user code**:
+
+```raku
+my $n = 0;
+multi sub f(Int:D $x where { $n++; True }) { 'int' }
+multi sub f($x where { $n++; True })       { 'any' }
+my $r = f(1);
+say "$r $n";   # rakudo: "int 1".  mutsu: "int 16".
+```
+
+The three sites, all inside one `dispatch_func_call_inner` invocation:
+
+1. `find_compiled_function_memo` → `resolve_function_multi_cached`;
+2. the `has_multi_candidates_cached` arm, re-resolving by name;
+3. `compile_and_call_function_def` → `push_multi_dispatch_frame`, resolving by
+   name a third time to work out which candidate it had just been handed.
+
+## Site 1 already had the machinery; it was withholding it
+
+The `memo` out-parameter added in #7573 exists precisely to hand site 1's answer
+to site 2, but it was filled **only when the resolution came from the type-keyed
+path**. The reasoning (recorded on the now-folded-away
+`resolve_function_multi_cached_keyed` twin) was
+that only a type-keyed answer is a pure function of
+`(package, name, argument type keys)`, whereas the un-keyed fallback also reads
+`pending_call_arg_sources` — an `is rw` parameter accepts only a writable
+lvalue — so two resolutions of the same call under different pending sources may
+legitimately differ. That is a sound rule for two resolutions in *different*
+dispatches; it is vacuous inside one. Both consumers of the memo resolve and
+consume within a single dispatch of a single call: in `OpCode::ExecCallPairs`
+nothing touches the pending sources in between, and in `dispatch_func_call_inner`
+the probe runs with the call's own `arg_sources` installed while the consumer ran
+with them already cleared — so the memoised answer is in fact the *more* accurate
+of the two. The memo is now filled for every resolution.
+
+Its gate had the exact inversion that makes a cache useless: it was withheld from
+the multis whose resolution is not cacheable, and therefore from precisely the
+calls where re-resolving costs the most.
+
+## Site 3 was re-deriving something it had been given
+
+`push_multi_dispatch_frame` needs the winning candidate for two things — to
+exclude it from the `remaining` list `nextsame`/`callsame` walk, and to read its
+scalar `is rw` params — and it obtained it by resolving the name again.
+`compile_and_call_function_def` is *handed* the resolved `FunctionDef` it is
+about to call, so a new `push_multi_dispatch_frame_with_winner` takes it
+directly. That is also strictly more accurate than resolving by name: the frame
+now describes the candidate actually being invoked, whatever resolver picked it
+(a user-defined operator, `MAIN`, a coercion, a trivial-proto dispatch).
+
+Rakudo resolves a call once. So does mutsu now.
+
+## Measured
+
+Release builds on the same box, 60,000 calls of a two-candidate `multi` with a
+`where` constraint (`tmp/bench-multi-where.raku`):
+
+| | before | after |
+| --- | --- | --- |
+| wall clock | 12.5s | 5.1s |
+| `function-full-resolve` per call | 3 | 1 |
+| `where` evaluations for one call of the repro | 16 | 6 |
+
+`bench-fib`, `bench-ctor`, `bench-class`, `poly-call`, `method-call` and
+`bench-grammar-parse` are unchanged within noise.
+
+The remaining `where` evaluations are a separate problem: the single resolution
+still tests candidates that a narrowest-first walk would not reach, and the
+winner's constraint is evaluated a second time while its parameters are bound.
+#7885 addresses the first half; rakudo's "evaluate once, reuse the bind" is
+still ahead of both.
+
+## Pins
+
+- `tests/multi_call_resolves_once.rs` — the `function-full-resolve` vm-stats
+  count is 1 per call for a `where`-constrained and for a subset-constrained
+  `multi`, and N for N calls in a loop.
+- `t/routines/dispatch/multi-where-single-resolution-redispatch.t` — the
+  redispatch chain still sees the right candidate list now that the frame is
+  told its winner instead of re-deriving it: `nextsame`/`callsame` out of a
+  `where`-constrained candidate, subset narrowness, and a user-defined operator
+  `multi`. Every expectation was checked against rakudo v2026.07 first.

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -864,34 +864,27 @@ impl Interpreter {
     /// args (named/Junction/container), value-dependent multis, and AMBIGUOUS
     /// results (which must re-raise their pending dispatch error every call).
     /// Behaviorally identical to `resolve_function_with_types` for the caller.
+    ///
+    /// This used to have a `_keyed` twin reporting whether the answer came from
+    /// the sound *type-keyed* path — i.e. was a pure function of
+    /// `(package, name, argument type keys)` and so depended on nothing else
+    /// about the call, `pending_call_arg_sources` included. That flag existed to
+    /// license `find_compiled_function_memo` handing one resolution forward to a
+    /// second consumer, on the reasoning that the un-keyed fallback runs the
+    /// full `resolve_function_with_types` candidate walk, which *does* read
+    /// `pending_call_arg_sources` (an `is rw` parameter accepts only a writable
+    /// lvalue), so two resolutions of the same call under different pending
+    /// sources may legitimately differ (#7573). Both consumers of that memo turn
+    /// out to resolve and consume inside a single dispatch of a single call,
+    /// where the pending sources are fixed, so the memo is handed over
+    /// unconditionally and the flag has no reader left (#7886).
     pub(crate) fn resolve_function_multi_cached(
         &mut self,
         name: &str,
         args: &[Value],
     ) -> Option<Arc<FunctionDef>> {
-        self.resolve_function_multi_cached_keyed(name, args).0
-    }
-
-    /// [`Self::resolve_function_multi_cached`], plus whether the answer came
-    /// from the sound *type-keyed* path — i.e. is a pure function of
-    /// `(package, name, argument type keys)` and so depends on nothing else
-    /// about the call, `pending_call_arg_sources` included.
-    ///
-    /// Only a `true` here licenses reusing one resolution for two consumers:
-    /// the un-keyed fallback runs the full `resolve_function_with_types`
-    /// candidate walk, which *does* read `pending_call_arg_sources` (an `is rw`
-    /// parameter accepts only a writable lvalue), so two resolutions of the
-    /// same call under different pending sources may legitimately differ. A
-    /// candidate set containing an `is rw` parameter is exactly what
-    /// `func_multi_dispatch_type_cacheable` refuses, so the two conditions line
-    /// up (#7573).
-    pub(crate) fn resolve_function_multi_cached_keyed(
-        &mut self,
-        name: &str,
-        args: &[Value],
-    ) -> (Option<Arc<FunctionDef>>, bool) {
         let Some(arg_keys) = self.multi_arg_type_keys(args) else {
-            return (self.resolve_function_with_types(name, args), false);
+            return self.resolve_function_with_types(name, args);
         };
         // The atomic mirror, not `current_package()`: the owned form is a
         // `RwLock` read plus a `String` heap allocation on a path that runs on
@@ -899,11 +892,11 @@ impl Interpreter {
         let pkg_sym = self.current_package_sym();
         let name_sym = Symbol::intern(name);
         if !self.func_multi_dispatch_type_cacheable(pkg_sym, name_sym, name) {
-            return (self.resolve_function_with_types(name, args), false);
+            return self.resolve_function_with_types(name, args);
         }
         let key = (pkg_sym, name_sym, arg_keys);
         if let Some(hit) = self.func_multi_resolve_cache.get(&key) {
-            return (hit.clone(), true);
+            return hit.clone();
         }
         let resolved = self.resolve_function_with_types(name, args);
         // Ambiguity is signaled by `None` + a pending dispatch error; that must be
@@ -912,7 +905,7 @@ impl Interpreter {
         if !ambiguous {
             self.func_multi_resolve_cache.insert(key, resolved.clone());
         }
-        (resolved, !ambiguous)
+        resolved
     }
 
     /// True when `class_name`'s MRO (or direct parents) includes a builtin
@@ -1327,6 +1320,26 @@ impl Interpreter {
     /// Push a multi dispatch frame for callsame/nextsame/callwith/nextwith support.
     /// Returns true if a frame was pushed (i.e. there are remaining candidates).
     pub(crate) fn push_multi_dispatch_frame(&mut self, name: &str, args: &[Value]) -> bool {
+        self.push_multi_dispatch_frame_with_winner(name, args, None)
+    }
+
+    /// [`Self::push_multi_dispatch_frame`], told which candidate is being
+    /// called instead of resolving the name a second time.
+    ///
+    /// The frame only needs the winner to (a) exclude it from `remaining` and
+    /// (b) read its scalar `is rw` params, so a caller that already holds the
+    /// resolved `FunctionDef` — `compile_and_call_function_def` is handed one —
+    /// can hand it over. That matters beyond the saved registry walk: for a
+    /// `multi` whose candidates carry `where` constraints the resolution is not
+    /// cacheable (`func_multi_dispatch_type_cacheable` refuses a value-dependent
+    /// multi), so a second resolution *re-runs user code*. Rakudo resolves a
+    /// call once; so should we (#7886).
+    pub(crate) fn push_multi_dispatch_frame_with_winner(
+        &mut self,
+        name: &str,
+        args: &[Value],
+        winner: Option<&FunctionDef>,
+    ) -> bool {
         // Collect ALL multi candidates regardless of arg matching. This is
         // needed because callwith() can re-dispatch with different args, so
         // candidates that don't match the original args may match the new ones.
@@ -1371,12 +1384,19 @@ impl Interpreter {
         // skips the registry walk + match/rank for a type+arity-deterministic
         // multi) and reuse it for both the fingerprint identity and the rw-param
         // capture below — the previous code resolved it twice per call.
-        let saved_err = self.take_pending_dispatch_error();
-        let current_def = self.resolve_function_multi_cached(name, args);
-        let current_fp = current_def.as_ref().map(|def| def.body_fingerprint());
-        if let Some(err) = saved_err {
-            self.set_pending_dispatch_error(err);
-        }
+        let resolved_def;
+        let current_def: Option<&FunctionDef> = match winner {
+            Some(def) => Some(def),
+            None => {
+                let saved_err = self.take_pending_dispatch_error();
+                resolved_def = self.resolve_function_multi_cached(name, args);
+                if let Some(err) = saved_err {
+                    self.set_pending_dispatch_error(err);
+                }
+                resolved_def.as_deref()
+            }
+        };
+        let current_fp = current_def.map(|def| def.body_fingerprint());
         let remaining: Vec<std::sync::Arc<super::FunctionDef>> = all_candidates
             .iter()
             .filter(|c| {
@@ -1388,7 +1408,6 @@ impl Interpreter {
         // Capture the FIRST (winning) candidate's scalar rw params so a
         // nextsame+rw redispatch can chain the rw value through it (§D).
         let rw_params = current_def
-            .as_ref()
             .map(|def| super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs))
             .unwrap_or_default();
         let dispatch_token = self.next_dispatch_token();

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -131,12 +131,11 @@ impl Interpreter {
     /// line, so the line is threaded in instead.
     ///
     /// `pre_resolved` short-circuits the `resolve_function_with_alias` below
-    /// with a winner the caller already resolved for these same arguments. Only
-    /// a *type-keyed* resolution may be handed over (`find_compiled_function_memo`
-    /// fills its memo only in that case): such an answer is a pure function of
-    /// `(package, name, argument type keys)` and so is exactly what resolving a
-    /// second time here would produce. See
-    /// [`Interpreter::resolve_function_multi_cached_keyed`] (#7573).
+    /// with a winner the caller already resolved for these same arguments
+    /// (`find_compiled_function_memo`). Resolving a second time here would
+    /// re-run the whole candidate walk on an identical call — and for a
+    /// value-dependent `multi` that walk runs user code (a `where` clause), so
+    /// the second resolution is not merely wasted but observable (#7886).
     pub(crate) fn exec_call_sanitized(
         &mut self,
         name: &str,

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -407,7 +407,15 @@ impl Interpreter {
         // Set up samewith and multi-dispatch context that call_compiled_function_named
         // expects the caller to manage (mirrors exec_call_fn_op).
         self.push_samewith_context(&name, None, None);
-        let pushed_dispatch = loan_env!(self, push_multi_dispatch_frame(&name, &args));
+        // The winner is already in hand — this function was *given* the
+        // resolved candidate — so the frame takes it instead of resolving the
+        // name all over again. For a value-dependent `multi` (a `where`
+        // constraint, a subset, a literal) that second resolution was not
+        // cacheable and re-ran user code (#7886).
+        let pushed_dispatch = loan_env!(
+            self,
+            push_multi_dispatch_frame_with_winner(&name, &args, Some(def))
+        );
 
         // Prefer the routine's own nested-sub table over the caller's: a
         // caller with no table of its own (e.g. `sub EXPORT` dispatch) must

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -262,8 +262,8 @@ impl Interpreter {
         crate::vm::vm_stats::record_dispatch_entry_outcome(
             "execcallpairs",
             if resolved_memo.is_some() {
-                // The probe above resolved the winner type-keyed and the carrier
-                // reuses it: one resolution per call instead of two.
+                // The probe above resolved the winner and the carrier reuses
+                // it: one resolution per call instead of two.
                 "carrier-preresolved"
             } else {
                 "carrier"

--- a/src/vm/vm_call_resolve.rs
+++ b/src/vm/vm_call_resolve.rs
@@ -17,10 +17,23 @@ impl Interpreter {
     /// `dispatch_func_call_inner` needs the same winner immediately afterwards
     /// when this returns `None` for a `multi` name, and used to resolve it a
     /// second time — rebuilding `multi_arg_type_keys` (a `Symbol` per argument
-    /// property) for an answer already in hand. `memo` is filled only when the
-    /// resolution came from the type-keyed path, which by construction cannot
-    /// depend on anything about the call that changed in between; see
-    /// [`Interpreter::resolve_function_multi_cached_keyed`] (#7573).
+    /// property) for an answer already in hand.
+    ///
+    /// The memo is filled for **every** resolution, type-keyed or not, and is
+    /// valid for the rest of the dispatch that requested it. It was originally
+    /// restricted to the type-keyed path (#7573), on the grounds that only such
+    /// an answer is a pure function of `(package, name, argument type keys)`
+    /// whereas the un-keyed fallback also reads `pending_call_arg_sources` (an
+    /// `is rw` parameter accepts only a writable lvalue). But that restriction
+    /// withheld the memo from exactly the value-dependent multis whose
+    /// resolution is *not* cacheable and therefore runs user code — a `where`
+    /// clause ran once per resolution, where rakudo evaluates it once per call
+    /// (#7886). Both callers resolve and consume inside one dispatch of one
+    /// call, so the pending sources cannot have changed under them: in
+    /// `OpCode::ExecCallPairs` nothing touches them in between, and in
+    /// `dispatch_func_call_inner` the probe runs with the call's own
+    /// `arg_sources` installed while the consumer ran with them already
+    /// cleared — so the memoised answer is the more accurate of the two.
     pub(super) fn find_compiled_function_memo<'a>(
         &mut self,
         compiled_fns: &'a CompiledFns,
@@ -92,11 +105,8 @@ impl Interpreter {
         // resolution itself is still cacheable whenever the candidates are
         // type+arity deterministic, and for a `multi` this call was otherwise a
         // full candidate walk on every single dispatch.
-        let (resolved_def, type_keyed) =
-            loan_env!(self, resolve_function_multi_cached_keyed(name, args));
-        if type_keyed {
-            memo.clone_from(&resolved_def);
-        }
+        let resolved_def = loan_env!(self, resolve_function_multi_cached(name, args));
+        memo.clone_from(&resolved_def);
         let expected_fingerprint = resolved_def.as_ref().map(|def| def.body_fingerprint());
         // If runtime resolution fails, avoid reusing stale compiled cache entries.
         // This can happen across repeated EVAL calls that redefine the same routine name.

--- a/t/routines/dispatch/multi-where-single-resolution-redispatch.t
+++ b/t/routines/dispatch/multi-where-single-resolution-redispatch.t
@@ -1,0 +1,48 @@
+use Test;
+
+# A value-dependent `multi` (a `where` clause, a subset) used to be resolved
+# three times per call, and `push_multi_dispatch_frame` was one of the three:
+# it re-resolved the name to work out which candidate was being called, so it
+# could exclude that one from the `remaining` list `nextsame`/`callsame` walk.
+# It is now handed the winner `compile_and_call_function_def` already holds
+# (#7886), so this file pins that the redispatch chain still sees the same
+# candidate list. Every expectation below was checked against rakudo first.
+#
+# The resolution COUNT itself is pinned by tests/multi_call_resolves_once.rs
+# (a MUTSU_VM_STATS check); this file pins the behaviour.
+
+plan 8;
+
+{
+    my @log;
+    multi sub f(Int:D $x where { True }) { @log.push('int'); nextsame; 'int' }
+    multi sub f($x) { @log.push('any'); 'any' }
+    is f(1), 'any', 'nextsame from a where-constrained winner reaches the wider candidate';
+    is @log.join(','), 'int,any', 'both candidate bodies ran, narrowest first';
+}
+
+{
+    multi sub g(Int:D $x where * > 0) { 'pos:' ~ callsame() }
+    multi sub g($x) { 'any' }
+    is g(5), 'pos:any', 'callsame from a where-constrained winner returns the wider result';
+    is g(-5), 'any', 'a failing where constraint still falls through to the wider candidate';
+}
+
+{
+    subset Pos of Int where * > 0;
+    multi sub h(Pos $x) { 'pos' }
+    multi sub h($x) { 'any' }
+    is h(3), 'pos', 'a subset-constrained candidate wins for a matching value';
+    is h(-3), 'any', 'a subset-constrained candidate is skipped for a non-matching value';
+}
+
+{
+    # A user-defined operator reaches the same dispatch frame through
+    # compile_and_call_function_def, with the winner already resolved.
+    multi sub infix:<qq>(Int $a where * > 0, Int $b) { 'pos' }
+    multi sub infix:<qq>($a, $b) { 'gen' }
+    is (1 qq 2), 'pos', 'a where-constrained operator candidate wins';
+    is (-1 qq 2), 'gen', 'a where-constrained operator candidate yields to the generic one';
+}
+
+done-testing;

--- a/tests/multi_call_resolves_once.rs
+++ b/tests/multi_call_resolves_once.rs
@@ -1,0 +1,125 @@
+//! Pins "one function call, one multi resolution" (#7886).
+//!
+//! `dispatch_func_call_inner` used to run the full `resolve_function_with_types`
+//! candidate walk **three** times for a single call:
+//!
+//! 1. `find_compiled_function_memo` -> `resolve_function_multi_cached_keyed`,
+//!    which handed its answer forward only when the resolution was *type-keyed*;
+//! 2. the `has_multi_candidates_cached` arm, re-resolving by name because the
+//!    memo above was empty;
+//! 3. `compile_and_call_function_def` -> `push_multi_dispatch_frame`, resolving
+//!    by name again to work out which candidate it had just been handed.
+//!
+//! For a `multi` whose candidates carry a `where` clause (or a subset, or a
+//! literal) none of that is cacheable — `func_multi_dispatch_type_cacheable`
+//! correctly refuses a value-dependent multi — so each of the three walks ran
+//! the constraint, i.e. **user code**. Rakudo resolves a call once.
+//!
+//! The memo is now filled for every resolution and the dispatch frame takes the
+//! winner it is already holding, so a call resolves exactly once. A regression
+//! shows up as `f=N` climbing back to a multiple of the call count in the
+//! `function-full-resolve` vm-stats line.
+
+use std::process::Command;
+
+fn run(src: &str) -> (String, String, bool) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.arg("-e").arg(src);
+    cmd.env("MUTSU_VM_STATS", "1");
+    let out = cmd.output().expect("failed to spawn mutsu");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    )
+}
+
+/// The `<name>=N` count in the `function-full-resolve` vm-stats line, or 0 when
+/// the routine never reached a full candidate walk.
+fn full_resolves(stderr: &str, name: &str) -> u64 {
+    let key = format!("{name}=");
+    stderr
+        .lines()
+        .filter(|l| l.contains("] function-full-resolve total="))
+        .find_map(|l| {
+            l.split_whitespace()
+                .find_map(|w| w.strip_prefix(key.as_str()))
+                .and_then(|v| v.parse().ok())
+        })
+        .unwrap_or(0)
+}
+
+#[test]
+fn a_where_constrained_multi_resolves_once_per_call() {
+    let src = "multi sub f(Int:D $x where { True }) { 1 }\n\
+               multi sub f($x) { 2 }\n\
+               say f(1);";
+    let (out, err, ok) = run(src);
+    assert!(ok, "run failed: {err}");
+    assert_eq!(out, "1\n");
+    assert_eq!(
+        full_resolves(&err, "f"),
+        1,
+        "one call must resolve its candidates once: {err}"
+    );
+}
+
+#[test]
+fn a_where_constrained_multi_resolves_once_per_call_in_a_loop() {
+    let src = "multi sub f(Int:D $x where { True }) { 1 }\n\
+               multi sub f($x) { 2 }\n\
+               my $s = 0; for ^5 { $s += f(1) }; say $s;";
+    let (out, err, ok) = run(src);
+    assert!(ok, "run failed: {err}");
+    assert_eq!(out, "5\n");
+    assert_eq!(
+        full_resolves(&err, "f"),
+        5,
+        "five calls must resolve five times, not fifteen: {err}"
+    );
+}
+
+#[test]
+fn a_subset_constrained_multi_resolves_once_per_call() {
+    // The other flavour of value-dependent dispatch the resolution cache has to
+    // refuse: a subset's `where` is user code just as an inline one is.
+    let src = "subset Pos of Int where * > 0;\n\
+               multi sub f(Pos $x) { 1 }\n\
+               multi sub f($x) { 2 }\n\
+               my $s = 0; for ^5 { $s += f(1) }; say $s;";
+    let (out, err, ok) = run(src);
+    assert!(ok, "run failed: {err}");
+    assert_eq!(out, "5\n");
+    assert_eq!(
+        full_resolves(&err, "f"),
+        5,
+        "five calls must resolve five times, not fifteen: {err}"
+    );
+}
+
+#[test]
+fn a_where_clause_runs_far_fewer_times_than_it_used_to() {
+    // The user-visible consequence. Rakudo evaluates the winning candidate's
+    // constraint once per call; mutsu still re-evaluates it while binding the
+    // winner, but the count must no longer scale with a *re-resolution* of the
+    // same call. Three resolutions of this two-candidate multi cost 16
+    // evaluations before #7886.
+    let src = "my $n = 0;\n\
+               multi sub f(Int:D $x where { $n++; True }) { 'int' }\n\
+               multi sub f($x where { $n++; True }) { 'any' }\n\
+               my $r = f(1);\n\
+               say \"$r $n\";";
+    let (out, err, ok) = run(src);
+    assert!(ok, "run failed: {err}");
+    let n: u64 = out
+        .trim()
+        .strip_prefix("int ")
+        .unwrap_or_else(|| panic!("wrong candidate won: {out}"))
+        .parse()
+        .unwrap_or_else(|_| panic!("unparseable count: {out}"));
+    assert!(
+        n <= 8,
+        "the winning candidate's `where` ran {n} times for one call (was 16 \
+         across three resolutions; rakudo runs it once): {out}{err}"
+    );
+}


### PR DESCRIPTION
`dispatch_func_call_inner` ran the full `resolve_function_with_types` candidate walk **three times** for a single `multi` call. For a type+arity deterministic multi the second and third walks were served from `func_multi_resolve_cache` and cost a few hash lookups. For a *value-dependent* one — a `where` clause, a subset, a literal, a coercion — `func_multi_dispatch_type_cacheable` correctly refuses to cache the winner, so all three walks ran the constraint, i.e. **user code**.

```raku
my $n = 0;
multi sub f(Int:D $x where { $n++; True }) { 'int' }
multi sub f($x where { $n++; True })       { 'any' }
my $r = f(1);
say "$r $n";   # rakudo: "int 1".  mutsu on main: "int 16".
```

## Site 1 already had the machinery; its gate was inverted

The `memo` out-parameter added in #7573 exists precisely to hand site 1's answer to site 2, but it was filled **only when the resolution came from the type-keyed path**. The reasoning (recorded on `resolve_function_multi_cached_keyed`) was that only a type-keyed answer is a pure function of `(package, name, argument type keys)`, whereas the un-keyed fallback also reads `pending_call_arg_sources` — an `is rw` parameter accepts only a writable lvalue — so two resolutions of the same call under different pending sources may legitimately differ.

That is a sound rule for two resolutions in *different* dispatches, and vacuous inside one. Both consumers of the memo resolve and consume within a single dispatch of a single call: in `OpCode::ExecCallPairs` nothing touches the pending sources in between, and in `dispatch_func_call_inner` the probe runs with the call's own `arg_sources` installed while the consumer ran with them already **cleared** — so the memoised answer is in fact the *more* accurate of the two. The memo is now filled unconditionally.

The gate had the exact inversion that makes a cache useless: it was withheld from the multis whose resolution is not cacheable, and therefore from precisely the calls where re-resolving costs the most.

## Site 3 was re-deriving something it had been given

`push_multi_dispatch_frame` needs the winning candidate for two things — to exclude it from the `remaining` list the `nextsame`/`callsame` walk uses, and to read its scalar `is rw` params — and it obtained it by resolving the name again. `compile_and_call_function_def` is *handed* the resolved `FunctionDef` it is about to call, so a new `push_multi_dispatch_frame_with_winner` takes it directly. That is also strictly more accurate than resolving by name: the frame now describes the candidate actually being invoked, whatever resolver picked it (a user-defined operator, a coercion, a trivial-proto dispatch, `MAIN`).

With no reader left for its `bool`, `resolve_function_multi_cached_keyed` is folded back into `resolve_function_multi_cached`.

## Measured

Release builds, same box, `main` at c9d1846 against this branch. 60,000 calls of a two-candidate `multi` with a `where` constraint:

| | main | after |
| --- | --- | --- |
| wall clock | 12.5s | **5.1s** |
| `function-full-resolve` per call | 3 | **1** |
| `where` evaluations for one call of the issue's repro | 16 | 6 |

`bench-fib` (0.167 → 0.162), `bench-ctor` (0.421 → 0.417), `bench-class` (0.247 → 0.258), `poly-call` (0.123 → 0.129), `method-call` (0.200 → 0.192) and `bench-grammar-parse` (0.025 → 0.024) are unchanged within noise.

The remaining `where` evaluations are a separate problem: the single resolution still tests candidates a narrowest-first walk would not reach, and the winner's constraint is evaluated again while its parameters are bound. #7885 addresses the first half; rakudo's "evaluate once, reuse the bind" is still ahead of both. This change is independent of #7885 — it removes re-*resolutions*, not the per-resolution cost — so the two compose.

## Verification

- New pin `tests/multi_call_resolves_once.rs`: the `function-full-resolve` vm-stats count is 1 per call for a `where`-constrained and for a subset-constrained `multi`, and N for N calls in a loop. Fails on `main` (3 and 15), passes here.
- New pin `t/routines/dispatch/multi-where-single-resolution-redispatch.t`: 8 assertions that the redispatch chain still sees the right candidate list now that the frame is told its winner instead of re-deriving it — `nextsame`/`callsame` out of a `where`-constrained candidate, subset narrowness, and a user-defined operator `multi`. Every expectation was checked against rakudo v2026.07 first; the file passes under `raku`.
- `make lint` clean (default clippy, `jit` off, wasm32, rustdoc).
- `make test`: 3964 files, 42157 tests, PASS.
- `make roast`: 1436 files, 218939 tests. The only failures are the three `docs/agent-environments.md` records as container-specific, with the exact shapes that document lists — `6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8/10) and `S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64/69-72/77-80/101/103/105/107/109/111/117/121/125), both `chmod`-based and meaningless at `uid 0` (`id -u` is 0 here), and `S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17", sandboxed network).

Closes #7886

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmQyG4JLfsNo4sBFUsqQam

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmQyG4JLfsNo4sBFUsqQam)_