### PR TITLE
perf(dispatch): intern the builtin-type catalog's ancestry chains once, and borrow them

### DIFF
--- a/news/2026-09/builtin-type-catalog-chains-interned-once.md
+++ b/news/2026-09/builtin-type-catalog-chains-interned-once.md
@@ -1,0 +1,78 @@
+# The builtin-type catalog's ancestry chains are built once, not per dispatch
+
+`Str.^mro` is a constant. So is `Int`'s, `Bool`'s and every other row of
+`builtins/builtin_type_catalog.rs` — the raku-adjudicated table ADR-0019's E1
+classifier and the registry both read to answer "what is this receiver's
+ancestry". mutsu rebuilt each of those constants from scratch on **every method
+dispatch that reached it**: an 88-row linear scan of the catalog with a string
+compare per row to find the row, a `Symbol::intern` per ancestor name to turn it
+into a chain, and a fresh `Vec`/`Arc` allocation to hold the result.
+
+Measured on `use Test; plan 2000; for ^2000 { ok 1, "x" }` under callgrind (the
+benchmark [#7766](https://github.com/tokuhirom/mutsu/issues/7766) is written
+against), `receiver_class::catalog_chain_for_name` alone was **the single
+largest `Symbol::intern` caller in the program** — 16.5 of the ~49 interns per
+assertion, and 1.44% of the run's retired instructions for an answer that could
+not change.
+
+## What changed
+
+The catalog now interns each row's `mro` **once per process**, in both shapes
+its two consumers want, beside the row itself:
+
+- `builtin_type_mro_syms(name) -> Option<Arc<[Symbol]>>` for
+  `Registry::class_mro`/`class_mro_readonly`, whose builtin path hands the chain
+  straight back as an `Arc<[Symbol]>` — now a refcount bump.
+- `builtin_type_mro_ids(name) -> Option<&'static [TypeId]>` for the E1
+  classifier, which splices chains together and so wants to borrow.
+
+The same table doubles as the catalog's name index, so `builtin_type_info` is an
+`FxHashMap` probe instead of the linear scan every one of those lookups sat on
+top of.
+
+Interning the chain once still left a copy of it per dispatch, because
+`dispatch_mro` handed out an owned `Vec<TypeId>`. Every consumer only ever
+*reads* the chain — `.first()`, `.iter()`, `&chain` into `resolve_sequence` — so
+the classifier's chain type is now `Chain = Cow<'static, [TypeId]>`: borrowed
+straight from the catalog for a plain builtin receiver, owned only for the
+composed cases that genuinely build something new (an Enum's `[EnumType,
+…base]`, a role mixin's role prefix, a user class's registry MRO with a catalog
+tail spliced on). No call site needed changing; the deref coercions carried it.
+
+## Measured
+
+Release, callgrind, warm precompilation cache, 2000 assertions, second run after
+the rebuild (the first is not comparable — see the ticket):
+
+| | before | after |
+| --- | --- | --- |
+| `Symbol::intern` calls | 98,096 | 66,805 |
+| `Symbol::intern` (inclusive Ir) | 17.84 M (3.75%) | 12.89 M (2.73%) |
+| `receiver_class::catalog_chain_for_name` (inclusive Ir) | 6.84 M (1.44%) | 1.31 M (0.28%) |
+| `receiver_class::dispatch_mro` (inclusive Ir) | 7.49 M (1.57%) | 1.96 M (0.41%) |
+| whole run (Ir) | 475.94 M | 472.88 M (−0.64%) |
+
+−31,291 interns, i.e. **−15.6 per assertion**, the largest single cut to that
+budget so far (#7871 took −11.9). `dispatch_mro` — which `type_matches_value`
+calls on every typed parameter bind and every smartmatch, not only in this
+benchmark — costs a quarter of what it did. Roughly half the whole-run saving is
+the interning and the linear scan; the other half is the per-dispatch `Vec` the
+`Cow` removes.
+
+## Regression cover
+
+`t/oo/class/builtin-catalog-mro.t` pins the thing this class of change can get
+wrong: a shared, pre-built chain that drops, reorders or cross-wires an ancestor
+is a *wrong ancestry*, not a slowdown — it changes which class answers a method.
+The file checks each catalog row's `.^mro` against raku's, that a repeat read is
+unchanged, that two user classes deriving from different builtins each get their
+own tail, and that a method augmented onto `Cool` is reachable from `Str`, `Int`
+and (through `Int`) `Bool`. `interned_views_agree_with_their_row` does the same
+at the unit level for every row in the catalog, both interned views at once.
+
+## Not done
+
+The rest of [#7766](https://github.com/tokuhirom/mutsu/issues/7766)'s unit 2 —
+the `_sym` variant chains for `call_compiled_function_named`,
+`user_method_overloads`/`has_user_method`, `multi_arg_type_keys` and the
+resolution layers — is untouched and still open, re-measured on the issue.

--- a/news/2026-09/builtin-type-catalog-chains-interned-once.md
+++ b/news/2026-09/builtin-type-catalog-chains-interned-once.md
@@ -70,6 +70,14 @@ own tail, and that a method augmented onto `Cool` is reachable from `Str`, `Int`
 and (through `Int`) `Bool`. `interned_views_agree_with_their_row` does the same
 at the unit level for every row in the catalog, both interned views at once.
 
+Two pre-existing `.^`-MOP divergences turned up while writing that file and are
+filed as [#7937](https://github.com/tokuhirom/mutsu/issues/7937): `.^isa` on a
+*concrete* builtin value answers False (`"x".^isa(Cool)`), and `.^mro` alone
+drops a parametrized name's base row (`Array[Int].^mro` stops at `Any`) where
+both the classifier and the registry splice it in. Neither is caused by this
+change — both reproduce on `main` — so the test uses `.isa` and omits the
+`Array[Int]` row, with a comment saying to swap them back.
+
 ## Not done
 
 The rest of [#7766](https://github.com/tokuhirom/mutsu/issues/7766)'s unit 2 —

--- a/src/builtins/builtin_type_catalog.rs
+++ b/src/builtins/builtin_type_catalog.rs
@@ -562,11 +562,81 @@ static CATALOG: &[BuiltinTypeInfo] = &[
     ),
 ];
 
+/// One catalog row with its `mro` already interned, in both shapes dispatch asks
+/// for: `Symbol`s for the registry's `Arc<[Symbol]>` MRO API, and [`crate::type_id::TypeId`]s for
+/// the E1 classifier's chains.
+///
+/// Both are constant for the life of the process — the rows are `&'static str`
+/// and a symbol id, once assigned, is never reused or remapped — but every
+/// consumer re-derived them per call: `receiver_class::catalog_chain_for_name`
+/// interned the whole ancestor chain and allocated a fresh `Vec<TypeId>` on
+/// every dispatch that reached it, and `Registry::class_mro_readonly` did the
+/// same into an `Arc<[Symbol]>`. Measured on `use Test; plan 2000; for ^2000 {
+/// ok 1, "x" }` that was 16.5 of the ~35 `Symbol::intern` calls *per assertion*
+/// and 1.28% of the program's retired instructions (#7766).
+struct InternedRow {
+    info: &'static BuiltinTypeInfo,
+    mro_syms: std::sync::Arc<[crate::symbol::Symbol]>,
+    mro_ids: Box<[crate::type_id::TypeId]>,
+}
+
+/// The catalog indexed by row name, with each row's `mro` interned once.
+///
+/// Doubles as the name index: [`builtin_type_info`] was a linear scan of all 88
+/// rows with a string compare each, and it sits under both of the MRO lookups
+/// above plus `Registry::class_mro_readonly`'s builtin path.
+fn interned_catalog() -> &'static rustc_hash::FxHashMap<&'static str, InternedRow> {
+    static INTERNED: std::sync::OnceLock<rustc_hash::FxHashMap<&'static str, InternedRow>> =
+        std::sync::OnceLock::new();
+    INTERNED.get_or_init(|| {
+        CATALOG
+            .iter()
+            .map(|info| {
+                (
+                    info.name,
+                    InternedRow {
+                        info,
+                        mro_syms: info
+                            .mro
+                            .iter()
+                            .map(|s| crate::symbol::Symbol::intern(s))
+                            .collect(),
+                        mro_ids: info
+                            .mro
+                            .iter()
+                            .map(|s| crate::type_id::TypeId::intern(s))
+                            .collect(),
+                    },
+                )
+            })
+            .collect()
+    })
+}
+
 /// Look up a builtin type's catalog row by its canonical (post-alias) name.
 /// `Buf`/`Blob` sized aliases (`buf8`, `blob16`, ...) must be normalized first — see
 /// `crate::runtime::utils::normalize_buf_type_name`.
 pub(crate) fn builtin_type_info(name: &str) -> Option<&'static BuiltinTypeInfo> {
-    CATALOG.iter().find(|row| row.name == name)
+    interned_catalog().get(name).map(|row| row.info)
+}
+
+/// `builtin_type_info(name).mro`, interned to `Symbol`s once per process.
+///
+/// The `Arc` is cloned, not rebuilt: a caller that hands the chain straight back
+/// as an `Arc<[Symbol]>` (`Registry::class_mro_readonly`) pays a refcount bump
+/// instead of an intern per ancestor plus a fresh allocation.
+pub(crate) fn builtin_type_mro_syms(name: &str) -> Option<std::sync::Arc<[crate::symbol::Symbol]>> {
+    interned_catalog().get(name).map(|row| row.mro_syms.clone())
+}
+
+/// `builtin_type_info(name).mro`, interned to [`crate::type_id::TypeId`]s once per process.
+///
+/// Borrowed rather than cloned: the E1 classifier splices chains together, so it
+/// wants to copy the elements into a chain it is building, not own the table's.
+/// Minting `TypeId`s here keeps the type's invariant intact — the catalog is one
+/// of the two places allowed to produce one (see [`crate::type_id`]).
+pub(crate) fn builtin_type_mro_ids(name: &str) -> Option<&'static [crate::type_id::TypeId]> {
+    interned_catalog().get(name).map(|row| &*row.mro_ids)
 }
 
 /// Every catalog row, for exhaustive tests and (eventually) E1b/E2 table generation.
@@ -601,6 +671,39 @@ mod tests {
                 row.name
             );
         }
+    }
+
+    /// The two pre-interned views (`builtin_type_mro_syms`,
+    /// `builtin_type_mro_ids`) must name exactly the row's own `mro`, in order,
+    /// for every row — a memo that drops or reorders an ancestor would silently
+    /// change method dispatch rather than merely slow it down (#7766). Also
+    /// pins the `builtin_type_info` name index against the raw `CATALOG`, which
+    /// it replaced a linear scan of.
+    #[test]
+    fn interned_views_agree_with_their_row() {
+        for row in all_builtin_type_info() {
+            assert_eq!(
+                builtin_type_info(row.name).map(|r| r.name),
+                Some(row.name),
+                "row {} must be reachable by name",
+                row.name
+            );
+            let syms: Vec<&str> = builtin_type_mro_syms(row.name)
+                .unwrap_or_else(|| panic!("row {} has no interned symbol mro", row.name))
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
+            assert_eq!(syms, row.mro, "symbol mro for {}", row.name);
+            let ids: Vec<&str> = builtin_type_mro_ids(row.name)
+                .unwrap_or_else(|| panic!("row {} has no interned TypeId mro", row.name))
+                .iter()
+                .map(|t| t.as_str())
+                .collect();
+            assert_eq!(ids, row.mro, "TypeId mro for {}", row.name);
+        }
+        assert!(builtin_type_info("NotACatalogType").is_none());
+        assert!(builtin_type_mro_syms("NotACatalogType").is_none());
+        assert!(builtin_type_mro_ids("NotACatalogType").is_none());
     }
 
     #[test]

--- a/src/runtime/receiver_class.rs
+++ b/src/runtime/receiver_class.rs
@@ -23,10 +23,25 @@
 //! fallback consolidation (E1c) is still out of scope here.
 
 use super::*;
-use crate::builtins::builtin_type_catalog::builtin_type_info;
+use crate::builtins::builtin_type_catalog::{builtin_type_info, builtin_type_mro_ids};
 use crate::type_id::{TypeId, well_known_types};
 use crate::value::ValueView;
+use std::borrow::Cow;
 use std::sync::Arc;
+
+/// An ordered owner chain, borrowed from the builtin-type catalog whenever the
+/// receiver's ancestry IS one of the catalog's rows.
+///
+/// Most receivers a dispatch classifies are plain builtin values (`Str`, `Int`,
+/// `Bool`, ...), whose chain is a constant the catalog already holds interned
+/// ([`crate::builtins::builtin_type_catalog::builtin_type_mro_ids`]). Returning
+/// an owned `Vec` meant allocating, copying and freeing that constant on every
+/// such dispatch — and every consumer only ever reads it (`.first()`,
+/// `.iter()`, `&chain` into `resolve_sequence`), so none of them needed to own
+/// one. The composed cases (an Enum's `[EnumType, ...base]`, a role mixin's
+/// role prefix, a user class's registry MRO plus catalog tail) still build a
+/// `Vec` and hand it over as `Cow::Owned` (#7766).
+pub(crate) type Chain = Cow<'static, [TypeId]>;
 
 /// Whether a receiver is a concrete value or a type object (`Foo` vs `Foo.new`).
 /// Mirrors the `:D`/`:U` smiley distinction; consulted by E4, not by any E1a probe.
@@ -108,20 +123,21 @@ impl Interpreter {
     /// its chain stops at itself and the cursor would relate to no type
     /// whatsoever. Rather than leave that hole, assert the invariant here — the
     /// one place a cursor's dispatch chain is computed.
-    fn ensure_match_in_chain(&mut self, mut chain: Vec<TypeId>) -> Vec<TypeId> {
+    fn ensure_match_in_chain(&mut self, chain: Chain) -> Chain {
         if chain.iter().any(|t| t.as_str() == "Match") {
             return chain;
         }
         let tail = self.class_chain("Match");
+        let mut chain = chain.into_owned();
         chain.retain(|t| !tail.contains(t));
-        chain.extend(tail);
-        chain
+        chain.extend_from_slice(&tail);
+        Cow::Owned(chain)
     }
 
     /// The full ordered owner chain (self first, `Mu` last except `Junction`, which
     /// raku itself skips `Any` for — see the catalog's `Junction` row) for `value`'s
     /// dispatch receiver.
-    pub(crate) fn dispatch_mro(&mut self, value: &Value) -> Vec<TypeId> {
+    pub(crate) fn dispatch_mro(&mut self, value: &Value) -> Chain {
         // Tag probe first: a lazy `Match` decodes to a `ValueView::Instance`
         // (see `value/nanbox/peek.rs`), which the `Instance` arm below would
         // answer with the same `class_chain` anyway — checking the tag avoids
@@ -149,11 +165,11 @@ impl Interpreter {
                     Some(cached) => self.dispatch_mro(&cached),
                     // Mirrors `value_type_name`'s uncached-thunk answer ("Scalar"),
                     // which is not itself a raku type — best-effort fallback only.
-                    None => vec![
+                    None => Cow::Owned(vec![
                         TypeId::intern("Scalar"),
                         well_known_types().any,
                         well_known_types().mu,
-                    ],
+                    ]),
                 }
             }
 
@@ -199,12 +215,12 @@ impl Interpreter {
                 enum_type, value, ..
             } => {
                 let mut chain = vec![TypeId::from_symbol(enum_type)];
-                chain.extend(self.catalog_chain_for_name(match value {
+                chain.extend_from_slice(&self.catalog_chain_for_name(match value {
                     crate::value::EnumValue::Str(_) => "Str",
                     crate::value::EnumValue::Int(_) => "Int",
                     crate::value::EnumValue::Generic(_) => "Any",
                 }));
-                chain
+                Cow::Owned(chain)
             }
 
             // Role mixins / allomorphs (V2, V4): see `mixin_chain`.
@@ -230,15 +246,20 @@ impl Interpreter {
     /// Falls back to a best-effort `[name, Any, Mu]` chain for names the catalog does
     /// not model (mutsu-internal types with no raku equivalent, e.g. `CustomType`) —
     /// never hit for a catalog-covered type.
-    fn catalog_chain_for_name(&self, name: &str) -> Vec<TypeId> {
-        if let Some(info) = builtin_type_info(name) {
-            return info.mro.iter().map(|s| TypeId::intern(s)).collect();
+    fn catalog_chain_for_name(&self, name: &str) -> Chain {
+        // The catalog's chains are interned once per process
+        // (`builtin_type_mro_ids`) and handed out BORROWED; this used to
+        // re-intern every ancestor name into a fresh `Vec` on every dispatch
+        // that reached it, which was the single largest `Symbol::intern` caller
+        // in the vendored `Test` assertion loop (#7766).
+        if let Some(mro) = builtin_type_mro_ids(name) {
+            return Cow::Borrowed(mro);
         }
         let normalized = crate::runtime::utils::normalize_buf_type_name(name);
         if normalized != name
-            && let Some(info) = builtin_type_info(&normalized)
+            && let Some(mro) = builtin_type_mro_ids(&normalized)
         {
-            return info.mro.iter().map(|s| TypeId::intern(s)).collect();
+            return Cow::Borrowed(mro);
         }
         // A parametrized name (`Array[Int]`, `array[int32]`, `CArray[uint8]`)
         // not itself in the catalog: strip the `[...]` argument and splice the
@@ -248,34 +269,34 @@ impl Interpreter {
         // dead-ended at itself, never reaching `Array`/`List`/`Any`/`Mu`.
         if let Some((base, _)) = name.split_once('[')
             && name.ends_with(']')
-            && let Some(info) = builtin_type_info(base)
+            && let Some(mro) = builtin_type_mro_ids(base)
         {
             let mut chain = vec![TypeId::intern(name)];
-            chain.extend(info.mro.iter().map(|s| TypeId::intern(s)));
-            return chain;
+            chain.extend_from_slice(mro);
+            return Cow::Owned(chain);
         }
-        vec![
+        Cow::Owned(vec![
             TypeId::intern(name),
             well_known_types().any,
             well_known_types().mu,
-        ]
+        ])
     }
 
     /// The dispatch chain for an Instance/Package/ParametricRole named `name`: a
     /// builtin-catalog chain if `name` (or its Buf/Blob-normalized form) is a catalog
     /// type, otherwise the registry's class MRO with a catalog tail spliced on where
     /// a builtin ancestor (e.g. a user class `is Array`) does not already carry one.
-    fn class_chain(&mut self, name: &str) -> Vec<TypeId> {
-        if let Some(info) = builtin_type_info(name) {
-            return info.mro.iter().map(|s| TypeId::intern(s)).collect();
+    fn class_chain(&mut self, name: &str) -> Chain {
+        if let Some(mro) = builtin_type_mro_ids(name) {
+            return Cow::Borrowed(mro);
         }
         let normalized = crate::runtime::utils::normalize_buf_type_name(name);
         if normalized != name
-            && let Some(info) = builtin_type_info(&normalized)
+            && let Some(mro) = builtin_type_mro_ids(&normalized)
         {
-            return info.mro.iter().map(|s| TypeId::intern(s)).collect();
+            return Cow::Borrowed(mro);
         }
-        self.class_chain_with_catalog_tail(name)
+        Cow::Owned(self.class_chain_with_catalog_tail(name))
     }
 
     /// The registry MRO for `class_name`, with a builtin catalog's tail spliced in the
@@ -303,8 +324,11 @@ impl Interpreter {
                     // would silently drop everything past this builtin ancestor.
                     chain.extend(reg_mro[i + 1..].iter().map(|s| TypeId::from_symbol(*s)));
                 } else {
-                    for tail_name in &info.mro[1..] {
-                        let tid = TypeId::intern(tail_name);
+                    // Same row, pre-interned: `builtin_type_mro_ids` and
+                    // `builtin_type_info` are two views of one table entry, so
+                    // the row's presence above guarantees this lookup hits.
+                    let row_ids = builtin_type_mro_ids(sym.as_str()).unwrap_or_default();
+                    for &tid in row_ids.iter().skip(1) {
                         if !chain.contains(&tid) {
                             chain.push(tid);
                         }
@@ -334,7 +358,7 @@ impl Interpreter {
         &mut self,
         inner: &Arc<Value>,
         mixins: &crate::gc::Gc<crate::value::MixinOverrides>,
-    ) -> Vec<TypeId> {
+    ) -> Chain {
         // `allomorph_type_name` is the single oracle for "is this map an
         // allomorph?"; this used to re-derive the answer from
         // `mixins.contains_key("Str")` plus a local inner-type match, which
@@ -367,8 +391,8 @@ impl Interpreter {
             .into_iter()
             .map(|(_, name)| TypeId::intern(name))
             .collect();
-        chain.extend(self.dispatch_mro(inner.as_ref()));
-        chain
+        chain.extend_from_slice(&self.dispatch_mro(inner.as_ref()));
+        Cow::Owned(chain)
     }
 
     /// ADR-0019 **E1b**: the dispatch-owner chain for a **non-Instance,
@@ -396,7 +420,7 @@ impl Interpreter {
     /// Allomorphs (`<1/3>`, `IntStr` et al.) are exempted from the skip: their
     /// classifier chain already starts with the allomorph type itself, not a
     /// role, so `dispatch_mro`'s answer is already correct.
-    pub(crate) fn dispatch_owner_chain(&mut self, value: &Value) -> Vec<TypeId> {
+    pub(crate) fn dispatch_owner_chain(&mut self, value: &Value) -> Chain {
         // Tag probe first (`is_mixin_value`): almost every receiver is not a
         // Mixin, and forcing `view()` here would materialize a lazy Match for
         // nothing — `dispatch_mro` below already has its own lazy-Match fast

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -1031,9 +1031,11 @@ impl Registry {
             // catalog's own chain directly rather than recursing through
             // `class_mro`, whose `compute_class_mro` fallback would otherwise
             // treat an un-registered `base` like "Array" as parentless.
-            if let Some(info) = crate::builtins::builtin_type_catalog::builtin_type_info(base) {
+            if let Some(base_mro) =
+                crate::builtins::builtin_type_catalog::builtin_type_mro_syms(base)
+            {
                 let mut mro = vec![Symbol::intern(class_name)];
-                mro.extend(info.mro.iter().map(|s| Symbol::intern(s)));
+                mro.extend_from_slice(&base_mro);
                 return mro.into();
             }
         }
@@ -1070,9 +1072,11 @@ impl Registry {
                     mro.extend(self.class_mro_readonly(base)?.iter().copied());
                     return Some(mro.into());
                 }
-                if let Some(info) = crate::builtins::builtin_type_catalog::builtin_type_info(base) {
+                if let Some(base_mro) =
+                    crate::builtins::builtin_type_catalog::builtin_type_mro_syms(base)
+                {
                     let mut mro = vec![Symbol::intern(class_name)];
-                    mro.extend(info.mro.iter().map(|s| Symbol::intern(s)));
+                    mro.extend_from_slice(&base_mro);
                     return Some(mro.into());
                 }
             }
@@ -1091,9 +1095,14 @@ impl Registry {
             // base (`Blob`) from `mro` (tracked instead via `roles`), so
             // matching it here first would drop `Blob` from the chain that
             // branch already builds correctly.
-            if let Some(info) = crate::builtins::builtin_type_catalog::builtin_type_info(class_name)
+            // Interned once per process (`builtin_type_mro_syms`): this is the
+            // MRO every builtin-receiver method dispatch walks, and re-interning
+            // the chain plus allocating a fresh `Arc` per call put it on the
+            // per-assertion `Symbol::intern` budget (#7766).
+            if let Some(mro) =
+                crate::builtins::builtin_type_catalog::builtin_type_mro_syms(class_name)
             {
-                return Some(info.mro.iter().map(|s| Symbol::intern(s)).collect());
+                return Some(mro);
             }
             // Not a registered class at all: the write side computes but has no
             // `ClassDef` to cache into, so the result is identical read-only.

--- a/t/oo/class/builtin-catalog-mro.t
+++ b/t/oo/class/builtin-catalog-mro.t
@@ -45,6 +45,12 @@ is mro-of(StrHeir), "StrHeir Str Cool Any Mu",
 # --- the ancestry is the one dispatch actually uses ---------------------------
 # `.^mro` could be right while the chain the method walk consults is wrong, so
 # pin a call that can only resolve through a catalog ancestor.
+#
+# `.isa`, not `.^isa`: the MOP spelling answers False for a concrete builtin
+# value (mutsu bug, #7937 -- `"x".^isa(Cool)` is 0 where raku says 1). Swap it
+# back when that is fixed. `Array[Int].^mro` is missing from the rows above for
+# the same reason: #7937's second half, where `.^mro` alone drops a
+# parametrized name's base row that every other ancestry consumer splices in.
 
 ok True.isa(Int), 'Bool is-a Int through the catalog chain';
 ok 1.5.Rat.isa(Cool), 'Rat is-a Cool through the catalog chain';

--- a/t/oo/class/builtin-catalog-mro.t
+++ b/t/oo/class/builtin-catalog-mro.t
@@ -1,0 +1,57 @@
+use v6;
+use Test;
+
+# The builtin-type catalog's MRO rows are interned ONCE per process
+# (`builtin_type_mro_syms` / `builtin_type_mro_ids`, #7766) instead of being
+# re-interned into a fresh chain on every dispatch that reaches them. The memo
+# is shared by every caller, so a mistake here is a *wrong ancestry* — a
+# dropped, reordered or cross-wired ancestor — not a slowdown: it would change
+# which class answers a method, not how fast it answers.
+#
+# Every expectation below is raku's own `.^mro` (Rakudo 2026.06).
+
+plan 20;
+
+# --- the catalog rows themselves ---------------------------------------------
+
+sub mro-of(Mu $t) { $t.^mro.map(*.^name).join(" ") }
+
+is mro-of(Str), "Str Cool Any Mu", 'Str keeps its own ancestry';
+is mro-of(Int), "Int Cool Any Mu", 'Int keeps its own ancestry';
+is mro-of(Bool), "Bool Int Cool Any Mu", 'Bool inherits through Int';
+is mro-of(Hash), "Hash Map Cool Any Mu", 'Hash inherits through Map';
+is mro-of(Array), "Array List Cool Any Mu", 'Array inherits through List';
+is mro-of(Map), "Map Cool Any Mu", 'Map is a sibling of Hash, not its child';
+is mro-of(Range), "Range Cool Any Mu", 'Range keeps its own ancestry';
+is mro-of(Seq), "Seq Cool Any Mu", 'Seq keeps its own ancestry';
+is mro-of(Pair), "Pair Any Mu", 'Pair does not inherit Cool';
+is mro-of(Junction), "Junction Mu", 'Junction skips Any';
+
+# A shared memo that handed out a chain the first caller could mutate would
+# show up as a second reader seeing a different answer.
+is mro-of(Str), "Str Cool Any Mu", 'a repeat read of a row is unchanged';
+is mro-of(Bool), "Bool Int Cool Any Mu", 'a repeat read of a longer row is unchanged';
+
+# --- chains spliced on top of a catalog row ----------------------------------
+
+class ArrayHeir is Array { }
+is mro-of(ArrayHeir), "ArrayHeir Array List Cool Any Mu",
+    'a user class deriving from a builtin gets the catalog tail';
+
+class StrHeir is Str { }
+is mro-of(StrHeir), "StrHeir Str Cool Any Mu",
+    'a second heir of a different builtin gets its own tail, not the first one';
+
+# --- the ancestry is the one dispatch actually uses ---------------------------
+# `.^mro` could be right while the chain the method walk consults is wrong, so
+# pin a call that can only resolve through a catalog ancestor.
+
+ok True.isa(Int), 'Bool is-a Int through the catalog chain';
+ok 1.5.Rat.isa(Cool), 'Rat is-a Cool through the catalog chain';
+nok (a => 1).isa(Cool), 'Pair is NOT a Cool';
+
+use MONKEY-TYPING;
+augment class Cool { method catalog-probe() { "cool/" ~ self.^name } }
+is "x".catalog-probe, "cool/Str", 'a Str finds a method augmented onto Cool';
+is 42.catalog-probe, "cool/Int", 'an Int finds the same method through its own chain';
+is True.catalog-probe, "cool/Bool", 'a Bool reaches Cool through Int';


### PR DESCRIPTION
`Str.^mro` is a constant. So is `Int`'s, `Bool`'s and every other row of the raku-adjudicated `builtins/builtin_type_catalog` — the table ADR-0019's E1 classifier and `Registry::class_mro_readonly` both read to answer "what is this receiver's ancestry". mutsu rebuilt each of those constants **on every method dispatch that reached it**: an 88-row linear scan of the catalog with a string compare per row to find the row, a `Symbol::intern` per ancestor name to turn it into a chain, and a fresh `Vec`/`Arc` allocation to hold the result.

This is the residue [#7766](https://github.com/tokuhirom/mutsu/issues/7766)'s previous session flagged as *"16.02 interns/assertion charged to `<Vec<T> as SpecFromIterNested>::from_iter`, by far the largest single row in the caller tree… probably worth attributing before starting any of the four splits above."* Attributed: the owner is `receiver_class::catalog_chain_for_name`, at 8,004 calls × 4 ancestors ≈ 32,000 of the row's 33,015 interns.

## What changed

**1. The catalog interns each row's `mro` once per process**, in both shapes its two consumers want, beside the row itself:

- `builtin_type_mro_syms(name) -> Option<Arc<[Symbol]>>` for the registry, whose builtin path hands the chain straight back as an `Arc<[Symbol]>` — now a refcount bump.
- `builtin_type_mro_ids(name) -> Option<&'static [TypeId]>` for the E1 classifier, which splices chains together and so wants to borrow. Minting the `TypeId`s in the catalog keeps that type's invariant intact — it is one of the two places allowed to produce one.

The same table doubles as the catalog's name index, so `builtin_type_info` is an `FxHashMap` probe instead of the linear scan every one of those lookups sat on top of.

**2. The classifier's chain is borrowed, not copied.** Interning once still left a copy per dispatch, because `dispatch_mro` handed out an owned `Vec<TypeId>` — and every consumer only ever *reads* it (`.first()`, `.iter()`, `&chain` into `resolve_sequence`). The chain type is now `Chain = Cow<'static, [TypeId]>`: borrowed straight from the catalog for a plain builtin receiver, owned only where something new is genuinely built (an Enum's `[EnumType, …base]`, a role mixin's role prefix, a user class's registry MRO with a catalog tail spliced on). No call site needed changing; the deref coercions carried it.

## Measured

Release, callgrind, `tmp/bench-ok-2k.raku` = `use Test; plan 2000; for ^2000 { ok 1, "x" }` under `MUTSU_REAL_TEST=1`, warm precompilation cache, second run after each rebuild (the first is not comparable — the ticket's warning is real).

| | before | after |
| --- | --- | --- |
| `Symbol::intern` calls | 98,096 | 66,805 |
| `Symbol::intern` (inclusive Ir) | 17.84 M (3.75%) | 12.89 M (2.73%) |
| `receiver_class::catalog_chain_for_name` (inclusive Ir) | 6.84 M (1.44%) | 1.31 M (0.28%) |
| `receiver_class::dispatch_mro` (inclusive Ir) | 7.49 M (1.57%) | 1.96 M (0.41%) |
| whole run (Ir) | 475.94 M | 472.88 M (−0.64%) |

−31,291 interns, i.e. **−15.6 per assertion** — the largest single cut to that budget so far (#7871 took −11.9). Roughly half the whole-run saving is the interning and the linear scan, the other half the per-dispatch `Vec` the `Cow` removes. `dispatch_mro` is not specific to this benchmark: `type_matches_value` calls it on every typed parameter bind and every smartmatch.

These are local callgrind numbers for review, not document numbers — nothing here is quoted into PERFORMANCE.md or PLAN.md.

## Regression cover

`t/oo/class/builtin-catalog-mro.t` pins what this class of change can get wrong: a shared, pre-built chain that drops, reorders or cross-wires an ancestor is a **wrong ancestry**, not a slowdown — it changes which class answers a method. It checks each catalog row's `.^mro` against raku's, that a repeat read is unchanged, that two user classes deriving from *different* builtins each get their own tail, and that a method augmented onto `Cool` is reachable from `Str`, `Int` and (through `Int`) `Bool`. `interned_views_agree_with_their_row` does the same at the unit level for every row, both interned views at once, plus the miss case.

Two pre-existing `.^`-MOP divergences turned up while writing that file and are filed as [#7937](https://github.com/tokuhirom/mutsu/issues/7937) — `.^isa` on a concrete builtin value, and `.^mro` dropping a parametrized name's base row. **Neither is caused by this PR**; both reproduce identically on `main`. The test uses `.isa` and omits the `Array[Int]` row, with a comment saying which issue to follow to swap them back.

## Verification

- `cargo fmt --all`, `make lint` — green (all four configurations).
- `make test` — green: 3992 files, 42505 tests.
- `make roast` — green except exactly the three failures `docs/agent-environments.md` documents as container artefacts, with the same failing test numbers: `6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8/10) and `S16-filehandles/filetest.t` (`Failed: 25`) from running as `uid 0`, and `S32-io/IO-Socket-Async.t` (exit 124) from the sandboxed network.

## Scope

This is one finding taken to completion, not a slice of #7766's four-way split. The `_sym` variant chains for `call_compiled_function_named`, `user_method_overloads`/`has_user_method`, `multi_arg_type_keys` and the resolution layers are untouched; the issue stays open for them and is re-measured in a comment.

Refs #7766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tk6gdMcBJZAkK7iaKTzPLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk6gdMcBJZAkK7iaKTzPLr)_