### PR TITLE
fix: seven interpreter gaps found by CSS::Module::CSS3::Selectors (blocked_load → 80/92)

### DIFF
--- a/ecosystem/dists/C/CSS--Module--CSS3--Selectors.json
+++ b/ecosystem/dists/C/CSS--Module--CSS3--Selectors.json
@@ -10,34 +10,58 @@
     "unresolved": []
   },
   "dist": "CSS::Module::CSS3::Selectors",
-  "files": [],
+  "files": [
+    {
+      "cmp": "partial",
+      "mutsu": {
+        "first_failure": "css3x-selectors simple-selector warnings",
+        "nok": 12,
+        "ok": 80,
+        "plan": 92,
+        "secs": 1.0,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "fail"
+      },
+      "path": "t/00basic.t",
+      "raku": {
+        "nok": 0,
+        "ok": 92,
+        "plan": 92,
+        "secs": 10.57,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    }
+  ],
   "load": {
-    "CSS::Module::CSS3::Selectors": "Inconsistent class hierarchy for CSS::Grammar::CSS21",
-    "CSS::Module::CSS3::Selectors::Actions": "Error while importing from 'CSS::Grammar::Defs': no such tag 'CSSTrait' declared"
+    "CSS::Module::CSS3::Selectors": "ok",
+    "CSS::Module::CSS3::Selectors::Actions": "ok"
   },
   "measured": {
-    "attempts": 2,
-    "date": "2026-09-10",
+    "attempts": 3,
+    "date": "2026-09-11",
     "harness": 1,
     "host": "linux-x86_64",
-    "mutsu_commit": "a7fe6d9",
+    "mutsu_commit": "99075c8",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
-    "sandbox": "bwrap"
+    "sandbox": "none"
   },
   "schema": 1,
   "source": {
     "index": "fez",
     "url": "https://360.zef.pm/C/SS/CSS_MODULE_CSS3_SELECTORS/7167453e1346af70f5194176044416f55906978f.tar.gz"
   },
-  "status": "blocked_load",
+  "status": "red",
   "totals": {
-    "baseline_assertions": 0,
-    "baseline_files": 0,
-    "mutsu_assertions": 0,
+    "baseline_assertions": 92,
+    "baseline_files": 1,
+    "mutsu_assertions": 80,
     "parity_files": 0,
-    "regressed_files": 0
+    "regressed_files": 1
   },
   "version": "0.0.6"
 }

--- a/news/2026-09/css-module-css3-selectors-blocked-load.md
+++ b/news/2026-09/css-module-css3-selectors-blocked-load.md
@@ -1,0 +1,117 @@
+# CSS::Module::CSS3::Selectors: from `blocked_load` to 80 of 92 assertions
+
+`CSS::Module::CSS3::Selectors` 0.0.6 was drawn at random from the `ecosystem/`
+ledger (lock board [#7884](https://github.com/tokuhirom/mutsu/issues/7884)) with
+status `blocked_load`: its provided module did not even `use`, so none of its
+suite could run. Seven interpreter bugs later its single baseline test file runs
+end to end and passes 80 of its 92 assertions.
+
+None of the seven is specific to CSS. Each was found by reducing a distribution
+failure to a few lines that run from this repo, checked against the `raku`
+oracle, and pinned by a `t/` test.
+
+## `also is Base` on a grammar replaces the implicit `Grammar` parent
+
+A `grammar` declarator with no `is` clause carries an implicit `Grammar` parent.
+mutsu kept that parent when the body later added one with `also is`, so
+`unit grammar CSS::Grammar::CSS21; also is CSS::Grammar;` asked for multiple
+inheritance from both `Grammar` and a grammar that itself inherits `Grammar` —
+a C3 merge with no linearization, reported as "Inconsistent class hierarchy for
+CSS::Grammar::CSS21". Rakudo linearizes `grammar G { also is Base }` exactly
+like `grammar G is Base { }`, so the implicit parent is now dropped when an
+`also is` supplies a real one. The block form `grammar G { also is Base; }` was
+not extracting its parent from the body at all (it reached the runtime as a bare
+`is(also, Base)` infix and died with "Two terms in a row"); it now shares the
+same extraction the `class` and unit forms use, including the named-grammar
+expression path that `grammar G { … }.parse($s)` takes.
+
+## `require Foo:ver(…)` / `:ver<…>` distribution selectors
+
+`require` accepted no version/auth/api adverb on its target, so
+`require CSS::Grammar:ver(v0.3.3+)` parsed as a call to an undeclared routine
+`CSS::Grammar:ver`. Both spellings are now consumed. The angle-bracket form is
+carried through to `use_module`, where `split_dist_selectors` and
+`select_dist_candidate` already refine which installed distribution is loaded;
+the parenthesized form holds an arbitrary expression and is discarded, exactly
+as `use` already discards it. The module's own name stays bare, so the stub
+`require` installs and the package it returns are unaffected.
+
+## `::` inside a `:sym<…>` is part of the name, not a package qualifier
+
+`rule pseudo:sym<::element>` is real Raku — it is how CSS::Grammar::CSS3 spells
+the CSS3 pseudo-element selector — and its action method is
+`method pseudo:sym<::element>($/)`. Method dispatch split every name on its last
+`::`, inventing a package qualifier `pseudo:sym<` and a method `element>`, so the
+action never fired ("Cannot dispatch to method element> on pseudo:sym<"). The
+four qualified-dispatch entry points now split only at a `::` that lies outside
+an extended-name adverb.
+
+## `method build handles<…>` needs no space before the angle-word list
+
+The `handles` trait on a *method* required whitespace after the keyword, while
+the attribute form had always accepted the tight spelling. `method build
+handles<token node list at-rule> { … }` — the spelling Raku's own documentation
+and `CSS::Grammar::Actions` use — therefore failed to parse, taking the `build`
+method with it.
+
+## A `Str enum`'s values are `Str`s
+
+mutsu hardcoded `Int` as the base type of every enum value: `dispatch_mro` put
+`Int` behind the enum type, the VM's two fast parameter type checks knew only
+the five scalar shapes, and string context answered the key. So
+`our Str enum CSSSelector «:PseudoElement<pseudo-elem> …>` — how
+`CSS::Grammar::Defs` declares every CSS selector and property type — produced
+"Type check failed in binding to parameter '$type'; expected Str but got Int"
+at the first action that passed one on. The base type an enum's values carry now
+decides its ancestry, its type checks and its string context, while `.gist`
+keeps answering the key (`say S::A` prints `A`, `~S::A` is `a-val`).
+
+## `:i'literal'` with no space
+
+A short inline regex adverb (`:i`, `:s`, `:r`, `:m`) only ended at a space, a
+`:` or a `/`. `/:i'not('/` — how CSS::Grammar spells every case-insensitive CSS
+keyword, and `:i` followed by a newline as well — therefore left the adverb
+unrecognized and the whole pattern failed to match. A short adverb now ends
+wherever an identifier would, which still rejects `:my`, `:sym<…>` and `:ss`
+because their next character continues the name.
+
+## Two calls to the same subrule at one position are siblings, not left recursion
+
+The streamed subrule path held its left-recursion activation across the
+*continuation* — the caller's remaining pattern — so a second call to the same
+rule at the same position read that activation's empty seed and failed. Every
+`rule` containing a bracketed group compiles to exactly that shape, because
+sigspace puts a `<.ws>` at the end of the group and another right after it
+(`'[' <.ws> [ <id> <.ws> ] <.ws> ']'`). The effect was invisible with the
+built-in `ws` and total with a user-defined one: a grammar that declares its own
+`ws`, as CSS::Grammar does, stopped matching *any* rule with a group in it,
+which took out `attrib`, `pseudo-function` and most of the CSS3 selector
+grammar. The activation is now lifted across the continuation and restored for
+the rest of the body walk, so the code-block re-entry it exists to catch is
+still covered.
+
+## What is left
+
+Twelve assertions still fail, each with an open issue and a reduction:
+
+- [#7909](https://github.com/tokuhirom/mutsu/issues/7909) — `Grammar.parse(:rule<proto>)` commits to one proto candidate and never falls through. Reaching the same proto as a *subrule* already falls through; only the top-level entry does not.
+- [#7910](https://github.com/tokuhirom/mutsu/issues/7910) — `$<name>=<.subrule>` does not run the subrule's action, so the aliased capture's `.ast` is `Nil`. This is what drops every integer out of the `nth-child(3n+1)` AST (8 of the 12).
+- [#7912](https://github.com/tokuhirom/mutsu/issues/7912) — a `(` inside a `<?before '…'>` literal makes a quantified `||` group stop matching, so the nested-`:not()` guard never fires.
+- [#7913](https://github.com/tokuhirom/mutsu/issues/7913) — `Pair.raku` renders a `Str`-enum key as `Enum::Key => value` rather than `:key(value)` (diagnostic only; `to-json` already agrees).
+
+One finding is unrelated to this suite's result but was too sharp to leave
+unrecorded: [#7914](https://github.com/tokuhirom/mutsu/issues/7914), an imported
+enum key overwriting a same-named lexical scalar, because enum keys and scalars
+share mutsu's sigil-less env namespace. `CSS::Grammar::Defs` exports `:s<time>`,
+so any script with a `my $s` that calls into it has that variable replaced
+mid-call.
+
+## Pins
+
+`t/grammar/grammar-also-is-replaces-implicit-parent.t`,
+`t/grammar/grammar-action-sym-with-double-colon.t`,
+`t/modules/import-export/require-dist-selectors.t`,
+`t/oo/trait/method-handles-no-space.t`,
+`t/types/enum-subset/enum-declared-base-type.t`,
+`t/regex/regex-short-adverb-tight-atom.t`,
+`t/regex/regex-sibling-subrule-same-position.t`.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1394,6 +1394,14 @@ pub(crate) enum Stmt {
         custom_traits: Vec<(String, Option<Expr>)>,
         /// Whether this class was declared with `unit class` (file-scoped body)
         is_unit: bool,
+        /// Whether the trailing `Grammar` entry in `parents` was supplied
+        /// implicitly, because a `grammar` declarator carried no `is` clause.
+        /// A later `also is Parent` in the body replaces it rather than adding a
+        /// second parent: Rakudo linearizes `grammar G { also is Base }` exactly
+        /// like `grammar G is Base { }` (`G, Base, ...`), and keeping both would
+        /// make the C3 merge inconsistent whenever `Base` itself is a grammar.
+        #[serde(default)]
+        implicit_grammar_parent: bool,
         /// Stable per-declaration-site id (parse-time assigned, non-zero) used to
         /// distinguish same-named lexical (`my`) classes in different scopes.
         /// 0 means "no stable site" (runtime-synthesized or deserialized node).

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -95,6 +95,7 @@ impl Compiler {
                 language_version,
                 custom_traits,
                 is_unit,
+                implicit_grammar_parent,
                 decl_id,
                 parent_args,
                 ..
@@ -123,6 +124,7 @@ impl Compiler {
                     language_version: language_version.clone(),
                     custom_traits: custom_traits.clone(),
                     is_unit: *is_unit,
+                    implicit_grammar_parent: *implicit_grammar_parent,
                     decl_id: *decl_id,
                     parent_args: new_parent_args,
                 }

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -3,8 +3,8 @@ use crate::parser::expr::{
     expression, expression_no_sequence, parse_fat_arrow_value, should_wrap_whatevercode, term_expr,
 };
 use crate::parser::helpers::{
-    consume_unspace, is_loop_label_name, is_raku_identifier_start, normalize_raku_identifier, ws,
-    ws1,
+    consume_unspace, is_loop_label_name, is_raku_identifier_start, normalize_raku_identifier,
+    skip_balanced_parens, ws, ws1,
 };
 use crate::parser::parse_result::{PError, PResult, merge_expected_messages, parse_char};
 use crate::parser::primary::current_line_number;
@@ -106,15 +106,86 @@ fn restore_do_stmt_terminator<'a>(orig: &'a str, after: &'a str) -> &'a str {
     }
 }
 
+/// Consume the distribution selectors (`:ver<…>` / `:ver(…)`, `:auth<…>`,
+/// `:api<…>`, and `:v<…>` — Raku's short spelling of `:ver<…>`) that may follow
+/// a `require` target's module name, returning the rest of the input and the
+/// angle-bracket-literal selectors in the canonical `:key<value>` spelling that
+/// `Interpreter::split_dist_selectors` understands.
+///
+/// These refine *which* distribution to load; they are not import tags, and
+/// without consuming them `require CSS::Grammar:ver(v0.3.3+)` parsed as a call
+/// to an undeclared routine `CSS::Grammar:ver`. `use` handles the same two forms
+/// (see `use_decl.rs`): the parenthesized form holds an arbitrary expression
+/// that cannot be reduced to a selector string at parse time, so — as there —
+/// it is consumed and discarded.
+fn parse_require_dist_selectors(input: &str) -> (&str, String) {
+    let mut rest = input;
+    let mut selectors = String::new();
+    loop {
+        let Some(after_colon) = rest.strip_prefix(':') else {
+            return (rest, selectors);
+        };
+        let name_len = after_colon
+            .bytes()
+            .take_while(|b| b.is_ascii_alphanumeric())
+            .count();
+        let (name, after_name) = after_colon.split_at(name_len);
+        if !matches!(name, "ver" | "v" | "auth" | "api") {
+            return (rest, selectors);
+        }
+        let canonical = if name == "v" { "ver" } else { name };
+        // `:ver:<0.0.5>` spells the value with an extra colon; both forms legal.
+        let after_name = after_name.strip_prefix(':').unwrap_or(after_name);
+        if let Some(after_angle) = after_name.strip_prefix('<') {
+            let Some(end) = after_angle.find('>') else {
+                return (rest, selectors);
+            };
+            selectors.push_str(&format!(":{}<{}>", canonical, &after_angle[..end]));
+            rest = &after_angle[end + 1..];
+        } else if after_name.starts_with('(') {
+            rest = skip_balanced_parens(after_name);
+        } else {
+            return (rest, selectors);
+        }
+    }
+}
+
+/// Split the distribution selectors back off a module name.
+///
+/// `parse_sub_name` reads an extended name, so the angle-bracket form of a
+/// selector (`require Test:ver<0.0.1+>:auth<perl>`) arrives folded into the name
+/// it returns, while the parenthesized form is still ahead in the input. The
+/// tail must be selectors all the way to the end of the name, so an ordinary
+/// package separator (`CSS::Grammar`) is never mistaken for one.
+fn split_dist_selectors_from_name(name: &str) -> (&str, String) {
+    for (i, _) in name.match_indices(':') {
+        let (after, selectors) = parse_require_dist_selectors(&name[i..]);
+        if !selectors.is_empty() && after.is_empty() {
+            return (&name[..i], selectors);
+        }
+    }
+    (name, String::new())
+}
+
 fn parse_require_expr<'a>(input: &'a str, rest: &'a str) -> PResult<'a, Expr> {
     let (mut rest, _) = ws1(rest)?;
+    let mut dist_selectors = String::new();
     let (r_target, target_raw) =
         if let Ok((r_mod, mod_name)) = crate::parser::stmt::parse_sub_name_pub(rest) {
-            if r_mod.starts_with(":file(") {
+            let (bare_name, name_selectors) = split_dist_selectors_from_name(&mod_name);
+            let (after_selectors, trailing_selectors) = parse_require_dist_selectors(r_mod);
+            // A parenthesized selector is consumed but contributes no literal
+            // (its value is an arbitrary expression), so test what was consumed
+            // rather than what came back.
+            if r_mod.starts_with(":file(")
+                || !name_selectors.is_empty()
+                || after_selectors.len() != r_mod.len()
+            {
+                dist_selectors = format!("{name_selectors}{trailing_selectors}");
                 (
-                    r_mod,
+                    after_selectors,
                     Expr::Literal(Value::package(Symbol::intern(&normalize_raku_identifier(
-                        &mod_name,
+                        bare_name,
                     )))),
                 )
             } else {
@@ -140,6 +211,15 @@ fn parse_require_expr<'a>(input: &'a str, rest: &'a str) -> PResult<'a, Expr> {
     rest = r_target;
 
     let mut args = vec![target];
+    if !dist_selectors.is_empty() {
+        args.push(Expr::Binary {
+            left: Box::new(Expr::Literal(Value::str(
+                "__mutsu_require_dist_selectors".to_string(),
+            ))),
+            op: crate::token_kind::TokenKind::FatArrow,
+            right: Box::new(Expr::Literal(Value::str(dist_selectors))),
+        });
+    }
 
     match module_name_for_parse {
         Some(module_name) => {

--- a/src/parser/primary/misc/anon_decl.rs
+++ b/src/parser/primary/misc/anon_decl.rs
@@ -145,6 +145,7 @@ pub(crate) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
             language_version: crate::parser::current_language_version(),
             custom_traits: Vec::new(),
             is_unit: false,
+            implicit_grammar_parent: false,
             decl_id: crate::ast::next_class_decl_id(),
             parent_args: Vec::new(),
         })),
@@ -177,13 +178,29 @@ pub(crate) fn anon_grammar_expr(input: &str) -> PResult<'_, Expr> {
     if !rest.starts_with('{') {
         return Err(PError::expected("'{' for anonymous grammar"));
     }
-    let (rest, body) = parse_block_body(rest)?;
+    let (rest, mut body) = parse_block_body(rest)?;
+    // Same `also is Base` extraction the statement path does: this is the route a
+    // named `grammar G { also is Base }.parse(...)` takes.
+    let mut parents = vec!["Grammar".to_string()];
+    let mut implicit_grammar_parent = true;
+    body.retain(|stmt| {
+        if let Some(parent_name) = crate::parser::stmt::class::stmt_also_is_parent(stmt) {
+            crate::parser::stmt::class::push_also_is_parent(
+                &mut parents,
+                &mut implicit_grammar_parent,
+                parent_name,
+            );
+            false
+        } else {
+            true
+        }
+    });
     Ok((
         rest,
         Expr::DoStmt(Box::new(Stmt::ClassDecl {
             name: Symbol::intern(&name),
             name_expr: None,
-            parents: vec!["Grammar".to_string()],
+            parents,
             class_is_rw: false,
             is_hidden: false,
             is_lexical: false,
@@ -194,6 +211,7 @@ pub(crate) fn anon_grammar_expr(input: &str) -> PResult<'_, Expr> {
             language_version: crate::parser::current_language_version(),
             custom_traits: Vec::new(),
             is_unit: false,
+            implicit_grammar_parent,
             decl_id: crate::ast::next_class_decl_id(),
             parent_args: Vec::new(),
         })),

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -13,7 +13,7 @@ mod token_body;
 
 // Shared attribute / body validation helpers used across submodules.
 pub(crate) use attr_checks::{
-    null_regex_error, reject_no_self_in_attr_where, reject_no_self_in_subs,
+    null_regex_error, push_also_is_parent, reject_no_self_in_attr_where, reject_no_self_in_subs,
     reject_no_twigil_attr_at_body_level, stmt_also_is_parent, stmt_is_also_is_rw,
 };
 

--- a/src/parser/stmt/class/attr_checks.rs
+++ b/src/parser/stmt/class/attr_checks.rs
@@ -201,6 +201,29 @@ pub(crate) fn stmt_also_is_parent(stmt: &Stmt) -> Option<String> {
     }
 }
 
+/// Record an `also is <Parent>` parent on a package declaration.
+///
+/// A `grammar` declarator with no `is` clause carries an implicit `Grammar`
+/// parent. An `also is Parent` in the body **replaces** that implicit parent
+/// instead of adding a second one, which is what Rakudo does:
+/// `grammar G { also is Base }` linearizes as `G, Base, Grammar, ...` — exactly
+/// like `grammar G is Base { }` — and never as multiple inheritance from both.
+/// Keeping both would make the C3 merge inconsistent for every grammar whose
+/// base is itself a grammar ("Inconsistent class hierarchy"), which is how
+/// CSS::Grammar::CSS21 (`unit grammar ...; also is CSS::Grammar;`) failed to
+/// load.
+pub(crate) fn push_also_is_parent(
+    parents: &mut Vec<String>,
+    implicit_grammar_parent: &mut bool,
+    parent_name: String,
+) {
+    if *implicit_grammar_parent {
+        parents.retain(|p| p != "Grammar");
+        *implicit_grammar_parent = false;
+    }
+    parents.push(parent_name);
+}
+
 pub(crate) fn reject_no_self_in_subs(body: &[Stmt]) -> Result<(), PError> {
     for stmt in body {
         if let Stmt::SubDecl { body: sub_body, .. } = stmt

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -382,6 +382,7 @@ pub(crate) fn anon_class_decl(input: &str) -> PResult<'_, Stmt> {
         language_version: super::super::simple::current_language_version(),
         custom_traits: Vec::new(),
         is_unit: false,
+        implicit_grammar_parent: false,
         decl_id: crate::ast::next_class_decl_id(),
         parent_args: Vec::new(),
     };
@@ -600,12 +601,15 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
     reject_no_self_in_subs(&body)?;
     reject_no_self_in_attr_where(&body)?;
     reject_no_twigil_attr_at_body_level(&body)?;
+    // `class`/`role` bodies never carry an implicit `Grammar` parent; the flag
+    // exists so the shared helper can serve the grammar path too.
+    let mut implicit_grammar_parent = false;
     body.retain(|stmt| {
         if stmt_is_also_is_rw(stmt) {
             class_is_rw = true;
             false
         } else if let Some(parent_name) = stmt_also_is_parent(stmt) {
-            parents.push(parent_name);
+            push_also_is_parent(&mut parents, &mut implicit_grammar_parent, parent_name);
             false
         } else {
             true
@@ -660,6 +664,7 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
         language_version: super::super::simple::current_language_version(),
         custom_traits,
         is_unit: false,
+        implicit_grammar_parent: false,
         decl_id: crate::ast::next_class_decl_id(),
         parent_args,
     };

--- a/src/parser/stmt/class/grammar_module.rs
+++ b/src/parser/stmt/class/grammar_module.rs
@@ -192,7 +192,8 @@ fn grammar_decl_inner(input: &str, is_lexical: bool) -> PResult<'_, Stmt> {
     // self-parent filter in `exec_register_class_op`). Decided before the
     // `does` clauses are read: a composed role is not an `is` parent, so
     // `grammar G does R { }` must still inherit Grammar.
-    if parents.is_empty() {
+    let mut implicit_grammar_parent = parents.is_empty();
+    if implicit_grammar_parent {
         parents.push("Grammar".to_string());
     }
     let mut does_parents = Vec::new();
@@ -214,10 +215,25 @@ fn grammar_decl_inner(input: &str, is_lexical: bool) -> PResult<'_, Stmt> {
         let (r2, _) = ws(r2)?;
         r = r2;
     }
-    let (rest, body) = {
+    let (rest, mut body) = {
         let _pkg = super::super::simple::push_package_path(&name);
         block(r)?
     };
+    // A `grammar G { also is Base; }` body carries its parent the same way a
+    // `class` body does; without this extraction the bare `is(also, Base)`
+    // infix expression would reach the runtime as "two terms in a row".
+    body.retain(|stmt| {
+        if let Some(parent_name) = crate::parser::stmt::class::stmt_also_is_parent(stmt) {
+            crate::parser::stmt::class::push_also_is_parent(
+                &mut parents,
+                &mut implicit_grammar_parent,
+                parent_name,
+            );
+            false
+        } else {
+            true
+        }
+    });
     super::super::simple::register_user_type(&name);
     // `grammar G { ... }.parse($s)` is one expression; see `reject_trailing_postfix`.
     super::reject_trailing_postfix(rest)?;
@@ -237,6 +253,7 @@ fn grammar_decl_inner(input: &str, is_lexical: bool) -> PResult<'_, Stmt> {
             language_version: super::super::simple::current_language_version(),
             custom_traits: Vec::new(),
             is_unit: false,
+            implicit_grammar_parent,
             decl_id: crate::ast::next_class_decl_id(),
             parent_args,
         },

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -325,6 +325,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     language_version: super::super::simple::current_language_version(),
                     custom_traits,
                     is_unit: true,
+                    implicit_grammar_parent: false,
                     decl_id: crate::ast::next_class_decl_id(),
                     parent_args,
                 },
@@ -495,7 +496,8 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         // (see the self-parent filter in `exec_register_class_op`). A composed
         // role is not an `is` parent, so `unit grammar G does R;` must still
         // inherit Grammar.
-        if is_parent_count == 0 {
+        let implicit_grammar_parent = is_parent_count == 0;
+        if implicit_grammar_parent {
             parents.push("Grammar".to_string());
         }
         let (r, _) = opt_char(r, ';');
@@ -518,6 +520,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     language_version: super::super::simple::current_language_version(),
                     custom_traits: Vec::new(),
                     is_unit: true,
+                    implicit_grammar_parent,
                     decl_id: crate::ast::next_class_decl_id(),
                     parent_args: Vec::new(),
                 },

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -344,6 +344,7 @@ pub(crate) fn stmt_list_with_mode(
                     body,
                     parents,
                     class_is_rw,
+                    implicit_grammar_parent,
                     ..
                 } => {
                     // A `class Foo { ... }` block extracts `also is Parent` and
@@ -356,18 +357,20 @@ pub(crate) fn stmt_list_with_mode(
                     // explicit `is` clause. `also is Parent` supplies that direct
                     // parent in Raku; retaining both `Grammar` and a grammar that
                     // already inherits it makes the C3 merge inconsistent.
-                    let has_implicit_grammar_parent = parents.len() == 1 && parents[0] == "Grammar";
-                    let mut replaced_implicit_grammar_parent = false;
+                    // `implicit_grammar_parent` is what the declarator recorded,
+                    // so this also holds for `unit grammar G does R;` (whose
+                    // `parents` already carries the role) and does NOT fire for an
+                    // explicit `unit grammar G is Grammar;`.
                     tail_stmts.retain(|stmt| {
                         if class::stmt_is_also_is_rw(stmt) {
                             *class_is_rw = true;
                             false
                         } else if let Some(parent_name) = class::stmt_also_is_parent(stmt) {
-                            if has_implicit_grammar_parent && !replaced_implicit_grammar_parent {
-                                parents.clear();
-                                replaced_implicit_grammar_parent = true;
-                            }
-                            parents.push(parent_name);
+                            class::push_also_is_parent(
+                                parents,
+                                implicit_grammar_parent,
+                                parent_name,
+                            );
                             false
                         } else {
                             true

--- a/src/parser/stmt/sub/traits.rs
+++ b/src/parser/stmt/sub/traits.rs
@@ -141,7 +141,13 @@ pub(crate) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
             ));
         }
         if let Some(r_after) = keyword("handles", r) {
-            let (r_after, _) = ws1(r_after)?;
+            // No space before the angle-word list is legal — `method build
+            // handles<token node at-rule> { ... }` is how CSS::Grammar::Actions
+            // (and Raku's own documentation) spells it — so only OPTIONAL
+            // whitespace may be required here. `keyword` already guards the word
+            // boundary, so `handlesfoo` still never matches. The attribute form
+            // in `has_decl.rs` has always used `ws` for the same reason.
+            let (r_after, _) = ws(r_after)?;
             let mut rest_out = r_after;
             super::super::decl::parse_handle_specs(r_after, &mut handles, &mut rest_out)?;
             input = rest_out;

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -483,6 +483,7 @@ fn lower_class(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         language_version: crate::parser::current_language_version(),
         custom_traits: Vec::new(),
         is_unit: false,
+        implicit_grammar_parent: false,
         // A hand-built or lowered declaration has no parse-time site, which is
         // exactly what `decl_id: 0` means.
         decl_id: 0,

--- a/src/runtime/builtins_system_require.rs
+++ b/src/runtime/builtins_system_require.rs
@@ -608,11 +608,19 @@ impl Interpreter {
     pub(super) fn builtin_require(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         let mut module_value: Option<Value> = None;
         let mut file_target: Option<String> = None;
+        let mut dist_selectors = String::new();
         let mut imports: Vec<String> = Vec::new();
         for arg in args {
             match arg.view() {
                 ValueView::Pair(key, value) if key == "__mutsu_require_file" => {
                     file_target = Some(value.to_string_value());
+                }
+                // `require Foo:ver<1.2>:auth<zef:bar>` — the selectors refine
+                // which installed distribution is loaded, exactly as they do on
+                // `use`, but they are not part of the module's name: the stub
+                // installed below and the package this returns stay bare.
+                ValueView::Pair(key, value) if key == "__mutsu_require_dist_selectors" => {
+                    dist_selectors = value.to_string_value();
                 }
                 ValueView::Array(items, ..) => {
                     imports.extend(items.iter().map(|v| v.to_string_value()));
@@ -673,7 +681,11 @@ impl Interpreter {
                 crate::runtime::cow_table_mut(&mut self.loaded_modules).remove(module);
             }
             let saved = std::mem::replace(&mut self.require_propagates_missing_module, true);
-            let result = self.use_module(module);
+            let result = if dist_selectors.is_empty() {
+                self.use_module(module)
+            } else {
+                self.use_module(&format!("{module}{dist_selectors}"))
+            };
             self.require_propagates_missing_module = saved;
             result?;
         } else {

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -4,6 +4,53 @@ use super::methods_signature_errors::{
 use super::*;
 use crate::symbol::Symbol;
 
+/// Byte offset of the first extended-name adverb in a method name (`:sym<…>`,
+/// `:sym«…»`, `:sym[…]`, and the nameless `:<…>` spelling), or the name's length
+/// when it has none.
+///
+/// A proto-regex candidate puts arbitrary text inside that adverb, `::`
+/// included: `rule pseudo:sym<::element>` is real Raku (CSS::Grammar::CSS3
+/// spells the CSS3 pseudo-element selector exactly that way), and so is the
+/// action method `method pseudo:sym<::element>($/)` that matches it. Splitting
+/// such a name on `::` invented a package qualifier `pseudo:sym<` and a method
+/// `element>`, so the action never dispatched.
+fn extended_name_adverb_start(method: &str) -> usize {
+    let b = method.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] != b':' || b.get(i + 1) == Some(&b':') {
+            i += 1;
+            continue;
+        }
+        let mut j = i + 1;
+        while j < b.len() && (b[j].is_ascii_alphanumeric() || b[j] == b'_' || b[j] == b'-') {
+            j += 1;
+        }
+        let opens_value = method[j..].starts_with(['<', '[']) || method[j..].starts_with('\u{ab}');
+        if opens_value {
+            return i;
+        }
+        i = j.max(i + 1);
+    }
+    method.len()
+}
+
+/// Split a method name into `(package qualifier, method)` at the LAST `::` that
+/// is a package separator — one outside any extended-name adverb (see
+/// [`extended_name_adverb_start`]).
+fn split_method_qualifier_last(method: &str) -> Option<(&str, &str)> {
+    let cut = extended_name_adverb_start(method);
+    let at = method[..cut].rfind("::")?;
+    Some((&method[..at], &method[at + 2..]))
+}
+
+/// Like [`split_method_qualifier_last`], but splits at the FIRST package-separating `::`.
+fn split_method_qualifier_first(method: &str) -> Option<(&str, &str)> {
+    let cut = extended_name_adverb_start(method);
+    let at = method[..cut].find("::")?;
+    Some((&method[..at], &method[at + 2..]))
+}
+
 impl Interpreter {
     /// Handle private method calls on non-Instance, non-Package values.
     /// Returns Some(err) if handled, None to continue.
@@ -70,7 +117,7 @@ impl Interpreter {
         if method.starts_with('!') || !args.is_empty() {
             return None;
         }
-        let (qualifier, actual_method) = method.rsplit_once("::")?;
+        let (qualifier, actual_method) = split_method_qualifier_last(method)?;
         if !matches!(qualifier, "Mu" | "Any" | "Cool") {
             return None;
         }
@@ -138,7 +185,7 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
-        let (qualifier, actual_method) = method.rsplit_once("::")?;
+        let (qualifier, actual_method) = split_method_qualifier_last(method)?;
         if method.starts_with('!') {
             return None;
         }
@@ -668,7 +715,7 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
-        let (qualifier, actual_method) = method.rsplit_once("::")?;
+        let (qualifier, actual_method) = split_method_qualifier_last(method)?;
         if method.starts_with('!') {
             return None;
         }
@@ -846,7 +893,7 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
-        let (qualifier, actual_method) = method.split_once("::")?;
+        let (qualifier, actual_method) = split_method_qualifier_first(method)?;
         if method.starts_with('!') || matches!(target.view(), ValueView::Instance { .. }) {
             return None;
         }

--- a/src/runtime/receiver_class.rs
+++ b/src/runtime/receiver_class.rs
@@ -189,11 +189,21 @@ impl Interpreter {
             // code path in `Value::isa_check`) was already True.
             ValueView::Promise(p) => self.class_chain(&p.class_name().resolve()),
 
-            // Enum (V3): raku puts the enum type itself ahead of Int, unlike
-            // `value_type_name`'s "Int" answer for every enum value.
-            ValueView::Enum { enum_type, .. } => {
+            // Enum (V3): raku puts the enum type itself ahead of its base type,
+            // unlike `value_type_name`'s "Int" answer for every enum value. The
+            // base type is the one the enum's VALUES carry, not always `Int`:
+            // `our Str enum S «:A<a>»` (how CSS::Grammar::Defs declares every
+            // CSS selector/property type) makes `S::A` a `Str`/`Cool`, so a
+            // `Str $x` parameter accepts it and `S::A ~~ Int` is False.
+            ValueView::Enum {
+                enum_type, value, ..
+            } => {
                 let mut chain = vec![TypeId::from_symbol(enum_type)];
-                chain.extend(self.catalog_chain_for_name("Int"));
+                chain.extend(self.catalog_chain_for_name(match value {
+                    crate::value::EnumValue::Str(_) => "Str",
+                    crate::value::EnumValue::Int(_) => "Int",
+                    crate::value::EnumValue::Generic(_) => "Any",
+                }));
                 chain
             }
 

--- a/src/runtime/regex/regex_match_lazy_subrule.rs
+++ b/src/runtime/regex/regex_match_lazy_subrule.rs
@@ -104,8 +104,10 @@ impl Interpreter {
         // highest-priority) path to reach an end wins, later ones are dropped.
         let mut seen_ends: Vec<usize> = Vec::new();
         let mut unwind = false;
+        let mut seed_consulted_in_cont = false;
         {
             let unwind = &mut unwind;
+            let seed_consulted_in_cont = &mut seed_consulted_in_cont;
             let mut cont = |interp: &mut Interpreter, end: usize, inner: RegexCaptures| -> bool {
                 if seen_ends.contains(&end) {
                     return false;
@@ -120,7 +122,24 @@ impl Interpreter {
                 let Some((end, delta)) = wrapped.into_iter().next() else {
                     return false;
                 };
-                if on(interp, store, end, delta) {
+                // The continuation is the CALLER's remaining pattern, not this
+                // rule's body, so this activation must not be visible while it
+                // runs. A *sibling* call to the same rule at the same position
+                // is ordinary, not left recursion — and it is exactly what a
+                // `rule` with a bracketed group compiles to, since sigspace puts
+                // a `<.ws>` both at the end of the group and right after it
+                // (`'[' <.ws> [ <id> <.ws> ] <.ws> ']'`). Leaving the activation
+                // up made that second `<.ws>` read this one's empty seed and
+                // fail, so every such rule stopped matching as soon as the
+                // grammar defined its own `ws` (CSS::Grammar does). Lift it
+                // across the continuation and restore it for the rest of the
+                // body walk; the code-block re-entry the activation exists to
+                // catch happens inside the body, which is still covered.
+                *seed_consulted_in_cont |=
+                    super::regex_match_atom::lr_end_activation(&lr_key, outer_seed_read);
+                let stop = on(interp, store, end, delta);
+                super::regex_match_atom::lr_begin_activation(&lr_key);
+                if stop {
                     *unwind = true;
                     return true;
                 }
@@ -139,7 +158,8 @@ impl Interpreter {
                 &mut MatchSink::Cont(&mut cont),
             );
         }
-        let seed_consulted = super::regex_match_atom::lr_end_activation(&lr_key, outer_seed_read);
+        let seed_consulted = super::regex_match_atom::lr_end_activation(&lr_key, outer_seed_read)
+            || seed_consulted_in_cont;
         if seed_consulted && !unwind {
             // A `{ ... }` block re-entered this key after all, so the single
             // pass above is not the growing-seed loop's answer. Nothing has

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -16,11 +16,17 @@ impl Interpreter {
         fn is_word_boundary(rest: &str) -> bool {
             rest.is_empty() || !rest.starts_with(|c: char| c.is_ascii_alphanumeric() || c == '_')
         }
+        // A short modifier (`:i`, `:s`, `:r`, `:m`) ends wherever an identifier
+        // would: the next character just has to not continue the adverb's name.
+        // Anything else (a quote, bracket, backslash, metacharacter) is the
+        // start of the atom the modifier scopes over, and Rakudo needs no space
+        // there — `/:i'not('/` is how CSS::Grammar spells every case-insensitive
+        // CSS keyword. Requiring a space/`:`/`/` here silently left `:i'...'`
+        // unrecognized, which made the whole pattern fail to match.
+        // Longer adverbs (`:my`, `:sym<…>`, `:ss`) are still rejected, because
+        // their next character IS an identifier character.
         fn is_short_boundary(rest: &str) -> bool {
-            rest.is_empty()
-                || rest.starts_with(' ')
-                || rest.starts_with(':')
-                || rest.starts_with('/')
+            is_word_boundary(rest)
         }
         // Check negated long forms first
         if let Some(rest) = remaining.strip_prefix("!ratchet")

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -310,6 +310,11 @@ pub(crate) fn gist_value(value: &Value) -> String {
             let inner = cell.lock().unwrap().clone();
             gist_value(&inner)
         }
+        // An enum value gists as its KEY, even when the enum's base type makes
+        // its string context the value (`our Str enum S «:A<a>»`: `say S::A`
+        // prints "A", `~S::A` is "a"). Without this arm the gist fell through
+        // to `to_string_value`, which answers the Str-context form.
+        ValueView::Enum { key, .. } => key.resolve(),
         // Promise has no custom gist, so it gists in the default `.raku` form.
         ValueView::Promise(p) => {
             crate::builtins::methods_0arg::raku_repr::promise_raku_repr(&p.status())

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -786,7 +786,14 @@ impl Value {
             ValueView::ValuePair(k, v) => {
                 format!("{}\t{}", k.to_str_context(), v.to_str_context())
             }
-            ValueView::Enum { key, .. } => key.resolve(),
+            // String context is the enum's `.Str`, which for a base-typed
+            // `Str enum` is the VALUE, not the key (`our Str enum S «:A<a>»;
+            // ~S::A` is "a"). `.gist` keeps answering the key and has its own
+            // path, so only string context changes here.
+            ValueView::Enum { key, value, .. } => match value {
+                crate::value::EnumValue::Str(s) => s.to_string(),
+                _ => key.resolve(),
+            },
             ValueView::CompUnitDepSpec { short_name } => {
                 format!("CompUnit::DependencySpecification({})", short_name)
             }

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -921,6 +921,18 @@ impl Interpreter {
             ValueView::Num(_) => matches!(kind, T::Num | T::Wild),
             ValueView::Bool(_) => matches!(kind, T::Bool | T::Wild),
             ValueView::Rat(_, _) => matches!(kind, T::Rat | T::Wild),
+            // An enum value satisfies the base type its values carry (`our Str
+            // enum S «:A<a>»` — `S::A` is a `Str`) as well as its own enum type,
+            // which the catch-all `Wild`-only arm below cannot express. Mirrors
+            // the by-name `fast_type_check`.
+            ValueView::Enum {
+                enum_type, value, ..
+            } => match (kind, value) {
+                (T::Wild, _)
+                | (T::Str, crate::value::EnumValue::Str(_))
+                | (T::Int, crate::value::EnumValue::Int(_)) => true,
+                _ => enum_type == name_sym,
+            },
             // Every other value shape satisfies only `Any`/`Mu` -- the
             // by-name form's `_` arm compares `value_type_name(val)` against a
             // name that, on this path, is always one of the five concrete
@@ -1017,6 +1029,17 @@ impl Interpreter {
             && !matches!(type_name, "Any" | "Mu")
         {
             return sym.resolve() == type_name;
+        }
+        // An enum value satisfies the base type its values carry (`our Str enum
+        // S «:A<a>»` — `S::A` is a `Str`), which neither the by-name arms below
+        // nor `value_type_name` (which answers the enum's own name) can see.
+        if let ValueView::Enum { value: ev, .. } = val.view() {
+            return match (type_name, ev) {
+                ("Str", crate::value::EnumValue::Str(_))
+                | ("Int", crate::value::EnumValue::Int(_))
+                | ("Any" | "Mu", _) => true,
+                _ => runtime::value_type_name(val) == type_name,
+            };
         }
         match type_name {
             "Int" => matches!(val.view(), ValueView::Int(_) | ValueView::BigInt(_)),

--- a/t/grammar/grammar-action-sym-with-double-colon.t
+++ b/t/grammar/grammar-action-sym-with-double-colon.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# A proto-regex candidate's `:sym<...>` adverb holds arbitrary text, `::`
+# included: `rule pseudo:sym<::element>` is how CSS::Grammar::CSS3 spells the
+# CSS3 pseudo-element selector, and the matching action method is
+# `method pseudo:sym<::element>($/)`. Splitting such a method name on `::`
+# invented a package qualifier `pseudo:sym<` and a method `element>`, so the
+# action never dispatched ("Cannot dispatch to method element> on pseudo:sym<").
+
+plan 4;
+
+grammar G {
+    proto token pseudo {*}
+    token pseudo:sym<::element> { '::' $<element>=[<[\w-]>+] }
+    token pseudo:sym<:element>  { ':'  $<element>=[<[\w-]>+] }
+}
+
+class Acts {
+    method pseudo:sym<::element>($/) { make 'dcolon:' ~ $<element> }
+    method pseudo:sym<:element>($/)  { make 'colon:'  ~ $<element> }
+}
+
+is G.parse('::my-elem', :rule<pseudo>, :actions(Acts.new)).ast, 'dcolon:my-elem',
+    'a `::`-bearing sym dispatches its action method';
+is G.parse(':my-elem', :rule<pseudo>, :actions(Acts.new)).ast, 'colon:my-elem',
+    'the single-colon sibling still dispatches';
+
+ok Acts.^can('pseudo:sym<::element>'), 'the method is registered under its full name';
+
+# A genuine package qualifier outside the adverb still splits.
+class Parent { method m { 'parent' } }
+class Child is Parent { method m { 'child' } }
+is Child.new.Parent::m, 'parent', 'an ordinary qualified call is unaffected';

--- a/t/grammar/grammar-also-is-replaces-implicit-parent.t
+++ b/t/grammar/grammar-also-is-replaces-implicit-parent.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# A `grammar` declarator with no `is` clause carries an implicit `Grammar`
+# parent. An `also is Base` in the body REPLACES it instead of adding a second
+# parent, exactly as `grammar G is Base { }` would: keeping both makes the C3
+# merge inconsistent whenever `Base` is itself a grammar.
+#
+# From CSS::Grammar::CSS21 (`unit grammar CSS::Grammar::CSS21; use CSS::Grammar;
+# also is CSS::Grammar;`), whose load died with "Inconsistent class hierarchy for
+# CSS::Grammar::CSS21".
+
+plan 6;
+
+grammar Base { token foo { 'x' } }
+grammar Sub { also is Base; }
+
+ok Sub.parse('x', :rule<foo>).defined, 'block-form grammar inherits via `also is`';
+is Sub.^mro.map(*.^name).join(' '), 'Sub Base Grammar Match Capture Cool Any Mu',
+    'the implicit Grammar parent is replaced, not duplicated';
+
+class Plain { method zz { 7 } }
+grammar Declared is Plain { }
+grammar Also { also is Plain; }
+is Also.^mro.map(*.^name).skip(1).join(' '), Declared.^mro.map(*.^name).skip(1).join(' '),
+    '`also is` linearizes exactly like the declarator form';
+is Also.new.zz, 7, 'a non-grammar parent reached through `also is` still dispatches';
+
+grammar Roled does Positional { }
+ok Roled.^mro.map(*.^name).grep('Grammar'), 'a `does` role leaves the implicit Grammar parent alone';
+
+# The `unit grammar G; also is Base;` form gathers its parent from a trailing
+# statement rather than from the declarator, and must drop the implicit parent
+# just the same. `t/lib/AlsoIsUnitGrammar.rakumod` is that form.
+use lib $?FILE.IO.parent(2).add('lib').Str;
+use AlsoIsUnitGrammar;
+ok AlsoIsUnitGrammar.parse('y', :rule<bar>).defined,
+    '`unit grammar ...; also is Base;` inherits its base grammar';

--- a/t/lib/AlsoIsUnitGrammar.rakumod
+++ b/t/lib/AlsoIsUnitGrammar.rakumod
@@ -1,0 +1,3 @@
+unit grammar AlsoIsUnitGrammar;
+use AlsoIsUnitGrammarBase;
+also is AlsoIsUnitGrammarBase;

--- a/t/lib/AlsoIsUnitGrammarBase.rakumod
+++ b/t/lib/AlsoIsUnitGrammarBase.rakumod
@@ -1,0 +1,2 @@
+unit grammar AlsoIsUnitGrammarBase;
+token bar { 'y' }

--- a/t/modules/import-export/require-dist-selectors.t
+++ b/t/modules/import-export/require-dist-selectors.t
@@ -1,0 +1,20 @@
+use v6;
+use Test;
+
+# `require Foo:ver(...)` / `require Foo:ver<...>` — the distribution selectors
+# refine WHICH distribution is loaded, exactly as they do on `use`. They are not
+# import tags and not part of the module's name; without consuming them,
+# `require CSS::Grammar:ver(v0.3.3+)` (CSS::Module::CSS3::Selectors' t/00basic.t)
+# parsed as a call to an undeclared routine `CSS::Grammar:ver`.
+
+plan 5;
+
+lives-ok { EVAL 'require Test:ver(v0.0.1+)' }, 'parenthesized :ver selector';
+lives-ok { EVAL 'require Test:ver<0.0.1+>' }, 'angle-bracket :ver selector';
+lives-ok { EVAL 'require Test:ver<0.0.1+>:auth<perl>' }, 'stacked :ver / :auth selectors';
+lives-ok { EVAL 'require Test:v<0.0.1+>' }, ':v is the short spelling of :ver';
+
+# The selectors ride on the resolution, not on the name: the package `require`
+# installs and returns is still the bare one.
+is EVAL('(require Test:ver<0.0.1+>).^name'), 'Test',
+    'the installed package keeps its bare name';

--- a/t/oo/trait/method-handles-no-space.t
+++ b/t/oo/trait/method-handles-no-space.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+# `method build handles<token node list at-rule> { ... }` — the `handles` trait
+# needs no whitespace before its angle-word list, which is how Raku's own
+# documentation and CSS::Grammar::Actions spell it. Requiring a space left the
+# whole declaration unparsed, so even `build` itself was missing
+# ("No such method 'build' for invocant of type ...").
+
+plan 5;
+
+class Helper {
+    method greet($n) { "hi $n" }
+    method at-rule   { 'AR' }
+}
+
+class NoSpace {
+    method build handles<greet at-rule> { Helper }
+}
+class WithSpace {
+    method build handles <greet at-rule> { Helper }
+}
+
+is NoSpace.new.build.^name, 'Helper', 'the `handles`-carrying method itself is declared';
+is NoSpace.new.greet('x'), 'hi x', 'delegation reaches the returned object';
+is NoSpace.new.at-rule, 'AR', 'a hyphenated delegated name works';
+is WithSpace.new.greet('y'), 'hi y', 'the spaced spelling still works';
+
+# The attribute form has always accepted the tight spelling; keep it pinned.
+class Attr { has $.h handles<greet> = Helper.new }
+is Attr.new.greet('z'), 'hi z', 'attribute `handles<...>` is unaffected';

--- a/t/regex/regex-short-adverb-tight-atom.t
+++ b/t/regex/regex-short-adverb-tight-atom.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# A short inline regex adverb (`:i`, `:s`, `:r`, `:m`) ends wherever an
+# identifier would: the atom it scopes over may follow immediately, with no
+# space. mutsu required a space, a `:` or a `/` after it, so `/:i'not('/ —
+# how CSS::Grammar spells every case-insensitive CSS keyword — left the adverb
+# unrecognized and the whole pattern failed to match.
+
+plan 11;
+
+ok 'abc' ~~ /:i'abc'/,   ":i'...' with no space";
+ok 'ABC' ~~ /:i'abc'/,   ":i'...' still ignores case";
+ok 'not(' ~~ /:i'not('/, 'a literal containing a metacharacter';
+ok 'a[b' ~~ /:i'a[b'/,   'a literal containing a bracket';
+ok 'a c' ~~ /:i 'a c'/,  'the spaced spelling still works';
+
+ok "x\ny" ~~ /:i"x\ny"/, 'a newline between the adverb and its atom is fine';
+ok 'AB' ~~ /:i<[ab]>+/,  ':i before a character class';
+
+# Longer adverbs must NOT be mistaken for a short one plus text.
+grammar G {
+    rule  r { :my $*seen = 1; 'a' { $*seen = 2 } 'b' }
+    proto token p {*}
+    token p:sym<ss> { 'ss' }
+    token ratchety { :r 'ab' }
+}
+ok G.parse('a b', :rule<r>).defined, ':my is not read as :m + "y"';
+ok G.parse('ss', :rule<p>).defined,  ':sym<...> is not read as :s + "ym..."';
+ok G.parse('ab', :rule<ratchety>).defined, ':r still parses';
+
+nok 'abc' ~~ /:i'xyz'/, 'a non-matching tight literal still fails';

--- a/t/regex/regex-sibling-subrule-same-position.t
+++ b/t/regex/regex-sibling-subrule-same-position.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+# Two calls to the SAME subrule at the same position are siblings, not left
+# recursion. The streamed subrule path held its left-recursion activation across
+# the continuation, so the second call read that activation's empty seed and
+# failed.
+#
+# Every `rule` with a bracketed group compiles to exactly that shape — sigspace
+# puts a `<.ws>` at the end of the group AND right after it
+# (`'[' <.ws> [ <id> <.ws> ] <.ws> ']'`) — so a grammar that defines its own
+# `ws` stopped matching any such rule. CSS::Grammar does
+# (`token ws { <!ww>[ <.wc> | <.comment> ]* }`), which took out `attrib`,
+# `pseudo-function` and most of the CSS3 selector grammar.
+
+plan 8;
+
+grammar A {
+    token zz { \s* }
+    token id { <[\w-]>+ }
+    token flat     {   <id> <.zz>   <.zz> ']' }
+    token grouped  { [ <id> <.zz> ] <.zz> ']' }
+    token grouped3 { [ <id> <.zz> ] <.zz> <.zz> ']' }
+    token inner    { [ <id> <.zz> ] ']' }
+    token outer    { [ <id> ]       <.zz> ']' }
+    token consumes { [ <id> <.zz> ] <.zz> ']' }
+}
+
+ok A.subparse('hello]', :rule<flat>).defined,     'two flat sibling calls at one position';
+ok A.subparse('hello]', :rule<grouped>).defined,  'a group-final call and the call after it';
+ok A.subparse('hello]', :rule<grouped3>).defined, 'three sibling calls at one position';
+ok A.subparse('hello]', :rule<inner>).defined,    'the group-final call alone';
+ok A.subparse('hello]', :rule<outer>).defined,    'the call after the group alone';
+ok A.subparse('hello  ]', :rule<consumes>).defined, 'the inner call consuming moves the outer one';
+
+grammar CustomWs {
+    token wc { \n | "\t" | " " }
+    token ws { <!ww>[ <.wc> ]* }
+    token id { <[\w-]>+ }
+    rule  bracketed { '[' [ <id> ] ']' }
+}
+ok CustomWs.subparse('[hello]', :rule<bracketed>).defined,
+    'a bracketed group in a rule of a grammar with its own `ws`';
+ok CustomWs.subparse('[ hello ]', :rule<bracketed>).defined,
+    '... and with real whitespace to consume';

--- a/t/types/enum-subset/enum-declared-base-type.t
+++ b/t/types/enum-subset/enum-declared-base-type.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# `our Str enum S «:A<a-val>»` — the base type the enum's VALUES carry is part
+# of the enum's identity: its values ARE `Str`s, they are not `Int`s, and string
+# context gives the value while `.gist` keeps the key. mutsu hardcoded `Int` as
+# every enum's base, so `sub f(Str $x)` rejected such a value ("expected Str but
+# got Int") and `~S::A` answered the key.
+#
+# From CSS::Grammar::Defs, which declares every CSS selector/property type as a
+# `Str enum` and passes the values to `Str $type` parameters.
+
+plan 14;
+
+our Str enum Sel « :Alpha<a-val> :Beta<b-val> »;
+enum IntE <X Y>;
+
+ok Sel::Alpha ~~ Str,   'a Str-enum value is a Str';
+ok Sel::Alpha ~~ Cool,  'a Str-enum value is Cool';
+nok Sel::Alpha ~~ Int,  'a Str-enum value is not an Int';
+nok Sel::Alpha ~~ Real, 'a Str-enum value is not Real';
+ok Sel::Alpha ~~ Sel,   'a Str-enum value is still its own enum type';
+
+ok IntE::X ~~ Int,  'an ordinary enum value is an Int';
+nok IntE::X ~~ Str, 'an ordinary enum value is not a Str';
+
+sub positional(Str $x) { $x }
+sub named(Str :$x) { $x }
+is positional(Sel::Alpha), 'a-val', 'a Str-enum value binds to a positional Str parameter';
+is named(:x(Sel::Beta)), 'b-val', 'a Str-enum value binds to a named Str parameter';
+
+is Sel::Alpha.Str, 'a-val', '.Str is the value';
+is ~Sel::Alpha, 'a-val', 'string context is the value';
+my $v = Sel::Alpha;
+is "$v", 'a-val', 'interpolation is the value';
+is Sel::Alpha.gist, 'Alpha', '.gist is still the key';
+is IntE::Y.Str, 'Y', 'an ordinary enum still stringifies to its key';


### PR DESCRIPTION
## Distribution

`CSS::Module::CSS3::Selectors` 0.0.6 (`pure` axis), drawn at random from the
`ecosystem/` ledger and locked on #7884.

| | before | after |
|---|---|---|
| record status | `blocked_load` | `red` |
| provided modules that load | 0 of 2 | 2 of 2 |
| baseline files | 0 | 1 (`t/00basic.t`) |
| assertions | 0 of 92 reachable | **80 of 92 pass** (rakudo: 92/92) |

## What was fixed

Seven gaps, none of them specific to CSS. Each was reduced to a few lines that
run from this repo, checked against the `raku` oracle, and pinned by a focused
`t/` test. Full write-up in `news/2026-09/css-module-css3-selectors-blocked-load.md`.

1. **`also is Base` on a grammar replaces the implicit `Grammar` parent.**
   Keeping both asked for multiple inheritance from `Grammar` and from a grammar
   that itself inherits `Grammar` — a C3 merge with no linearization, reported as
   "Inconsistent class hierarchy for CSS::Grammar::CSS21". Rakudo linearizes
   `grammar G { also is Base }` exactly like `grammar G is Base { }`. Separately,
   the block form was not extracting its parent from the body at all, so it
   reached the runtime as a bare `is(also, Base)` infix ("Two terms in a row");
   it now shares the extraction the `class` and unit forms use, including the
   named-grammar expression path taken by `grammar G { … }.parse($s)`.

2. **`require Foo:ver(…)` / `:ver<…>` distribution selectors.** Previously parsed
   as a call to an undeclared routine `Foo:ver`. The angle-bracket form is carried
   through to `use_module`, where `split_dist_selectors` / `select_dist_candidate`
   already refine which installed distribution is loaded; the parenthesized form
   holds an arbitrary expression and is discarded, exactly as `use` already
   discards it. The module's own name stays bare.

3. **A `::` inside a `:sym<…>` is part of the method's name.** Qualified method
   dispatch split every name on its last `::`, so the action method for
   `rule pseudo:sym<::element>` was looked up as method `element>` on package
   `pseudo:sym<` and never fired.

4. **`method build handles<…>` needs no space** before its angle-word list —
   the spelling Raku's own documentation and `CSS::Grammar::Actions` use.
   Requiring one left the whole declaration unparsed, taking `build` with it.

5. **A `Str enum`'s values really are `Str`s.** `Int` was hardcoded as every
   enum's base in `dispatch_mro` and in the VM's two fast parameter type checks,
   and string context answered the key. `sub f(Str $x)` therefore rejected
   `CSSSelector::PseudoElement` with "expected Str but got Int". The declared
   base type now decides ancestry, type checks and string context; `.gist` still
   answers the key (`say S::A` → `A`, `~S::A` → `a-val`).

6. **`:i'literal'` with no space.** A short inline regex adverb only ended at a
   space, `:` or `/`, so `/:i'not('/` — and `:i` followed by a newline — left the
   adverb unrecognized and the pattern unmatched. It now ends wherever an
   identifier would; `:my`, `:sym<…>` and `:ss` are still rejected.

7. **Two calls to the same subrule at one position are siblings, not left
   recursion.** The streamed subrule path held its left-recursion activation
   across the caller's *continuation*, so the second call read that activation's
   empty seed and failed. Every `rule` containing a bracketed group compiles to
   exactly that shape (`'[' <.ws> [ <id> <.ws> ] <.ws> ']'`), so a grammar that
   declares its own `ws` — as CSS::Grammar does — stopped matching **any** rule
   with a group in it. The activation is now lifted across the continuation and
   restored for the rest of the body walk, so the code-block re-entry it exists
   to catch is still covered.

## Still red, each with an issue

- #7909 — `Grammar.parse(:rule<proto>)` commits to one proto candidate and never falls through (as a *subrule* it already does).
- #7910 — `$<name>=<.subrule>` does not run the subrule's action, so the aliased capture's `.ast` is `Nil`. 8 of the 12 remaining assertions.
- #7912 — a `(` inside a `<?before '…'>` literal makes a quantified `||` group stop matching, so the nested-`:not()` guard never fires.
- #7913 — `Pair.raku` renders a `Str`-enum key as `Enum::Key => value` rather than `:key(value)` (diagnostic only; `to-json` agrees).

One finding unrelated to this suite's result, recorded rather than dropped:
#7914 — an imported enum key overwrites a same-named lexical scalar, because
enum keys and scalars share mutsu's sigil-less env namespace
(`CSS::Grammar::Defs` exports `:s<time>`, which replaces any `my $s`).

## Tests

New pins:

- `t/grammar/grammar-also-is-replaces-implicit-parent.t` (+ two `t/lib` fixtures for the `unit grammar` form)
- `t/grammar/grammar-action-sym-with-double-colon.t`
- `t/modules/import-export/require-dist-selectors.t`
- `t/oo/trait/method-handles-no-space.t`
- `t/types/enum-subset/enum-declared-base-type.t`
- `t/regex/regex-short-adverb-tight-atom.t`
- `t/regex/regex-sibling-subrule-same-position.t`

All seven pass under `raku` as well as mutsu.

## Verification

- `cargo fmt --all`, `make lint` — clean (all four configurations).
- `make test` — `Files=3972, Tests=42219, Result: PASS`.
- `make roast` — the only two files with real failures are
  `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8, 10) and
  `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64, 69-72, 77-80,
  101/103/105/107/109/111/117/121/125), which is exactly the `uid 0` set
  documented in `docs/agent-environments.md` (`id -u` is `0` here, so root
  bypasses the permission bits those tests assert on). Every other entry in the
  summary is a `TODO passed`, which does not fail a file. `IO-Socket-Async.t`
  passed this run.
- Ledger record re-measured against the release binary at `99075c8`
  (`--only … --sandbox none`); only the dist's own record is committed, not the
  index snapshot the sweep also refreshed.

Locked on #7884 for the duration of the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1aZJBmQrw2WwyUpAhwhxk

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1aZJBmQrw2WwyUpAhwhxk)_