### PR TITLE
fix: numify Match captures in sum

### DIFF
--- a/news/2026-09/quantified-code-assertion-sums-match-captures.md
+++ b/news/2026-09/quantified-code-assertion-sums-match-captures.md
@@ -1,0 +1,9 @@
+# Quantified code assertions can sum Match captures
+
+A code assertion after a quantified capture now numifies its Match values when
+using `.sum`. This lets the assertion retry with the captures from a shorter
+quantifier candidate and accept the candidate selected by the predicate.
+
+Pinned by `t/regex/match/quantified-code-assertion-capture-backtracking.t`.
+
+Closes #7904.

--- a/src/runtime/utils/radix_numeric.rs
+++ b/src/runtime/utils/radix_numeric.rs
@@ -216,6 +216,14 @@ pub(crate) fn coerce_to_numeric(val: Value) -> Value {
             .get("value")
             .cloned()
             .unwrap_or(Value::num(0.0)),
+        // A Match numifies through the text it matched. This matters when a
+        // quantified capture is reduced with `.sum`: the capture list holds
+        // Match values, not bare strings, so the normal arithmetic fold must
+        // reach the same coercion as `.Numeric`/`to_f64`.
+        ValueView::Instance { .. } if val.is_match_instance() => val
+            .match_str_value()
+            .map(coerce_to_numeric)
+            .unwrap_or_else(|| Value::int(0)),
         ValueView::Instance {
             class_name,
             attributes,

--- a/t/regex/match/quantified-code-assertion-capture-backtracking.t
+++ b/t/regex/match/quantified-code-assertion-capture-backtracking.t
@@ -1,0 +1,12 @@
+use Test;
+
+plan 2;
+
+# A code assertion after a quantified capture must be retried with the
+# captures from the shorter candidate. Match values numify through their text,
+# so `$0.sum` can select the candidate whose digits add up to 28.
+my @sums;
+my $match = "1 2 3 4 5 6 7 8 " ~~ /^ [(\d) \s]+ <?{ @sums.push($0.sum); $0.sum == 28 }>/;
+
+is @sums, (36, 28), 'the assertion sees each backtracked capture list';
+is ~$match, '1 2 3 4 5 6 7 ', 'the assertion accepts the shortened quantified match';


### PR DESCRIPTION
## Summary

- numify Match instances through their matched text during numeric coercion
- add regression coverage for quantified code assertion backtracking with `$0.sum`
- add release news for #7904

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`

Closes #7904