### PR TITLE
perf(react): deliver `whenever $promise` off the waiter list, not an OS thread

### DIFF
--- a/news/2026-09/react-whenever-promise-no-longer-parks-a-thread.md
+++ b/news/2026-09/react-whenever-promise-no-longer-parks-a-thread.md
@@ -1,0 +1,95 @@
+# `whenever <Promise>` no longer parks an OS thread per subscription
+
+Issue [#7609](https://github.com/tokuhirom/mutsu/issues/7609) tracks a rare, never-reproduced
+SIGSEGV in `roast/S17-procasync/stress.t`, whose last block runs the
+[rakudo#3299](https://github.com/rakudo/rakudo/issues/3299) regression: 1200 `Proc::Async`
+instances, each started inside its own `react`.
+
+```raku
+for ^1200 {
+  my $proc = Proc::Async.new('cat', '/dev/null');
+  react {
+      whenever $proc.start { done }
+      whenever signal(SIGTERM) {}
+      whenever Promise.in(5) {}
+  }
+}
+```
+
+The issue's own "where to look next" list put *"the `react` / `whenever` machinery itself under
+1200 rapid setup/teardown cycles"* first. Measuring the workload rather than reading it found
+something concrete there.
+
+## What the measurement showed
+
+Sampling `/proc/<pid>/task/*/comm` at the peak of a debug run:
+
+```
+peak=425
+    420 promise-wait
+      1 timer
+      1 signal-rd
+      1 pool
+      1 mutsu-main
+      1 mutsu
+```
+
+Every `whenever <Promise>` source built by the react loop (`vm/vm_react_loop.rs`) and by the
+`supply { whenever $promise { … } }` path (`runtime/supply_promise.rs`) spawned a dedicated
+`promise-wait` OS thread whose entire job was to block in `SharedPromise::wait()` and then push
+`Emit`/`Done` (or `Quit`) into a one-shot channel.
+
+For `whenever Promise.in(5)` that thread stays parked for the timer's **whole five seconds** — long
+after its react block ended, milliseconds later, via `done`. At ~70 iterations a second the workload
+therefore carried roughly 420 abandoned threads at once, each holding its default stack, which is
+where the 4.5 GB of address space came from.
+
+## The fix
+
+A `SharedPromise` already has a waiter list, and the drive loop already uses it: every promise
+subscription registers `p.on_resolve(|…| waker.notify())` so the loop wakes on resolution
+(`vm/vm_react_subscriptions.rs`). The value delivery now rides the same list instead of a thread:
+
+```rust
+shared.mark_observed();
+shared.on_resolve(Box::new(move |status, result, _output, _stderr| {
+    if status == "Broken" {
+        let _ = tx.send(SupplyEvent::Quit(result));
+    } else {
+        let _ = tx.send(SupplyEvent::Emit(result));
+        let _ = tx.send(SupplyEvent::Done);
+    }
+}));
+```
+
+`mark_observed` is what `wait()` used to do implicitly: a Broken promise consumed by a `whenever`
+must not also trip the destruction-time "unhandled" diagnostic. The waiter itself runs either inline
+on the registering thread (promise already resolved) or on a pooled worker via
+`SharedPromise::dispatch_waiters` — both registered GC mutators, which the `Value` clone inside
+`send` requires.
+
+Delivery ordering improves as a side effect: the value-sending waiter is registered before the
+drive loop's waker-notifying one, so the event is in the channel before the loop is woken, instead
+of racing it.
+
+## Measurements
+
+Debug build, `tmp/segv-3299.raku` (the rakudo#3299 block standalone), 4-core container:
+
+| | before | after |
+| --- | --- | --- |
+| peak OS threads | 425 | 6 |
+| peak `VmSize` | 4.6 GB | 0.9 GB |
+| wall clock | 17.1 s | 3.8 s |
+| system time | 42.2 s | 1.5 s |
+
+## What this does and does not settle
+
+It does **not** root-cause #7609's SIGSEGV — that crash has still never been reproduced, and the
+issue stays open. What it removes is the largest piece of resource pressure the crashing workload
+was under, and one of the three candidate mechanisms the issue named. A file that ran with 420
+concurrent threads and 4.5 GB of address space now runs with six threads; whatever remains to be
+explained is being asked of a much smaller system.
+
+Pinned by `t/concurrency/supply/react-whenever-promise-threads.t`, which fails (test 1, thread
+count) against the pre-fix binary.

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -585,16 +585,14 @@ impl Interpreter {
                 if let ValueView::Promise(shared) = source.view() {
                     let (tx, rx) =
                         crate::runtime::native_methods::supply_channel::supply_event_channel();
-                    let shared_clone = shared.clone();
-                    crate::runtime::builtins_system::spawn_gc_helper_thread(
-                        "promise-wait",
-                        move || {
-                            let (result, _, _) = shared_clone.wait();
-                            let _ =
-                                tx.send(crate::runtime::native_methods::SupplyEvent::Emit(result));
-                            let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Done);
-                        },
-                    );
+                    // Same thread-free delivery as the react loop's promise
+                    // source (see `vm/vm_react_loop.rs`): the promise's own
+                    // waiter list, not an OS thread parked in `wait()`.
+                    shared.mark_observed();
+                    shared.on_resolve(Box::new(move |_status, result, _output, _stderr| {
+                        let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Emit(result));
+                        let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Done);
+                    }));
                     react_subs.push(crate::runtime::react_whenever::ReactSubscription {
                         receiver: Some(rx),
                         promise: Some(shared.clone()),

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -531,23 +531,32 @@ impl Interpreter {
                         // Create a one-shot channel for the promise
                         let (tx, rx) =
                             crate::runtime::native_methods::supply_channel::supply_event_channel();
-                        let shared_clone = shared.clone();
-                        // Registered spawn: `wait()` clones the resolved
-                        // result `Value` and the promise handle drops at
-                        // thread exit — both are `Gc` mutations that must not
-                        // race a cycle scan (the wait itself is STW-aware).
-                        crate::runtime::builtins_system::spawn_gc_helper_thread(
-                            "promise-wait",
-                            move || {
-                                let (result, _, _) = shared_clone.wait();
-                                if shared_clone.status() == "Broken" {
-                                    let _ = tx.send(SupplyEvent::Quit(result));
-                                } else {
-                                    let _ = tx.send(SupplyEvent::Emit(result));
-                                    let _ = tx.send(SupplyEvent::Done);
-                                }
-                            },
-                        );
+                        // Delivery rides the promise's own waiter list rather
+                        // than an OS thread parked in `wait()`: a `whenever
+                        // <Promise>` costs no thread, and a react that ends
+                        // before its promise settles leaves nothing behind
+                        // (issue #7609 — `roast/S17-procasync/stress.t`'s
+                        // 1200 `whenever Promise.in(5)` blocks peaked at 420
+                        // concurrent `promise-wait` threads, each pinned for
+                        // the timer's whole 5s long after its react was
+                        // over). `mark_observed` is what `wait()` used to do
+                        // for us: a Broken promise consumed by a `whenever`
+                        // must not also trip the destruction-time
+                        // "unhandled" diagnostic. The waiter runs either
+                        // inline here (already-resolved promise, on this
+                        // registered thread) or on a pooled worker from
+                        // `dispatch_waiters`; both are registered GC
+                        // mutators, which the `Value` clone in `send`
+                        // requires.
+                        shared.mark_observed();
+                        shared.on_resolve(Box::new(move |status, result, _output, _stderr| {
+                            if status == "Broken" {
+                                let _ = tx.send(SupplyEvent::Quit(result));
+                            } else {
+                                let _ = tx.send(SupplyEvent::Emit(result));
+                                let _ = tx.send(SupplyEvent::Done);
+                            }
+                        }));
                         react_subs.push(ReactSubscription {
                             whenever_id,
                             receiver: Some(rx),

--- a/t/concurrency/supply/react-whenever-promise-threads.t
+++ b/t/concurrency/supply/react-whenever-promise-threads.t
@@ -1,0 +1,64 @@
+use v6;
+use Test;
+
+# Pin for issue #7609: a `whenever <Promise>` inside `react`/`supply` must
+# deliver its result through the promise's own waiter list, not through a
+# dedicated OS thread parked in a blocking wait.
+#
+# Before this, every `whenever $promise` spawned one `promise-wait` thread
+# that lived until the promise settled -- even after the enclosing react had
+# already finished via `done`. `roast/S17-procasync/stress.t`'s 1200 reacts,
+# each with a `whenever Promise.in(5)`, peaked at 420 concurrent threads and
+# 4.5 GB of address space for that reason alone.
+
+plan 4;
+
+# Each react ends immediately (the first whenever's promise is already kept),
+# but leaves a second whenever watching a promise that cannot fire during this
+# test. None of those may hold a thread.
+for ^100 {
+    my $ready = Promise.new;
+    $ready.keep(1);
+    react {
+        whenever $ready { done }
+        whenever Promise.in(600) { }
+    }
+}
+
+my $threads = "/proc/$*PID/status".IO.lines.first(*.starts-with('Threads:'));
+my $n = $threads.words[1].Int;
+ok $n < 40, "100 abandoned `whenever <Promise>` sources hold no threads (got $n)"
+    or diag "Threads: $n -- a `whenever <Promise>` is parking an OS thread again";
+
+# The delivery itself must still work, for both outcomes.
+my $kept = Promise.new;
+start { sleep 0.05; $kept.keep(42) }
+my $got;
+react {
+    whenever $kept -> $v { $got = $v; done }
+    whenever Promise.in(5) { done }
+}
+is $got, 42, 'a kept promise still reaches its whenever body';
+
+my $broken = Promise.new;
+start { sleep 0.05; $broken.break('nope') }
+my $died;
+try {
+    react {
+        whenever $broken { flunk 'a broken promise must not run the whenever body' }
+        whenever Promise.in(5) { done }
+    }
+    CATCH { default { $died = $_ } }
+}
+ok $died.defined && $died.message.contains('nope'),
+    'a broken promise still dies the react block';
+
+# A promise already resolved when the whenever is registered still fires.
+my $pre = Promise.new;
+$pre.keep('early');
+my $seen;
+react {
+    whenever $pre -> $v { $seen = $v; done }
+    whenever Promise.in(5) { done }
+}
+is $seen, 'early', 'an already-kept promise fires its whenever body';


### PR DESCRIPTION
Works [#7609](https://github.com/tokuhirom/mutsu/issues/7609) (the issue stays open — see "What this does not settle").

## The finding

#7609's "where to look next" list puts *"the `react` / `whenever` machinery itself under 1200 rapid setup/teardown cycles"* first. Measuring that workload rather than reading it found something concrete.

Sampling `/proc/<pid>/task/*/comm` while running the issue's rakudo#3299 block standalone (1200 `Proc::Async`, each started inside its own `react`):

```
peak=425
    420 promise-wait
      1 timer
      1 signal-rd
      1 pool
      1 mutsu-main
      1 mutsu
```

Every `whenever <Promise>` source built by the react loop (`vm/vm_react_loop.rs`) and by the `supply { whenever $promise { … } }` path (`runtime/supply_promise.rs`) spawned a dedicated `promise-wait` OS thread whose only job was to block in `SharedPromise::wait()` and then push `Emit`/`Done` (or `Quit`) into a one-shot channel.

For `whenever Promise.in(5)` that thread stays parked for the timer's **whole five seconds** — long after its react block ended, milliseconds later, via `done`. At ~70 iterations a second the workload therefore carried ~420 abandoned threads at once, which is where the 4.6 GB of address space came from.

## The change

A `SharedPromise` already has a waiter list, and the drive loop already uses it: every promise subscription registers `p.on_resolve(|…| waker.notify())` so the loop wakes on resolution (`vm/vm_react_subscriptions.rs`). The value delivery now rides the same list instead of a thread:

```rust
shared.mark_observed();
shared.on_resolve(Box::new(move |status, result, _output, _stderr| {
    if status == "Broken" {
        let _ = tx.send(SupplyEvent::Quit(result));
    } else {
        let _ = tx.send(SupplyEvent::Emit(result));
        let _ = tx.send(SupplyEvent::Done);
    }
}));
```

`mark_observed` is what `wait()` used to do implicitly: a Broken promise consumed by a `whenever` must not also trip the destruction-time "unhandled" diagnostic. The waiter runs either inline on the registering thread (promise already resolved) or on a pooled worker via `SharedPromise::dispatch_waiters` — both registered GC mutators, which the `Value` clone inside `send` requires.

Delivery ordering improves as a side effect: the value-sending waiter is registered before the drive loop's waker-notifying one, so the event is in the channel before the loop is woken instead of racing it.

## Measurements

Debug build, the rakudo#3299 block standalone, 4-core container:

| | before | after |
| --- | --- | --- |
| peak OS threads | 425 | 6 |
| peak `VmSize` | 4.6 GB | 0.9 GB |
| wall clock | 17.1 s | 3.8 s |
| system time | 42.2 s | 1.5 s |

## What this does not settle

It does **not** root-cause #7609's SIGSEGV. That crash still has never reproduced — 28 more clean runs this session at 4-way concurrency under the `gc-stress` environment, on top of the ~310 recorded on the issue. What this removes is the largest piece of resource pressure the crashing workload was under, and one of the three candidate mechanisms the issue named. #7609 stays open.

Also filed while working it: [#7917](https://github.com/tokuhirom/mutsu/issues/7917), the `signal()` registration / supply-channel leak (candidate 2 on #7609's list). It is a real defect but provably cannot free anything prematurely, so it is out of this PR's scope — as the 2026-08-19 audit on #7609 already concluded.

## Testing

- `t/concurrency/supply/react-whenever-promise-threads.t` — new pin. Test 1 (the thread count) was verified to **fail** against a binary with this change reverted, and to pass with it. Tests 2-4 cover kept / broken / already-resolved delivery.
- `make test`: 3972 files, 42250 tests, `Result: PASS`.
- `make roast`: 1436 files, 218939 tests; the only failing files are the three container-only cases documented in `docs/agent-environments.md`, with their exact documented subtest ranges (`roast/6.c/S32-io/file-tests.t` tests 6-8/10 and `roast/S16-filehandles/filetest.t` tests 57-64/… both need a non-root uid; `roast/S32-io/IO-Socket-Async.t` exit 124 under the sandboxed network). `roast/S17-procasync/stress.t` itself passes.
- `make lint`: exit 0, zero warnings in all four configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KC9afJ1Jq7ucv9GYmMzhHk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KC9afJ1Jq7ucv9GYmMzhHk)_