### PR TITLE
ecosystem: keep index-snapshot.json out of a --only re-measure, install bwrap at container setup

### DIFF
--- a/.agents/skills/ecosystem-dist-fix/SKILL.md
+++ b/.agents/skills/ecosystem-dist-fix/SKILL.md
@@ -222,18 +222,37 @@ re-running a suite. In a remote container, confirm any red `make roast` is a sub
 the environment-only failures in
 [docs/agent-environments.md](../../../docs/agent-environments.md).
 
-## 7. Re-measure and update the ledger record
+## 7. Re-measure with `--only` and update the ledger record
 
-The record is part of the deliverable — a fix that leaves the ledger saying `red` has not been
-reported.
+**Every interpreter change made in this loop ends with a `--only` re-measure — no exceptions.** It
+is not a formality: it is how you learn whether the fix moved the distribution at all, and how
+often it moved a *different* file than the one you were chasing. The record is part of the
+deliverable, and a fix that leaves the ledger saying `red` has not been reported. This applies to
+the small fixes too — one method, one operator, one parse gap — and to a run that ends in an issue
+rather than a fix, where the re-measure is what proves the residue is what you say it is.
 
 ```sh
 touch src/main.rs && cargo build --release        # a stale binary is measured silently
-MUTSU_BIN=target/release/mutsu scripts/ecosystem-sweep.py --only String::Utils --sandbox none
+MUTSU_BIN=target/release/mutsu scripts/ecosystem-sweep.py --only String::Utils
 ```
 
-- `--sandbox none` is permitted **only** with `--only`, for a distribution you have read. A shard or
-  corpus sweep needs `bubblewrap`, which a remote container does not have — do not attempt one there.
+- **Re-measure with the release binary you actually built.** `touch src/main.rs` is not
+  superstition: the sweep reads `MUTSU_BIN` and will happily measure yesterday's binary, producing
+  a record that says your fix did nothing.
+- **`ecosystem/index-snapshot.json` must not appear in your diff.** It is corpus-level provenance —
+  "the records beside me were resolved against this fez/REA snapshot" — so a one-distribution run
+  has no business dating the whole ledger to today's index. `--only` therefore leaves it alone
+  (the sweep logs `index-snapshot.json: left unchanged`); `--no-index-snapshot` does the same for a
+  `--status` / `--stale` re-measure after a fix. If it shows up in `git status` anyway, revert it
+  rather than committing it: `git checkout -- ecosystem/index-snapshot.json`.
+- **The sandbox is the default and you should keep it.** `.claude/hooks/session-start.sh` installs
+  and verifies `bwrap` in a remote container too, so the "no bubblewrap here" excuse is gone. Drop
+  to `--sandbox none` only when the hook reported that the sandbox does not work (`bwrap --version`
+  to check), and then only for a `--only` distribution whose suite you have read — never for a shard
+  or a corpus sweep, which the sweep refuses unsandboxed by design.
+- A **corpus or shard sweep still does not belong in a remote container** — 4 cores and a fixed disk
+  allowance, not a missing sandbox, are what rule it out. Dispatch
+  `.github/workflows/ecosystem-sweep.yml` instead (`docs/ecosystem-parity.md` §8.1).
 - The sweep aborts unless `use Test` reaches the vendored `modules/Rakudo-Core/lib/Test.rakumod` on
   both sides. That is the fairness precondition, not a nuisance: fix it rather than working around it.
 - Timestamps are date-granular, so an unchanged same-day re-run produces no diff. A record that did
@@ -244,7 +263,15 @@ MUTSU_BIN=target/release/mutsu scripts/ecosystem-sweep.py --only String::Utils -
   design, not implementation — the harness does not accept them today. Use the flags in
   `--help`.
 
-Commit the changed `ecosystem/dists/<S>/<Dist--Name>.json` in the same PR as the fix.
+**If the fix plausibly reaches beyond this distribution, re-measure the neighbours too** — one
+`--only` per distribution, in the same run. A parser or builtin gap is rarely one module's alone,
+and a second record flipping to `green` for free is the cheapest evidence this loop produces that
+the fix was general rather than a dressed-up special case. Pick them by the root cause (the ledger
+records naming the same failing construct), not by convenience, and add them to the PR body.
+
+Commit the changed `ecosystem/dists/<S>/<Dist--Name>.json` files — and nothing else under
+`ecosystem/` — in the same PR as the fix. `git status --porcelain ecosystem/` before you commit is
+the one-command check: every line should be a `dists/` record.
 
 ## 8. Publish — to `tokuhirom/mutsu`
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,7 +2,7 @@
 # SessionStart hook: bring a freshly provisioned container up to the toolchain
 # this repository needs, before the agent runs its first command.
 #
-# Two things are routinely missing or stale in the ephemeral containers that
+# Four things are routinely missing or stale in the ephemeral containers that
 # Claude Code on the web / the Claude app provision:
 #
 #   1. rustc — the base image ships whatever stable it was built with, which is
@@ -14,8 +14,12 @@
 #   3. libmysqlclient — the base image ships libpq and libsqlite3 but not this
 #      one, so every DBIish MySQL file in the battery suite dies with a
 #      NativeCall "symbol 'mysql_init' not found ... dlsym failed".
+#   4. bubblewrap — the ecosystem sweep (scripts/ecosystem-sweep.py) executes
+#      unaudited third-party test suites and confines every interpreter run in
+#      `bwrap`. Without it the sweep refuses a corpus outright and a single
+#      `--only` re-measure has to fall back to `--sandbox none`.
 #
-# All three are mechanical to fix, so fix them here rather than paying for the
+# All four are mechanical to fix, so fix them here rather than paying for the
 # rediscovery every session.
 #
 # Local checkouts are left alone: a developer machine is pinned by .mise.toml
@@ -31,6 +35,21 @@ cd "$REPO"
 
 say() { printf 'session-start: %s\n' "$*"; }
 warn() { printf 'session-start: WARNING: %s\n' "$*" >&2; }
+
+# Package installs are best-effort: a container that is not root, or has no
+# apt, gets a warning from the caller rather than a failed session start.
+can_apt() { [ "$(id -u)" = 0 ] && command -v apt-get >/dev/null 2>&1; }
+
+# A stale package index is the usual reason the first attempt fails, and
+# `apt-get update` is slow enough to be worth skipping unless it is needed.
+apt_install() {
+  export DEBIAN_FRONTEND=noninteractive
+  if apt-get install -y --no-install-recommends "$@" >/dev/null 2>&1; then
+    return 0
+  fi
+  apt-get update -qq >/dev/null 2>&1 || true
+  apt-get install -y --no-install-recommends "$@" >/dev/null 2>&1
+}
 
 # ------------------------------------------------------------------- rustc --
 # Three places declare a Rust version and they can drift apart, so take the
@@ -132,30 +151,57 @@ setup_native_libs() {
     return 0
   fi
 
-  if [ "$(id -u)" != 0 ] || ! command -v apt-get >/dev/null 2>&1; then
+  if ! can_apt; then
     warn "missing native libraries (${missing[*]}) and no way to install them; the DBIish MySQL battery files will fail with 'dlsym failed'"
     return 0
   fi
 
   say "installing native libraries: ${missing[*]}"
-  export DEBIAN_FRONTEND=noninteractive
-  if apt-get install -y --no-install-recommends "${missing[@]}" >/dev/null 2>&1; then
+  if apt_install "${missing[@]}"; then
     say "native libraries installed"
-    return 0
-  fi
-  # A stale package index is the usual reason the first attempt fails; an
-  # `apt-get update` is slow enough to be worth skipping unless it is needed.
-  apt-get update -qq >/dev/null 2>&1 || true
-  if apt-get install -y --no-install-recommends "${missing[@]}" >/dev/null 2>&1; then
-    say "native libraries installed (after apt-get update)"
   else
     warn "could not install ${missing[*]}; the DBIish MySQL battery files will fail with 'dlsym failed'"
+  fi
+}
+
+# ------------------------------------------------------------------- bwrap --
+# scripts/ecosystem-sweep.py runs each zef distribution's own test suite under
+# both interpreters. Loading a module already executes its BEGIN phasers, so
+# every run is confined with bubblewrap (no network, read-only root, throwaway
+# HOME) and the sweep refuses a corpus sweep when `bwrap` is absent -- leaving
+# `--sandbox none`, which is only defensible for one distribution you have read.
+# Installing it is a two-second apt away, so do it up front rather than
+# discovering the gap in the middle of an ecosystem-dist-fix run.
+#
+# The probe matters as much as the package: a container can ship `bwrap` and
+# still deny the unprivileged user namespace `--unshare-all` needs, and that
+# failure surfaces as an unexplained non-zero exit from every measured file.
+setup_bwrap() {
+  if command -v bwrap >/dev/null 2>&1; then
+    say "bwrap already present: $(bwrap --version 2>/dev/null)"
+  elif ! can_apt; then
+    warn "bwrap is absent and cannot be installed; an ecosystem sweep will need --sandbox none"
+    return 0
+  else
+    say "installing bubblewrap (the ecosystem sweep's sandbox)"
+    if ! apt_install bubblewrap; then
+      warn "could not install bubblewrap; an ecosystem sweep will need --sandbox none"
+      return 0
+    fi
+  fi
+
+  if bwrap --unshare-all --ro-bind / / --dev /dev --proc /proc \
+       --die-with-parent true >/dev/null 2>&1; then
+    say "bwrap sandbox verified"
+  else
+    warn "bwrap is installed but its sandbox does not work here (unprivileged user namespaces are probably restricted); an ecosystem sweep will need --sandbox none"
   fi
 }
 
 setup_rust
 setup_raku
 setup_native_libs
+setup_bwrap
 
 # Warm the crate cache so the first build is compile-only. Cheap next to the
 # build itself, and the container image is snapshotted after this hook.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,20 +491,22 @@ anything not on `origin` is not saved.
 ### Remote containers self-provision via a SessionStart hook
 
 Sessions started from the Claude app / Claude Code on the web get a **fresh container** whose base
-image usually ships a rustc older than this repo compiles under, no `raku` at all, and none of the
-C shared libraries the bundled batteries `dlopen`. All three are fixed automatically by
-`.claude/hooks/session-start.sh`, registered as a `SessionStart` hook in
+image usually ships a rustc older than this repo compiles under, no `raku` at all, none of the
+C shared libraries the bundled batteries `dlopen`, and no `bwrap`. All four are fixed automatically
+by `.claude/hooks/session-start.sh`, registered as a `SessionStart` hook in
 `.claude/settings.json`: it installs the highest Rust version declared by the repo (the `ci.yml`
 toolchain pin, `Cargo.toml`'s `rust-version`, `.mise.toml`) via rustup, runs
 `.agents/skills/install-raku/install-raku.sh` when `raku` is missing, apt-installs the native
 libraries listed in its `NATIVE_LIBS` array (currently just `libmysqlclient21`, which DBIish's mysql
-driver needs), and warms the crate cache with `cargo fetch`. It is idempotent (~0.14s when
-everything is already in place) and does nothing on a local checkout unless `MUTSU_SETUP_FORCE=1`
-is set — a developer machine is pinned by `.mise.toml` and owns its own toolchain.
+driver needs), installs `bubblewrap` and probes that its sandbox actually works (the ecosystem
+sweep confines every measured run in it), and warms the crate cache with `cargo fetch`. It is
+idempotent (~0.14s when everything is already in place) and does nothing on a local checkout unless
+`MUTSU_SETUP_FORCE=1` is set — a developer machine is pinned by `.mise.toml` and owns its own
+toolchain.
 
-So **do not hand-install rustc, rakudo or `libmysqlclient` at the start of a remote session** — it
-has already happened, and the `raku` oracle is available there too. If a build still fails with `E0658`, the hook
-did not run (check for its `session-start: environment ready` line) and
+So **do not hand-install rustc, rakudo, `libmysqlclient` or `bubblewrap` at the start of a remote
+session** — it has already happened, and the `raku` oracle is available there too. If a build still
+fails with `E0658`, the hook did not run (check for its `session-start: environment ready` line) and
 `.claude/skills/rustc-too-old/SKILL.md` applies. Whenever a version pin moves, the hook follows it
 with no edit; only the *sources* of the pins are hardcoded, so add a new one there if the repo ever
 grows a `rust-toolchain.toml`.

--- a/docs/agent-environments.md
+++ b/docs/agent-environments.md
@@ -73,14 +73,14 @@ Two consequences worth spelling out:
   `pull_request_read`/`get_check_runs` again after doing other work, or use
   `subscribe_pr_activity` so CI results and review comments wake the session.
 
-## Provisioning: rust, raku and the native C libraries
+## Provisioning: rust, raku, the native C libraries and the sandbox
 
 `.claude/hooks/session-start.sh` (registered as a `SessionStart` hook in `.claude/settings.json`)
 installs the highest Rust version the repo declares, runs `.agents/skills/install-raku/install-raku.sh`
-when `raku` is missing, installs the C shared libraries the bundled batteries `dlopen`, and warms
-the crate cache with `cargo fetch`. It is idempotent (~0.3s when everything is in place) and does
-nothing on a local checkout unless `MUTSU_SETUP_FORCE=1` is set — a developer machine is pinned by
-`.mise.toml` and owns its own toolchain.
+when `raku` is missing, installs the C shared libraries the bundled batteries `dlopen`, installs and
+verifies `bubblewrap`, and warms the crate cache with `cargo fetch`. It is idempotent (~0.3s when
+everything is in place) and does nothing on a local checkout unless `MUTSU_SETUP_FORCE=1` is set —
+a developer machine is pinned by `.mise.toml` and owns its own toolchain.
 
 The native-library list is the `NATIVE_LIBS` array at the top of `setup_native_libs()`, one
 `"<soname> <apt package>"` row each. It currently holds a single entry, `libmysqlclient.so.21` /
@@ -89,9 +89,18 @@ The native-library list is the `NATIVE_LIBS` array at the top of `setup_native_l
 which DBIish's `NativeLibs::Searcher.try-versions('mysqlclient', 16..21)` does not match. Installing
 it costs about 2s on a cold container; the whole hook then takes ~0.14s on every later run.
 
-So **do not hand-install rustc or rakudo at the start of a remote session** — it has already
-happened, and `raku` is available as the oracle. If a build still fails with `E0658`, the hook did
-not run (look for its `session-start: environment ready` line) and
+`bubblewrap` is there for `scripts/ecosystem-sweep.py`, which confines every measured interpreter
+run (unaudited third-party test suites) and refuses a corpus sweep without it. The hook does not
+just install the package: it runs the same `bwrap --unshare-all --ro-bind / /` probe the CI workflow
+does, because a container can ship `bwrap` and still deny the unprivileged user namespace it needs.
+Verified working in the remote containers as of 2026-09-11, so an `--only` re-measure there keeps
+the default sandbox; `--sandbox none` is for the case where the hook warned that the probe failed.
+A *corpus* sweep still does not belong in a remote container — 4 cores and the disk allowance, not
+the sandbox, are what rule it out (`docs/ecosystem-parity.md` §8.1 dispatches it to CI instead).
+
+So **do not hand-install rustc, rakudo or bubblewrap at the start of a remote session** — it has
+already happened, and `raku` is available as the oracle. If a build still fails with `E0658`, the
+hook did not run (look for its `session-start: environment ready` line) and
 `.claude/skills/rustc-too-old/SKILL.md` applies. When a version pin moves the hook follows it with
 no edit; only the *sources* of the pins are hardcoded, so add a new one there if the repo ever
 grows a `rust-toolchain.toml`.

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -274,6 +274,7 @@ scripts/ecosystem-sweep.py --rollup
 
 Other flags: `--timeout` (default 120s/file, both sides), `--max-files` (per
 dist, to bound a pathological suite), `--include-xt`, `--sandbox {bwrap,none}`,
+`--no-index-snapshot` (see below),
 `--mutsu-only` (see *Baseline caching* below), `--refresh-baseline`, `--dry-run` (resolve and print the
 plan without executing), `--json -` (emit records to stdout instead of the tree).
 
@@ -281,6 +282,17 @@ Environment: `MUTSU_BIN` (default `target/release/mutsu`), `RAKU_BIN` (default
 `raku`), `MUTSU_ECO_HOST` (what `measured.host` records; default
 `<uname>-<machine>`, which cannot tell a hosted runner from the maintainer's box
 — §8.1 sets it to `gha-*`).
+
+**`index-snapshot.json` is corpus-level provenance and a targeted run leaves it
+alone.** The file says "the records beside me were resolved against this
+fez/REA snapshot"; rewriting it after re-measuring one distribution would date
+the entire ledger to today's index on the strength of a single record, and puts
+an unrelated file in a bug-fix PR's diff where it reads as a corpus refresh.
+So `--only` never writes it (the run logs `index-snapshot.json: left
+unchanged`), and `--no-index-snapshot` extends that to a `--status` / `--stale`
+re-measure, which has the same problem. A corpus or shard run does write it —
+that is what it is for, and §8.1's workflow pins one index across all its shards
+so they agree on its content.
 
 `scripts/ecosystem-ci.py` is the CI-side companion: `plan` turns
 `.github/workflows/ecosystem-sweep.yml`'s dispatch inputs into a validated job
@@ -398,7 +410,10 @@ on overlapping selections, or the second to finish overwrites the first.
 ### 8.0 Locally
 
 A machine with the cores to spare — the maintainer's 12-core box, not an
-ephemeral remote container (4 cores, a fixed disk allowance, and no `bwrap`).
+ephemeral remote container (4 cores and a fixed disk allowance; `bwrap` is no
+longer the obstacle there, since `.claude/hooks/session-start.sh` installs and
+verifies it, but a corpus sweep still does not fit). A single `--only`
+re-measure after a fix is fine in either.
 
 ```sh
 apt-get install bubblewrap          # required; the sweep refuses to run a corpus without it

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -68,7 +68,13 @@ scripts/ecosystem-sweep.py --rollup              # regenerate summary.* and the 
 ```
 
 Requires `bubblewrap` (the sweep runs unaudited test suites and refuses to run a
-corpus without a sandbox) and a `raku` on PATH.
+corpus without a sandbox) and a `raku` on PATH. Agent containers get both from
+`.claude/hooks/session-start.sh`.
+
+`index-snapshot.json` is corpus-level provenance, so a `--only` run deliberately
+leaves it untouched — a single re-measured record must not date the whole ledger
+to today's index. `--no-index-snapshot` does the same for a `--status` / `--stale`
+re-measure.
 
 **Or from GitHub Actions**, when no many-core box with `bwrap` is at hand: run
 the [`Ecosystem sweep`](../.github/workflows/ecosystem-sweep.yml) workflow

--- a/news/2026-09/ecosystem-only-remeasure-keeps-index-snapshot.md
+++ b/news/2026-09/ecosystem-only-remeasure-keeps-index-snapshot.md
@@ -1,0 +1,48 @@
+# A `--only` re-measure no longer rewrites `index-snapshot.json`, and every container has `bwrap`
+
+Three changes that all belong to the same loop — the `ecosystem-dist-fix` skill, where a mutsu bug
+fix is followed by re-measuring the distribution that exposed it.
+
+## The re-measure is now stated as mandatory, and says what may be in the diff
+
+`ecosystem-dist-fix` step 7 already described the `--only` re-measure, but as the last item of the
+loop rather than as part of what a fix *is*. It now opens with the rule ("every interpreter change
+made in this loop ends with a `--only` re-measure — no exceptions"), says explicitly that it also
+applies to the one-method fixes and to a run whose outcome was an issue rather than a patch, and
+ends with the check that the ledger side of the diff is nothing but `ecosystem/dists/` records
+(`git status --porcelain ecosystem/`). It also asks for a re-measure of the *neighbouring* records
+when the root cause plausibly reaches past one distribution — a second record going green for free
+is the cheapest evidence available that a fix was general rather than a dressed-up special case.
+
+## `index-snapshot.json` is corpus provenance, so a targeted run leaves it alone
+
+`ecosystem/index-snapshot.json` records which fez/REA index snapshot the ledger was resolved
+against. `scripts/ecosystem-sweep.py` rewrote it unconditionally, including on a single-distribution
+run — which dated the *whole* corpus to today's index on the strength of one record, and put an
+unrelated file into a bug-fix PR's diff where a reviewer reads it as a corpus refresh. It is the
+same failure mode `.github/workflows/ecosystem-sweep.yml` already avoids by pinning one index across
+all of its shards.
+
+A `--only` run therefore no longer writes the file (it logs `index-snapshot.json: left unchanged`),
+and the new `--no-index-snapshot` flag extends that to a `--status` / `--stale` re-measure after a
+fix, which has exactly the same problem. Corpus and shard runs still write it — that is what it is
+for.
+
+## `bubblewrap` is installed at container setup
+
+The sweep confines every measured interpreter run in `bwrap`, because loading a third-party
+distribution already executes its `BEGIN` phasers. Remote containers had no `bwrap`, so the
+documentation told agents to fall back to `--sandbox none` for their `--only` re-measure — running
+unaudited test-suite code unconfined for want of a two-second `apt-get install`.
+
+`.claude/hooks/session-start.sh` now installs `bubblewrap` alongside rustc, rakudo and the native
+libraries, and then runs the same `bwrap --unshare-all --ro-bind / /` probe the CI workflow does:
+a container can ship the binary and still deny the unprivileged user namespace it needs, and that
+failure would otherwise surface as an unexplained non-zero exit from every measured file. Both the
+install and the probe were verified in a remote container (bubblewrap 0.9.0, no AppArmor relaxation
+needed), as was a full `--only BTree` sweep under the default sandbox.
+
+So the sandbox is now the default everywhere and `--sandbox none` is reserved for the case where
+the hook warned that the probe failed. What still rules a corpus sweep out of a remote container is
+its four cores and fixed disk allowance, not the sandbox — dispatch the workflow instead
+(`docs/ecosystem-parity.md` §8.1).

--- a/scripts/ecosystem-sweep.py
+++ b/scripts/ecosystem-sweep.py
@@ -328,6 +328,33 @@ def load_records():
     return out
 
 
+def write_index_snapshot(index, args):
+    """Record which ecosystem index this run drew from -- corpus runs only.
+
+    `index-snapshot.json` is provenance for the ledger as a WHOLE: "the records
+    beside me were resolved against this fez/REA snapshot". A targeted run
+    re-measures one or a handful of distributions, so rewriting it would date
+    the entire corpus to today's index on the strength of a single record --
+    the same failure mode `.github/workflows/ecosystem-sweep.yml` avoids by
+    pinning one index across its shards. It also puts an unrelated file in a
+    bug-fix PR's diff, where a reviewer reads it as a corpus refresh.
+
+    So an `--only` run never touches it, and `--no-index-snapshot` extends that
+    to any other selection (a `--status` / `--stale` re-measure after a fix has
+    exactly the same problem). `--dry-run` writes nothing at all, this file
+    included -- "resolve and print the plan" is not a measurement.
+    """
+    if args.no_index_snapshot or args.only or args.dry_run:
+        why = ("--no-index-snapshot" if args.no_index_snapshot
+               else "targeted --only run" if args.only else "--dry-run")
+        log(f"index-snapshot.json: left unchanged ({why})")
+        return
+    with open(os.path.join(DATA_DIR, "index-snapshot.json"), "w", encoding="utf-8") as fh:
+        json.dump({"fetched": dt.date.today().isoformat(), **index.snapshot}, fh,
+                  indent=2, sort_keys=True)
+        fh.write("\n")
+
+
 # --- rollup ------------------------------------------------------------------
 
 def rollup(append_history=False):
@@ -544,6 +571,10 @@ def main():
     ap.add_argument("--include-xt", action="store_true")
     ap.add_argument("--sandbox", choices=["bwrap", "none"], default="bwrap")
     ap.add_argument("--refresh-index", action="store_true")
+    ap.add_argument("--no-index-snapshot", action="store_true",
+                    help="do not rewrite ecosystem/index-snapshot.json "
+                         "(already implied by --only: corpus-level provenance "
+                         "must not be dated by a targeted re-measure)")
     ap.add_argument("--dry-run", action="store_true", help="resolve and print the plan only")
     args = ap.parse_args()
 
@@ -557,10 +588,7 @@ def main():
     args = preflight(args)
     index = eco.load_index(refresh=args.refresh_index)
     os.makedirs(DATA_DIR, exist_ok=True)
-    with open(os.path.join(DATA_DIR, "index-snapshot.json"), "w", encoding="utf-8") as fh:
-        json.dump({"fetched": dt.date.today().isoformat(), **index.snapshot}, fh,
-                  indent=2, sort_keys=True)
-        fh.write("\n")
+    write_index_snapshot(index, args)
 
     bundled = bundled_modules()
     names = select(index, args)


### PR DESCRIPTION
Three changes to the `ecosystem-dist-fix` loop — the part that runs after a mutsu bug fix, when the distribution that exposed it is re-measured.

## 1. `ecosystem/index-snapshot.json` is no longer rewritten by a targeted run

`scripts/ecosystem-sweep.py` rewrote it unconditionally, a single-distribution run included. That file is corpus-level provenance — "the records beside me were resolved against this fez/REA snapshot" — so dating the whole ledger to today's index on the strength of one re-measured record is wrong, and it drops an unrelated file into a bug-fix PR's diff where a reviewer reads it as a corpus refresh. It is the same failure mode `.github/workflows/ecosystem-sweep.yml` already avoids by pinning one index across all of its shards.

- `--only` now leaves the file alone and logs `index-snapshot.json: left unchanged (targeted --only run)`.
- New `--no-index-snapshot` flag extends that to a `--status` / `--stale` re-measure after a fix, which has the same problem.
- `--dry-run` no longer writes it either — "resolve and print the plan" should not modify the tree.
- Corpus and shard runs still write it; that is what it is for.

## 2. `bubblewrap` is installed and verified at container setup

The sweep confines every measured interpreter run in `bwrap`, because loading a third-party distribution already executes its `BEGIN` phasers. Remote containers had no `bwrap`, so the documentation told agents to fall back to `--sandbox none` for their `--only` re-measure — running unaudited test-suite code unconfined for want of a two-second `apt-get install`.

`.claude/hooks/session-start.sh` now installs `bubblewrap` alongside rustc, rakudo and the native libraries, and then runs the same `bwrap --unshare-all --ro-bind / /` probe the CI workflow does: a container can ship the binary and still deny the unprivileged user namespace it needs, and that failure would otherwise surface as an unexplained non-zero exit from every measured file. The apt path is factored into `can_apt` / `apt_install`, shared with `setup_native_libs`.

## 3. The skill states the `--only` re-measure as part of what a fix is

`.agents/skills/ecosystem-dist-fix/SKILL.md` §7 was a trailing chore; it is now the rule, and it says what the diff may contain:

- it applies to the small fixes too, and to a run that ended in an issue rather than a patch;
- only `ecosystem/dists/**` records may appear under `ecosystem/` (`git status --porcelain ecosystem/` is the check);
- the sandbox is the default — `--sandbox none` only when the hook reported that the probe failed;
- a corpus or shard sweep still does not belong in a remote container (4 cores and the disk allowance, not the sandbox, are what rule it out);
- re-measure neighbouring records when the root cause plausibly reaches past one distribution.

## Verification

Measured in this remote container:

- `apt-get purge bubblewrap` → re-running the hook installs bubblewrap 0.9.0 and reports `bwrap sandbox verified`, with no AppArmor relaxation needed.
- `scripts/ecosystem-sweep.py --only BTree` completes under the default `bwrap` sandbox, updates only `ecosystem/dists/B/BTree.json`, and leaves `index-snapshot.json` untouched. (That record was reverted — it was measured with a debug binary.)
- `--prefix Z --dry-run --no-index-snapshot` and `--prefix Z --dry-run` both write nothing; a `--prefix` run without `--dry-run` still writes the snapshot.
- `scripts/ci-docs-only.sh --self-test`, `--check-inputs`, and `--classify` on this change set (`true` — no Rust or test input is touched, so the build jobs skip by design).

Documentation updated to match: `CLAUDE.md`, `docs/agent-environments.md`, `docs/ecosystem-parity.md`, `ecosystem/README.md`, plus `news/2026-09/ecosystem-only-remeasure-keeps-index-snapshot.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pu9Qypj1p1svHmqdsGnxsQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pu9Qypj1p1svHmqdsGnxsQ)_