### PR TITLE
fix: deduplicate ancestor role bodies during composition

### DIFF
--- a/news/2026-09/role-proto-diamond-deduplicates-ancestor-bodies.md
+++ b/news/2026-09/role-proto-diamond-deduplicates-ancestor-bodies.md
@@ -1,0 +1,15 @@
+# Shared role proto declarations are not re-registered through a diamond
+
+When a class or grammar composed two roles that both inherited the same role,
+mutsu ran the shared ancestor's deferred body once per composition path. A
+`proto rule`, `proto token`, or `proto regex` in that body was therefore
+mistaken for a second declaration and raised `X::Redeclaration`.
+
+Ancestor role bodies now use the same `(composing type, role)` composition memo
+as direct role bodies. This keeps candidates contributed by the ancestor and
+child roles available while preserving genuine redeclaration errors within one
+body. The regression coverage is in
+`t/grammar/role-proto-diamond.t` and
+`t/oo/role-proto-diamond-class.t`.
+
+Fixes [#7901](https://github.com/tokuhirom/mutsu/issues/7901).

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1258,13 +1258,41 @@ impl Interpreter {
         regex_owner: &str,
     ) -> Result<(), RuntimeError> {
         for ancestor in self.role_ancestor_names(role_name) {
+            // An ancestor can be reached through more than one directly
+            // composed role (for example, a diamond through B and C). Its
+            // deferred body belongs to the consuming type and must run only
+            // once for that (type, role) pair, just like the direct role body
+            // in `compose_role_into_class`. Without this guard a `proto
+            // rule`/`token`/`regex` in the shared ancestor is registered once
+            // per path and the second registration is mistaken for a genuine
+            // redeclaration.
+            let compose_key = format!("class:{regex_owner}:{ancestor}");
+            if !self
+                .registry_mut()
+                .composed_role_bodies
+                .insert(compose_key.clone())
+            {
+                continue;
+            }
             let (ops, decl_file) = self
                 .registry()
                 .roles
                 .get(&ancestor)
                 .map(|r| (r.deferred_body.clone(), r.decl_file.clone()))
                 .unwrap_or_default();
-            self.run_role_body_for_composition(&ancestor, regex_owner, &ops, decl_file.as_deref())?;
+            if let Err(error) = self.run_role_body_for_composition(
+                &ancestor,
+                regex_owner,
+                &ops,
+                decl_file.as_deref(),
+            ) {
+                // A failed role composition must remain retryable. The direct
+                // role path removes its memo key on the same kind of failure.
+                self.registry_mut()
+                    .composed_role_bodies
+                    .remove(&compose_key);
+                return Err(error);
+            }
         }
         Ok(())
     }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -376,12 +376,11 @@ pub(crate) struct Registry {
     pub(crate) role_hides: HashMap<String, Vec<String>>,
     /// Declared type parameters per parameterized role: role -> [param names].
     pub(crate) role_type_params: HashMap<String, Vec<String>>,
-    /// Compositions whose role body has already been run, keyed
-    /// `"{kind}:{role}"` (`pun:R`, `mixin:R`). Rakudo runs a role body once per
-    /// composition and memoises the composed type, so punning a role twice — or
-    /// mixing it into a second value — must not run its body again. A `does`
-    /// composition is not memoised here: each consuming class is its own
-    /// composition and runs the body again, as Rakudo does.
+    /// Compositions whose role body has already been run, keyed by kind and
+    /// target (`pun:R`, `mixin:R`, or `class:C:R`). A role body runs once per
+    /// composed target: repeated paths to the same ancestor role in one class
+    /// must not run it again, while each distinct consuming class remains its
+    /// own composition.
     pub(crate) composed_role_bodies: HashSet<String>,
     /// Bound role type parameters per class: class -> (param name -> value).
     pub(crate) class_role_param_bindings: HashMap<String, HashMap<String, Value>>,

--- a/t/oo/role/role-proto-diamond-class.t
+++ b/t/oo/role/role-proto-diamond-class.t
@@ -1,0 +1,16 @@
+use Test;
+
+plan 1;
+
+role ProtoDiamondClass::Base {
+    proto rule filler {*}
+}
+role ProtoDiamondClass::Left does ProtoDiamondClass::Base { }
+role ProtoDiamondClass::Right does ProtoDiamondClass::Base { }
+class ProtoDiamondClass::Consumer
+    does ProtoDiamondClass::Left
+    does ProtoDiamondClass::Right
+{ }
+
+lives-ok { ProtoDiamondClass::Consumer.new },
+    'a class can compose a shared proto rule through a diamond';

--- a/t/oo/role/role-proto-diamond.t
+++ b/t/oo/role/role-proto-diamond.t
@@ -1,0 +1,151 @@
+use Test;
+
+plan 14;
+
+# The same role listed twice directly was already deduplicated and remains so.
+my $direct = EVAL q:to/DIRECT/;
+    role ProtoDiamond::DirectBase {
+        proto rule directfiller {*}
+        rule directfiller:sym<English> { 'en' }
+    }
+    grammar ProtoDiamond::DirectGrammar
+        does ProtoDiamond::DirectBase
+        does ProtoDiamond::DirectBase
+    {
+        rule TOP { <directfiller> }
+    }
+    ProtoDiamond::DirectGrammar.parse('en') ?? 'PARSED' !! 'NO MATCH'
+    DIRECT
+is $direct, 'PARSED', 'a role listed twice directly remains deduplicated';
+
+# A proto regex declaration in a shared role must be installed once when the
+# role is reached through a diamond.
+role ProtoDiamond::RuleBase {
+    proto rule filler {*}
+}
+role ProtoDiamond::RuleLeft does ProtoDiamond::RuleBase { }
+role ProtoDiamond::RuleRight does ProtoDiamond::RuleBase { }
+grammar ProtoDiamond::RuleGrammar does ProtoDiamond::RuleLeft does ProtoDiamond::RuleRight {
+    rule TOP { 'x' }
+}
+
+ok ProtoDiamond::RuleGrammar.parse('x'),
+    'a grammar can compose a shared proto rule through a diamond';
+
+# Candidates from the shared role and one of its children must remain in the
+# same composing grammar after the ancestor body is deduplicated.
+role ProtoDiamond::CandidateBase {
+    proto rule candidate {*}
+    rule candidate:sym<English> { 'en' }
+}
+role ProtoDiamond::CandidateLeft does ProtoDiamond::CandidateBase {
+    rule candidate:sym<Bulgarian> { 'bg' }
+}
+role ProtoDiamond::CandidateRight does ProtoDiamond::CandidateBase { }
+grammar ProtoDiamond::CandidateGrammar
+    does ProtoDiamond::CandidateLeft
+    does ProtoDiamond::CandidateRight
+{
+    rule TOP { <candidate> }
+}
+
+ok ProtoDiamond::CandidateGrammar.parse('en'),
+    'the shared role candidate still matches';
+ok ProtoDiamond::CandidateGrammar.parse('bg'),
+    'the child role candidate still matches';
+
+# proto token and proto regex use the same deferred-body registration path.
+role ProtoDiamond::TokenBase {
+    proto token tokenfiller {*}
+    token tokenfiller:sym<English> { 'en' }
+}
+role ProtoDiamond::TokenLeft does ProtoDiamond::TokenBase {
+    token tokenfiller:sym<Bulgarian> { 'bg' }
+}
+role ProtoDiamond::TokenRight does ProtoDiamond::TokenBase { }
+grammar ProtoDiamond::TokenGrammar
+    does ProtoDiamond::TokenLeft
+    does ProtoDiamond::TokenRight
+{
+    token TOP { <tokenfiller> }
+}
+
+ok ProtoDiamond::TokenGrammar.parse('en'),
+    'proto token shared-role candidate still matches';
+ok ProtoDiamond::TokenGrammar.parse('bg'),
+    'proto token child-role candidate still matches';
+
+role ProtoDiamond::RegexBase {
+    proto regex regexfiller {*}
+    regex regexfiller:sym<English> { 'en' }
+}
+role ProtoDiamond::RegexLeft does ProtoDiamond::RegexBase {
+    regex regexfiller:sym<Bulgarian> { 'bg' }
+}
+role ProtoDiamond::RegexRight does ProtoDiamond::RegexBase { }
+grammar ProtoDiamond::RegexGrammar
+    does ProtoDiamond::RegexLeft
+    does ProtoDiamond::RegexRight
+{
+    token TOP { <regexfiller> }
+}
+
+ok ProtoDiamond::RegexGrammar.parse('en'),
+    'proto regex shared-role candidate still matches';
+ok ProtoDiamond::RegexGrammar.parse('bg'),
+    'proto regex child-role candidate still matches';
+
+# A real duplicate in one body is not a repeated composition and must remain
+# an X::Redeclaration.
+throws-like q:to/ROLE-REDECL/, X::Role::Instantiation,
+    role ProtoDiamond::BadRole {
+        proto rule filler {*}
+        proto rule filler {*}
+    }
+    class ProtoDiamond::BadRoleConsumer does ProtoDiamond::BadRole { }
+    ROLE-REDECL
+    'a genuine proto rule redeclaration is still rejected';
+
+throws-like 'class ProtoDiamond::BadClass { proto rule filler {*}; proto rule filler {*} }',
+    X::Redeclaration, 'a genuine class proto rule redeclaration is still rejected';
+
+# Existing non-proto and method composition controls remain unchanged.
+role ProtoDiamond::MethodBase { method hi { 'A' } }
+role ProtoDiamond::MethodLeft does ProtoDiamond::MethodBase { }
+role ProtoDiamond::MethodRight does ProtoDiamond::MethodBase { }
+class ProtoDiamond::MethodClass
+    does ProtoDiamond::MethodLeft
+    does ProtoDiamond::MethodRight
+{ }
+is ProtoDiamond::MethodClass.new.hi, 'A',
+    'a plain method still composes through a diamond';
+
+role ProtoDiamond::PlainRuleBase { rule filler { 'x' } }
+role ProtoDiamond::PlainRuleLeft does ProtoDiamond::PlainRuleBase { }
+role ProtoDiamond::PlainRuleRight does ProtoDiamond::PlainRuleBase { }
+grammar ProtoDiamond::PlainRuleGrammar
+    does ProtoDiamond::PlainRuleLeft
+    does ProtoDiamond::PlainRuleRight
+{
+    rule TOP { <filler> }
+}
+ok ProtoDiamond::PlainRuleGrammar.parse('x'),
+    'a plain rule still composes through a diamond';
+
+role ProtoDiamond::MethodProtoBase {
+    proto method greet(|) {*}
+    multi method greet(Int) { 'int' }
+}
+role ProtoDiamond::MethodProtoLeft does ProtoDiamond::MethodProtoBase {
+    multi method greet(Str) { 'str' }
+}
+role ProtoDiamond::MethodProtoRight does ProtoDiamond::MethodProtoBase { }
+class ProtoDiamond::MethodProtoClass
+    does ProtoDiamond::MethodProtoLeft
+    does ProtoDiamond::MethodProtoRight
+{ }
+my $method-proto = ProtoDiamond::MethodProtoClass.new;
+is $method-proto.greet(1), 'int',
+    'a proto method still dispatches its integer candidate';
+is $method-proto.greet('x'), 'str',
+    'a proto method still dispatches its string candidate';


### PR DESCRIPTION
## Summary

- memoize deferred ancestor role bodies per composing class and role
- preserve retry behavior when role composition fails
- add grammar and class diamond-composition regressions for proto rule/token/regex declarations

## Validation

- `make lint`
- `make test`
- `make roast`

Closes #7901