### PR TITLE
fix(parser): approximate a `sub EXPORT` module's exports at parse time

### DIFF
--- a/docs/adr/0087-runtime-export-hook-parse-time-approximation.md
+++ b/docs/adr/0087-runtime-export-hook-parse-time-approximation.md
@@ -1,0 +1,134 @@
+# ADR-0087: A `sub EXPORT` module's parse-time export set is approximated by its unit-scope routines
+
+- Status: Accepted (implemented)
+- Date: 2026-09-11
+- Related: [#7881](https://github.com/tokuhirom/mutsu/issues/7881), ADR-0081 (compunit-scoped module import aliases), ADR-0085 (ecosystem test-suite parity measurement)
+
+## Context
+
+mutsu's parser pre-scans every `use`d module file for the names it exports
+(`src/parser/stmt/simple/module_exports.rs`). That is what lets an imported name
+parse as a listop: knowing `root` is a routine is what makes `root <abcd abce>`
+a call with a quote-word argument rather than an infix `<` comparison against a
+bareword.
+
+The scan is **static**. It reads `is export` traits out of the module's AST (with
+a regex fallback for declarations the best-effort parse drops). A module that
+exports through Raku's run-time hook instead —
+
+```raku
+my sub EXPORT(*@names) {
+    Map.new: UNIT::.grep: { .key.starts-with('&') && !(.key eq '&EXPORT') }
+}
+```
+
+— carries no `is export` trait anywhere, so the scan finds **nothing** and the
+importer's parse learns nothing. Every call shape that needs the parser to know
+the name is a routine is then a hard parse error:
+
+| | `use String::Utils; say root <abcd abce>` |
+|---|---|
+| `raku` | `ab` |
+| mutsu (before) | `===SORRY!=== Confused. expected expression after infix operator` |
+
+The parenthesised call `root(<abcd abce>)` parsed and ran correctly, and the
+identical listop shape parsed fine for a locally-declared `sub root`, so the
+missing piece was precisely "the parser does not know `root` is a routine".
+
+The idiom is not rare. `String::Utils` exports its entire surface this way and
+uses the listop shape on eight lines of `t/01-basic.rakutest`, which made the
+whole file unparseable — 0 of a 124-assertion baseline
+(`ecosystem/dists/S/String--Utils.json`).
+
+The root difficulty is real: the export set is *computed by running the module*,
+and rakudo gets to run it because it loads compunits at BEGIN time. mutsu loads
+modules at run time, so at the moment the importing file is parsed the set
+genuinely does not exist yet.
+
+## Decision
+
+**When a module declares a unit-scope `sub EXPORT`, approximate its export set
+with the routines the module declares in its own unit scope, and register those
+as imported callables for the importer's parse.**
+
+Implemented in `src/parser/stmt/simple/module_exports/export_hook.rs`, driven
+from `scan_module_source`:
+
+1. Detect the hook — a unit-scope `Stmt::SubDecl`/`Stmt::ProtoDecl` named
+   `EXPORT`, descending through a `unit module Foo;` wrapper, with a
+   line-anchored source regex as the fallback for a declaration the best-effort
+   parse dropped.
+2. Only then, collect the module's unit-scope routine names (again AST-first,
+   source-regex as fallback), excluding `EXPORT` itself and any qualified
+   `sub Foo::bar`, which is installed in a package rather than in the compunit's
+   lexical scope.
+3. Feed them into the same `exports` map the `is export` scan fills, so a real
+   `is export` entry — which carries precedence and associativity — always wins
+   over the approximation.
+
+### Why a superset is the right shape
+
+The approximation is neither sound nor complete, and that is deliberate:
+
+- It can name a routine the module keeps to itself (the `UNIT::` idiom's own
+  exclusion list, `&is-CCLASS` in String::Utils).
+- It misses a name a hook synthesises out of thin air rather than drawing from
+  its unit scope.
+
+What makes the trade acceptable is that **the set is parse-time knowledge only**.
+It lands in `Scope::imported_functions`, whose sole consumer is
+`is_imported_function` — every call site of which is a parser decision about
+whether an identifier is a routine. Run-time name resolution is untouched: it
+still resolves against the import set produced by actually running `sub EXPORT`.
+
+So an over-named routine costs a worse diagnostic (a run-time "undeclared
+routine" where a parse error once stood) and can never change the meaning of a
+program that runs. An under-named one leaves exactly today's behavior. Against
+that, registering nothing — the status quo — makes every such call shape a hard
+parse error, which is strictly worse than both.
+
+The gate on "the module declares `sub EXPORT`" is what keeps the
+over-approximation confined. A module with `is export` traits is unaffected; the
+approximation only ever applies where the scan's current answer is the empty set.
+
+## Alternatives considered
+
+### 1. Load modules at parse time (rakudo's model)
+
+The correct fix, and the same prerequisite several other parse-time-knowledge
+gaps share. It is also an architectural campaign, not a patch: it means BEGIN-time
+compunit loading, a re-entrant interpreter inside the parser, and a decision about
+the side effects a module's mainline is allowed to have during a parse. Rejected
+*for now* as out of proportion to one parse gap — not rejected as the eventual
+answer. This ADR does not block it: when parse-time loading lands, the
+approximation here becomes dead code and should be deleted, not preserved.
+
+### 2. Evaluate `sub EXPORT` alone, at parse time
+
+A narrower version of (1): run just the hook. Rejected because the hook is a
+closure over the module's mainline — `UNIT::` only has entries once the mainline
+has run — so "just the hook" is not a smaller thing than loading the module.
+
+### 3. Fall back at the use site
+
+When an identifier is unknown and is followed by whitespace and a `<...>` that
+closes on the same line, prefer the quote-word listop reading. Rejected: it is a
+guess made where the parser has *least* information (it knows nothing about the
+name), it would fire for genuinely undeclared names and turn a precise parse
+error into a confusing run-time one, and it addresses only the `<...>` shape
+rather than the underlying "we don't know this is a routine" gap. The decision
+above makes the guess at the point where the evidence actually is — the module
+file — and every other call shape benefits too.
+
+## Consequences
+
+- `String::Utils`'s `t/01-basic.rakutest` parses, taking it from a 0-assertion
+  parse death to 117 passing assertions against a 124 baseline. The residue is
+  unrelated run-time bugs, not parsing.
+- The parse-time export set for a `sub EXPORT` module is explicitly an
+  approximation. Anything that starts to use `imported_functions` for something
+  other than a parser decision about routine-ness must revisit this ADR first —
+  the soundness argument above is the whole licence for the superset.
+- Pinned by `t/modules/import-export/runtime-export-listop-parse.t`, which
+  covers both directions: the listop call must parse, and a unit-scope routine
+  the hook deliberately withholds must still be unresolvable at run time.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -112,3 +112,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0084](0084-the-frame-env-is-not-the-programs-symbol-table.md) | The per-frame `Env` is not the program's symbol table — type/package names and internal markers move to side tables | Proposed (design complete; implementation not started) |
 | [0085](0085-ecosystem-testsuite-parity-measurement.md) | The ecosystem KPI is per-distribution test-suite parity against rakudo | Accepted (P1 implemented; P2-P5 open — see "Implementation status") |
 | [0086](0086-builtin-dynamics-are-not-closure-capture-material.md) | The built-in dynamics are not closure-capture material — they belong in a per-interpreter never-copied tier | Proposed (design complete; implementation not started) |
+| [0087](0087-runtime-export-hook-parse-time-approximation.md) | A `sub EXPORT` module's parse-time export set is approximated by its unit-scope routines | Accepted (implemented) |

--- a/news/2026-09/runtime-export-hook-listop-parse.md
+++ b/news/2026-09/runtime-export-hook-listop-parse.md
@@ -1,0 +1,61 @@
+# A routine exported by a run-time `sub EXPORT` now parses as a listop
+
+mutsu's parser pre-scans each `use`d module for the names it exports, and that
+scan is what lets an imported name parse as a listop — knowing `root` is a
+routine is the difference between `root <abcd abce>` being a call with a
+quote-word argument and being an infix `<` comparison against a bareword.
+
+The scan only ever looked for `is export` traits. A module that computes its
+exports at load time through Raku's `sub EXPORT` hook carries no such trait, so
+the scan came back empty and the importer's parse learned nothing about it. Every
+call shape that needs the parser to know the name is a routine was then a hard
+parse error:
+
+```raku
+use String::Utils;
+say root <abcd abce>;   # raku: ab     mutsu: ===SORRY!=== Confused.
+```
+
+The parenthesised form `root(<abcd abce>)` worked, and the same listop shape
+worked for a locally-declared `sub root`, which located the gap precisely.
+
+Fixing it properly would mean knowing a module's exports at parse time, and those
+names exist only once the module has run — rakudo gets them because it loads
+compunits at BEGIN time, and mutsu loads modules at run time. Rather than start
+that campaign for one parse gap, the scan now *approximates*: when a module
+declares a unit-scope `sub EXPORT`, its unit-scope routine declarations are
+registered as the importer's imported callables. That is verbatim what the
+dominant idiom exports —
+
+```raku
+my sub EXPORT(*@names) {
+    Map.new: UNIT::.grep: { .key.starts-with('&') && !(.key eq '&EXPORT') }
+}
+```
+
+— and every other hook shape draws its `Pair` values from the same pool of
+unit-scope routines.
+
+The approximation is a superset, and that asymmetry is deliberate. The set is
+parse-time knowledge only: it lands in `Scope::imported_functions`, whose every
+consumer is a parser decision about whether an identifier is a routine. Run-time
+name resolution still resolves against the import set produced by actually
+running `sub EXPORT`. So naming a routine the hook withholds costs a worse
+diagnostic at worst and can never change the meaning of a program that runs,
+while registering nothing — the old behavior — made the call shape unparseable.
+The gate on "this module declares `sub EXPORT`" confines the approximation to
+exactly the modules whose current answer is the empty set.
+
+`String::Utils` is the dist this was measured on: its `t/01-basic.rakutest` uses
+the listop shape on eight lines and previously died during parsing with zero
+assertions run, against a 124-assertion `raku` baseline. It now reaches 117
+passing assertions, with the residue being unrelated run-time bugs rather than
+parsing.
+
+The decision, the three alternatives weighed against it (parse-time compunit
+loading, evaluating the hook alone, and a use-site `<...>` guess), and the
+soundness argument for the superset are recorded in
+[ADR-0087](../../docs/adr/0087-runtime-export-hook-parse-time-approximation.md).
+Pinned by `t/modules/import-export/runtime-export-listop-parse.t`, which checks
+both directions: the listop call parses, and a unit-scope routine the hook
+deliberately withholds stays unresolvable at run time.

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -2,6 +2,12 @@ use super::*;
 use std::cell::Cell;
 use std::rc::Rc;
 
+mod export_hook;
+use export_hook::{
+    collect_unit_scope_routines, declares_export_sub, source_declares_export_sub,
+    unit_scope_routine_names_fallback,
+};
+
 /// Everything one module-file scan learns that importers need replayed:
 /// the `is export` subs, the declared type names (own + transitive), and the
 /// declared enum values (own + transitive). Cached per resolved file path so
@@ -565,6 +571,22 @@ fn scan_module_source(source: &str, path: &str) -> ModuleScanResult {
     collect_module_constant_names(&stmts, &mut value_terms);
     let mut exports: HashMap<String, InlineModuleExport> = HashMap::new();
     collect_exported_subs(&stmts, &mut exports);
+    // A module whose exports are computed by a run-time `sub EXPORT` hook has
+    // no `is export` traits to find, so the scan above returns nothing at all.
+    // Approximate its export set with the routines it declares in its own unit
+    // scope, which is what the dominant `UNIT::`-grep idiom exports verbatim
+    // (ADR-0087).
+    if declares_export_sub(&stmts) || source_declares_export_sub(source) {
+        collect_unit_scope_routines(&stmts, &mut exports);
+        for name in unit_scope_routine_names_fallback(source) {
+            exports.entry(name.clone()).or_insert(InlineModuleExport {
+                name,
+                precedence: None,
+                associativity: None,
+                is_test_assertion: false,
+            });
+        }
+    }
     // Fallback scan for modules that use syntax not yet fully covered by parse_program_partial.
     // This keeps imported exported-callables discoverable for statement-call parsing.
     for (name, is_test_assertion) in extract_exported_names_fallback(source) {

--- a/src/parser/stmt/simple/module_exports/export_hook.rs
+++ b/src/parser/stmt/simple/module_exports/export_hook.rs
@@ -1,0 +1,125 @@
+//! Approximating the export set of a module that exports through a run-time
+//! `sub EXPORT` hook (ADR-0087).
+//!
+//! The surrounding static scan looks for `is export` traits. A module that
+//! computes its exports in `sub EXPORT` carries none, so it contributes nothing
+//! to the importer's parse-time knowledge and every call shape that needs the
+//! parser to know a name is a routine — a listop call above all — fails to
+//! parse. This module supplies the approximation the scan falls back to.
+
+use super::InlineModuleExport;
+use crate::ast::Stmt;
+use regex::Regex;
+use std::collections::HashMap;
+
+/// Does this module install its imports at run time through a `sub EXPORT`
+/// hook, rather than through `is export` traits?
+///
+/// `sub EXPORT` is Raku's escape hatch for computing an export set at load
+/// time: whatever `Map` it returns becomes the importer's lexical import. The
+/// static scan in the parent module cannot evaluate it — mutsu loads modules at run time, so
+/// the set genuinely does not exist while the importing file is being parsed —
+/// which is why its presence switches on the unit-scope approximation here
+/// (ADR-0087).
+///
+/// Only a *unit-scope* `EXPORT` counts: that is the only place rakudo looks for
+/// the hook, so a `sub EXPORT` nested inside a class body is an ordinary
+/// routine and says nothing about how the module exports.
+pub(super) fn declares_export_sub(stmts: &[Stmt]) -> bool {
+    stmts.iter().any(|stmt| match stmt {
+        Stmt::SubDecl { name, .. } | Stmt::ProtoDecl { name, .. } => name.resolve() == "EXPORT",
+        // `unit module Foo;` wraps the rest of the file, but its declarations
+        // are still the compunit's own unit scope.
+        Stmt::Package {
+            body,
+            is_unit: true,
+            ..
+        } => declares_export_sub(body),
+        _ => false,
+    })
+}
+
+/// Approximate the export set of a `sub EXPORT` module with the routines it
+/// declares in its own unit scope (ADR-0087).
+///
+/// The dominant idiom exports exactly that set — `UNIT::.grep: { .key.starts-with('&') }`
+/// (String::Utils, and most of lizmat's ecosystem) — and every other shape
+/// draws its `Pair` values from the same pool of unit-scope routines. The
+/// approximation is therefore a superset in practice: it can name a routine the
+/// module keeps to itself, and it misses a name the hook synthesises out of
+/// thin air.
+///
+/// That asymmetry is deliberate. The only thing the parse phase does with this
+/// set is decide that an identifier is a routine, which is what lets
+/// `root <abcd abce>` parse as a listop call instead of an infix `<` comparison.
+/// A name that is *not* really exported still resolves against the run-time
+/// import set, which is computed by actually running `sub EXPORT`, so a
+/// superset costs a worse diagnostic at worst and never changes the meaning of
+/// a program that runs. Registering nothing — today's behavior — makes every
+/// such call shape a hard parse error.
+pub(super) fn collect_unit_scope_routines(
+    stmts: &[Stmt],
+    out: &mut HashMap<String, InlineModuleExport>,
+) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::SubDecl { name, .. } | Stmt::ProtoDecl { name, .. } => {
+                let resolved = name.resolve();
+                // `EXPORT` is the hook itself; rakudo never exports it, and the
+                // `UNIT::` idiom excludes it by name. A qualified `sub Foo::bar`
+                // is installed in a package, not in the unit's lexical scope.
+                if resolved.is_empty() || resolved == "EXPORT" || resolved.contains("::") {
+                    continue;
+                }
+                out.entry(resolved.clone()).or_insert(InlineModuleExport {
+                    name: resolved,
+                    precedence: None,
+                    associativity: None,
+                    is_test_assertion: false,
+                });
+            }
+            Stmt::Package {
+                body,
+                is_unit: true,
+                ..
+            } => collect_unit_scope_routines(body, out),
+            _ => {}
+        }
+    }
+}
+
+/// Source-level companion to [`collect_unit_scope_routines`], for the case the
+/// AST walk cannot cover: `parse_program_partial` silently drops every
+/// statement it cannot parse, and the modules that reach for `sub EXPORT` are
+/// disproportionately the ones that also reach for `nqp::` internals, so some
+/// of their declarations are missing from `stmts` entirely.
+///
+/// "Unit scope" is approximated by "the declaration starts at column 0". A
+/// routine nested in a class or block body is indented by every house style in
+/// the ecosystem, and an over-indented unit-scope routine only costs us the
+/// same name the AST walk already found.
+pub(super) fn unit_scope_routine_names_fallback(source: &str) -> Vec<String> {
+    let sub_re = Regex::new(
+        r"(?m)^(?:my\s+|our\s+)?(?:proto\s+|multi\s+|only\s+)?sub\s+([A-Za-z_][A-Za-z0-9_'\-]*(?:::[A-Za-z_][A-Za-z0-9_'\-]*)*)",
+    )
+    .expect("valid unit-scope sub regex");
+    let mut names: Vec<String> = sub_re
+        .captures_iter(source)
+        .filter_map(|caps| caps.get(1).map(|m| m.as_str().to_string()))
+        // A qualified `sub Foo::bar` is installed in a package, not in the
+        // compunit's lexical scope, so it is not part of what `UNIT::` sees.
+        .filter(|name| name != "EXPORT" && !name.contains("::"))
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Source-level detection of the `sub EXPORT` hook, for the same reason
+/// [`unit_scope_routine_names_fallback`] exists: the hook's own
+/// declaration may be one of the statements the best-effort parse dropped.
+pub(super) fn source_declares_export_sub(source: &str) -> bool {
+    Regex::new(r"(?m)^(?:my\s+|our\s+)?sub\s+EXPORT\b")
+        .expect("valid EXPORT-hook regex")
+        .is_match(source)
+}

--- a/t/lib/RuntimeExport/RuntimeExportListop.rakumod
+++ b/t/lib/RuntimeExport/RuntimeExportListop.rakumod
@@ -1,0 +1,18 @@
+# A module in the String::Utils shape: nothing carries an `is export` trait,
+# and the whole export set is computed at load time by `sub EXPORT` out of the
+# compunit's own unit scope. `private-helper` is deliberately withheld from the
+# returned Map, so it exercises the one place the parse-time approximation is a
+# superset of the real import set.
+
+my sub private-helper($x) { $x ~ "!" }
+
+my sub first-word(*@words) { @words[0] }
+
+my sub joined(@words) { @words.join("-") }
+
+my sub EXPORT(*@names) {
+    Map.new: UNIT::.grep: {
+        .key.starts-with('&')
+          && !(.key eq '&EXPORT' | '&private-helper')
+    }
+}

--- a/t/modules/import-export/runtime-export-listop-parse.t
+++ b/t/modules/import-export/runtime-export-listop-parse.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# A module that exports through a run-time `sub EXPORT` hook carries no
+# `is export` traits, so mutsu's static export scan used to learn nothing from
+# it. With the name unknown to the parser, the listop call shape
+# `first-word <a b c>` was a hard parse error -- `<` was taken as infix
+# less-than and the quote-word list was a syntax error -- even though the
+# parenthesised call worked fine.
+#
+# ADR-0087: the scan now approximates such a module's export set with the
+# routines it declares in its own unit scope, which is exactly what the
+# dominant `UNIT::.grep: { .key.starts-with('&') }` idiom exports.
+#
+# https://github.com/tokuhirom/mutsu/issues/7881
+
+plan 5;
+
+use lib 't/lib/RuntimeExport';
+use RuntimeExportListop;
+
+is first-word(<abcd abce>), 'abcd',
+    'the parenthesised call form still works';
+
+is (first-word <abcd abce>), 'abcd',
+    'a listop call with a quote-word argument parses';
+
+is (joined <a b c>), 'a-b-c',
+    'a second run-time-exported routine parses as a listop too';
+
+# The approximation is parse-time knowledge only. `private-helper` is declared
+# in the module's unit scope but withheld by the hook, so it must stay
+# unresolvable at run time -- knowing the name is a routine must not make it
+# callable.
+dies-ok { EVAL 'private-helper("x")' },
+    'a unit-scope routine the hook withholds is still not imported';
+
+# The listop reading must not swallow a genuine numeric comparison.
+ok 1 < 2, 'infix < still parses as less-than';


### PR DESCRIPTION
## Problem

mutsu's parser pre-scans every `use`d module for the names it exports, and that scan is what lets an imported name parse as a listop — knowing `root` is a routine is the difference between `root <abcd abce>` being a call with a quote-word argument and being an infix `<` comparison against a bareword.

The scan only ever looked for `is export` traits. A module that computes its exports at load time through Raku's `sub EXPORT` hook carries no such trait, so the scan came back empty and the importer's parse learned nothing about it:

```raku
use String::Utils;
say root <abcd abce>;   # raku: ab     mutsu: ===SORRY!=== Confused.
```

The parenthesised form `root(<abcd abce>)` worked, and the same listop shape worked for a locally-declared `sub root`, which locates the gap precisely: the parser does not know the name is a routine.

## Decision (ADR-0087)

Fixing this properly means knowing a module's exports at parse time, and those names exist only once the module has run — rakudo gets them because it loads compunits at BEGIN time, and mutsu loads modules at run time. Rather than start that campaign for one parse gap, the scan now **approximates**: when a module declares a unit-scope `sub EXPORT`, its unit-scope routine declarations are registered as the importer's imported callables. That is verbatim what the dominant idiom exports —

```raku
my sub EXPORT(*@names) {
    Map.new: UNIT::.grep: { .key.starts-with('&') && !(.key eq '&EXPORT') }
}
```

— and every other hook shape draws its `Pair` values from the same pool of unit-scope routines.

**The approximation is a superset, deliberately.** The set is parse-time knowledge only: it lands in `Scope::imported_functions`, whose every consumer is a parser decision about whether an identifier is a routine, while run-time name resolution still resolves against the import set produced by actually running `sub EXPORT`. So naming a routine the hook withholds costs a worse diagnostic at worst and can never change the meaning of a program that runs, whereas registering nothing — the old behavior — made the call shape unparseable. Gating on "this module declares `sub EXPORT`" confines the approximation to exactly the modules whose current answer is the empty set.

The two alternatives the issue raised are recorded as rejected in the ADR, with reasons: parse-time compunit loading (the correct eventual fix, out of proportion to one parse gap — the ADR says to delete this code when it lands), and a use-site `<...>` guess (a guess made where the parser has *least* information, and it would only address the one call shape).

## Result

`String::Utils`' `t/01-basic.rakutest` goes from dying during the parse with **0** assertions run to **117 passing**, against a 124-assertion `raku` baseline. The residue is unrelated run-time bugs, not parsing — `Match.^lookup` does not expose the NQP cursor protocol, filed separately as #7931.

## Changes

- `src/parser/stmt/simple/module_exports/export_hook.rs` (new): hook detection and the unit-scope routine collection, each AST-first with a line-anchored source regex as the fallback for declarations the best-effort parse dropped.
- `src/parser/stmt/simple/module_exports.rs`: drives it from `scan_module_source`, feeding the names into the same `exports` map so a real `is export` entry — which carries precedence and associativity — always wins.
- `t/modules/import-export/runtime-export-listop-parse.t` + `t/lib/RuntimeExport/RuntimeExportListop.rakumod`: pins both directions — the listop call parses, and a unit-scope routine the hook deliberately withholds stays unresolvable at run time. Verified to fail without the `src/` change, and passes under `raku` as well as mutsu.
- `docs/adr/0087-*.md`, `docs/adr/README.md`, `news/2026-09/runtime-export-hook-listop-parse.md`.

## Verification

- `cargo fmt --all`, `make lint` — green.
- `make test` — green (3990 files, 42465 tests).
- `make roast` — the three documented environment-only failures and nothing else, matching `docs/agent-environments.md` by name *and* by subtest range: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8/10, `uid 0`), `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64/69-72/77-80/101-125 odd, `uid 0`), `roast/S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17, sandboxed network).

Closes #7881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFBobozrSYurmgyPgPerSd

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFBobozrSYurmgyPgPerSd)_