### PR TITLE
feat(parser): C99 hexadecimal float literals (0x1.8p+1)

### DIFF
--- a/news/2026-09/c99-hexadecimal-float-literals.md
+++ b/news/2026-09/c99-hexadecimal-float-literals.md
@@ -1,0 +1,54 @@
+# C99 hexadecimal float literals (`0x1.8p+1`)
+
+mutsu now parses C99 hexadecimal floating-point literals — a hex mantissa with
+an optional `.` fraction and a mandatory `p`/`P` binary exponent, yielding a
+plain `Num`. This is the literal syntax rakudo tracks as
+[rakudo/rakudo#6524](https://github.com/rakudo/rakudo/issues/6524) and that the
+2026-09-07 roast re-vendor added eighteen subtests for in
+`S02-literals/numeric.t`.
+
+Before this, the number lexer recognised `0x` plus hex digits as an `Int` and
+stopped, so `say 0x1.8p+1` lexed as a hex integer followed by a postfix method
+call and died with `No such method '8p' for invocant of type 'Int'`. Because a
+parse error aborts compilation, that single unparsable literal cost the whole
+89-subtest file, not just the eighteen new subtests.
+
+## The ambiguity, and what resolves it
+
+After a `.` following hex digits, the lexer has to choose between a hexfloat
+fraction and a method call on a hex integer — `0x1.abs` scans `ab` as perfectly
+good hex digits. The `p`/`P` exponent is the only disambiguator, and it can
+appear after a fraction (`0x1.8p+1`), directly after the integer part
+(`0x1p-2`), or with no integer part at all (`0x.8p+1`).
+
+The new `src/parser/primary/hexfloat.rs` therefore scans the whole candidate
+literal speculatively and commits only once it has seen the `p`/`P` *and* at
+least one exponent digit; anything short of that returns a non-fatal parse error
+and the input falls through to the existing radix-integer path unchanged. A
+fraction is taken only when the `.` is followed by a hex digit, which keeps
+`0x1.p3` a method call too. `0x1.abs` still evaluates to `1`, and `0x1.8` — a
+hex float with no binary exponent — is still a compile error.
+
+## Correct rounding, in one step
+
+Rust's `f64` has no hexfloat parser, so the conversion is ours. A naive
+`mantissa * 2f64.powi(exp)` double-rounds and gets the interesting cases wrong,
+which is exactly what the spec subtests probe. Instead the mantissa digits
+(underscore separators stripped) become an exact `BigUint`, the fraction width
+and the binary exponent collapse into a single scale, and the exact value
+`m * 2^exp` is rounded **once** to the nearest `f64` with ties to even.
+
+The rounding quantum is `max(leading_exponent - 52, -1074)`, which is what makes
+the subnormal grid fall out of the same code path as the normal one: at
+`0x1.8p-1074` the exact value sits midway between two subnormals and ties-to-even
+picks `1e-323`, while `0x0.8p-1074` ties down to zero. Exponents are clamped
+before any shifting, so `0x1p+9999` gives `Inf` and `0x1p-9999` gives `0e0`
+without materialising anything large. Underscores are legal in both the mantissa
+(`0xde_ad.be_efp+0`) and the exponent (`0x1p+1_0`).
+
+With this in place all 89 subtests of the re-vendored
+`roast/S02-literals/numeric.t` pass, including the eighteen new ones — a file
+the local rakudo v2026.07 oracle still rejects outright with `===SORRY!===`.
+
+Pinned by `t/lang/literal-hex-float.t` (29 assertions) and four unit tests in
+the new module.

--- a/src/parser/primary/hexfloat.rs
+++ b/src/parser/primary/hexfloat.rs
@@ -1,0 +1,306 @@
+//! C99 hexadecimal floating-point literals (`0x1.8p+1`), per rakudo/rakudo#6524
+//! and `roast/S02-literals/numeric.t`.
+//!
+//! The literal is `0x` / `0X`, a hex mantissa with an optional `.` fraction,
+//! then a mandatory `p` / `P` binary exponent written in decimal. The exponent
+//! is what makes it a float: without it, `0x1.abs` must keep parsing as a
+//! method call on the hex integer `0x1`, and `0x1.8` must stay a syntax error.
+//! So this scanner commits to the float reading only once it has seen the
+//! `p`/`P` *and* its digits, and otherwise returns a non-fatal error so the
+//! ordinary radix-integer path gets its turn.
+//!
+//! Rust's `f64` has no hexfloat parser, so the conversion is done here: the
+//! mantissa digits become an exact `BigUint`, the fraction and the exponent
+//! collapse into a single binary scale, and the exact value `m * 2^exp` is
+//! rounded once to the nearest `f64` with ties to even. Doing it in one
+//! rounding step is what makes the subnormal, overflow and underflow cases
+//! come out right — a naive `mantissa * 2f64.powi(exp)` double-rounds.
+
+use super::super::parse_result::{PError, PResult};
+use crate::ast::Expr;
+use crate::value::Value;
+
+use num_bigint::BigUint;
+use num_traits::{One, ToPrimitive, Zero};
+
+/// Largest binary exponent worth tracking. Anything past this is unambiguously
+/// an overflow to `Inf` or an underflow to zero, so clamping keeps the shift
+/// arithmetic in range without changing any representable result.
+const EXP_CLAMP: i128 = 1 << 40;
+
+fn hex_digit_value(c: char) -> Option<u32> {
+    c.to_digit(16)
+}
+
+/// Scan a run of hex digits, allowing a single `_` **between** two digits.
+/// Returns the remaining input and the digits with the separators removed.
+fn scan_hex_digits(input: &str) -> (&str, String) {
+    let mut clean = String::new();
+    let mut end = 0;
+    let mut chars = input.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if c == '_' {
+            if clean.is_empty() {
+                break;
+            }
+            let next_is_digit = chars
+                .peek()
+                .is_some_and(|(_, nc)| hex_digit_value(*nc).is_some());
+            if !next_is_digit {
+                break;
+            }
+            end = i + c.len_utf8();
+            continue;
+        }
+        match hex_digit_value(c) {
+            Some(_) => {
+                clean.push(c);
+                end = i + c.len_utf8();
+            }
+            None => break,
+        }
+    }
+    (&input[end..], clean)
+}
+
+/// Scan the decimal exponent digits, allowing a single `_` between two digits.
+fn scan_exponent_digits(input: &str) -> (&str, String) {
+    let mut clean = String::new();
+    let mut end = 0;
+    let mut chars = input.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if c == '_' {
+            if clean.is_empty() {
+                break;
+            }
+            let next_is_digit = chars.peek().is_some_and(|(_, nc)| nc.is_ascii_digit());
+            if !next_is_digit {
+                break;
+            }
+            end = i + c.len_utf8();
+            continue;
+        }
+        if c.is_ascii_digit() {
+            clean.push(c);
+            end = i + c.len_utf8();
+            continue;
+        }
+        break;
+    }
+    (&input[end..], clean)
+}
+
+/// Parse a C99 hexadecimal float literal, e.g. `0x1.8p+1`.
+///
+/// Returns a non-fatal `PError` whenever the input is not one, so that `0x1`,
+/// `0x1.abs` and `0x1.8` all fall through to the radix-integer parser and keep
+/// their existing meanings.
+pub(super) fn hex_float(input: &str) -> PResult<'_, Expr> {
+    // Deliberately the same expectation the integer parser reports, so that
+    // merely trying a hexfloat first does not add a new alternative to the
+    // "expected ... or ... or ..." list of every unrelated parse failure.
+    let rest = input
+        .strip_prefix("0x")
+        .or_else(|| input.strip_prefix("0X"))
+        .ok_or_else(|| PError::expected("digits"))?;
+
+    let (rest, int_digits) = scan_hex_digits(rest);
+
+    // A fraction is taken only when the `.` is actually followed by a hex
+    // digit. `0x1.p3` therefore stays a method call, and so does `0x1.abs`
+    // (which does scan a fraction `ab`, but then finds no `p` exponent and
+    // rewinds wholesale by returning an error).
+    let (rest, frac_digits) = match rest.strip_prefix('.') {
+        Some(after_dot) if after_dot.starts_with(|c: char| hex_digit_value(c).is_some()) => {
+            let (r, digits) = scan_hex_digits(after_dot);
+            (r, digits)
+        }
+        _ => (rest, String::new()),
+    };
+
+    if int_digits.is_empty() && frac_digits.is_empty() {
+        return Err(PError::expected("hexadecimal float mantissa"));
+    }
+
+    let after_p = rest
+        .strip_prefix(['p', 'P'])
+        .ok_or_else(|| PError::expected("binary exponent in hexadecimal float literal"))?;
+
+    let (after_sign, negative_exp) = if let Some(r) = after_p.strip_prefix('+') {
+        (r, false)
+    } else if let Some(r) = after_p.strip_prefix('-') {
+        (r, true)
+    } else if let Some(r) = after_p.strip_prefix('\u{2212}') {
+        // U+2212 MINUS SIGN, normalized to ASCII minus like the `e` exponent.
+        (r, true)
+    } else {
+        (after_p, false)
+    };
+
+    let (rest, exp_digits) = scan_exponent_digits(after_sign);
+    if exp_digits.is_empty() {
+        return Err(PError::expected(
+            "digits in the binary exponent of a hexadecimal float literal",
+        ));
+    }
+
+    let magnitude: i128 = exp_digits
+        .parse::<i128>()
+        .unwrap_or(EXP_CLAMP)
+        .min(EXP_CLAMP);
+    let exponent = if negative_exp { -magnitude } else { magnitude };
+
+    let mantissa_digits = format!("{}{}", int_digits, frac_digits);
+    let mantissa =
+        BigUint::parse_bytes(mantissa_digits.as_bytes(), 16).unwrap_or_else(BigUint::zero);
+    // Each fraction digit is four binary places, folded into one scale.
+    let scale = exponent - 4 * frac_digits.len() as i128;
+
+    let value = scale_to_f64(&mantissa, scale);
+    Ok((rest, Expr::Literal(Value::num(value))))
+}
+
+/// Round the exact value `mantissa * 2^exp` to the nearest `f64`, ties to even.
+///
+/// Correct for the whole range: normals, subnormals (where the quantum is
+/// pinned at `2^-1074` rather than 53 significant bits), exponent overflow to
+/// `Inf`, and exponent underflow to `0`.
+fn scale_to_f64(mantissa: &BigUint, exp: i128) -> f64 {
+    if mantissa.is_zero() {
+        return 0.0;
+    }
+    let bits = mantissa.bits() as i128;
+    // Binary exponent of the mantissa's leading one.
+    let leading = bits - 1 + exp;
+    if leading > 1023 {
+        return f64::INFINITY;
+    }
+    // The value is rounded to a multiple of 2^quantum: 53 significant bits for
+    // a normal, or the fixed 2^-1074 grid once it goes subnormal.
+    let quantum = std::cmp::max(leading - 52, -1074);
+    let shift = quantum - exp;
+
+    let rounded: BigUint = if shift <= 0 {
+        // `shift` is bounded below by `bits - 53 >= -52`, so this never
+        // materializes a large number.
+        mantissa << ((-shift) as usize)
+    } else if shift > bits {
+        // Strictly less than half a quantum: everything rounds away.
+        BigUint::zero()
+    } else {
+        let s = shift as usize;
+        let truncated = mantissa >> s;
+        let half = BigUint::one() << (s - 1);
+        let remainder = mantissa - (&truncated << s);
+        match remainder.cmp(&half) {
+            std::cmp::Ordering::Greater => truncated + BigUint::one(),
+            std::cmp::Ordering::Less => truncated,
+            std::cmp::Ordering::Equal => {
+                if (&truncated & BigUint::one()).is_one() {
+                    truncated + BigUint::one()
+                } else {
+                    truncated
+                }
+            }
+        }
+    };
+
+    if rounded.is_zero() {
+        return 0.0;
+    }
+    // After rounding to at most 53 bits (54 if a carry propagated) the
+    // significand always fits a u64.
+    let Some(significand) = rounded.to_u64() else {
+        return f64::INFINITY;
+    };
+    let width = 64 - significand.leading_zeros() as i128;
+    let leading = width - 1 + quantum;
+    if leading > 1023 {
+        return f64::INFINITY;
+    }
+    if leading < -1022 {
+        // Subnormal: the quantum is 2^-1074, so the significand *is* the
+        // fraction field.
+        return f64::from_bits(significand);
+    }
+    // A carry out of the 53rd bit means the significand is exactly 2^53; drop
+    // the (zero) low bit to renormalize, which leaves `leading` unchanged.
+    let significand = if width == 54 {
+        significand >> 1
+    } else {
+        significand
+    };
+    let fraction = significand & ((1u64 << 52) - 1);
+    let biased = (leading + 1023) as u64;
+    f64::from_bits((biased << 52) | fraction)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(src: &str) -> f64 {
+        match hex_float(src) {
+            Ok((rest, Expr::Literal(v))) => {
+                assert_eq!(rest, "", "unconsumed input for {src}");
+                match v.view() {
+                    crate::value::ValueView::Num(n) => n,
+                    other => panic!("{src} produced {other:?}, expected Num"),
+                }
+            }
+            Ok((_, other)) => panic!("{src} produced {other:?}"),
+            Err(e) => panic!("{src} failed to parse: {e:?}"),
+        }
+    }
+
+    #[test]
+    fn spec_table() {
+        assert_eq!(parse("0x1.8p+1"), 3.0);
+        assert_eq!(parse("0x1p-2"), 0.25);
+        assert_eq!(parse("0x.8p+1"), 1.0);
+        assert_eq!(parse("0x1.8P4"), 24.0);
+        assert_eq!(parse("0x1.999999999999ap-4"), 0.1);
+        assert_eq!(parse("0xde_ad.be_efp+0"), parse("0xdead.beefp0"));
+        assert_eq!(parse("0x1p+1_0"), 1024.0);
+        assert_eq!(parse("0x1.fffffffffffffp+1023"), f64::MAX);
+        assert_eq!(parse("0x1p-1022"), f64::MIN_POSITIVE);
+        assert_eq!(parse("0x1p-1074"), 5e-324);
+        assert_eq!(parse("0x1.8p-1074"), 1e-323);
+        assert_eq!(parse("0x1p+9999"), f64::INFINITY);
+        assert_eq!(parse("0x1p-9999"), 0.0);
+        assert!(parse("0x0p+0").is_sign_positive());
+        assert_eq!(parse("0x0p+0"), 0.0);
+    }
+
+    #[test]
+    fn ties_round_to_even() {
+        // 2^-1074 * 1.5 sits exactly between two subnormals; the even one wins.
+        assert_eq!(parse("0x1.8p-1074"), 2.0 * 5e-324);
+        // 2^-1074 * 0.5 is exactly half the smallest subnormal: ties to even
+        // means zero.
+        assert_eq!(parse("0x0.8p-1074"), 0.0);
+        // Just over half rounds up instead.
+        assert_eq!(parse("0x0.81p-1074"), 5e-324);
+    }
+
+    #[test]
+    fn not_a_hexfloat() {
+        // No exponent at all: the integer parser must get these back.
+        assert!(hex_float("0x1.abs").is_err());
+        assert!(hex_float("0x1.8").is_err());
+        assert!(hex_float("0x1").is_err());
+        assert!(hex_float("0x1.pi").is_err());
+        // `p` with no digits after it is not an exponent either.
+        assert!(hex_float("0x1p").is_err());
+        assert!(hex_float("0x1p+").is_err());
+        // Not a hex literal to begin with.
+        assert!(hex_float("42").is_err());
+        assert!(hex_float("0b1p+1").is_err());
+    }
+
+    #[test]
+    fn stops_at_the_end_of_the_literal() {
+        let (rest, _) = hex_float("0x1p+1, 2").expect("parses");
+        assert_eq!(rest, ", 2");
+    }
+}

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use container::angle_list;
 pub(in crate::parser) mod ident;
 pub(in crate::parser) mod misc;
 pub(crate) use misc::next_anon_role_name;
+mod hexfloat;
 mod number;
 pub(in crate::parser) mod quote_adverbs;
 pub(crate) mod regex;
@@ -295,6 +296,7 @@ pub(super) fn primary(input: &str) -> PResult<'_, Expr> {
         }
 
         try_primary!(number::dot_decimal(input));
+        try_primary!(hexfloat::hex_float(input));
         try_primary!(number::decimal(input));
         try_primary!(number::integer(input));
         try_primary!(number::generic_radix(input));

--- a/t/lang/literal-hex-float.t
+++ b/t/lang/literal-hex-float.t
@@ -1,0 +1,54 @@
+use Test;
+
+# C99 hexadecimal floating point literals - rakudo/rakudo#6524.
+# Mirrors the table in roast/S02-literals/numeric.t, plus the edge cases that
+# only a single correctly-rounded conversion gets right.
+
+plan 29;
+
+isa-ok 0x1.8p+1, Num, 'hexfloat literal produces a Num';
+
+is-deeply 0x1.8p+1,  3e0,    'hexfloat with fraction';
+is-deeply 0x1p-2,    0.25e0, 'hexfloat without fraction, negative exponent';
+is-deeply 0x.8p+1,   1e0,    'hexfloat without integer part';
+is-deeply 0x1.8P4,   24e0,   'capital P exponent without sign';
+is-deeply -0x1.8p+1, -3e0,   'negated hexfloat';
+is-deeply 0X1.8p+1,  3e0,    'capital X prefix';
+
+is-deeply 0x1.999999999999ap-4, 0.1e0, 'full-precision mantissa';
+is-deeply 0xde_ad.be_efp+0, 0xdead.beefp0, 'underscores in mantissa';
+is-deeply 0x1p+1_0, 1024e0, 'underscore in exponent';
+
+is-deeply 0x1.fffffffffffffp+1023, 1.7976931348623157e308, 'largest double';
+is-deeply 0x1p-1022, 2.2250738585072014e-308, 'smallest normal';
+is-deeply 0x1p-1074, 5e-324, 'smallest subnormal';
+is-deeply 0x1.8p-1074, 1e-323, 'subnormal tie rounds to even';
+is-deeply 0x0.8p-1074, 0e0, 'half the smallest subnormal ties down to zero';
+is-deeply 0x0.81p-1074, 5e-324, 'just over half rounds up';
+
+is-deeply 0x1p+9999, Inf, 'exponent overflow gives Inf';
+is-deeply 0x1p-9999, 0e0, 'exponent underflow gives 0';
+is-deeply -0x1p+9999, -Inf, 'negated overflow gives -Inf';
+ok (-0x0p+0) === -0e0, 'negative zero survives';
+
+# Rounding of a mantissa wider than the 53 bits a double holds: the exact value
+# is 2^53 + 1, which has no double, and ties-to-even takes it down to 2^53.
+is-deeply 0x2000000000000_1p+0, 9007199254740992e0, 'over-wide mantissa rounds to even';
+is-deeply 0x2000000000000_3p+0, 9007199254740996e0, 'over-wide mantissa rounds up';
+
+# The literal is a term like any other, so it composes.
+is-deeply 0x1p+1 + 0x1p+1, 4e0, 'hexfloats add';
+is-deeply (0x1p+2, 0x1p+3), (4e0, 8e0), 'hexfloats in a list';
+
+# Unchanged behaviours: the p/P exponent is the only thing that makes a hex
+# literal a float.
+is-deeply 0x1.abs, 1, 'method call on hex integer literal still works';
+is-deeply 0xff, 255, 'plain hex integer literal still works';
+is-deeply 0x1.Str, '1', 'another method call on a hex integer literal';
+
+throws-like '0x1.8', Exception,
+    'hexfloat without binary exponent is still an error';
+throws-like '0x1p', Exception,
+    'binary exponent without digits is still an error';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Closes #7902.

The number lexer recognised `0x` plus hex digits as an `Int` and stopped, so `say 0x1.8p+1` lexed as the hex integer `0x1` followed by a postfix method call and died with `No such method '8p' for invocant of type 'Int'`. A parse error aborts compilation, so that one unparsable literal costs the whole 89-subtest `roast/S02-literals/numeric.t`, not just the 18 subtests the 2026-09-07 roast re-vendor added for it (rakudo/rakudo#6524).

## The ambiguity, and what resolves it

After a `.` following hex digits the lexer has to choose between a hexfloat fraction and a method call on a hex integer — `0x1.abs` scans `ab` as perfectly good hex digits. The `p`/`P` exponent is the only disambiguator, and it can follow a fraction (`0x1.8p+1`), come directly after the integer part (`0x1p-2`), or appear with no integer part at all (`0x.8p+1`).

The new `src/parser/primary/hexfloat.rs` scans the whole candidate speculatively and commits only once it has seen the `p`/`P` **and** at least one exponent digit; anything short of that returns a non-fatal parse error and the input falls through to the existing radix-integer path untouched. A fraction is taken only when the `.` is followed by a hex digit, which keeps `0x1.p3` a method call too.

Unchanged, and pinned by tests: `0x1.abs` is still `1`, `0xff` is still `255`, and `0x1.8` (no binary exponent) is still a compile error.

## Correct rounding, in one step

Rust's `f64` has no hexfloat parser, so the conversion is ours. A naive `mantissa * 2f64.powi(exp)` double-rounds and gets exactly the cases the spec subtests probe wrong. Instead the mantissa digits (underscores stripped) become an exact `BigUint`, the fraction width and the binary exponent collapse into a single binary scale, and the exact value `m * 2^exp` is rounded **once** to the nearest `f64` with ties to even.

The rounding quantum is `max(leading_exponent - 52, -1074)`, which makes the subnormal grid fall out of the same code path as the normal one: `0x1.8p-1074` sits midway between two subnormals and ties up to `1e-323`, while `0x0.8p-1074` ties down to zero. Exponents are clamped before any shifting, so `0x1p+9999` is `Inf` and `0x1p-9999` is `0e0` without materialising anything large. Underscores are legal in both the mantissa (`0xde_ad.be_efp+0`) and the exponent (`0x1p+1_0`).

## Keeping unrelated parse errors byte-identical

The scanner is tried right after `dot_decimal` and reports the same `expected digits` as the integer parser on a non-match. Both details matter: `update_best_error` merges same-score expectation lists, so a new message or a new try order would otherwise have added `hexadecimal float literal` to — or reordered — the `expected ... or ... or ...` line of every unrelated parse failure in the tree. Verified by hand on `1 + `, which reads exactly as it did before.

## Verification

- `make test` **PASS** — 3971 files, 42265 tests.
- `make roast` — the only failures are exactly the three container-only ones documented in `docs/agent-environments.md`: `6.c/S32-io/file-tests.t` tests 6-8/10 and `S16-filehandles/filetest.t` tests 57-64/69-72/77-80/101,103,105,107,109,111,117,121,125 (both from running as `uid 0`, confirmed with `id -u`), and `S32-io/IO-Socket-Async.t` exit 124 (network sandbox). Subtest sets match the documented ones exactly.
- `make lint` **PASS** — all four configurations (default clippy, `jit` off, wasm32 lib, rustdoc).
- The re-vendored `roast/S02-literals/numeric.t` (taken from #7900's branch and run out-of-tree) passes **89/89**, including all 18 new hexfloat subtests — a file the local rakudo v2026.07 oracle still rejects outright with `===SORRY!===`.
- Rounding cross-checked against Python's correctly-rounded `float.fromhex` over 414 literals: 400 random mantissa/exponent combinations spanning `p-1120` to `p+1090` plus the boundary cases (smallest subnormal, smallest normal, largest double, ties either side of half an ulp, overflow, underflow). All 414 agree.

## Whitelist / BLOCKERS coordination

This PR touches neither `roast-whitelist.txt` nor `TODO_roast/BLOCKERS.md`, because #7900 (the re-vendor that drops `numeric.t` from the whitelist and adds its blocker row) has not landed yet — on today's `main` the file is still whitelisted and still passing, so there is nothing here to reconcile. Whichever of the two lands second should do the reconciliation: if #7900 merges after this, its whitelist drop and blocker row for `S02-literals/numeric.t` should simply be omitted, since the file passes 89/89 with this change in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB6qGoJvkK9r67is8wVdNL

---
_Generated by [Claude Code](https://claude.ai/code/session_01KB6qGoJvkK9r67is8wVdNL)_