### PR TITLE
feat(regex): expose the NQP cursor protocol to user code

### DIFF
--- a/news/2026-09/nqp-cursor-protocol.md
+++ b/news/2026-09/nqp-cursor-protocol.md
@@ -1,0 +1,77 @@
+# The NQP cursor protocol is available to user code
+
+Rakudo's regex engine drives a regex by hand through a *cursor* — a `Match` that has not finished
+matching yet — and exposes that protocol to user code. Ecosystem distributions reach for it to match
+at a known position and read the resulting cursor's `$!from` / `$!pos` instead of going through `~~`
+and a `Match` object. mutsu had none of it: `Match.^lookup("!cursor_init")` answered `Nil`, so the
+whole idiom died at its first line ([#7883](https://github.com/tokuhirom/mutsu/issues/7883)).
+
+```raku
+my $cursor-init = Match.^lookup("!cursor_init");
+my $cursor := /foo/($cursor-init(Match, "xfoox", :0c));
+say $cursor.pos;   # 4
+```
+
+## What the issue expected to be needed, and what actually was
+
+The issue priced this as three deep problems: private methods in `Match`'s MOP surface, a cursor as
+a first-class value distinct from a `Match`, and a new calling convention for `Regex`. Measuring
+rakudo 2026.07 shrank all three:
+
+- `!cursor_init` is not a Raku private method. A leading `!` is an ordinary identifier character in
+  NQP, and rakudo lists `!cursor_init` among `Match.^methods` and answers `Match.^can("!cursor_init")
+  .elems` with 1 — so it needed a named source in `.^lookup`, not the `is_private` machinery.
+- A cursor **is** a `Match`: `$cursor-init(Match, "xfoox", :0c).^name` is `Match`, not some `Cursor`
+  type. mutsu's own `Match` representation carries it, with rakudo's `$!orig` / `$!from` / `$!pos`
+  mapped onto `orig` / `from` / `to` (`.pos` already read `to`).
+- The calling convention already had a precedent: `regex_token_method.rs` has run a grammar token
+  method against a `Match` cursor since the custom-HOW `find_method` work.
+
+The one genuinely new thing measurement turned up is the scan/anchor discriminator. `$!from == -1`
+is rakudo's own "this cursor has not started matching" marker, and it — not the regex, not the call
+site — is what decides whether a cursor call scans forward or anchors:
+
+| init | `$!from` | `$!pos` | `/foo/` on `"xfoox"` |
+| --- | --- | --- | --- |
+| `:c(0)` | -1 | 0 | from=1 pos=4 (scanned) |
+| `:p(0)` | 0 | 0 | from=0 pos=-3 (anchored, failed) |
+| `:p(1)` | 1 | 1 | from=1 pos=4 (anchored, matched) |
+
+A failed cursor is a *failed* `Match` — `.defined` is `True`, `.Bool` is `False`, it gists as
+`#<failed match>` — whose `$!from` stays at the position the attempt started from and whose `$!pos`
+is -3, NQP's backtracking-state marker.
+
+## What shipped
+
+`src/runtime/regex/regex_cursor.rs` owns the protocol: which methods `Match` answers for, how a
+cursor is built from `:c` / `:p`, and the shared "match at (or from) this cursor and wrap the
+outcome" body. `.^lookup` / `.^find_method` / `.^can` consult it as their own named source, because
+`Match`'s builtin-catalog row carries no methods at all. `Regex.CALL-ME` on a cursor and the
+`!cursor_init` re-dispatch both funnel through `call_method_with_values`, gated on the method name.
+The existing token-method path gained the scanning half for a not-yet-started cursor.
+
+The issue's claim that `nqp::getattr_i` "itself works now" was not true when this was filed --
+there was no `getattr` op at all, only `bindattr`. A sibling `String::Utils` slice landed the
+`nqp::getattr` family (and `nqp::substr`, `nqp::index`, ...) on `main` while this was in flight, so
+what remains here is the `Match` half of it: a `Match`'s NQP-level attribute names are not the keys
+mutsu stores, and a still-lazy `Match` is not an `Instance` at all, so neither the bare-name nor the
+twigil spelling reached them. `nqp_attr_value` now aliases `$!pos` / `$!from` / `$!orig` onto
+`to` / `from` / `orig`, which is what makes `nqp::getattr_i($cursor, Match, '$!pos')` answer.
+
+## The consumer
+
+`String::Utils`'s `replace` (`lib/String/Utils.rakumod:563`) is written entirely in this idiom, so
+every `replace`/`replace-all` assertion in that distribution's `t/01-basic.rakutest` *died* rather
+than failing. Lifted verbatim into `t/regex/match/match-cursor-protocol.t`, it now produces rakudo's
+answers.
+
+## Scope
+
+Only the entry point the idiom needs. The rest of the protocol (`!cursor_start`, `!cursor_pass`,
+`!cursor_capture`, the `$!shared` / `$!braid` state NQP threads through a parse) stays internal to
+mutsu's engine: a cursor here is produced complete, never advanced step by step by user code. One
+consequence is that a cursor mutsu returns carries its captures, where rakudo's carries none until
+`!reduce` builds the Match — strictly more information, and not something the idiom reads.
+
+The pin is `t/regex/match/match-cursor-protocol.t`: 32 assertions, every expectation measured
+against rakudo 2026.07, and the file passes unchanged under both interpreters.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -176,6 +176,22 @@ impl Interpreter {
         if let Some(err) = super::any_cool_method_gate::cool_method_not_found(&target, method) {
             return Err(err);
         }
+        // The NQP cursor protocol (#7883), both halves of it: building a
+        // cursor (`Match.!cursor_init($s, :0c)`, reached through the callable
+        // `Match.^lookup("!cursor_init")` hands back) and *calling a regex on*
+        // one (`$needle($cursor)`, which arrives here as `Regex.CALL-ME`).
+        // Gated on the method name so the common dispatch pays one comparison
+        // against an interned-length string and nothing else.
+        if method.as_bytes().first() == Some(&b'!')
+            && let Some(result) = self.try_cursor_protocol_method(&target, method, &args)
+        {
+            return result;
+        }
+        if method == "CALL-ME"
+            && let Some(result) = self.try_call_regex_on_cursor(&target, &args)
+        {
+            return result;
+        }
         // `X::Promise::Broken` is composed into a broken promise's cause by
         // `Promise.result`, and the role overrides `gist` (only `gist` — see
         // `promise_broken_gist`). mutsu registers the role with no method

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -289,6 +289,17 @@ impl Interpreter {
         if self.is_builtin_type_method(&class_name_str, method_name) {
             return Some(self.make_native_method_object(method_name, &class_name_str));
         }
+        // The NQP cursor protocol (#7883): `Match.^lookup("!cursor_init")`.
+        // A leading `!` is an ordinary identifier character in NQP, not Raku's
+        // private-method marker, and rakudo answers these from `.^lookup` /
+        // `.^find_method` / `.^methods` like any other method -- so they are
+        // their own named source here rather than a `Match` entry in the
+        // builtin catalog (`Match`'s catalog row carries no methods at all).
+        if crate::runtime::regex::regex_cursor::is_cursor_protocol_method(method_name)
+            && (class_name_str == "Match" || mro.iter().any(|c| c.as_str() == "Match"))
+        {
+            return Some(self.make_native_method_object(method_name, &class_name_str));
+        }
         None
     }
 

--- a/src/runtime/nqp_ops_builtin.rs
+++ b/src/runtime/nqp_ops_builtin.rs
@@ -319,6 +319,23 @@ impl Interpreter {
         if let ValueView::Hash(_) = obj.view() {
             return Some(obj.clone());
         }
+        // A `Match`'s NQP-level attribute names are not the keys mutsu stores,
+        // and a still-lazy Match is not an `Instance` at all, so neither the
+        // bare-name nor the twigil spelling would find them. rakudo's `$!pos`
+        // is mutsu's `to` -- the position the match (or cursor) reached, which
+        // `.pos` already reads -- and there is no separate `$!to`. This is what
+        // lets the cursor protocol's `nqp::getattr_i($cursor, Match, '$!pos')`
+        // read where a hand-driven regex got to (#7883).
+        if obj.is_match_instance() {
+            let bare = Self::nqp_attr_keys(name).swap_remove(0);
+            return match bare.as_str() {
+                "pos" | "to" => obj.match_to().map(Value::int),
+                "from" => obj.match_from().map(Value::int),
+                "orig" => obj.match_orig(),
+                "made" | "ast" => Some(obj.match_ast().unwrap_or(Value::NIL)),
+                _ => None,
+            };
+        }
         let ValueView::Instance { attributes, .. } = obj.view() else {
             return None;
         };

--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -1,5 +1,6 @@
 mod regex_call_graph;
 mod regex_casefold;
+pub(crate) mod regex_cursor;
 pub(crate) mod regex_dynparams;
 mod regex_eval;
 mod regex_eval_class;

--- a/src/runtime/regex/regex_cursor.rs
+++ b/src/runtime/regex/regex_cursor.rs
@@ -1,0 +1,267 @@
+//! The NQP cursor protocol, as far as mutsu exposes it to user code (#7883).
+//!
+//! Rakudo's regex engine drives a regex by hand through a *cursor*: a `Match`
+//! that has not finished matching yet. Ecosystem code reaches for the same
+//! protocol to match at a known position and read the resulting cursor's
+//! `$!from` / `$!pos` instead of going through `~~` and a `Match` object
+//! (`String::Utils`'s `replace`/`replace-all` are written entirely in it):
+//!
+//! ```raku
+//! my $cursor-init = Match.^lookup("!cursor_init");
+//! my $cursor := /foo/($cursor-init(Match, "xfoox", :0c));
+//! say $cursor.pos;   # 4
+//! ```
+//!
+//! Three pieces make that work, and this module owns all three:
+//!
+//! 1. `Match.^lookup("!cursor_init")` must find a method whose name begins
+//!    with `!`. Those are not Raku private methods — in NQP a leading `!` is
+//!    an ordinary part of the identifier, and rakudo lists `!cursor_init`
+//!    among `Match.^methods` — so they are exposed here as a small named set
+//!    rather than through the `is_private` machinery.
+//! 2. `!cursor_init` itself, which builds the cursor.
+//! 3. Invoking a `Regex` (or a grammar token method) **on a cursor**, which
+//!    means "match at this cursor and report where you got to".
+//!
+//! ## Cursor shape
+//!
+//! A cursor is a `Match`, not a separate type — verified against rakudo:
+//! `Match.^lookup("!cursor_init")(Match, "xfoox", :0c).^name` is `Match`. So
+//! mutsu reuses its own `Match` representation, with rakudo's two NQP-level
+//! attributes mapped onto it:
+//!
+//! | rakudo | mutsu `Match` attribute |
+//! | --- | --- |
+//! | `$!orig` | `orig` |
+//! | `$!from` | `from` |
+//! | `$!pos`  | `to` (`.pos` already reads `to`) |
+//!
+//! `$!from == -1` is rakudo's own "this cursor has not started matching"
+//! marker, and it is what selects scanning over anchoring — measured against
+//! rakudo 2026.07:
+//!
+//! | init | `$!from` | `$!pos` | `/foo/` on `"xfoox"` |
+//! | --- | --- | --- | --- |
+//! | `:c(0)` | -1 | 0 | from=1 pos=4 (scanned) |
+//! | `:p(0)` | 0 | 0 | from=0 pos=-3 (anchored, failed) |
+//! | `:p(1)` | 1 | 1 | from=1 pos=4 (anchored, matched) |
+//!
+//! A failed cursor is a *failed* `Match` (`.defined` is `True`, `.Bool` is
+//! `False`, gists as `#<failed match>`) whose `$!from` is the position the
+//! attempt started at and whose `$!pos` is [`CURSOR_FAIL_POS`].
+//!
+//! ## What this does NOT adopt
+//!
+//! Only the entry point the idiom needs. The rest of the protocol
+//! (`!cursor_start`, `!cursor_pass`, `!cursor_capture`, the `$!shared` /
+//! `$!braid` state NQP threads through a parse) stays internal to mutsu's own
+//! engine: a cursor here is produced complete, never advanced step by step by
+//! user code. One consequence is that a cursor mutsu returns carries its
+//! captures, where rakudo's carries none until `!reduce` builds the Match —
+//! strictly more information, and not something the idiom reads.
+
+use super::super::*;
+
+/// `$!pos` of a cursor whose match failed. rakudo reports -3 (an NQP
+/// backtracking-state marker, not merely "negative"), and consumers test
+/// `$pos >= 0`, so any negative value works — this one matches the oracle.
+pub(crate) const CURSOR_FAIL_POS: i64 = -3;
+
+/// `$!from` of a cursor that has not started matching (`:c`). Selects
+/// scanning; a `:p` cursor carries its anchor position here instead.
+pub(crate) const CURSOR_NOT_STARTED: i64 = -1;
+
+/// The cursor-protocol methods mutsu answers for. `.^lookup` / `.^find_method`
+/// consult this so `Match.^lookup("!cursor_init")` returns a callable instead
+/// of `Nil`.
+pub(crate) const CURSOR_PROTOCOL_METHODS: &[&str] = &["!cursor_init"];
+
+/// Is `method_name` one of them? The receiver's own `Match`-ness is the
+/// caller's check — `Match` itself, or any grammar, since a grammar IS a
+/// `Match` subclass.
+pub(crate) fn is_cursor_protocol_method(method_name: &str) -> bool {
+    CURSOR_PROTOCOL_METHODS.contains(&method_name)
+}
+
+impl Interpreter {
+    /// `Type.!cursor_init($target, :c($pos))` / `:p($pos)` — build a fresh
+    /// cursor over `$target`. `None` when `method` is not a cursor-protocol
+    /// method mutsu answers for, so the caller falls through to normal
+    /// dispatch.
+    pub(crate) fn try_cursor_protocol_method(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if method != "!cursor_init" {
+            return None;
+        }
+        // The receiver is the type object the cursor should have: `Match` for
+        // a plain regex, the grammar's own type for a parse (rakudo: a
+        // grammar's cursors are Match objects of the grammar's own type).
+        let cursor_class = match target.view() {
+            ValueView::Package(name) => name.resolve(),
+            ValueView::Instance { class_name, .. } => class_name.resolve(),
+            _ => "Match".to_string(),
+        };
+        if cursor_class != "Match"
+            && !self
+                .class_mro(&cursor_class)
+                .iter()
+                .any(|c| c.as_str() == "Match")
+        {
+            return None;
+        }
+        let Some(orig) = args
+            .iter()
+            .find(|a| !matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
+        else {
+            return Some(Err(RuntimeError::new(
+                "!cursor_init requires a target string",
+            )));
+        };
+        let orig = orig.to_string_value();
+        let mut from = CURSOR_NOT_STARTED;
+        let mut pos = 0i64;
+        for arg in args {
+            if let ValueView::Pair(key, value) = arg.view() {
+                match key.as_str() {
+                    // `:c` — continue/scan from here: the cursor has not
+                    // started, so calling a regex on it searches forward.
+                    "c" => pos = value.to_f64() as i64,
+                    // `:p` — anchored at here: the cursor is already at its
+                    // start, so calling a regex on it matches exactly there.
+                    "p" => {
+                        pos = value.to_f64() as i64;
+                        from = pos;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Some(Ok(Self::make_cursor_value(
+            &cursor_class,
+            &orig,
+            from,
+            pos,
+            false,
+        )))
+    }
+
+    /// Build a cursor `Match` value directly from its NQP-level attributes.
+    /// `failed` marks it as a failed match (`.Bool` is `False`), which is what
+    /// a cursor whose regex did not match is.
+    fn make_cursor_value(
+        cursor_class: &str,
+        orig: &str,
+        from: i64,
+        pos: i64,
+        failed: bool,
+    ) -> Value {
+        let mut attrs = HashMap::new();
+        attrs.insert("str".to_string(), Value::str_from(""));
+        attrs.insert("from".to_string(), Value::int(from));
+        attrs.insert("to".to_string(), Value::int(pos));
+        // `make_failed_match_value` keeps a redundant `pos` alongside `to`;
+        // mirror that shape so every eager Match instance looks the same.
+        attrs.insert("pos".to_string(), Value::int(pos));
+        attrs.insert("orig".to_string(), Value::str(orig.to_string()));
+        attrs.insert("list".to_string(), Value::array(Vec::new()));
+        attrs.insert("named".to_string(), Value::hash_bare_values(HashMap::new()));
+        if failed {
+            attrs.insert("__failed_match__".to_string(), Value::TRUE);
+        }
+        if cursor_class != "Match" {
+            attrs.insert(
+                crate::value::match_view::CURSOR_MATCH_MARKER.to_string(),
+                Value::TRUE,
+            );
+        }
+        Value::make_instance(Symbol::intern(cursor_class), attrs)
+    }
+
+    /// The `(orig, start, anchored)` triple a cursor argument denotes, or
+    /// `None` when `value` is not a cursor. `anchored` is rakudo's
+    /// `$!from != -1`: a `:p` cursor matches exactly at its position, a `:c`
+    /// cursor scans forward from it.
+    ///
+    /// Only an EXPLICIT `$!from == -1` unanchors. Anchoring is what every
+    /// pre-existing caller of a Match-as-cursor means (`regex_token_method`'s
+    /// custom-HOW subrule dispatch above all), so a Match that carries no
+    /// `from` at all must keep it rather than silently start scanning.
+    pub(crate) fn cursor_call_position(value: &Value) -> Option<(String, usize, bool)> {
+        if !value.is_match_instance() {
+            return None;
+        }
+        let orig = value.match_orig()?.to_string_value();
+        let pos = value.match_to().unwrap_or(0);
+        let start = usize::try_from(pos).ok()?;
+        let anchored = value.match_from() != Some(CURSOR_NOT_STARTED);
+        Some((orig, start, anchored))
+    }
+
+    /// `$regex($cursor)` — run a `Regex` value against the cursor and return
+    /// the resulting cursor. `None` when the argument is not a cursor, so an
+    /// ordinary (unsupported) `Regex.CALL-ME` still reports itself as such.
+    pub(crate) fn try_call_regex_on_cursor(
+        &mut self,
+        regex: &Value,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let pattern = match regex.view() {
+            ValueView::Regex(p) => p.to_string(),
+            ValueView::RegexWithAdverbs(a) => a.pattern.to_string(),
+            _ => return None,
+        };
+        let cursor = args.first()?;
+        let (orig, start, anchored) = Self::cursor_call_position(cursor)?;
+        let cursor_class = cursor.match_dispatch_class().to_string();
+        Some(Ok(self.run_regex_at_cursor(
+            &pattern,
+            &orig,
+            start,
+            anchored,
+            &cursor_class,
+        )))
+    }
+
+    /// Shared body of a cursor call: match `pattern` against `orig` at (or
+    /// from) `start`, and wrap the outcome as a cursor.
+    pub(crate) fn run_regex_at_cursor(
+        &mut self,
+        pattern: &str,
+        orig: &str,
+        start: usize,
+        anchored: bool,
+        cursor_class: &str,
+    ) -> Value {
+        let caps = if anchored {
+            self.regex_match_with_captures_at(pattern, orig, start)
+        } else {
+            self.regex_match_with_captures_from(pattern, orig, start)
+        };
+        match caps {
+            Some(caps) => {
+                let target = caps
+                    .target
+                    .clone()
+                    .unwrap_or_else(|| MatchTarget::new(orig));
+                Value::make_match_object_full(
+                    caps.from as i64,
+                    caps.to as i64,
+                    &caps.positional,
+                    &caps.named,
+                    target,
+                )
+            }
+            None => Self::cursor_failure(cursor_class, orig, start),
+        }
+    }
+
+    /// The cursor a failed match yields: rakudo leaves `$!from` at the position
+    /// the attempt started from and sets `$!pos` to [`CURSOR_FAIL_POS`].
+    pub(crate) fn cursor_failure(cursor_class: &str, orig: &str, start: usize) -> Value {
+        Self::make_cursor_value(cursor_class, orig, start as i64, CURSOR_FAIL_POS, true)
+    }
+}

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -52,6 +52,20 @@ impl Interpreter {
         // Cursor: a Match instance (orig + to = current position) or a plain Str.
         let (text, pos) = match args.first() {
             Some(m) if m.is_match_instance() => {
+                // A cursor that has not started matching (`!cursor_init`'s
+                // `:c`, marked by `$!from == -1`) means SCAN forward from its
+                // position rather than anchor at it -- rakudo's own
+                // discriminator, and the only case where a token method call
+                // is not anchored. See `regex_cursor`.
+                if let Some((orig, start, false)) = Self::cursor_call_position(m) {
+                    return Some(self.run_token_method_scanning(
+                        pkg,
+                        name,
+                        &args[1..],
+                        &orig,
+                        start,
+                    ));
+                }
                 let orig = m.match_orig().map(|v| v.to_string_value())?;
                 let to = m.match_to().filter(|t| *t >= 0).unwrap_or(0) as usize;
                 (orig, to)
@@ -60,6 +74,29 @@ impl Interpreter {
             _ => return None,
         };
         Some(self.run_token_method_at(pkg, name, &args[1..], &text, pos))
+    }
+
+    /// A token method called on a not-yet-started cursor: try `run_token_method_at`
+    /// at each position from `start` on, returning the first cursor that
+    /// matched, and a failed cursor if none did. This is the scanning half of
+    /// the cursor protocol (#7883); the anchored half is `run_token_method_at`
+    /// itself.
+    fn run_token_method_scanning(
+        &mut self,
+        pkg: &str,
+        name: &str,
+        extra_args: &[Value],
+        text: &str,
+        start: usize,
+    ) -> Result<Value, RuntimeError> {
+        let len = text.chars().count();
+        for pos in start..=len {
+            let m = self.run_token_method_at(pkg, name, extra_args, text, pos)?;
+            if m.is_match_instance() {
+                return Ok(m);
+            }
+        }
+        Ok(Self::cursor_failure(pkg, text, start))
     }
 
     /// Run token `pkg::name` anchored at char position `pos` of `text` and

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -313,6 +313,19 @@ impl Interpreter {
             {
                 return res;
             }
+            // A cursor-protocol method value (`Match.^lookup("!cursor_init")`,
+            // #7883) is a METHOD, and `Match` is a builtin type with no
+            // `registry().classes` entry -- so the `has_class` method-dispatch
+            // fallback further down never fires for it and the name fell
+            // through to "Unknown function". Re-dispatch it on its first
+            // argument, which is the type object the cursor belongs to.
+            if super::regex::regex_cursor::is_cursor_protocol_method(&name.resolve())
+                && !args.is_empty()
+            {
+                let mut args = args;
+                let invocant = args.remove(0);
+                return self.call_method_with_values(invocant, &name.resolve(), args);
+            }
             if !package.is_empty() && package != "GLOBAL" {
                 let fq = format!("{package}::{name}");
                 if self.resolve_function(&fq).is_some() {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -226,7 +226,7 @@ mod identity_hash;
 pub use hash_key::HashKey;
 /// ADR-0016 P5 seam: `Match`-representation accessor helpers.
 mod match_lazy;
-mod match_view;
+pub(crate) mod match_view;
 pub(crate) mod which_id;
 pub(crate) use match_lazy::MatchNode;
 /// NaN-boxed 8-byte representation core (3b-1 step B): the packed word that

--- a/t/regex/match/match-cursor-protocol.t
+++ b/t/regex/match/match-cursor-protocol.t
@@ -1,0 +1,106 @@
+use v6;
+use Test;
+use nqp;
+
+# The NQP cursor protocol exposed to user code (#7883): `Match.^lookup
+# ("!cursor_init")` builds a cursor, invoking a Regex (or a grammar token) on
+# that cursor matches at/from it, and `nqp::getattr_i($cursor, Match, '$!pos')`
+# reads where it got to. Ecosystem code drives regexes by hand with it --
+# `String::Utils`'s `replace`/`replace-all` are written entirely in this idiom.
+#
+# Every expectation below was measured against rakudo 2026.07.
+
+plan 32;
+
+# `.^lookup`'s result is an NQPRoutine in rakudo, which answers neither
+# `.defined` nor `.Bool` -- so `.^can` is the portable presence check, and the
+# lookup itself is proved to work by being CALLED below.
+my $cursor-init = Match.^lookup("!cursor_init");
+is Match.^can("!cursor_init").elems, 1, 'Match.^can finds !cursor_init';
+
+# A leading `!` is an ordinary NQP identifier character, not Raku's
+# private-method marker: the method is found by its full name, and nothing
+# named `cursor_init` exists.
+is Match.^can("cursor_init").elems, 0, 'the bare name (no "!") is not a method';
+is Match.^lookup("cursor_init").^name, 'Mu', 'and .^lookup of it answers Mu';
+
+# ---- the cursor a fresh `:c` init produces -------------------------------
+# `:c(n)` means "not started, continue from n": $!from is -1, $!pos is n.
+my $init := $cursor-init(Match, "xfoox", :0c);
+is nqp::getattr_i($init, Match, '$!from'), -1, ':c cursor has $!from == -1';
+is nqp::getattr_i($init, Match, '$!pos'), 0, ':c cursor has $!pos == :c value';
+is $init.pos, 0, '.pos reads $!pos';
+
+my $init3 := $cursor-init(Match, "xfoox", :c(3));
+is nqp::getattr_i($init3, Match, '$!pos'), 3, ':c(3) starts at 3';
+
+# `:p(n)` means "anchored at n": $!from is n, so calling a regex on it does
+# NOT scan forward.
+my $anchored := $cursor-init(Match, "xfoox", :p(2));
+is nqp::getattr_i($anchored, Match, '$!from'), 2, ':p cursor carries its anchor in $!from';
+is nqp::getattr_i($anchored, Match, '$!pos'), 2, ':p cursor $!pos is the anchor too';
+
+# ---- invoking a Regex on a cursor ---------------------------------------
+my $hit := /foo/($cursor-init(Match, "xfoox", :0c));
+is nqp::getattr_i($hit, Match, '$!from'), 1, 'a :c cursor SCANS: $!from is where the match started';
+is nqp::getattr_i($hit, Match, '$!pos'), 4, '$!pos is where the match ended';
+is $hit.from, 1, '.from agrees';
+is $hit.to, 4, '.to agrees';
+is $hit.Str, 'foo', '.Str is the matched text';
+ok ?$hit, 'a matched cursor is True';
+
+# A cursor whose regex did not match is a *failed* Match: defined, but false,
+# with $!pos set to the failure marker and $!from left at the start position.
+my $miss := /zzz/($cursor-init(Match, "xfoox", :c(2)));
+ok $miss.defined, 'a failed cursor is still defined';
+nok ?$miss, 'a failed cursor is False';
+is nqp::getattr_i($miss, Match, '$!pos'), -3, 'a failed cursor reports $!pos == -3';
+is nqp::getattr_i($miss, Match, '$!from'), 2, 'a failed cursor leaves $!from at the start position';
+is $miss.Str, '', 'a failed cursor stringifies empty';
+
+# Scanning starts at the cursor position, not at 0.
+is (/foo/($cursor-init(Match, "xfoox", :c(3)))).pos, -3,
+    'scanning from past the match fails';
+is (/o/($cursor-init(Match, "xfoox", :c(3)))).from, 3,
+    'scanning from 3 finds the second "o"';
+
+# `:p` anchors instead of scanning.
+is (/foo/($cursor-init(Match, "xfoox", :p(0)))).pos, -3,
+    ':p(0) anchors, so /foo/ does not match "xfoox" there';
+is (/foo/($cursor-init(Match, "xfoox", :p(1)))).pos, 4,
+    ':p(1) anchors exactly where the match is';
+
+# An `rx//` held in a variable works the same as a literal.
+my $needle = rx/foo/;
+is ($needle($cursor-init(Match, "xfoox", :0c))).pos, 4, 'a Regex in a variable is callable on a cursor';
+
+# Positions are in characters, not bytes.
+is (/b/($cursor-init(Match, "\c[SNOWMAN]bc", :0c))).pos, 2,
+    'cursor positions count characters, not bytes';
+
+# ---- a grammar token on a cursor ----------------------------------------
+grammar CursorG { token foo { foo } }
+my $tok = CursorG.^lookup("foo");
+my $tok-hit := $tok($cursor-init(CursorG, "xfoox", :0c));
+is nqp::getattr_i($tok-hit, Match, '$!from'), 1, 'a token scans from a :c cursor too';
+is nqp::getattr_i($tok-hit, Match, '$!pos'), 4, 'and reports where it ended';
+is nqp::getattr_i($tok($cursor-init(CursorG, "xzzzx", :0c)), Match, '$!pos'), -3,
+    'a token that never matches yields a failed cursor';
+
+# ---- the idiom this exists for ------------------------------------------
+# `String::Utils::replace`, verbatim (lib/String/Utils.rakumod:563).
+my sub replace(str $haystack, Regex:D $needle, str $replacement) {
+    my $cursor := $needle($cursor-init(Match, $haystack, :0c));
+    my int $pos = nqp::getattr_i($cursor, Match, '$!pos');
+    $pos >= 0
+      ?? nqp::substr($haystack, 0, nqp::getattr_i($cursor, Match, '$!from'))
+           ~ $replacement
+           ~ nqp::substr($haystack, $pos)
+      !! $haystack
+}
+
+is replace("foobarfoo", /bar/, "BAZ"), "fooBAZfoo", 'String::Utils-style replace hits';
+is replace("foobarfoo", /zzz/, "BAZ"), "foobarfoo", 'and leaves the string alone on a miss';
+is replace("hello world", /\s+/, "-"), "hello-world", 'and replaces only the first match';
+
+done-testing;


### PR DESCRIPTION
Rakudo's regex engine drives a regex by hand through a *cursor* — a `Match` that has not finished
matching yet — and exposes that protocol to user code. Ecosystem distributions reach for it to match
at a known position and read the resulting cursor's `$!from` / `$!pos` instead of going through `~~`
and a `Match` object. mutsu had none of it: `Match.^lookup("!cursor_init")` answered `Nil`, so the
whole idiom died at its first line.

```raku
my $cursor-init = Match.^lookup("!cursor_init");
my $cursor := /foo/($cursor-init(Match, "xfoox", :0c));
say $cursor.pos;   # 4
```

## The issue priced this as three deep problems; measurement shrank all three

- **`!cursor_init` is not a Raku private method.** A leading `!` is an ordinary identifier character
  in NQP, and rakudo lists `!cursor_init` among `Match.^methods` and answers
  `Match.^can("!cursor_init").elems` with 1 — so it needs a *named source* in `.^lookup`, not the
  `is_private` machinery.
- **A cursor IS a `Match`**, not a separate type: `$cursor-init(Match, "xfoox", :0c).^name` is
  `Match`. mutsu's own `Match` representation carries it, with rakudo's `$!orig` / `$!from` / `$!pos`
  mapped onto `orig` / `from` / `to` (`.pos` already read `to`).
- **The calling convention had a precedent**: `regex_token_method.rs` has run a grammar token method
  against a `Match` cursor since the custom-HOW `find_method` work.

The one genuinely new thing measurement turned up is the **scan/anchor discriminator**. `$!from == -1`
is rakudo's own "this cursor has not started matching" marker, and it — not the regex, not the call
site — decides whether a cursor call scans forward or anchors:

| init | `$!from` | `$!pos` | `/foo/` on `"xfoox"` |
| --- | --- | --- | --- |
| `:c(0)` | -1 | 0 | from=1 pos=4 (scanned) |
| `:p(0)` | 0 | 0 | from=0 pos=-3 (anchored, failed) |
| `:p(1)` | 1 | 1 | from=1 pos=4 (anchored, matched) |

A failed cursor is a *failed* `Match` (`.defined` is `True`, `.Bool` is `False`, gists as
`#<failed match>`) whose `$!from` stays at the position the attempt started from and whose `$!pos`
is -3, NQP's backtracking-state marker.

## What shipped

`src/runtime/regex/regex_cursor.rs` owns the protocol: which methods `Match` answers for, how a
cursor is built from `:c` / `:p`, and the shared "match at (or from) this cursor and wrap the
outcome" body. `.^lookup` / `.^find_method` / `.^can` consult it as their own named source, because
`Match`'s builtin-catalog row carries no methods at all. `Regex.CALL-ME` on a cursor and the
`!cursor_init` re-dispatch both funnel through `call_method_with_values`, gated on the method name.
The existing token-method path gained the scanning half for a not-yet-started cursor.

Only an **explicit** `$!from == -1` unanchors, so every pre-existing Match-as-cursor caller (the
custom-HOW subrule dispatch above all) keeps anchoring exactly as before.

Reading a cursor needs `nqp::getattr_i`, which the issue believed already worked; it did not, but
#7893's String::Utils slice landed the `getattr` family on `main` while this was in flight. What
remains here is its `Match` half: a `Match`'s NQP-level attribute names are not the keys mutsu
stores, and a still-lazy `Match` is not an `Instance` at all, so neither the bare-name nor the
twigil spelling reached them. `nqp_attr_value` now aliases `$!pos` / `$!from` / `$!orig` onto
`to` / `from` / `orig`.

## Scope

Only the entry point the idiom needs. The rest of the protocol (`!cursor_start`, `!cursor_pass`,
`!cursor_capture`, the `$!shared` / `$!braid` state NQP threads through a parse) stays internal to
mutsu's engine: a cursor here is produced complete, never advanced step by step by user code. One
consequence is that a cursor mutsu returns carries its captures, where rakudo's carries none until
`!reduce` builds the Match — strictly more information, and not something the idiom reads.

## Testing

`t/regex/match/match-cursor-protocol.t` — 32 assertions, every expectation measured against rakudo
2026.07, and the file **passes unchanged under both interpreters**. It covers `.^lookup` / `.^can`
(including that the bare `cursor_init` is still not a method), `:c` vs `:p` init, scanning and
anchoring, the failed-cursor shape, character-not-byte positions, a grammar token on a cursor, and
`String::Utils`'s `replace` lifted verbatim from `lib/String/Utils.rakumod:563` — the code that
*died* rather than failed before this.

- `make test` — PASS (3970 files, 42260 tests)
- `make roast` — the only red is the documented container-only set (`6.c/S32-io/file-tests.t` and
  `S16-filehandles/filetest.t` under `uid 0`, `S32-io/IO-Socket-Async.t` under the network sandbox);
  see `docs/agent-environments.md`
- `make lint` — green in all four configurations

Closes #7883

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyYLPH5NGHA6Si2pwMgoN8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyYLPH5NGHA6Si2pwMgoN8)_