### PR TITLE
fix(ci): a sweep must not overwrite a fix that landed while it ran

### DIFF
--- a/.github/workflows/ecosystem-sweep.yml
+++ b/.github/workflows/ecosystem-sweep.yml
@@ -428,9 +428,14 @@ jobs:
           client-id: ${{ vars.TAGPR_APP_CLIENT_ID }}
           private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
 
+      # `ref: main` deliberately, not the dispatch-time commit: a corpus sweep
+      # runs for over an hour and main moves under it, so the records are
+      # assembled on top of whatever main is NOW. `fetch-depth: 0` is what lets
+      # `ecosystem-ci.py apply` order two commits with `merge-base`.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
+          ref: main
           fetch-depth: 0
 
       # A sweep whose every verdict matched what is already committed uploads no
@@ -445,12 +450,18 @@ jobs:
           merge-multiple: true
           path: /tmp/incoming
 
+      # Not `cp -a`: a record the base branch measured at a NEWER mutsu commit
+      # must survive. An interpreter fix that lands mid-sweep re-measures the one
+      # distribution it fixed, and copying the sweep's older measurement over it
+      # would silently re-open a record that is already green -- and produce
+      # exactly the merge conflict this job exists to avoid. The rule and its
+      # git-backed ordering are in scripts/ecosystem-ci.py, under --self-test.
       - name: Apply them to the tree
         id: apply
         run: |
           set -euo pipefail
           if [ -d /tmp/incoming ] && [ -n "$(find /tmp/incoming -type f -print -quit)" ]; then
-            cp -a /tmp/incoming/. .
+            python3 scripts/ecosystem-ci.py apply --source /tmp/incoming --repo .
           fi
           # Same `-uall` requirement as the staging step above: a new shard
           # directory would otherwise arrive as a single directory entry, which
@@ -528,6 +539,9 @@ jobs:
             echo "| rakudo | ${{ needs.build.outputs.raku-version }} |"
             echo "| shards | ${{ needs.build.outputs.count }} (\`${{ needs.sweep.result }}\`) |"
             echo "| records changed | ${{ steps.apply.outputs.changed }} |"
+            if [ "${{ steps.apply.outputs.superseded || 0 }}" != "0" ]; then
+              echo "| records left alone (base branch measured them later) | ${{ steps.apply.outputs.superseded }} |"
+            fi
             # These are rates over the WHOLE ledger, not over this run's slice:
             # that is what the published KPI is, and a per-run rate over a
             # hand-picked subset is not one.

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -296,7 +296,8 @@ so they agree on its content.
 
 `scripts/ecosystem-ci.py` is the CI-side companion: `plan` turns
 `.github/workflows/ecosystem-sweep.yml`'s dispatch inputs into a validated job
-matrix, and `provenance` groups a set of records by the
+matrix, `apply` lands a finished sweep's records on top of whatever main has
+become meanwhile (§8.2), and `provenance` groups a set of records by the
 `(mutsu commit, rakudo, host)` triple that measured them. Both are useful
 locally too — `--self-test` covers them, so a change to either is checked without
 dispatching a run.
@@ -487,6 +488,40 @@ what you want (it measures that ref's mutsu), but the records are then only
 pushed to a branch: a pull request from a feature ref into `main` would carry
 that ref's other commits alongside the records, so the workflow declines to open
 one and says so.
+
+### 8.2 What happens when the ledger moves during a sweep
+
+A corpus sweep measures for over an hour, and the interesting case is that a
+*fix* lands while it runs: a `todo:ticket` PR repairs an interpreter bug and
+re-measures the one distribution it fixed, at a **newer** mutsu commit. The
+sweep's own record for that distribution is then stale before it is even
+committed.
+
+So the `collect` job does not copy its records over the tree. It checks out
+**main as it is now** (not the commit the sweep was dispatched from) and applies
+each record through `scripts/ecosystem-ci.py apply`, whose rule is:
+
+> **The newer mutsu commit wins.** A record says what mutsu did at one commit, so
+> a record measured at a later commit is the more current answer, whoever
+> measured it.
+
+Ordering is decided by `git merge-base --is-ancestor`, so it is the real commit
+graph and not a date heuristic; when git cannot order two commits (an unknown
+sha) the recorded date breaks the tie, and when even that ties the record already
+on the branch is kept. A record is never overwritten by one that cannot be shown
+to supersede it, and the run summary reports how many were left alone.
+
+Two consequences worth knowing:
+
+- **This is also the merge-conflict answer.** Records are one file per
+  distribution, so the only way a sweep can conflict with a sibling PR is by
+  touching the same record — which is exactly the case the rule resolves, before
+  the branch is created. A 1600-file data PR does not need hand resolution.
+- **A locally-measured record can shadow a sweep's for a while.** A dist-fix PR
+  measured on a dev box (often `"sandbox": "none"`, a different `host`) wins over
+  the sandboxed `gha-*` measurement while its commit is the newer one. The record
+  says so in its own provenance, and the next sweep at a newer commit replaces
+  it — or `--stale` does, sooner.
 
 Two things it will refuse to do:
 

--- a/news/2026-09/ecosystem-sweep-newer-commit-wins.md
+++ b/news/2026-09/ecosystem-sweep-newer-commit-wins.md
@@ -1,0 +1,71 @@
+# A sweep no longer overwrites a fix that landed while it ran
+
+The corpus sweep measures for about an hour and a half. Interpreter fixes land in
+that window — and a `todo:ticket` PR that repairs a bug re-measures the one
+distribution it fixed, at a **newer** mutsu commit. The sweep's own record for
+that distribution is stale before it is even committed.
+
+`.github/workflows/ecosystem-sweep.yml` used to `cp -a` its records over a
+checkout of the **dispatch-time** commit. Both halves of that were wrong: the
+checkout was up to ninety minutes out of date, and the copy was unconditional, so
+the sweep's older measurement would overwrite the fresher one — silently
+re-opening a record that had just gone green, and producing precisely the merge
+conflict that makes a 1600-file data pull request unpleasant.
+
+## The rule
+
+The `collect` job now checks out **main as it is now** and applies each record
+through `scripts/ecosystem-ci.py apply`:
+
+> **The newer mutsu commit wins.** A record says what mutsu did at one commit, so
+> a record measured at a later commit is the more current answer, whoever
+> measured it.
+
+Ordering is `git merge-base --is-ancestor` on the two recorded commits — the real
+commit graph, not a date heuristic, which is why the job checks out with
+`fetch-depth: 0`. When git cannot order them (an unknown sha) the recorded date
+breaks the tie; when even that ties, the record already on the branch is kept. A
+record is never overwritten by one that cannot be *shown* to supersede it, and
+the run summary reports how many were left alone.
+
+This is also the merge-conflict answer. Records are one file per distribution, so
+the only way a sweep can conflict with a sibling pull request is by touching the
+same record — exactly the case the rule decides, before the branch is created.
+
+## Why it is a script with a self-test rather than three lines of shell
+
+The rule is the one piece of this workflow that can silently corrupt the ledger:
+get the ancestry direction backwards and every sweep quietly reverts recent
+fixes, with a green diff and no error. So it lives in `ecosystem-ci.py` behind
+`--self-test`, which builds a throwaway git repository with three real commits and
+checks the direction from both sides, equal commits (a commit must not count as
+newer than itself), an unknown sha, the date fallback in both directions, and an
+unreadable record on either side.
+
+It was rehearsed end to end before shipping: a fake sweep measured `DAWG` and
+`BTree` at an old commit while the branch carried a newer, green `BTree` — the
+newer record survived, the sweep's `DAWG` landed, and the summary said "1 applied,
+2 superseded".
+
+## One consequence, recorded rather than hidden
+
+A dist-fix PR measured on a dev box (often `"sandbox": "none"`, a different
+`host`) now wins over a sandboxed `gha-*` measurement of the same distribution
+while its commit is the newer one. Each record states its own sandbox and host, so
+nothing is misrepresented, and the next sweep at a newer commit replaces it — or
+a `scope: stale` run does, sooner.
+
+## Measured while preparing the corpus sweep
+
+Projected from the `D` shard's real numbers (128 distributions, 26.1 min of
+measurement on a 4-vCPU runner), the whole 1624-distribution corpus is far more
+evenly spread than the design's estimate assumed:
+
+| | |
+|---|---|
+| largest shard | `A`, 154 distributions → ~31 min |
+| total measurement | ~5.5 h of job time |
+| wall clock at `max-parallel: 8` | ~1 h, plus a 5 min shared build |
+
+No shard comes near the 6-hour job ceiling the fan-out exists to respect, so the
+sharding is comfortable rather than marginal.

--- a/scripts/ecosystem-ci.py
+++ b/scripts/ecosystem-ci.py
@@ -6,6 +6,7 @@ locally (`--self-test`) instead of being debugged one dispatched run at a time.
 
     scripts/ecosystem-ci.py plan --scope all --shards letters
     scripts/ecosystem-ci.py plan --scope only --only 'BTree, Trie'
+    scripts/ecosystem-ci.py apply --source /tmp/incoming
     scripts/ecosystem-ci.py provenance ecosystem/dists/B/BTree.json …
     scripts/ecosystem-ci.py --self-test
 
@@ -14,6 +15,10 @@ locally (`--self-test`) instead of being debugged one dispatched run at a time.
 validates every input here, at plan time, so a typo fails in seconds instead of
 after a build and a rakudo install — and so the workflow can word-split
 `args` without smuggling anything into a shell.
+
+`apply` copies a finished sweep's records onto the checkout, skipping any record
+the base branch measured at a NEWER mutsu commit. That is what keeps a
+multi-hour sweep from undoing an interpreter fix that landed while it ran.
 
 `provenance` answers the question docs/ecosystem-parity.md section 8 makes the
 operator ask before landing a sweep: was all of this measured by ONE mutsu
@@ -34,6 +39,7 @@ import collections
 import json
 import os
 import re
+import subprocess
 import sys
 
 # One shard per `ecosystem/dists/` directory: A-Z plus `_` for a distribution
@@ -190,6 +196,107 @@ def cmd_provenance(args):
     return 0
 
 
+# --- apply -------------------------------------------------------------------
+
+def commit_is_ancestor(older, newer, repo="."):
+    """True when `older` is an ancestor of `newer` (so `newer` is the later commit).
+
+    Returns None when git cannot decide -- an unknown sha, a shallow clone.
+    """
+    if older == newer:
+        return False
+    proc = subprocess.run(["git", "-C", repo, "merge-base", "--is-ancestor", older, newer],
+                          capture_output=True, text=True)
+    if proc.returncode == 0:
+        return True
+    if proc.returncode == 1:
+        return False
+    return None
+
+
+def record_measured(path):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)["measured"]
+    except (OSError, ValueError, KeyError, TypeError):
+        # TypeError covers a file that parses as JSON but is not an object --
+        # any of these means "I cannot read a measurement here", and the caller
+        # must then not claim one side supersedes the other.
+        return None
+
+
+def decide(incoming, existing, *, repo="."):
+    """Which of two measurements of the same distribution should be kept?
+
+    Returns ("apply"|"superseded"|"new", reason).
+
+    The rule is "the newer mutsu commit wins", and it is not a tie-break
+    convenience: a record says what mutsu did at one commit, so a record
+    measured at a LATER commit is simply the more current answer. A sweep runs
+    for over an hour, and an interpreter fix that lands during it re-measures
+    the one distribution it fixed -- at a newer commit, by definition. Letting
+    the sweep's older measurement overwrite that would silently undo the fix in
+    the published ledger and re-open a record that is already green.
+    """
+    if existing is None:
+        return "new", "no record on the base branch"
+    inc, ext = record_measured(incoming), record_measured(existing)
+    if inc is None or ext is None:
+        return "apply", "unreadable record on one side"
+    newer = commit_is_ancestor(inc["mutsu_commit"], ext["mutsu_commit"], repo=repo)
+    if newer is True:
+        return "superseded", f"base branch has {ext['mutsu_commit']}, newer than {inc['mutsu_commit']}"
+    if newer is False:
+        return "apply", f"ours ({inc['mutsu_commit']}) is not older than {ext['mutsu_commit']}"
+    # Git could not order them: fall back on the recorded date, and when even
+    # that ties, keep what is already on the branch. Never clobber a record we
+    # cannot prove ours supersedes.
+    if inc.get("date", "") > ext.get("date", ""):
+        return "apply", "unorderable commits; ours is newer by date"
+    return "superseded", "unorderable commits; keeping the base branch record"
+
+
+def cmd_apply(args):
+    """Copy a sweep's records over the checkout, skipping superseded ones."""
+    src_root = os.path.join(args.source, "ecosystem")
+    if not os.path.isdir(src_root):
+        emit("applied", 0)
+        emit("superseded", 0)
+        print("nothing to apply", file=sys.stderr)
+        return 0
+    applied = superseded = 0
+    notes = []
+    for dirpath, _dirs, names in os.walk(src_root):
+        for name in sorted(names):
+            src = os.path.join(dirpath, name)
+            rel = os.path.relpath(src, args.source)
+            dest = os.path.join(args.repo, rel)
+            # Only per-distribution records carry a measurement to compare;
+            # everything else the sweep produced (index-snapshot.json) is ours.
+            if re.match(r"^ecosystem/dists/.+\.json$", rel.replace(os.sep, "/")):
+                verdict, why = decide(src, dest if os.path.exists(dest) else None, repo=args.repo)
+            else:
+                verdict, why = "apply", "not a distribution record"
+            if verdict == "superseded":
+                superseded += 1
+                notes.append(f"{rel}: {why}")
+                continue
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with open(src, "rb") as fh:
+                data = fh.read()
+            with open(dest, "wb") as fh:
+                fh.write(data)
+            applied += 1
+    for note in notes:
+        print(f"superseded {note}", file=sys.stderr)
+    if superseded:
+        print(f"::notice title=records superseded::{superseded} record(s) on the base branch "
+              "were measured at a newer mutsu commit and were left alone", file=sys.stderr)
+    emit("applied", applied)
+    emit("superseded", superseded)
+    return 0
+
+
 # --- self-test ---------------------------------------------------------------
 
 def self_test():
@@ -256,6 +363,71 @@ def self_test():
     triples, unreadable = provenance([])
     check("provenance of nothing is not uniform", (len(triples), unreadable), (0, []))
 
+    # --- apply's decision rule, against a REAL throwaway git repo, because the
+    # rule is "the newer mutsu commit wins" and only git can order two shas.
+    import tempfile
+
+    def git(repo, *args):
+        subprocess.run(["git", "-C", repo, *args], check=True,
+                       capture_output=True, text=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        git(tmp, "init", "-q")
+        git(tmp, "config", "user.email", "t@example.com")
+        git(tmp, "config", "user.name", "t")
+        shas = []
+        for n in range(3):
+            with open(os.path.join(tmp, "f"), "w", encoding="utf-8") as fh:
+                fh.write(str(n))
+            git(tmp, "add", "f")
+            git(tmp, "commit", "-q", "-m", f"c{n}")
+            shas.append(subprocess.run(["git", "-C", tmp, "rev-parse", "--short", "HEAD"],
+                                       capture_output=True, text=True).stdout.strip())
+        old_sha, mid_sha, new_sha = shas
+
+        def rec(path, commit, date="2026-09-11"):
+            full = os.path.join(tmp, path)
+            os.makedirs(os.path.dirname(full), exist_ok=True)
+            with open(full, "w", encoding="utf-8") as fh:
+                json.dump({"measured": {"mutsu_commit": commit, "raku_version": "2026.07",
+                                        "host": "h", "date": date}}, fh)
+            return full
+
+        ours = rec("ours.json", old_sha)
+        theirs_newer = rec("newer.json", new_sha)
+        theirs_older = rec("older.json", old_sha)
+        theirs_same = rec("same.json", old_sha)
+        mid = rec("mid.json", mid_sha)
+
+        check("ancestry: old is an ancestor of new",
+              commit_is_ancestor(old_sha, new_sha, repo=tmp), True)
+        check("ancestry: new is not an ancestor of old",
+              commit_is_ancestor(new_sha, old_sha, repo=tmp), False)
+        check("ancestry: a commit is not treated as newer than itself",
+              commit_is_ancestor(old_sha, old_sha, repo=tmp), False)
+        check("ancestry: an unknown sha is undecidable",
+              commit_is_ancestor("0" * 12, new_sha, repo=tmp), None)
+
+        check("no record on the base branch -> new",
+              decide(ours, None, repo=tmp)[0], "new")
+        check("base branch measured later -> superseded",
+              decide(ours, theirs_newer, repo=tmp)[0], "superseded")
+        check("base branch measured earlier -> apply",
+              decide(rec("o2.json", new_sha), theirs_older, repo=tmp)[0], "apply")
+        check("same commit -> apply (ours is the fresher measurement)",
+              decide(ours, theirs_same, repo=tmp)[0], "apply")
+        check("mid commit is still newer than ours -> superseded",
+              decide(ours, mid, repo=tmp)[0], "superseded")
+
+        unknown = rec("unknown.json", "0" * 12)
+        check("unorderable, ours newer by date -> apply",
+              decide(rec("o3.json", old_sha, date="2026-09-12"), unknown, repo=tmp)[0], "apply")
+        check("unorderable, no date edge -> keep the base branch",
+              decide(rec("o4.json", old_sha, date="2026-09-01"), unknown, repo=tmp)[0],
+              "superseded")
+        check("an unreadable side is never silently dropped",
+              decide(ours, os.path.join(tmp, "f"), repo=tmp)[0], "apply")
+
     print(f"\n{'FAILED' if failures else 'PASS'}: {failures} failure(s)")
     return 1 if failures else 0
 
@@ -274,6 +446,12 @@ def main():
     p.add_argument("--status", default="")
     p.add_argument("--shards", default="auto", choices=["auto", "letters", "single"])
     p.set_defaults(func=cmd_plan)
+
+    a = sub.add_parser("apply", help="copy a sweep's records over the checkout")
+    a.add_argument("--source", required=True,
+                   help="directory holding the downloaded artifacts (an ecosystem/ tree)")
+    a.add_argument("--repo", default=".", help="the checkout to apply them to")
+    a.set_defaults(func=cmd_apply)
 
     q = sub.add_parser("provenance", help="group records by (mutsu commit, rakudo, host)")
     q.add_argument("paths", nargs="*", help="record paths; read from stdin when absent")


### PR DESCRIPTION
Prep for **P2**, the full-corpus sweep (#7785). The corpus run measures for about ninety minutes, and the interesting thing that happens in that window is a **fix**: a `todo:ticket` PR repairs an interpreter bug and re-measures the one distribution it fixed, at a newer mutsu commit. The sweep's own record for that distribution is stale before it is even committed — and there are two such PRs open right now (#7893, #7895), each re-measuring a record a corpus sweep would also write.

`collect` used to `cp -a` its records over a checkout of the **dispatch-time** commit. Both halves were wrong: the checkout was up to ninety minutes out of date, and the copy was unconditional, so the sweep's *older* measurement overwrote the fresher one — silently re-opening a record that had just gone green, and producing exactly the merge conflict that makes a 1600-file data PR unpleasant to land.

## The rule

Check out `main` **as it is now** (with `fetch-depth: 0`) and apply each record through `scripts/ecosystem-ci.py apply`:

> **The newer mutsu commit wins.** A record says what mutsu did at one commit, so a record measured at a later commit is the more current answer, whoever measured it.

Ordering is `git merge-base --is-ancestor` on the two recorded commits — the real commit graph, not a date heuristic. When git cannot order them (an unknown sha) the recorded date breaks the tie; when even that ties, the record already on the branch is kept. **A record is never overwritten by one that cannot be shown to supersede it**, and the run summary reports how many were left alone.

This is also the merge-conflict answer: records are one file per distribution, so the only way a sweep can conflict with a sibling PR is by touching the same record — exactly the case the rule decides, *before* the branch is created.

## Why a script with a self-test and not three lines of shell

This is the one piece of the workflow that can silently corrupt the ledger. Reverse the ancestry direction and every sweep quietly reverts recent fixes, with a green diff and no error message. So `--self-test` builds a throwaway git repository with three real commits and checks:

| case | expected |
|---|---|
| old vs new, both directions | correct ordering |
| **a commit against itself** | not "newer" (ours applies) |
| an unknown sha | undecidable → date fallback |
| date fallback, ours newer / not newer | apply / keep the branch's |
| an unreadable record on either side | never silently dropped |

Rehearsed end to end before shipping: a fake sweep measured `DAWG` and `BTree` at an old commit while the branch carried a newer, **green** `BTree` →

```
superseded ecosystem/dists/B/BTree.json: base branch has 61357d62, newer than 832f8fb3
applied=1  superseded=2
BTree  status green  commit 61357d62  <- kept the newer one
DAWG   status partial commit 134a1da  <- the sweep landed
```

## One consequence, recorded rather than hidden

A dist-fix record measured on a dev box (often `"sandbox": "none"`, a different `host`) now wins over a sandboxed `gha-*` measurement of the same distribution while its commit is the newer one. Each record states its own sandbox and host, so nothing is misrepresented, and the next sweep at a newer commit — or a `scope: stale` run, sooner — replaces it. Written down in `docs/ecosystem-parity.md` §8.2 rather than left for someone to rediscover.

## Also measured while preparing P2

From the `D` shard's real numbers (128 dists, 26.1 min of measurement on a 4-vCPU runner), projected across the 1624-distribution corpus:

| | |
|---|---|
| largest shard | `A`, 154 dists → ~31 min |
| total measurement | ~5.5 h of job time |
| wall clock at `max-parallel: 8` | ~1 h, plus a 5 min shared build |

So no shard comes near the 6-hour job ceiling the fan-out exists to respect — the sharding is comfortable, not marginal. This also corrects the design's "~20 CPU-hours / ~2.5 h" estimate downward; that figure was extrapolated from 14 dependency-free distributions before the harness existed.

## Verification

- `scripts/ecosystem-ci.py --self-test` — 33 checks (23 existing + 10 for the new rule), all passing.
- The end-to-end rehearsal above, against this repo's real commit graph.
- YAML parses; the collect job's downstream steps are unchanged (`apply` still emits `changed` from `git status -uall`, now computed against the *latest* main).
- No Rust, no `t/`, no roast inputs (workflow YAML + one Python script + docs + a news entry), so `make test` / `make roast` / `make lint` results are identical to `main` by construction. CI runs the full suite anyway because `.github/workflows/ci.yml`'s allowlist excludes `.github/**/ci.yml`… and this diff touches `scripts/ecosystem-ci.py`, which #7891 put *on* the allowlist — so the build jobs may correctly report `skipped` here.

Once this merges I will dispatch `scope: all` with `history: true` — the first corpus KPI.

Refs #7785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164xafjtgmTPhHatdSuMR9a

---
_Generated by [Claude Code](https://claude.ai/code/session_0164xafjtgmTPhHatdSuMR9a)_