### PR TITLE
fix: preserve sigilless captures in anonymous sub callbacks

### DIFF
--- a/news/2026-09/anonymous-sigilless-proxy-store.md
+++ b/news/2026-09/anonymous-sigilless-proxy-store.md
@@ -1,0 +1,7 @@
+# An anonymous sub's sigilless parameters remain visible in a nested Proxy callback
+
+An anonymous `sub` with sigilless parameters (`\\obj`, `\\key`) can return a
+`Proxy` whose `STORE` callback uses those parameters. The interpreter-path
+recompilation of the sub body now preserves that lexical context, so the
+callback receives the original argument values instead of treating the names
+as barewords.

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -868,6 +868,20 @@ impl Interpreter {
                     .cloned()
                     .collect(),
             );
+            // Tell the fresh-compiler body path which parameters are sigilless
+            // (`\\attr`) so a nested closure captures them by name instead of
+            // compiling a bare reference as a bareword. The compiled closure
+            // path already carries this context in its nested code; this is
+            // needed only by the interpreter-path carrier, which recompiles
+            // the body from its AST.
+            let saved_eval_sigilless = std::mem::replace(
+                &mut self.pending_eval_sigilless,
+                data.param_defs
+                    .iter()
+                    .filter(|pd| pd.sigilless && !pd.name.is_empty())
+                    .map(|pd| pd.name.clone())
+                    .collect(),
+            );
             // Package-scoped name resolution: run the body under the closure's
             // declaring package so nested-class short names and `our`-vars
             // resolve when the Sub value is invoked from a foreign frame —
@@ -961,6 +975,7 @@ impl Interpreter {
                 self.set_current_package(p);
             }
             self.pending_eval_placeholder_params = saved_eval_placeholders;
+            self.pending_eval_sigilless = saved_eval_sigilless;
             self.frame_authoritative = saved_frame_auth;
             self.frame_owned = saved_frame_owned;
             let result = match body_result {

--- a/t/routines/closure/anon-sigilless-proxy-store.t
+++ b/t/routines/closure/anon-sigilless-proxy-store.t
@@ -1,0 +1,15 @@
+use Test;
+
+plan 1;
+
+my $out = "";
+my $f = sub (\obj, \key) is rw {
+    Proxy.new(
+        FETCH => { "f" },
+        STORE => -> $, $v { $out = "s:" ~ obj ~ ":" ~ key },
+    )
+};
+
+($f("OBJ", "KEY")) = "V";
+is $out, "s:OBJ:KEY",
+    "a Proxy STORE closure captures sigilless parameters of an anonymous sub";


### PR DESCRIPTION
Fixes #7879.

An anonymous `sub` with sigilless parameters can return a `Proxy` whose `STORE` callback refers to those parameters. The interpreter-path carrier recompiles the body with a fresh compiler, so pass the routine's sigilless parameter names through `pending_eval_sigilless` during that compilation.

Added a focused regression test and a news entry.

Validation:
- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
