### PR TITLE
fix(proc): report exitcode 0 for a signal-killed child, like rakudo

### DIFF
--- a/news/2026-09/proc-signal-exitcode.md
+++ b/news/2026-09/proc-signal-exitcode.md
@@ -1,0 +1,41 @@
+# A signal-killed `Proc` now reports `exitcode = 0`, like rakudo
+
+A process killed by a signal has no exit status at all: `waitpid` reports it as
+*signalled*, not exited, and Rust's `ExitStatus::code()` is `None` there. mutsu
+passed that `None` straight through as `-1`, so every signal-killed child came
+back as `exitcode = -1`:
+
+```raku
+my $p = Proc::Async.new: $*EXECUTABLE, "-e", "sleep 60";
+my $started = $p.start;
+await $p.ready;
+$p.kill: SIGTERM;
+my $res = await $started;
+say $res.exitcode, " ", $res.signal;
+```
+
+mutsu said `-1 15`; rakudo says `0 15`. Rakudo derives both numbers from the raw
+wait status — `exitcode` is its high byte, `signal` its low one — so a signal
+death reports `exitcode = 0` and carries the information in `.signal` alone.
+Anything that inspected a killed process's `.exitcode` got the wrong number, and
+`run`/`shell` diverged the same way.
+
+The five places that turned a finished child's `ExitStatus` into a `Proc`
+(`run`, `shell`, the `run(:in, ...)` live-proc finalization, `IO::Pipe.close`
+and `Proc::Async`'s wait thread) each open-coded `status.code().unwrap_or(-1)`
+plus a `#[cfg(unix)]` `signal()` block. They now share one
+`builtins_system::exit_status_parts()` helper, which reports `0` for a signal
+death and keeps `-1` for the case it was actually meant for — a child whose exit
+status could not be read at all.
+
+Normalising the exit code to `0` removes the only evidence a signal-killed `Proc`
+had that it was unsuccessful, so the two consumers that read `exitcode` alone
+were taught to consult `.signal` as well: sinking such a `Proc` still throws
+`X::Proc::Unsuccessful` (rakudo throws there too, reporting
+`exit code: 0, signal: 15`), and `Proc.Bool` is still `False` (rakudo:
+`$!exitcode == 0 && $!signal == 0`). A child that genuinely exits non-zero is
+untouched and still reports its own code — this is not "always report 0".
+
+Pinned by `t/io/proc-signal-exitcode.t`, which covers `run`, `shell` and
+`Proc::Async` for a signal death, a non-zero exit and a clean exit, plus the
+sink-context and `Bool` behaviour. It passes unchanged under rakudo.

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -105,6 +105,33 @@ where
     })
 }
 
+/// Split a finished child's `ExitStatus` into rakudo's `(exitcode, signal)`
+/// pair.
+///
+/// A process killed by a signal has no exit status at all — `waitpid` reports
+/// it as signalled, not exited, and Rust's `ExitStatus::code()` is `None`
+/// there. Rakudo derives both numbers from the raw wait status (`exitcode` is
+/// the high byte, `signal` the low one), so a signal death reports
+/// `exitcode = 0` and carries the information in `.signal`; only a genuine
+/// non-zero exit reports a non-zero `exitcode`. Reporting `-1` for a signal
+/// death instead (what `code().unwrap_or(-1)` gives) made `.exitcode` wrong
+/// for every killed process (#7924).
+pub(crate) fn exit_status_parts(status: &std::process::ExitStatus) -> (i64, i64) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        let signal = status.signal().unwrap_or(0) as i64;
+        // `code()` is `None` exactly when the child was signalled; rakudo
+        // reports 0 there rather than a synthetic failure code.
+        let exitcode = status.code().unwrap_or(if signal != 0 { 0 } else { -1 }) as i64;
+        (exitcode, signal)
+    }
+    #[cfg(not(unix))]
+    {
+        (status.code().unwrap_or(-1) as i64, 0i64)
+    }
+}
+
 /// State for a live child process (when `:in` is used with `run`).
 pub(super) struct LiveProcState {
     pub(super) child: std::process::Child,

--- a/src/runtime/builtins_system_run.rs
+++ b/src/runtime/builtins_system_run.rs
@@ -252,14 +252,7 @@ impl Interpreter {
                 };
                 match child.wait() {
                     Ok(status) => {
-                        let exitcode = status.code().unwrap_or(-1) as i64;
-                        #[cfg(unix)]
-                        let signal = {
-                            use std::os::unix::process::ExitStatusExt;
-                            status.signal().unwrap_or(0) as i64
-                        };
-                        #[cfg(not(unix))]
-                        let signal = 0i64;
+                        let (exitcode, signal) = super::builtins_system::exit_status_parts(&status);
                         Ok(Self::make_proc_instance_bin(
                             exitcode,
                             signal,
@@ -338,14 +331,8 @@ impl Interpreter {
                             };
                             return match child.wait() {
                                 Ok(status) => {
-                                    let exitcode = status.code().unwrap_or(-1) as i64;
-                                    #[cfg(unix)]
-                                    let signal = {
-                                        use std::os::unix::process::ExitStatusExt;
-                                        status.signal().unwrap_or(0) as i64
-                                    };
-                                    #[cfg(not(unix))]
-                                    let signal = 0i64;
+                                    let (exitcode, signal) =
+                                        super::builtins_system::exit_status_parts(&status);
                                     Ok(Self::make_proc_instance(
                                         exitcode,
                                         signal,
@@ -482,14 +469,7 @@ impl Interpreter {
                 };
                 match child.wait() {
                     Ok(status) => {
-                        let exitcode = status.code().unwrap_or(-1) as i64;
-                        #[cfg(unix)]
-                        let signal = {
-                            use std::os::unix::process::ExitStatusExt;
-                            status.signal().unwrap_or(0) as i64
-                        };
-                        #[cfg(not(unix))]
-                        let signal = 0i64;
+                        let (exitcode, signal) = super::builtins_system::exit_status_parts(&status);
                         Ok(Self::make_proc_instance(
                             exitcode,
                             signal,

--- a/src/runtime/native_io/io_pipe.rs
+++ b/src/runtime/native_io/io_pipe.rs
@@ -169,17 +169,7 @@ impl Interpreter {
                         None
                     };
                     let (exitcode, signal): (i64, i64) = match state.child.wait() {
-                        Ok(status) => {
-                            let ec = status.code().unwrap_or(-1) as i64;
-                            #[cfg(unix)]
-                            let sig = {
-                                use std::os::unix::process::ExitStatusExt;
-                                status.signal().unwrap_or(0) as i64
-                            };
-                            #[cfg(not(unix))]
-                            let sig = 0i64;
-                            (ec, sig)
-                        }
+                        Ok(status) => super::builtins_system::exit_status_parts(&status),
                         Err(_) => (-1i64, 0i64),
                     };
                     if let Ok(mut fmap) = super::builtins_system::finalized_proc_map().lock() {

--- a/src/runtime/native_methods/proc.rs
+++ b/src/runtime/native_methods/proc.rs
@@ -54,10 +54,16 @@ impl Interpreter {
         if let Some(v) = new_attrs.as_map().get("exitcode") {
             updated.insert("exitcode".to_string(), v.clone());
         }
+        let signal = match new_attrs.as_map().get("signal").map(Value::view) {
+            Some(ValueView::Int(s)) => s,
+            _ => 0,
+        };
         if let Some(v) = new_attrs.as_map().get("signal") {
             updated.insert("signal".to_string(), v.clone());
         }
-        Ok((Value::truth(exitcode == 0), updated))
+        // `.spawn`/`.run` return whether the child succeeded; a signal-killed
+        // child reports `exitcode = 0`, so the signal decides there.
+        Ok((Value::truth(exitcode == 0 && signal == 0), updated))
     }
 
     // --- Proc::Async immutable ---
@@ -227,17 +233,7 @@ impl Interpreter {
                     None
                 };
                 let (exitcode, signal): (i64, i64) = match state.child.wait() {
-                    Ok(status) => {
-                        let exitcode = status.code().unwrap_or(-1) as i64;
-                        #[cfg(unix)]
-                        let signal = {
-                            use std::os::unix::process::ExitStatusExt;
-                            status.signal().unwrap_or(0) as i64
-                        };
-                        #[cfg(not(unix))]
-                        let signal = 0i64;
-                        (exitcode, signal)
-                    }
+                    Ok(status) => super::super::builtins_system::exit_status_parts(&status),
                     Err(_) => (-1i64, 0i64),
                 };
                 // Cache the finalized results
@@ -320,7 +316,13 @@ impl Interpreter {
                     Some(ValueView::Int(c)) => c,
                     _ => -1,
                 };
-                Value::truth(exitcode == 0)
+                // A signal-killed child reports `exitcode = 0`, so the signal
+                // has to be consulted too (rakudo: `$!exitcode == 0 && $!signal == 0`).
+                let signal = match attributes.get("signal").map(Value::view) {
+                    Some(ValueView::Int(s)) => s,
+                    _ => 0,
+                };
+                Value::truth(exitcode == 0 && signal == 0)
             }
             _ => Value::NIL,
         }

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -868,24 +868,10 @@ impl Interpreter {
 
                     // Wait for child to exit (quiescent for the GC's STW)
                     let status = crate::gc::block_quiescent(|| child.wait());
-                    let exit_code = status
+                    let (exit_code, signal) = status
                         .as_ref()
-                        .map(|s| s.code().unwrap_or(-1))
-                        .unwrap_or(-1) as i64;
-                    let signal = {
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::process::ExitStatusExt;
-                            status
-                                .as_ref()
-                                .map(|s| s.signal().unwrap_or(0))
-                                .unwrap_or(0) as i64
-                        }
-                        #[cfg(not(unix))]
-                        {
-                            0i64
-                        }
-                    };
+                        .map(super::builtins_system::exit_status_parts)
+                        .unwrap_or((-1, 0));
 
                     // Join reader threads and collect output
                     let collected_stdout = stdout_handle

--- a/src/value/types_truthy.rs
+++ b/src/value/types_truthy.rs
@@ -88,11 +88,18 @@ impl Value {
                 ..
             } => {
                 if class_name == "Proc" {
-                    // Proc is truthy when exitcode == 0
-                    return match attributes.as_map().get("exitcode").map(Value::view) {
+                    // Proc is truthy when the child both exited with 0 and was
+                    // not killed by a signal (a signal death reports
+                    // `exitcode = 0`, so the exit code alone is not enough).
+                    let exited_clean = match attributes.as_map().get("exitcode").map(Value::view) {
                         Some(ValueView::Int(code)) => code == 0,
                         _ => false,
                     };
+                    let signal = match attributes.as_map().get("signal").map(Value::view) {
+                        Some(ValueView::Int(sig)) => sig,
+                        _ => 0,
+                    };
+                    return exited_clean && signal == 0;
                 }
                 if class_name == "Failure" {
                     return false;

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3488,7 +3488,8 @@ impl Interpreter {
                             // under, and `.map`/`.grep`'s own native loop
                             // already enforces `use fatal` at the correct,
                             // per-element time.
-                            // Sinking a Proc with non-zero exitcode throws X::Proc::Unsuccessful
+                            // Sinking an unsuccessful Proc (non-zero exitcode, or killed
+                            // by a signal) throws X::Proc::Unsuccessful
                             if let ValueView::Instance {
                                 class_name,
                                 attributes,
@@ -3508,12 +3509,15 @@ impl Interpreter {
                                     attributes.as_map().get("live").map(Value::view),
                                     Some(ValueView::Bool(true))
                                 );
-                                if exitcode != 0 && !is_live {
-                                    let signal =
-                                        match attributes.as_map().get("signal").map(Value::view) {
-                                            Some(ValueView::Int(i)) => i,
-                                            _ => 0,
-                                        };
+                                let signal =
+                                    match attributes.as_map().get("signal").map(Value::view) {
+                                        Some(ValueView::Int(i)) => i,
+                                        _ => 0,
+                                    };
+                                // A signal-killed child reports `exitcode = 0`
+                                // (see `exit_status_parts`), so the signal is
+                                // the only evidence that it was unsuccessful.
+                                if (exitcode != 0 || signal != 0) && !is_live {
                                     let command = attributes
                                         .as_map()
                                         .get("command")

--- a/t/io/proc-signal-exitcode.t
+++ b/t/io/proc-signal-exitcode.t
@@ -1,0 +1,79 @@
+use v6;
+use Test;
+
+# A process killed by a signal has no exit status at all: waitpid reports it
+# as signalled, not exited. Rakudo normalises that to `exitcode = 0` and keeps
+# the information in `.signal`; mutsu used to pass through what Rust's
+# `ExitStatus::code()` gives for a signal death (`None`) as -1.
+#
+# The whole point is that this is NOT "always report 0": a child that genuinely
+# exits non-zero must still report that code, and everything that treats a Proc
+# as unsuccessful (sink context, Bool) must keep doing so on a signal death even
+# though its exitcode is now 0.
+
+plan 16;
+
+# --- run ---------------------------------------------------------------
+
+my $killed = run '/bin/sh', '-c', 'kill -TERM $$', :out, :err;
+is $killed.exitcode, 0, 'run: a signal-killed child reports exitcode 0';
+is $killed.signal, 15, 'run: ... and carries the signal in .signal';
+nok $killed.Bool, 'run: a signal-killed Proc is still falsy';
+
+my $failed = run '/bin/sh', '-c', 'exit 3', :out, :err;
+is $failed.exitcode, 3, 'run: a genuine non-zero exit still reports its code';
+is $failed.signal, 0, 'run: ... with no signal';
+nok $failed.Bool, 'run: a non-zero-exit Proc is falsy';
+
+my $clean = run '/bin/sh', '-c', 'exit 0', :out, :err;
+is $clean.exitcode, 0, 'run: a clean exit reports 0';
+is $clean.signal, 0, 'run: ... with no signal';
+ok $clean.Bool, 'run: a clean Proc is truthy';
+
+# --- shell -------------------------------------------------------------
+
+my $sh = shell 'kill -TERM $$', :out, :err;
+is $sh.exitcode, 0, 'shell: a signal-killed child reports exitcode 0';
+is $sh.signal, 15, 'shell: ... and carries the signal in .signal';
+
+# --- Proc::Async -------------------------------------------------------
+
+{
+    my $p = Proc::Async.new: 'sleep', '60';
+    my $started = $p.start;
+    await $p.ready;
+    $p.kill: SIGTERM;
+    my $proc = await $started;
+    is $proc.exitcode, 0, 'Proc::Async: a killed child reports exitcode 0';
+    is $proc.signal, 15, 'Proc::Async: ... and carries the signal in .signal';
+}
+
+# --- sink context ------------------------------------------------------
+
+# Sinking an unsuccessful Proc throws X::Proc::Unsuccessful. A signal death now
+# reports exitcode 0, so the signal is the only evidence left that it failed.
+{
+    my $threw = '';
+    my $message = '';
+    {
+        run '/bin/sh', '-c', 'kill -TERM $$', :out, :err;
+        CATCH {
+            default {
+                $threw = .^name;
+                $message = .message;
+            }
+        }
+    }
+    is $threw, 'X::Proc::Unsuccessful',
+        'sinking a signal-killed Proc still throws X::Proc::Unsuccessful';
+    like $message, /'signal: 15'/, '... and the message reports the killing signal';
+}
+
+{
+    my $threw = '';
+    {
+        run '/bin/sh', '-c', 'exit 0', :out, :err;
+        CATCH { default { $threw = .^name } }
+    }
+    is $threw, '', 'sinking a successful Proc does not throw';
+}


### PR DESCRIPTION
A process killed by a signal has no exit status at all: `waitpid` reports it as *signalled*, not exited, and Rust's `ExitStatus::code()` is `None` there. mutsu passed that `None` straight through as `-1`, so every signal-killed child came back with `exitcode = -1`:

```raku
my $p = Proc::Async.new: $*EXECUTABLE, "-e", "sleep 60";
my $started = $p.start;
await $p.ready;
$p.kill: SIGTERM;
my $res = await $started;
say $res.exitcode, " ", $res.signal;
```

| | mutsu (before) | raku v2026.07 |
| --- | --- | --- |
| `Proc::Async` + `.kill: SIGTERM` | `-1 15` | `0 15` |
| `run '/bin/sh', '-c', 'kill -TERM $$'` | `-1 15` | `0 15` |
| `shell 'kill -TERM $$'` | `-1 15` | `0 15` |

Rakudo derives both numbers from the raw wait status — `exitcode` is its high byte, `signal` its low one — so a signal death reports `exitcode = 0` and carries the information in `.signal` alone.

## Root cause and fix

The five places that turned a finished child's `ExitStatus` into a `Proc` — `run`, `shell`, the `run(:in, ...)` live-proc finalization, `IO::Pipe.close` and `Proc::Async`'s wait thread — each open-coded `status.code().unwrap_or(-1)` plus a `#[cfg(unix)]` `signal()` block. They now share one `builtins_system::exit_status_parts()` helper, which reports `0` for a signal death and keeps `-1` for the case it was actually meant for: an exit status that could not be read at all.

Normalising the exit code to `0` removes the only evidence a signal-killed `Proc` had that it was unsuccessful, so the two consumers that read `exitcode` alone were taught to consult `.signal` as well — both measured against rakudo first:

- Sinking such a `Proc` still throws `X::Proc::Unsuccessful`. Rakudo throws there too, with the message `The spawned command '/bin/sh' exited unsuccessfully (exit code: 0, signal: 15)`.
- `Proc.Bool` is still `False` (rakudo: `$!exitcode == 0 && $!signal == 0`).

A child that genuinely exits non-zero is untouched and still reports its own code — this is deliberately not "always report 0".

## Tests

New `t/io/proc-signal-exitcode.t` (16 tests) covers `run`, `shell` and `Proc::Async` across a signal death, a non-zero exit and a clean exit, plus the sink-context and `Bool` behaviour. **It passes unchanged under `prove -e raku`**, so it pins the rakudo semantics rather than mutsu's current ones.

## Verification

- `cargo fmt --all`, `make lint` — clean.
- `make test` — PASS (3989 files, 42472 tests).
- `make roast` — the only failures are the three documented container-environment exceptions from `docs/agent-environments.md` (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` are meaningless under `uid 0`; `S32-io/IO-Socket-Async.t` times out on the sandboxed network), each matching its recorded failure shape exactly.

Closes #7924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dt1hyeYXvFExjsnrru8tfX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dt1hyeYXvFExjsnrru8tfX)_