### PR TITLE
fix: commit a delta from mutable native-method dispatch, not the whole attr map

### DIFF
--- a/news/2026-09/native-mut-dispatch-delta-commit.md
+++ b/news/2026-09/native-mut-dispatch-delta-commit.md
@@ -1,0 +1,77 @@
+# Mutable native-method dispatch commits a delta, not the whole attribute map
+
+Two threads working on one `Proc::Async` could lose each other's attribute
+writes, and `roast/S17-procasync/kill.t` test 7 failed intermittently on `main`
+because of it — blocking unrelated PRs. Both halves of that are now fixed
+([#7923](https://github.com/tokuhirom/mutsu/issues/7923), closing
+[#7892](https://github.com/tokuhirom/mutsu/issues/7892)).
+
+## The lost update
+
+Every mutable native method is a read-modify-write over the receiver's whole
+attribute map. The dispatcher cloned the map (`to_map()`), handed the clone to
+the per-class handler, and stored whatever came back (`commit_attrs()`). The two
+locks are individually safe and the pair is not: any key a *different* thread
+committed in between was silently replaced by the snapshot's older version. That
+shape routed `Promise`, `Channel`, `Supply`, `Supplier`, `Proc`, `Proc::Async`,
+`Encoding::Decoder`, `ThreadPoolScheduler` and `IO::CatHandle`, from four
+separate call sites — `Proc::Async` is only where roast deliberately puts two
+threads on one instance, so it is where the hole showed first.
+
+The ticket asked for a decision between a delta commit and serializing the whole
+dispatch per instance. **Delta commit won.** Serializing would hold one lock
+across the handler, and these handlers block for a long time — `Proc::Async.start`
+spawns a process, `IO::CatHandle` reads files — so it trades a lost update for a
+stall, and still does nothing about writes arriving from outside this path.
+
+So a mutable native method's returned `AttrMap` now means *the new state of the
+keys it touched*, not the instance's complete new state.
+`InstanceAttrs::commit_attrs_delta` takes the boxed-word before-image of the map
+as it was read (`AttrMap::bits_image`) and, under one write lock, stores the keys
+whose word changed, removes the keys that are gone, and leaves everything else
+alone — so a key neither side touched keeps the other thread's value. Where both
+threads rewrote the same key, the last commit wins; there is no happens-before
+between them to prefer, and it is what a per-key write lock would have given.
+
+"Did the handler touch this key" is answered by comparing NaN-box words rather
+than values: cloning a `Value` preserves the word (a pointer clone bumps the
+refcount but keeps the address), so an entry carried through untouched compares
+equal, and the before-image costs one `u64` per attribute instead of a second
+full map clone. It errs in the safe direction — a word that differs for a
+semantically equal value just commits a write that the old code made anyway.
+
+The one entry point, `call_native_instance_method_mut_in_place`, now owns the
+snapshot-dispatch-commit triple, and the function that let a call site commit by
+hand is gone. The bug cannot be reintroduced at a fifth call site.
+
+## The late publication
+
+The delta commit alone does not fix `kill.t`. Measuring the failure showed the
+killer thread's `await $p.ready` returning and `$p.started` reading `False`
+immediately after — not a lost write but a write that had not landed yet.
+`Proc::Async.start` keeps the `.ready` promise as soon as the child is spawned
+and then carries on (stdin registry, reader threads, the waiter thread) before
+returning, so the thread it just woke reads the instance while `started` and
+`pid` still live only in the handler's local copy. Committing at return is too
+late no matter what the commit does.
+
+`start` therefore publishes `started`, `pid` and `spawn_error` straight through
+the shared cell before the keep that hands them to another thread. Rakudo sets
+its `$!started` first thing in `start` for the same reason, and that write is on
+the shared object too.
+
+## Measurements
+
+The ticket's repro (~1.5% per run) was too weak to judge a fix by, so the race
+was probed directly: one thread on `await $p.ready` reading `$p.started`, with
+both handles tapped so `start` has real work left to do after the keep. That
+loses the race on 7-12 of 12 rounds before the fix and 0 after, in 0.02s — it is
+the new `t/concurrency/procasync-ready-publishes-started.t`, which caught the bug
+on 10 of 10 pre-fix runs and passed 30 of 30 post-fix runs, idle and under 4x CPU
+load. `roast/S17-procasync/kill.t` went 25 for 25 under the same load.
+
+The delta commit has its own deterministic pins in
+`src/value/value_instance/tests.rs`: a concurrent writer's key surviving (and the
+old whole-map path losing it), removals still applying, the contended-key
+tie-break, an untouched map committing nothing at all, and four threads hammering
+one cell.

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1245,14 +1245,12 @@ impl Interpreter {
                         | "stderr"
                         | "Supply"
                 ) {
-                    let (result, updated) = self.call_native_instance_method_mut(
+                    return self.call_native_instance_method_mut_in_place(
+                        &attributes,
                         &class_name.resolve(),
-                        attributes.to_map(),
                         method,
                         args,
-                    )?;
-                    attributes.commit_attrs(updated);
-                    return Ok(result);
+                    );
                 }
                 if matches!(
                     method,
@@ -1278,14 +1276,12 @@ impl Interpreter {
                 // Every IO::CatHandle method advances internal read state, so route
                 // through the mutable path and commit the updated attributes back to
                 // the receiver's shared cell.
-                let (result, updated) = self.call_native_instance_method_mut(
+                return self.call_native_instance_method_mut_in_place(
+                    &attributes,
                     &class_name.resolve(),
-                    attributes.to_map(),
                     method,
                     args,
-                )?;
-                attributes.commit_attrs(updated);
-                return Ok(result);
+                );
             }
             // A user-defined method shadows an inherited native one: for a user
             // subclass of a builtin (`class S is IO::Handle { method Str {...} }`),

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -3002,16 +3002,19 @@ impl Interpreter {
                     }
                 }
                 // Try mutable dispatch first; if no mutable handler, fall back to immutable
-                match self.call_native_instance_method_mut(
+                match self.call_native_instance_method_mut_in_place(
+                    &attributes,
                     &class_name.resolve(),
-                    attributes.to_map(),
                     method,
                     args.clone(),
                 ) {
-                    Ok((result, updated)) => {
+                    Ok(result) => {
+                        // The delta commit already landed in the shared cell, so
+                        // rebinding the name is all that is left (no second write
+                        // of a whole map, which is what lost concurrent updates).
                         self.env.insert(
                             target_var.to_string(),
-                            Value::write_back_sharing(&attributes, class_name, updated, target_id),
+                            Value::instance_sharing_cell(&attributes, class_name, target_id),
                         );
                         return Ok(result);
                     }

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -1297,14 +1297,13 @@ impl Interpreter {
             if self.is_native_method(&class_name.resolve(), method) {
                 let mut all_args = method_args.clone();
                 all_args.push(value.clone());
-                match self.call_native_instance_method_mut(
+                match self.call_native_instance_method_mut_in_place(
+                    &attributes,
                     &class_name.resolve(),
-                    attributes.to_map(),
                     method,
                     all_args,
                 ) {
-                    Ok((result, updated_attrs)) => {
-                        attributes.commit_attrs(updated_attrs);
+                    Ok(result) => {
                         if let Some(var_name) = target_var {
                             self.env.insert_through(
                                 var_name.to_string(),

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -271,14 +271,63 @@ impl Interpreter {
         }
     }
 
-    /// Dispatch a mutable native instance method.
-    /// Returns (result_value, updated_attributes).
-    pub(super) fn call_native_instance_method_mut(
+    /// Dispatch a mutable native instance method against the receiver's **live**
+    /// attribute cell, committing only what the handler actually changed.
+    ///
+    /// Every mutable native method is a read-modify-write over the attribute map:
+    /// the handler takes the map by value and hands back the version it wants
+    /// stored. Committing that with `InstanceAttrs::commit_attrs` *replaces* the
+    /// map, so a write another thread landed between the read and the commit was
+    /// silently discarded — two threads on one `Proc::Async` lost `.start`'s
+    /// `started`/`pid` to a concurrent `.ready`, and the next `.kill` threw
+    /// `X::Proc::Async::MustBeStarted` (tokuhirom/mutsu#7923). Routing the commit
+    /// through [`crate::value::InstanceAttrs::commit_attrs_delta`] keeps the keys the handler
+    /// never touched, so the concurrent write survives.
+    ///
+    /// This is the **only** entry to the mutable native handlers: having one place
+    /// own the snapshot-dispatch-commit triple is what keeps the lost update from
+    /// being reintroduced at a fifth call site.
+    pub(super) fn call_native_instance_method_mut_in_place(
+        &mut self,
+        attributes: &crate::value::InstanceAttrs,
+        class_name: &str,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        let working = attributes.to_map();
+        let before = working.bits_image();
+        let (result, updated) = self.dispatch_native_instance_method_mut(
+            class_name,
+            working,
+            method,
+            args,
+            Some(attributes),
+        )?;
+        attributes.commit_attrs_delta(&before, &updated);
+        Ok(result)
+    }
+
+    /// Run the per-class mutable native handler and hand back
+    /// `(result, updated_attributes)`.
+    ///
+    /// Deliberately private: the only way in is
+    /// [`Interpreter::call_native_instance_method_mut_in_place`], so the
+    /// whole-map write-back that lost concurrent updates
+    /// (tokuhirom/mutsu#7923) cannot be written at a call site again.
+    ///
+    /// `cell` is the receiver's live attribute cell, for handlers that must make a
+    /// mutation **visible before they return** because they also publish a promise
+    /// or wake another thread mid-flight: committing at return is too late,
+    /// whatever the commit does. `Proc::Async.start` is the case that forced it —
+    /// it keeps the `.ready` promise as soon as the child is spawned, and the
+    /// thread that wakes on it immediately reads `started`.
+    fn dispatch_native_instance_method_mut(
         &mut self,
         class_name: &str,
         attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
+        cell: Option<&crate::value::InstanceAttrs>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         let dispatch_class = if matches!(
             class_name,
@@ -333,7 +382,7 @@ impl Interpreter {
             "Supplier" | "Supplier::Preserving" => {
                 self.native_supplier_mut(attributes, method, args)
             }
-            "Proc::Async" => self.native_proc_async_mut(attributes, method, args),
+            "Proc::Async" => self.native_proc_async_mut(attributes, method, args, cell),
             "Encoding::Decoder" => Self::native_encoding_decoder_mut(attributes, method, args),
             "ThreadPoolScheduler" | "CurrentThreadScheduler" => {
                 Interpreter::native_scheduler_mut(attributes, method, args)

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -222,11 +222,18 @@ pub(in crate::runtime) fn malformed_utf8_quit_value() -> Value {
 }
 
 impl Interpreter {
+    /// `live` is the receiver's shared attribute cell when the caller has it.
+    /// `start` needs it: it keeps the `.ready` promise as soon as the child is
+    /// spawned, and whatever wakes on that promise reads `started`/`pid` off the
+    /// cell straight away — long before this handler returns and its caller
+    /// commits. Publishing those two through the cell *before* the keep is what
+    /// makes `await $p.ready; $p.kill` well-defined (tokuhirom/mutsu#7923).
     pub(super) fn native_proc_async_mut(
         &mut self,
         mut attrs: AttrMap,
         method: &str,
         args: Vec<Value>,
+        live: Option<&crate::value::InstanceAttrs>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "start" => {
@@ -236,6 +243,15 @@ impl Interpreter {
                     return Err(proc_async_error("X::Proc::Async::AlreadyStarted", &[]));
                 }
                 attrs.insert("started".to_string(), Value::TRUE);
+                // Publish `started` now, not at commit time: spawning the child is
+                // the slow part of this method and it keeps the `.ready` promise
+                // on the way, so a thread blocked on `await $p.ready` can read
+                // `$p.started` while we are still in here. Rakudo sets its
+                // `$!started` attribute first thing in `start` for the same
+                // reason, and that write is on the shared object too.
+                if let Some(live) = live {
+                    live.insert("started", Value::TRUE);
+                }
 
                 // The merged Supply may have been fetched before `.start()`;
                 // its later `.tap`/`whenever` registration must still reject
@@ -444,6 +460,12 @@ impl Interpreter {
                     );
                     let os_error = Value::make_instance(Symbol::intern("X::OS"), ex_attrs);
                     attrs.insert("spawn_error".to_string(), os_error.clone());
+                    // Published before the break below, for the same reason as
+                    // `started`: whoever wakes on the broken `.ready` promise may
+                    // ask this object about the failure before we return.
+                    if let Some(live) = live {
+                        live.insert("spawn_error", os_error.clone());
+                    }
 
                     // Break ready promise if set
                     if let Some(ValueView::Promise(ready)) =
@@ -480,6 +502,12 @@ impl Interpreter {
 
                 let pid = child.id();
                 attrs.insert("pid".to_string(), Value::int(pid as i64));
+                // Same reason as `started` above: the `.ready` keep a few lines
+                // down hands the pid to another thread, which may then ask this
+                // object for it.
+                if let Some(live) = live {
+                    live.insert("pid", Value::int(pid as i64));
+                }
 
                 if let Some(ValueView::Instance {
                     attributes: stdout_attrs,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1066,7 +1066,7 @@ impl Interpreter {
                 // `.listen()` before tapping it (e.g. IO::Socket::Async::SSL's
                 // `!server-setup`, which fell through to treating the listener
                 // itself as a single accepted connection when the smartmatch
-                // failed). See `call_native_instance_method_mut`'s hardcoded
+                // failed). See `dispatch_native_instance_method_mut`'s hardcoded
                 // class list in `native_methods/mod.rs`, which must also list this
                 // class name explicitly -- its MRO-walk fallback would otherwise
                 // now match `Supply` and route `tap`/`act` to the wrong (generic,

--- a/src/value/attr_map.rs
+++ b/src/value/attr_map.rs
@@ -221,6 +221,46 @@ impl AttrMap {
             }
         }
     }
+
+    /// The boxed-word before-image of this map; see [`AttrBits`].
+    pub(crate) fn bits_image(&self) -> AttrBits {
+        AttrBits(self.0.iter().map(|(k, v)| (*k, v.nanbox_bits())).collect())
+    }
+}
+
+/// The boxed-word image of an [`AttrMap`] — the before-image a delta commit
+/// diffs against (see [`super::InstanceAttrs::commit_attrs_delta`]).
+///
+/// Why not just keep a cloned `AttrMap` as the before-image: cloning the map
+/// clones every `Value`, which for the pointer variants means a refcount bump
+/// per attribute on a path that already pays one full clone (the working copy
+/// handed to the native method). The *only* question the diff asks of the
+/// before-image is "is the value still the same boxed word", and that is one
+/// `u64` per key — no `Value` clones, one allocation.
+///
+/// Safe against address reuse (an ABA on a pointer variant) because the
+/// working copy the handler holds keeps every snapshotted value alive until the
+/// commit: the addresses in here cannot be recycled in between.
+#[derive(Default)]
+pub(crate) struct AttrBits(FxHashMap<Symbol, u64>);
+
+impl AttrBits {
+    /// The boxed word `key` held when the image was taken, or `None` if the key
+    /// was absent. Equal bits mean the entry was never touched.
+    #[inline]
+    pub(crate) fn bits(&self, key: Symbol) -> Option<u64> {
+        self.0.get(&key).copied()
+    }
+
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[inline]
+    pub(crate) fn keys(&self) -> std::collections::hash_map::Keys<'_, Symbol, u64> {
+        self.0.keys()
+    }
 }
 
 impl Extend<(Symbol, Value)> for AttrMap {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -266,7 +266,7 @@ mod seq_body_shapes;
 
 pub(crate) use crate::gc::gc_contents_mut;
 pub(crate) use aliased_mut::gc_data_mut;
-pub(crate) use attr_map::{AttrKey, AttrMap, attr_twigil_base};
+pub(crate) use attr_map::{AttrBits, AttrKey, AttrMap, attr_twigil_base};
 pub(crate) use entry_path::EntryRoot;
 pub use entry_path::EntryStep;
 pub(crate) use entry_path::EntryTerminal;
@@ -405,9 +405,42 @@ thread_local! {
     static PENDING_CELL_WRITES: RefCell<Vec<PendingCellWrite>> = const { RefCell::new(Vec::new()) };
 }
 
-/// A deferred cell write: `(cell address, cell, new map)`. See
+/// A deferred cell write: `(cell address, cell, what to write)`. See
 /// [`PENDING_CELL_WRITES`].
-type PendingCellWrite = (usize, AttrCell, AttrMap);
+type PendingCellWrite = (usize, AttrCell, PendingWrite);
+
+/// What a deferred cell write does once it can take the write lock.
+#[derive(Debug)]
+pub(crate) enum PendingWrite {
+    /// Replace the whole map ([`InstanceAttrs::commit_attrs`]).
+    Replace(AttrMap),
+    /// Apply a per-key delta ([`InstanceAttrs::commit_attrs_delta`]): `Some(v)`
+    /// stores, `None` removes. Keys absent from the list keep whatever the cell
+    /// holds — which is the whole point, since another thread may have written
+    /// them while this write was queued.
+    Delta(Vec<(Symbol, Option<Value>)>),
+}
+
+impl PendingWrite {
+    /// Apply to an already-locked map.
+    fn apply(self, map: &mut AttrMap) {
+        match self {
+            PendingWrite::Replace(new) => *map = new,
+            PendingWrite::Delta(ops) => {
+                for (key, op) in ops {
+                    match op {
+                        Some(value) => {
+                            map.insert(key, value);
+                        }
+                        None => {
+                            map.remove(key);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
 
 /// How many deferred cell writes exist across all threads. Deferral is a rare
 /// self-deadlock escape hatch, but EVERY [`AttrReadGuard`] drop had to consult
@@ -694,14 +727,14 @@ pub fn make_frozen_container(value: Value, constraint: Option<&str>) -> Value {
 /// When this thread is *not* reading the cell we take a blocking write lock,
 /// which is required for correctness under genuine cross-thread contention
 /// (e.g. concurrent `cas` on a shared instance attribute must not drop updates).
-fn write_cell_respecting_reads(cell: &AttrCell, map: AttrMap) {
+fn write_cell_respecting_reads(cell: &AttrCell, write: PendingWrite) {
     let addr = cell_addr(cell);
     if HELD_READ_CELLS.with(|c| c.borrow().contains(&addr)) {
-        PENDING_CELL_WRITES.with(|p| p.borrow_mut().push((addr, cell.clone(), map)));
+        PENDING_CELL_WRITES.with(|p| p.borrow_mut().push((addr, cell.clone(), write)));
         note_pending_cell_write_pushed();
         return;
     }
-    *write_attrs(cell) = map;
+    write.apply(&mut write_attrs(cell));
 }
 
 /// Recover the map from a poisoned lock instead of propagating the panic. A
@@ -1350,27 +1383,29 @@ impl std::fmt::Debug for Value {
     }
 }
 
-/// Raw NaN-box word access for the JIT Tier B inline emitter (see
-/// `jit_words`). Read-only: exposing the bits does not breach the newtype
-/// seal's ownership rules (the word still owns its payload reference).
-#[cfg(feature = "jit")]
 impl Value {
+    /// Raw NaN-box word: the bit-identical inline payload, or the heap address
+    /// for a pointer variant. Read-only, so exposing the bits does not breach
+    /// the newtype seal's ownership rules (the word still owns its payload
+    /// reference).
+    ///
+    /// Used by the JIT Tier B inline emitter (see `jit_words`) and, as a
+    /// *stored* before-image, by [`AttrBits`] — which needs the bits themselves
+    /// rather than [`Self::same_binding`]'s pairwise compare, because it keeps
+    /// them after the values it read are gone.
+    #[inline]
     pub(crate) fn nanbox_bits(&self) -> u64 {
         self.0.bits()
     }
-}
 
-impl Value {
     /// O(1) *binding* identity: the same immediate value, or the same heap
     /// allocation. Unlike `PartialEq` it never walks container contents, so it is
     /// usable on hot paths that only need to know whether a name was **rebound**
     /// (as opposed to its container being mutated in place, which leaves the
     /// binding — and these bits — unchanged).
-    ///
-    /// Available in every build, unlike the `jit`-gated `nanbox_bits`.
     #[inline]
     pub(crate) fn same_binding(&self, other: &Value) -> bool {
-        self.0.bits() == other.0.bits()
+        self.nanbox_bits() == other.nanbox_bits()
     }
 }
 

--- a/src/value/nanbox/mod.rs
+++ b/src/value/nanbox/mod.rs
@@ -589,9 +589,8 @@ unsafe impl Send for NanBox {}
 unsafe impl Sync for NanBox {}
 
 impl NanBox {
-    /// Raw word bits (tests / future tag-dispatch fast paths).
+    /// Raw word bits (tests; `Value::nanbox_bits`).
     #[inline]
-    #[allow(dead_code)]
     pub(in crate::value) fn bits(&self) -> u64 {
         self.0.get()
     }

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -37,22 +37,25 @@ impl Drop for AttrReadGuard<'_> {
         if !super::pending_cell_writes_possible() {
             return;
         }
+        // Partition rather than `retain` + clone: a `PendingWrite` owns its map
+        // (or its delta ops), and the queue is drained in push order.
         let flush = PENDING_CELL_WRITES.with(|p| {
             let mut v = p.borrow_mut();
-            let mut mine: Vec<(AttrCell, AttrMap)> = Vec::new();
-            v.retain(|(a, cell, map)| {
-                if *a == self.addr {
-                    mine.push((cell.clone(), map.clone()));
-                    false
+            let mut mine: Vec<(AttrCell, PendingWrite)> = Vec::new();
+            let mut keep: Vec<PendingCellWrite> = Vec::new();
+            for (addr, cell, write) in std::mem::take(&mut *v) {
+                if addr == self.addr {
+                    mine.push((cell, write));
                 } else {
-                    true
+                    keep.push((addr, cell, write));
                 }
-            });
+            }
+            *v = keep;
             mine
         });
         super::note_pending_cell_writes_drained(flush.len());
-        for (cell, map) in flush {
-            *write_attrs(&cell) = map;
+        for (cell, write) in flush {
+            write.apply(&mut write_attrs(&cell));
         }
     }
 }
@@ -284,7 +287,58 @@ impl InstanceAttrs {
     /// (`overwrite_instance_bindings_by_identity` / `update_instance_cell`), which
     /// computed an updated `HashMap` and looked the cell up by id.
     pub(crate) fn commit_attrs(&self, map: AttrMap) {
-        write_cell_respecting_reads(&self.attributes, map);
+        write_cell_respecting_reads(&self.attributes, PendingWrite::Replace(map));
+    }
+
+    /// Commit only what actually changed, instead of replacing the whole map.
+    ///
+    /// `before` is the [`AttrMap::bits_image`] of the map as it was read, and
+    /// `updated` is the map the caller produced from it. Keys whose boxed word is
+    /// unchanged are left alone; keys that were added or rewritten are stored;
+    /// keys that were in `before` and are gone from `updated` are removed. The
+    /// whole delta goes in under **one** write lock.
+    ///
+    /// This is what makes a read-modify-write over the attribute map safe to run
+    /// concurrently on one instance. [`Self::commit_attrs`] replaces the map, so
+    /// the snapshot-dispatch-commit shape every mutable *native* method goes
+    /// through (`Interpreter::call_native_instance_method_mut_in_place`) silently threw
+    /// away any key another thread committed in between: two threads on one
+    /// `Proc::Async` would lose `.start`'s `started`/`pid` to a concurrent
+    /// `.ready`, and `.kill` would then throw `X::Proc::Async::MustBeStarted`
+    /// (tokuhirom/mutsu#7923). A key *neither* side touched is not in the delta at
+    /// all, so the other thread's write survives.
+    ///
+    /// Tie-break when both threads rewrote the same key: last commit wins. There
+    /// is no happens-before between them to prefer, and it matches what a single
+    /// write lock per key would have given.
+    pub(crate) fn commit_attrs_delta(&self, before: &AttrBits, updated: &AttrMap) {
+        let mut ops: Vec<(Symbol, Option<Value>)> = Vec::new();
+        // How many of `updated`'s keys were also in `before`. Removals exist iff
+        // that overlap is smaller than `before` — so the usual case (a method that
+        // only inserts or rewrites) never scans `before` at all.
+        let mut overlap = 0usize;
+        for (key, value) in updated.iter() {
+            match before.bits(*key) {
+                Some(bits) => {
+                    overlap += 1;
+                    if bits != value.nanbox_bits() {
+                        ops.push((*key, Some(value.clone())));
+                    }
+                }
+                None => ops.push((*key, Some(value.clone()))),
+            }
+        }
+        if overlap < before.len() {
+            for key in before.keys() {
+                if !updated.contains_key(*key) {
+                    ops.push((*key, None));
+                }
+            }
+        }
+        if ops.is_empty() {
+            return;
+        }
+        write_cell_respecting_reads(&self.attributes, PendingWrite::Delta(ops));
     }
 
     /// Phase 3 cell-CAS: atomically compare-and-swap one attribute under a
@@ -407,3 +461,6 @@ impl Drop for InstanceAttrs {
         self.finalize_destroy();
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/value/value_instance/tests.rs
+++ b/src/value/value_instance/tests.rs
@@ -1,0 +1,131 @@
+//! Concurrency pins for the instance attribute cell — above all
+//! [`crate::value::InstanceAttrs::commit_attrs_delta`], the commit that made a mutable native
+//! method safe to run on an instance another thread is also mutating
+//! (tokuhirom/mutsu#7923).
+
+use super::*;
+use crate::symbol::Symbol;
+
+fn attrs() -> InstanceAttrs {
+    InstanceAttrs::new(Symbol::intern("T"), AttrMap::new(), 1, false)
+}
+
+/// The defect behind tokuhirom/mutsu#7923: a read-modify-write over the whole
+/// attribute map discards whatever another thread committed in between.
+/// `commit_attrs` loses it; `commit_attrs_delta` keeps it.
+#[test]
+fn delta_commit_keeps_a_concurrent_writers_key() {
+    let cell = attrs();
+
+    // Thread A reads the map...
+    let working = cell.to_map();
+    let before = working.bits_image();
+
+    // ...thread B inserts `b` and commits while A is still working...
+    cell.insert("b", Value::int(2));
+
+    // ...and A commits its own insert of `a`.
+    let mut updated = working;
+    updated.insert("a", Value::int(1));
+    cell.commit_attrs_delta(&before, &updated);
+
+    assert_eq!(cell.as_map().get("a"), Some(&Value::int(1)));
+    assert_eq!(
+        cell.as_map().get("b"),
+        Some(&Value::int(2)),
+        "a key neither side touched must survive the commit"
+    );
+
+    // The whole-map replacement this replaced is what dropped `b`.
+    let working = cell.to_map();
+    cell.insert("c", Value::int(3));
+    cell.commit_attrs(working);
+    assert_eq!(cell.as_map().get("c"), None);
+}
+
+/// A key the method genuinely removed is removed, and nothing else is.
+#[test]
+fn delta_commit_applies_removals() {
+    let cell = attrs();
+    cell.insert("keep", Value::int(1));
+    cell.insert("drop", Value::int(2));
+
+    let working = cell.to_map();
+    let before = working.bits_image();
+    let mut updated = working;
+    updated.remove("drop");
+    // Another thread adds a key after the snapshot.
+    cell.insert("late", Value::int(3));
+    cell.commit_attrs_delta(&before, &updated);
+
+    assert_eq!(cell.as_map().get("keep"), Some(&Value::int(1)));
+    assert_eq!(cell.as_map().get("drop"), None);
+    assert_eq!(cell.as_map().get("late"), Some(&Value::int(3)));
+}
+
+/// Both threads rewrote the same key: last commit wins, and the key the other
+/// thread *added* still survives.
+#[test]
+fn delta_commit_last_writer_wins_on_a_contended_key() {
+    let cell = attrs();
+    cell.insert("x", Value::int(0));
+
+    let working = cell.to_map();
+    let before = working.bits_image();
+    cell.insert("x", Value::int(9));
+    cell.insert("other", Value::int(7));
+
+    let mut updated = working;
+    updated.insert("x", Value::int(1));
+    cell.commit_attrs_delta(&before, &updated);
+
+    assert_eq!(cell.as_map().get("x"), Some(&Value::int(1)));
+    assert_eq!(cell.as_map().get("other"), Some(&Value::int(7)));
+}
+
+/// A handler that changed nothing must not write at all, so it cannot clobber
+/// a concurrent writer even on a key it merely carried through.
+#[test]
+fn delta_commit_of_an_untouched_map_is_a_no_op() {
+    let cell = attrs();
+    cell.insert("x", Value::int(0));
+
+    let working = cell.to_map();
+    let before = working.bits_image();
+    cell.insert("x", Value::int(5));
+    cell.commit_attrs_delta(&before, &working);
+
+    assert_eq!(cell.as_map().get("x"), Some(&Value::int(5)));
+}
+
+/// Two threads hammering one cell through the delta commit: every key
+/// inserted must be present at the end.
+#[test]
+fn delta_commit_survives_real_concurrency() {
+    let cell = Arc::new(attrs());
+    let threads: Vec<_> = (0..4)
+        .map(|t| {
+            let cell = Arc::clone(&cell);
+            std::thread::spawn(move || {
+                for i in 0..200 {
+                    let working = cell.to_map();
+                    let before = working.bits_image();
+                    let mut updated = working;
+                    updated.insert(format!("t{t}_{i}"), Value::int(i));
+                    cell.commit_attrs_delta(&before, &updated);
+                }
+            })
+        })
+        .collect();
+    for t in threads {
+        t.join().unwrap();
+    }
+    for t in 0..4 {
+        for i in 0..200 {
+            assert!(
+                cell.contains_key(format!("t{t}_{i}").as_str()),
+                "lost t{t}_{i}"
+            );
+        }
+    }
+}

--- a/t/concurrency/procasync-ready-publishes-started.t
+++ b/t/concurrency/procasync-ready-publishes-started.t
@@ -1,0 +1,53 @@
+use Test;
+
+# Regression pin for tokuhirom/mutsu#7923: a mutable native method must publish
+# what it changed before anything it wakes can observe the instance.
+#
+# `Proc::Async.start` keeps the `.ready` promise as soon as the child is spawned,
+# so a thread blocked on `await $p.ready` is released while `start` is still
+# running. It used to read `$p.started` as False there -- `started` reached the
+# shared attribute cell only when the dispatcher committed `start`'s whole
+# returned attribute map, which happens after the keep -- and the `.kill` that
+# followed threw X::Proc::Async::MustBeStarted. That is what made roast's
+# S17-procasync/kill.t test 7 fail intermittently on main.
+#
+# Tapping both handles is what makes this a dependable pin rather than a 3%
+# coin flip: it gives `start` real work to do after the keep (a reader thread
+# and supply registration per handle), so the woken thread reliably gets in
+# first. Pre-fix that loses the race on 7-12 of the 12 rounds below; the fix is
+# an ordering rather than a wider window, so post-fix it is 0 on any box.
+
+plan 3;
+
+my $rounds = 12;
+my $lost-started = 0;
+my $lost-pid = 0;
+my $kill-failed = 0;
+my $spawned = 0;
+
+for ^$rounds {
+    my $p = Proc::Async.new($*EXECUTABLE, '-e', 'sleep');
+    $p.stdout.tap({ });
+    $p.stderr.tap({ });
+    my $ready = $p.ready;
+
+    # Wakes inside `.start`, while the spawn is still in flight.
+    my $probe = start {
+        await $ready;
+        ($p.started, $p.pid.defined)
+    }
+
+    my $done = $p.start;
+    my ($started, $has-pid) = await $probe;
+    $lost-started++ unless $started;
+    $lost-pid++ unless $has-pid;
+
+    # The failure mode the roast test actually reports.
+    $kill-failed++ unless try { $p.kill: 'TERM'; True };
+    $spawned++ if $p.pid.defined;
+    my $proc = try await $done;
+}
+
+is $spawned, $rounds, "all $rounds children really were spawned (the race was exercised)";
+is $lost-started, 0, "\$p.started is True for every thread woken by \$p.ready";
+is $kill-failed + $lost-pid, 0, '$p.kill after await $p.ready never hits the not-started guard';


### PR DESCRIPTION
Two threads working on one instance lost each other's attribute writes, and `roast/S17-procasync/kill.t` test 7 failed intermittently on `main` because of it — blocking unrelated PRs.

## The lost update

Every mutable native method is a read-modify-write over the receiver's whole attribute map: the dispatcher cloned the map (`to_map()`), handed the clone to the per-class handler, and stored whatever came back (`commit_attrs()`). Each lock is safe and the pair is not, so any key another thread committed in between was replaced by the snapshot's older version. That shape routed `Promise`, `Channel`, `Supply`, `Supplier`, `Proc`, `Proc::Async`, `Encoding::Decoder`, `ThreadPoolScheduler` and `IO::CatHandle` from four call sites; `Proc::Async` is only where roast deliberately puts two threads on one instance, so it is where the hole showed first.

**Of the ticket's two candidate designs, this takes the delta commit.** Serializing the dispatch per instance would hold one lock across handlers that block for a long time (`Proc::Async.start` spawns a process, `IO::CatHandle` reads files), trading a lost update for a stall, and would still miss writes arriving from outside this path.

So a mutable native method's returned `AttrMap` now means **the new state of the keys it touched**, not the instance's complete new state. `InstanceAttrs::commit_attrs_delta` takes the boxed-word before-image of the map as it was read (`AttrMap::bits_image`) and, under one write lock, stores the keys whose word changed, removes the keys that are gone, and leaves everything else alone — so a key neither side touched keeps the other thread's value. Where both threads rewrote one key, the last commit wins: there is no happens-before between them to prefer, and it is what a per-key write lock would have given.

"Did the handler touch this key" compares NaN-box words rather than values. Cloning a `Value` preserves the word (a pointer clone bumps the refcount but keeps the address), so an entry carried through untouched compares equal, and the before-image costs one `u64` per attribute instead of a second full map clone. It errs in the safe direction — a word that differs for a semantically equal value just commits a write the old code made anyway.

`call_native_instance_method_mut_in_place` now owns the snapshot-dispatch-commit triple, and the function that let a call site commit by hand is **gone**, so the lost update cannot come back at a fifth call site.

## The late publication

The delta commit alone does not fix `kill.t`. Measuring the failure showed the killer thread's `await $p.ready` returning and `$p.started` reading `False` straight after — not a lost write but one that had not landed yet. `Proc::Async.start` keeps the `.ready` promise as soon as the child is spawned and then carries on (stdin registry, reader threads, the waiter thread) before returning, so the thread it just woke reads the instance while `started` and `pid` still live only in the handler's local copy. Committing at return is too late whatever the commit does.

`start` therefore publishes `started`, `pid` and `spawn_error` through the shared cell before the keep that hands them to another thread. Rakudo sets its `$!started` first thing in `start` for the same reason, and that write is on the shared object too.

## Verification

The ticket's repro (~1.5% per run) is too weak to judge a fix by, so the new `t/concurrency/procasync-ready-publishes-started.t` probes the race directly, with both handles tapped so `start` has real work left after the keep:

| | pre-fix | post-fix |
|---|---|---|
| rounds losing the race (of 12) | 7–12 | 0 |
| test runs caught / failed | 10 of 10 caught | 0 of 30 failed (idle **and** under 4× CPU load) |
| `roast/S17-procasync/kill.t` under 4× load | intermittent on `main` | 25 of 25 green |

It runs in 0.02s. The delta commit has deterministic pins of its own in `src/value/value_instance/tests.rs`: a concurrent writer's key surviving (and the old whole-map path losing it), removals still applying, the contended-key tie-break, an untouched map committing nothing at all, and four threads hammering one cell.

Full local gate: `cargo fmt`, `make lint`, `make test` (3989 files / 42459 tests, PASS) and `make roast` (1436 files / 218939 tests) all run. The only roast failures are the three documented container artifacts in `docs/agent-environments.md`, matching subtest-for-subtest: `6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8/10) and `S16-filehandles/filetest.t` (`Failed: 25`) both from running as `uid 0`, and `S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17) from the sandboxed network.

Closes #7923
Closes #7892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLFp9Kge1gxkCpKVB7qmKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLFp9Kge1gxkCpKVB7qmKb)_