### PR TITLE
fix: preserve subtraction in negated class lookahead

### DIFF
--- a/news/2026-09/negated-lookahead-preserves-class-subtraction.md
+++ b/news/2026-09/negated-lookahead-preserves-class-subtraction.md
@@ -1,0 +1,13 @@
+# Negated lookahead preserves character-class subtraction
+
+A negated lookahead over a compound character class, such as
+`<![a] - [b]>`, was parsed as a named assertion instead of retaining the
+class subtraction. It therefore failed to match characters removed by the
+subtraction, even though the negated assertion should succeed for them.
+
+Negated lookaheads now parse leading bracket classes through the same
+character-class composition path as positive lookaheads. This restores the
+affected `roast/S05-metasyntax/charset.t` case and adds regression coverage in
+`t/regex/syntax/regex-negated-charclass-lookahead.t`.
+
+Fixes [#7905](https://github.com/tokuhirom/mutsu/issues/7905).

--- a/news/2026-09/role-proto-diamond-deduplicates-ancestor-bodies.md
+++ b/news/2026-09/role-proto-diamond-deduplicates-ancestor-bodies.md
@@ -9,7 +9,7 @@ Ancestor role bodies now use the same `(composing type, role)` composition memo
 as direct role bodies. This keeps candidates contributed by the ancestor and
 child roles available while preserving genuine redeclaration errors within one
 body. The regression coverage is in
-`t/grammar/role-proto-diamond.t` and
-`t/oo/role-proto-diamond-class.t`.
+`t/oo/role/role-proto-diamond.t` and
+`t/oo/role/role-proto-diamond-class.t`.
 
 Fixes [#7901](https://github.com/tokuhirom/mutsu/issues/7901).

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -439,6 +439,7 @@ roast/S05-metachars/line-anchors.t
 roast/S05-metachars/newline.t
 roast/S05-metachars/tilde.t
 roast/S05-metasyntax/assertions.t
+roast/S05-metasyntax/charset.t
 roast/S05-metasyntax/changed.t
 roast/S05-metasyntax/delimiters.t
 roast/S05-metasyntax/interpolating-closure.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -439,8 +439,8 @@ roast/S05-metachars/line-anchors.t
 roast/S05-metachars/newline.t
 roast/S05-metachars/tilde.t
 roast/S05-metasyntax/assertions.t
-roast/S05-metasyntax/charset.t
 roast/S05-metasyntax/changed.t
+roast/S05-metasyntax/charset.t
 roast/S05-metasyntax/delimiters.t
 roast/S05-metasyntax/interpolating-closure.t
 roast/S05-metasyntax/litvar.t

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -2244,27 +2244,43 @@ impl Interpreter {
                                     cc_content.push(ch);
                                 }
                             }
-                            // Parse the character class content (e.g., [a], -[a], [\n])
+                            // Parse the character class content (e.g., [a], -[a], [\n]).
+                            // Compound bracket classes must stay as CompositeClass atoms:
+                            // stripping only the outer brackets would turn `[a] - [b]` into
+                            // ordinary class text and lose the set subtraction before the
+                            // Lookaround matcher can apply its outer negation.
                             let cc_trimmed = cc_content.trim();
-                            let (cc_negated, cc_inner) =
-                                if let Some(rest) = cc_trimmed.strip_prefix("-[") {
-                                    (true, rest.strip_suffix(']').unwrap_or(rest))
-                                } else if let Some(rest) = cc_trimmed.strip_prefix('[') {
-                                    (false, rest.strip_suffix(']').unwrap_or(rest))
-                                } else {
-                                    (false, cc_trimmed)
-                                };
+                            let inner_atom = if (cc_trimmed.starts_with('[')
+                                || cc_trimmed.starts_with("-[")
+                                || cc_trimmed.starts_with("+["))
+                                && cc_trimmed.ends_with(']')
+                            {
+                                self.parse_bracket_char_class(cc_trimmed)
+                            } else if cc_trimmed.starts_with('[')
+                                || cc_trimmed.starts_with("-[")
+                                || cc_trimmed.starts_with("+[")
+                            {
+                                self.parse_combined_class(cc_trimmed, mode)
+                            } else {
+                                let (cc_negated, cc_inner) =
+                                    if let Some(rest) = cc_trimmed.strip_prefix("-[") {
+                                        (true, rest.strip_suffix(']').unwrap_or(rest))
+                                    } else if let Some(rest) = cc_trimmed.strip_prefix('[') {
+                                        (false, rest.strip_suffix(']').unwrap_or(rest))
+                                    } else {
+                                        (false, cc_trimmed)
+                                    };
+                                self.parse_raku_char_class(cc_inner, cc_negated)
+                                    .map(RegexAtom::CharClass)
+                            };
                             // The outer `?`/`!` negation is carried by the
-                            // Lookaround's `negated` flag below; the char class
-                            // itself only reflects an inner `-[...]`. Folding
-                            // `negated` into the class here too (`!cc_negated`)
-                            // double-negated `<![...]>`, inverting it into a
-                            // positive lookahead.
-                            if let Some(class) = self.parse_raku_char_class(cc_inner, cc_negated) {
+                            // Lookaround's `negated` flag below; the inner atom
+                            // only reflects an explicitly negated class form.
+                            if let Some(inner_atom) = inner_atom {
                                 // Build a lookahead with the char class as the inner pattern
                                 let inner_pattern = RegexPattern {
                                     tokens: vec![RegexToken {
-                                        atom: RegexAtom::CharClass(class),
+                                        atom: inner_atom,
                                         quant: RegexQuant::One,
                                         named_capture: None,
                                         hash_capture: None,

--- a/t/regex/syntax/regex-negated-charclass-lookahead.t
+++ b/t/regex/syntax/regex-negated-charclass-lookahead.t
@@ -6,7 +6,7 @@ use Test;
 # into the Lookaround), inverting `<![...]>` into a positive lookahead.
 # (raku-doc Language/regexes.rakudoc)
 
-plan 10;
+plan 12;
 
 # <?[...]>  positive lookahead of the class
 is ("3x" ~~ /<?[0..9]>\w/).Str, "3",   '<?[0..9]> matches before a digit';
@@ -28,3 +28,9 @@ nok ("ax" ~~ /<!-[0..9]>\w/),          '<!-[0..9]> fails before a non-digit';
 my regex key {^^ <![#-]> \d+ }
 is ("333" ~~ &key).Str, "333",         '<![#-]> after ^^ inside a named regex';
 nok ("#333" ~~ &key),                  '<![#-]> rejects a leading # at line start';
+
+# A negated lookahead must preserve a compound class as one inner assertion.
+is ("bb" ~~ /<![a] - [b]> ./).Str, "b",
+    '<![a] - [b]> matches a subtracted character';
+nok ("aa" ~~ /<![a] - [b]> ./),
+    '<![a] - [b]> rejects a character remaining in the class';


### PR DESCRIPTION
## Summary

- preserve compound bracket-class subtraction inside `<?...>` and `<!...>` lookarounds
- restore `roast/S05-metasyntax/charset.t` to the whitelist
- add focused regression coverage
- correct the test paths in the previously merged #7901 news entry

## Validation

- `make lint`
- `make test`
- `make roast`

Closes #7905