### PR TITLE
fix: preserve phaser expressions in scalar binds

### DIFF
--- a/news/2026-09/bind-phaser-expression.md
+++ b/news/2026-09/bind-phaser-expression.md
@@ -1,0 +1,7 @@
+---
+title: Preserve phaser-expression initializers in `:=` bindings
+---
+
+`:=` bindings whose right-hand side was a `BEGIN` or `INIT` expression could
+lose their initializer when phaser reordering split the declaration. The
+initializer is now retained, so the phaser runs and its value is bound.

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -890,7 +890,9 @@ fn reorder_at_level(
             // initializer with the `__has_initializer` custom trait (checked
             // the same way at e.g. `compiler/stmt.rs`'s `has_init` sites) —
             // use that instead of guessing from the expression shape.
-            let has_init = custom_traits.iter().any(|(n, _)| n == "__has_initializer");
+            let has_init = custom_traits
+                .iter()
+                .any(|(n, _)| n == "__has_initializer" || n == "__scalar_bind");
             // The hoisted bare declaration's interim value (before any real
             // initializer in `rest` runs) must match what an uninitialized
             // declaration of this sigil actually holds: `Nil` for a scalar,

--- a/t/control/bind-phaser-expression.t
+++ b/t/control/bind-phaser-expression.t
@@ -1,0 +1,17 @@
+use Test;
+
+plan 3;
+
+my $begin-runs = 0;
+my $begin-value := BEGIN {
+    $begin-runs = 1;
+    42
+};
+is $begin-value, 42, ':= keeps the value of a BEGIN expression';
+is $begin-runs, 1, 'the BEGIN expression body runs for a binding';
+
+my $init-value := INIT {
+    state $init-runs = 0;
+    ++$init-runs
+};
+is $init-value, 1, ':= keeps the value of an INIT expression';


### PR DESCRIPTION
Fixes #7880

Preserve scalar binding initializers when phaser reordering splits a declaration. This keeps BEGIN and INIT expression bodies executable and binds their values.

Regression coverage is included under t/control, with a news entry. Full local lint, test, and roast suites pass.