### PR TITLE
feat(sprintf): implement the %a / %A hexadecimal-float directives

### DIFF
--- a/news/2026-09/sprintf-hexfloat-directives.md
+++ b/news/2026-09/sprintf-hexfloat-directives.md
@@ -1,0 +1,44 @@
+# `sprintf("%a", ...)` / `%A` hexadecimal-float directives
+
+`sprintf`'s directive table had no `a`/`A` entry, so a C99 hexadecimal-float
+directive fell through to the unknown-directive path and threw
+`X::Str::Sprintf::Directives::Unsupported`. Both directives are implemented
+now, in a new `src/runtime/sprintf_hexfloat.rs` alongside the `%e`/`%f`/`%g`
+formatters.
+
+`%a` renders a `Num` as its exact binary value: a `0x` prefix, one hex digit
+before the radix point, the mantissa in hex after it, then `p` and a *decimal*
+signed binary exponent — `sprintf("%a", 1e0)` is `0x1p+0`. `%A` is the same
+with uppercase hex digits and `0X`/`P`.
+
+Because an f64's fraction field is exactly 52 bits — 13 hex digits — the
+rendering is exact whenever no precision is given, and trailing zeroes are
+stripped. The details that are easy to get wrong, all matched against glibc:
+
+- **Rounding is ties-to-even**, on the mantissa taken as a whole including its
+  integer digit, and a carry out of that digit is **not** renormalized:
+  `sprintf("%.0a", 27.1)` is `0x2p+4`, not `0x1p+5`. A carry that widens the
+  mantissa keeps the requested width (`%.1a` of `1.9999999e0` is `0x2.0p+0`).
+- **Subnormals** are printed with a leading `0` digit at the fixed minimum
+  exponent rather than normalized, so `%a` of `5e-324` is
+  `0x0.0000000000001p-1022`.
+- **`#`** forces the radix point when the fraction is empty (`%#a` of `0e0` is
+  `0x0.p+0`).
+- **The `0` flag pads between the `0x` prefix and the mantissa** and is ignored
+  when combined with `-`. The existing `apply_width` / `zero_pad_prefix_len`
+  helpers already thread a sign and an `0x`/`0X` prefix out of the padding, so
+  `%024a` of `-2.71` comes out as `-0x0001.5ae147ae147aep+1` with no new
+  padding code.
+- A `Rat` argument renders the double it denotes, like every other float
+  directive, and `Inf`/`-Inf`/`NaN` keep Raku's spelling for `%A` as well —
+  `%E` does not uppercase them either.
+
+Rakudo has not implemented these directives (rakudo#6524), so there is no local
+oracle; the expected values come from glibc's `printf` and from the spec test
+itself.
+
+Pinned by `t/types/string/sprintf-hexfloat.t` (38 tests) and five unit tests in
+the new module. Upstream roast's new `S32-str/sprintf-a.t` — 586 subtests
+covering every permutation of the flag set against widths, precisions and a
+star precision — passes completely; it can join `roast-whitelist.txt` as soon
+as the roast re-vendor that introduces the file has landed.

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -64,7 +64,7 @@ impl Interpreter {
             let method = match spec.to_ascii_lowercase() {
                 's' => "Str",
                 'd' | 'i' | 'u' | 'b' | 'o' | 'x' | 'c' => "Int",
-                'e' | 'f' | 'g' => "Numeric",
+                'a' | 'e' | 'f' | 'g' => "Numeric",
                 _ => continue,
             };
             // A role-mixed value is neither an `Instance` nor a `Package` view,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -825,6 +825,7 @@ pub(crate) mod slang_activation;
 mod source_code_text;
 pub(super) mod sprintf;
 mod sprintf_helpers;
+mod sprintf_hexfloat;
 mod sprintf_validate;
 pub(crate) mod str_numeric;
 mod supply_classify;

--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -5,6 +5,7 @@ use super::sprintf_helpers::{
     apply_float_minus_zero, apply_width, format_float_fixed, format_g, format_inf_nan,
     format_rat_fixed, format_rat_sci, normalize_sci_exponent, sign_prefix,
 };
+use super::sprintf_hexfloat::format_hexfloat;
 pub(crate) use super::sprintf_validate::{
     directives_count_message, sprintf_arg_specs, sprintf_directive_count,
     validate_sprintf_arg_types, validate_sprintf_directives,
@@ -545,6 +546,19 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
                     let formatted = format_g(abs, p, spec == 'G', hash_flag);
                     format!("{}{}", prefix, formatted)
                 }
+            }
+            'a' | 'A' => {
+                // C99 hexadecimal float. The rendering is of the f64 itself, so
+                // a Rat argument is first converted to the double it denotes
+                // (`sprintf("%a", 27.1)` is the hexfloat of 27.1e0).
+                format_hexfloat(
+                    float_val(),
+                    prec_num,
+                    plus_sign,
+                    space_flag,
+                    hash_flag,
+                    spec == 'A',
+                )
             }
             'c' => {
                 let i = int_val();

--- a/src/runtime/sprintf_hexfloat.rs
+++ b/src/runtime/sprintf_hexfloat.rs
@@ -1,0 +1,170 @@
+//! C99 hexadecimal-float rendering for the sprintf `%a` / `%A` directives.
+//!
+//! `%a` writes a `Num` as an exact binary value: a `0x` prefix, one hex digit
+//! before the radix point, the mantissa in hex after it, then `p` and a
+//! *decimal* signed binary exponent (`sprintf("%a", 1e0)` is `0x1p+0`). `%A`
+//! is the same with uppercase hex digits and `0X`/`P`.
+//!
+//! Because an f64 mantissa is exactly 52 bits — 13 hex digits — the rendering
+//! is exact whenever no precision is given; trailing zeroes are then omitted.
+//! With a precision the mantissa is rounded to that many fractional hex digits,
+//! ties-to-even, and a carry out of the leading digit is *not* renormalized
+//! (C prints `0x2p+4`, not `0x1p+5`), matching glibc.
+
+use super::sprintf_helpers::{format_inf_nan, sign_prefix};
+
+/// Hex digits in an f64's 52-bit fraction field.
+const FRACTION_HEX_DIGITS: usize = 13;
+
+/// Render `f` for `%a` (`upper == false`) or `%A` (`upper == true`).
+///
+/// `prec` is the requested number of fractional hex digits; `None` means "as
+/// many as the value needs", which is the exact representation with trailing
+/// zeroes stripped. `hash_flag` forces the radix point even when the fraction
+/// is empty.
+pub(super) fn format_hexfloat(
+    f: f64,
+    prec: Option<usize>,
+    plus_sign: bool,
+    space_flag: bool,
+    hash_flag: bool,
+    upper: bool,
+) -> String {
+    if f.is_nan() || f.is_infinite() {
+        // Raku spells the special values `Inf`/`-Inf`/`NaN` for every float
+        // directive, and `%E` does not uppercase them; `%A` follows `%E`.
+        return format_inf_nan(f, plus_sign, space_flag);
+    }
+    let bits = f.to_bits();
+    let is_neg = (bits >> 63) != 0;
+    let biased_exp = ((bits >> 52) & 0x7ff) as i32;
+    let fraction = bits & ((1u64 << 52) - 1);
+    // A normal number has an implicit leading 1 and an exponent of
+    // `biased - 1023`. A subnormal has a leading 0 and, like C, is printed at
+    // the fixed minimum exponent -1022 rather than being normalized. Zero is
+    // printed as `0x0p+0`.
+    let (leading_digit, exponent) = if biased_exp == 0 {
+        (0u64, if fraction == 0 { 0 } else { -1022 })
+    } else {
+        (1u64, biased_exp - 1023)
+    };
+
+    let digits = mantissa_digits(leading_digit, fraction, prec);
+    let (int_digit, frac_digits) = digits.split_at(1);
+    let frac_digits = match prec {
+        // Exact rendering: drop the trailing zeroes the 13-digit field pads with.
+        None => frac_digits.trim_end_matches('0'),
+        Some(_) => frac_digits,
+    };
+
+    let mut out = String::with_capacity(digits.len() + 8);
+    out.push_str(sign_prefix(is_neg, plus_sign, space_flag));
+    out.push_str(if upper { "0X" } else { "0x" });
+    out.push_str(int_digit);
+    if !frac_digits.is_empty() {
+        out.push('.');
+        out.push_str(frac_digits);
+    } else if hash_flag {
+        out.push('.');
+    }
+    if upper {
+        out.make_ascii_uppercase();
+        out.push('P');
+    } else {
+        out.push('p');
+    }
+    out.push(if exponent < 0 { '-' } else { '+' });
+    out.push_str(&exponent.unsigned_abs().to_string());
+    out
+}
+
+/// The mantissa as `1 + p` hex digits: the integer digit followed by exactly
+/// `p` fractional digits (`p` defaults to the full 13-digit fraction field).
+/// Rounding is half-to-even, and a carry into the integer digit is kept as-is
+/// (`0x1.b...` at precision 0 becomes `2`, not a renormalized `1` at `exp + 1`).
+fn mantissa_digits(leading_digit: u64, fraction: u64, prec: Option<usize>) -> String {
+    let p = prec.unwrap_or(FRACTION_HEX_DIGITS);
+    if p >= FRACTION_HEX_DIGITS {
+        // No rounding needed: the whole fraction field fits, pad with zeroes.
+        let mut s = format!("{leading_digit}{fraction:013x}");
+        s.extend(std::iter::repeat_n('0', p - FRACTION_HEX_DIGITS));
+        return s;
+    }
+    let shift = 4 * (FRACTION_HEX_DIGITS - p) as u32;
+    let full = (leading_digit << 52) | fraction;
+    let mut kept = full >> shift;
+    let dropped = full & ((1u64 << shift) - 1);
+    let half = 1u64 << (shift - 1);
+    if dropped > half || (dropped == half && kept & 1 == 1) {
+        kept += 1;
+    }
+    // `kept` needs at most `p + 1` hex digits even after a carry, because the
+    // largest possible value is `0x2000...0`.
+    format!("{kept:0width$x}", width = p + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_hexfloat;
+
+    fn a(f: f64, prec: Option<usize>) -> String {
+        format_hexfloat(f, prec, false, false, false, false)
+    }
+
+    #[test]
+    fn exact_rendering_matches_c() {
+        assert_eq!(a(0.0, None), "0x0p+0");
+        assert_eq!(a(-0.0, None), "-0x0p+0");
+        assert_eq!(a(1.0, None), "0x1p+0");
+        assert_eq!(a(27.1, None), "0x1.b19999999999ap+4");
+        assert_eq!(a(-2.71, None), "-0x1.5ae147ae147aep+1");
+    }
+
+    #[test]
+    fn precision_rounds_ties_to_even_without_renormalizing() {
+        assert_eq!(a(27.1, Some(0)), "0x2p+4");
+        assert_eq!(a(-2.71, Some(0)), "-0x1p+1");
+        assert_eq!(a(27.1, Some(3)), "0x1.b1ap+4");
+        assert_eq!(a(-2.71, Some(3)), "-0x1.5aep+1");
+        assert_eq!(a(0.0, Some(3)), "0x0.000p+0");
+        assert_eq!(a(1.9999999, Some(1)), "0x2.0p+0");
+        assert_eq!(a(27.1, Some(20)), "0x1.b19999999999a0000000p+4");
+    }
+
+    #[test]
+    fn subnormals_use_the_minimum_exponent() {
+        assert_eq!(a(5e-324, None), "0x0.0000000000001p-1022");
+        assert_eq!(a(2.2250738585072014e-308, None), "0x1p-1022");
+    }
+
+    #[test]
+    fn flags_and_case() {
+        assert_eq!(
+            format_hexfloat(0.0, None, false, false, true, false),
+            "0x0.p+0"
+        );
+        assert_eq!(
+            format_hexfloat(1.0, Some(0), false, false, true, false),
+            "0x1.p+0"
+        );
+        assert_eq!(
+            format_hexfloat(27.1, None, true, false, false, false),
+            "+0x1.b19999999999ap+4"
+        );
+        assert_eq!(
+            format_hexfloat(27.1, None, false, true, false, false),
+            " 0x1.b19999999999ap+4"
+        );
+        assert_eq!(
+            format_hexfloat(27.1, None, false, false, false, true),
+            "0X1.B19999999999AP+4"
+        );
+    }
+
+    #[test]
+    fn inf_and_nan_use_raku_spelling() {
+        assert_eq!(a(f64::INFINITY, None), "Inf");
+        assert_eq!(a(f64::NEG_INFINITY, None), "-Inf");
+        assert_eq!(a(f64::NAN, None), "NaN");
+    }
+}

--- a/src/runtime/sprintf_validate.rs
+++ b/src/runtime/sprintf_validate.rs
@@ -228,6 +228,8 @@ pub(crate) fn validate_sprintf_directives(fmt: &str, arg_count: usize) -> Result
                     | 'E'
                     | 'g'
                     | 'G'
+                    | 'a'
+                    | 'A'
                     | 'c'
             )
         {

--- a/t/types/string/sprintf-hexfloat.t
+++ b/t/types/string/sprintf-hexfloat.t
@@ -1,0 +1,76 @@
+use Test;
+
+# The `%a` / `%A` sprintf directives render a Num as a C99 hexadecimal float:
+# a `0x` prefix, one hex digit before the radix point, the mantissa in hex
+# after it, then `p` and a *decimal* signed binary exponent. Expected values
+# below are glibc's printf output for the same double.
+
+plan 38;
+
+# Exact rendering (no precision): the full 52-bit fraction, trailing zeroes
+# stripped.
+is sprintf("%a", 0e0), "0x0p+0", "%a of 0";
+is sprintf("%a", -0e0), "-0x0p+0", "%a keeps the sign of negative zero";
+is sprintf("%a", 1e0), "0x1p+0", "%a of 1";
+is sprintf("%a", 2e0), "0x1p+1", "%a of 2";
+is sprintf("%a", 0.5e0), "0x1p-1", "%a of 0.5";
+is sprintf("%a", 27.1e0), "0x1.b19999999999ap+4", "%a of 27.1e0";
+is sprintf("%a", -2.71e0), "-0x1.5ae147ae147aep+1", "%a of -2.71e0";
+
+# A Rat argument renders the double it denotes, like every other float
+# directive.
+is sprintf("%a", 27.1), "0x1.b19999999999ap+4", "%a of the Rat 27.1";
+is sprintf("%a", -2.71), "-0x1.5ae147ae147aep+1", "%a of the Rat -2.71";
+is sprintf("%a", 0), "0x0p+0", "%a of the Int 0";
+
+# %A is the same with uppercase hex digits, `0X` and `P`.
+is sprintf("%A", 27.1), "0X1.B19999999999AP+4", "%A uppercases digits, 0X and P";
+is sprintf("%A", -2.71), "-0X1.5AE147AE147AEP+1", "%A of a negative value";
+
+# With a precision the mantissa is rounded to that many fractional hex digits,
+# ties-to-even. A carry out of the leading digit is NOT renormalized: C prints
+# `0x2p+4`, not `0x1p+5`.
+is sprintf("%.0a", 27.1), "0x2p+4", "%.0a rounds up without renormalizing";
+is sprintf("%.0a", -2.71), "-0x1p+1", "%.0a rounds down";
+is sprintf("%.3a", 27.1), "0x1.b1ap+4", "%.3a rounds the mantissa up";
+is sprintf("%.3a", -2.71), "-0x1.5aep+1", "%.3a rounds the mantissa down";
+is sprintf("%.3a", 0), "0x0.000p+0", "%.3a of 0 pads the fraction";
+is sprintf("%.1a", 1.9999999e0), "0x2.0p+0", "a carry keeps the requested width";
+is sprintf("%.20a", 27.1), "0x1.b19999999999a0000000p+4",
+  "a precision past the 13-digit fraction pads with zeroes";
+is sprintf("%.*a", 3, 27.1), "0x1.b1ap+4", "a star precision is honoured";
+
+# Subnormals are printed at the fixed minimum exponent with a leading 0,
+# rather than being normalized.
+is sprintf("%a", 5e-324), "0x0.0000000000001p-1022", "%a of the smallest subnormal";
+is sprintf("%a", 2.2250738585072014e-308), "0x1p-1022", "%a of the smallest normal";
+
+# The `#` flag forces the radix point even when the fraction is empty.
+is sprintf("%#a", 0e0), "0x0.p+0", "%#a of 0 keeps the radix point";
+is sprintf("%#.0a", 1e0), "0x1.p+0", "%#.0a keeps the radix point";
+is sprintf("%#a", 27.1), "0x1.b19999999999ap+4", "%#a is a no-op when a fraction is present";
+
+# Sign flags.
+is sprintf("%+a", 27.1), "+0x1.b19999999999ap+4", "the + flag signs a positive value";
+is sprintf("% a", 27.1), " 0x1.b19999999999ap+4", "the space flag pads a positive value";
+is sprintf("%+a", -2.71), "-0x1.5ae147ae147aep+1", "the + flag leaves a negative sign alone";
+
+# Width: the `0` flag pads between the `0x` prefix and the mantissa, and is
+# ignored when combined with `-`, exactly as in C.
+is sprintf("%24a", 27.1), "    0x1.b19999999999ap+4", "a width right-aligns with spaces";
+is sprintf("%024a", 27.1), "0x00001.b19999999999ap+4", "the 0 flag pads after the 0x prefix";
+is sprintf("%024a", -2.71), "-0x0001.5ae147ae147aep+1", "zero padding goes after the sign too";
+is sprintf("%0 24a", 0e0), " 0x000000000000000000p+0", "the space flag shares the field";
+is sprintf("%-24a|", 27.1), "0x1.b19999999999ap+4    |", "the - flag left-aligns";
+is sprintf("%-024a|", 27.1), "0x1.b19999999999ap+4    |", "- beats 0";
+
+# Inf/NaN use Raku's spelling for every float directive, `%A` included.
+is sprintf("%a", Inf), "Inf", "%a of Inf";
+is sprintf("%a", -Inf), "-Inf", "%a of -Inf";
+is sprintf("%A", NaN), "NaN", "%A of NaN";
+
+# The directive is recognised, so the unsupported-directive exception no
+# longer fires for it.
+lives-ok { sprintf("%a", 1e0) }, "%a is a supported directive";
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The `sprintf` directive table had no `a`/`A` entry, so a C99 hexadecimal-float directive fell through to the unknown-directive path and threw `X::Str::Sprintf::Directives::Unsupported`. Both are implemented now, in a new `src/runtime/sprintf_hexfloat.rs` next to the `%e`/`%f`/`%g` formatters.

`%a` renders a `Num` as its exact binary value: a `0x` prefix, one hex digit before the radix point, the mantissa in hex after it, then `p` and a *decimal* signed binary exponent — `sprintf("%a", 1e0)` is `0x1p+0`. `%A` is the same with uppercase hex digits and `0X`/`P`. An f64's fraction field is exactly 52 bits (13 hex digits), so the rendering is exact whenever no precision is given, with trailing zeroes stripped.

## The details that are easy to get wrong

All matched against glibc's `printf`:

- **Rounding is ties-to-even**, on the mantissa taken as a whole including its integer digit, and a carry out of that digit is **not** renormalized: `sprintf("%.0a", 27.1)` is `0x2p+4`, not `0x1p+5`. A carry that widens the mantissa keeps the requested width (`%.1a` of `1.9999999e0` is `0x2.0p+0`).
- **Subnormals** print with a leading `0` digit at the fixed minimum exponent rather than normalized, so `%a` of `5e-324` is `0x0.0000000000001p-1022`.
- **`#`** forces the radix point when the fraction is empty (`%#a` of `0e0` is `0x0.p+0`).
- **The `0` flag pads between the `0x` prefix and the mantissa** and is ignored when combined with `-`. `apply_width` / `zero_pad_prefix_len` already thread a sign and an `0x`/`0X` prefix out of the padding, so `%024a` of `-2.71` comes out as `-0x0001.5ae147ae147aep+1` with no new padding code.
- A `Rat` argument renders the double it denotes, like every other float directive, and `Inf`/`-Inf`/`NaN` keep Raku's spelling for `%A` as well — `%E` does not uppercase them either.

Rakudo has not implemented these directives, so there is no local oracle; the expected values come from glibc and from the spec test itself.

## Changes

- `src/runtime/sprintf_hexfloat.rs` (new) — the formatter, plus 5 unit tests.
- `src/runtime/sprintf.rs` — the `'a' | 'A'` arm.
- `src/runtime/sprintf_validate.rs` — `a`/`A` accepted as directives.
- `src/runtime/builtins_string.rs` — `%a` joins the float directives that dispatch a user object's `.Numeric`.
- `t/types/string/sprintf-hexfloat.t` (new) — 38 tests.
- `news/2026-09/sprintf-hexfloat-directives.md`.

## Verification

- `make lint` **PASS** (all four configurations).
- `make test` **PASS** — 3972 files, 42284 tests.
- `make roast` — the only failures are exactly the three container-only ones documented in `docs/agent-environments.md`, with matching subtest sets: `6.c/S32-io/file-tests.t` (`Failed: 4`) and `S16-filehandles/filetest.t` (`Failed: 25` — 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125), both from running as `uid 0`, and `S32-io/IO-Socket-Async.t` exit 124 from the sandboxed network.
- Upstream roast's new `S32-str/sprintf-a.t` — 586 subtests over every permutation of the flag set against widths, precisions and a star precision — **586/586 PASS**. That file is not in `main` yet (it arrives with the roast re-vendor in #7900), so it was run from that branch and **no whitelist entry is added here**; it can join `roast-whitelist.txt` once #7900 lands.

Closes #7903

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8XhJF8TQ1Cdr4MDeU5ZjD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8XhJF8TQ1Cdr4MDeU5ZjD)_