### PR TITLE
fix: preserve List identity for variable traits

### DIFF
--- a/news/2026-09/list-trait-preserves-list-identity.md
+++ b/news/2026-09/list-trait-preserves-list-identity.md
@@ -1,0 +1,11 @@
+# `is List` preserves the declared container identity
+
+An `@` variable declared with `is List` was backed by an `Array` even though
+mutsu already enforced the List's immutable assignment behavior. The variable
+now retags its existing backing store as a List when the variable trait is
+applied, so `.^name`, `.raku`, `is-deeply`, and mutation errors agree with
+Rakudo.
+
+Pinned by `t/oo/trait/list-trait-readonly.t` and `roast/S32-list/create.t`.
+
+Closes #7882.

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -229,6 +229,20 @@ impl Interpreter {
                 if has_arg {
                     self.stack.pop(); // discard unsupported trait argument
                 }
+                // `SetLocal` normally gives an `@` declaration an Array-backed
+                // value, but `is List` changes the declared container itself.
+                // Retag the existing backing store instead of only marking the
+                // variable readonly; otherwise `.^name`/`.raku` still report
+                // Array even though List's immutability is enforced.
+                let name_str = name.to_string();
+                if let Some(current) = self.read_var_trait_target(code, eff_slot, &name_str)
+                    && let ValueView::Array(items, _) = current.view()
+                {
+                    let list = Value::array_with_kind(items.clone(), crate::value::ArrayKind::List);
+                    if !self.write_var_trait_target(code, eff_slot, &name_str, list.clone()) {
+                        self.set_env_with_main_alias(&name_str, list);
+                    }
+                }
                 self.mark_readonly_with(name, crate::ast::ReadonlyKind::ImmutableValue);
                 return Ok(());
             }

--- a/t/oo/trait/list-trait-readonly.t
+++ b/t/oo/trait/list-trait-readonly.t
@@ -1,9 +1,11 @@
 use Test;
 
-plan 3;
+plan 5;
 
 my @a is List = 1, 2, 3;
 
+is @a.^name, 'List', 'array declared with `is List` has List identity';
+is @a.raku, '(1, 2, 3)', 'array declared with `is List` renders as a List';
 isa-ok @a, List, 'array declared with `is List` is a List';
 is @a, (1, 2, 3), '`is List` keeps declared values';
 throws-like { @a = 4, 5, 6 }, X::Assignment::RO, '`is List` array cannot be reassigned';


### PR DESCRIPTION
## Summary

`my @a is List` was left backed by an Array. Retag the declaration's existing backing store as `ArrayKind::List` when applying the variable trait, while preserving the existing immutable binding behavior.

The regression test now checks the exact type name and `.raku` representation, in addition to the existing value and readonly checks.

Validation: `make lint`, `make test`, and `make roast`.

Closes #7882.