### PR TITLE
docs(ecosystem): the corpus is measured — retire the "P2 has not run" claim

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -102,10 +102,13 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 
 - [ ] **★Ecosystem parity KPI** — run every zef distribution's own test suite on **both** rakudo and
       mutsu and publish the difference as the project's headline compatibility number, with
-      per-distribution machine-readable records in `ecosystem/`. **P1 (the harness) and P3 (the site
-      page) have landed, and the sweep can now be dispatched from GitHub Actions** (`Ecosystem
-      sweep`, ADR-0085 D9 amendment); the next step is **P2, the first corpus sweep** — `scope: all`,
-      which is what produces the first real numbers.
+      per-distribution machine-readable records in `ecosystem/`. **P1-P3 have landed: the corpus is
+      measured.** Run 34566091231 (2026-09-11, `scope: all`, 27/27 shards green) covers all 1624
+      distributions at one commit — **41.2%** dist parity, 53.6% file, 62.4% assertion — and the
+      first `history.tsv` row exists. The next step is **P5**: root-cause the 393 `blocked_load`
+      records (53 of them `raku_also_fails`, i.e. not mutsu's; the rest normalise to 133 distinct
+      load errors whose top ten cover ~1/3) into `todo:ticket` issues, so the KPI feeds the work
+      queue. P4's remaining sliver is a local `make`-level wrapper for the sweep.
       Decisions: [ADR-0085](docs/adr/0085-ecosystem-testsuite-parity-measurement.md);
       operations manual and phases (P1-P5, one PR each):
       [docs/ecosystem-parity.md](docs/ecosystem-parity.md);

--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ For interactive use:
 
 mutsu passes **1,433 out of 1,464** official [Roast](https://github.com/Raku/roast) test files in full. Compatibility is improving daily; the [site](https://tokuhirom.github.io/mutsu/) shows the figure counted at its last deploy.
 
+Roast measures the language against its spec. The other question — *does the
+module I actually use work?* — is measured by running each zef distribution's own
+test suite under both rakudo and mutsu and comparing the two. Across all
+**1,624** distributions in the ecosystem index, **41.2%** pass every test file
+that rakudo passes (**53.6%** of test files, **62.4%** of assertions). Look up a
+particular distribution on the [ecosystem
+page](https://tokuhirom.github.io/mutsu/ecosystem.html); the per-distribution
+records are in [`ecosystem/`](ecosystem/), the metric over time is
+[`ecosystem/history.tsv`](ecosystem/history.tsv) and its chart
+[`ecosystem/history.svg`](ecosystem/history.svg), and the method is
+[docs/ecosystem-parity.md](docs/ecosystem-parity.md). rakudo is the denominator
+throughout: a test rakudo also fails is not counted against mutsu.
+
 ## What Works
 
 ### Variables and Basic Types

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -24,13 +24,15 @@ sides, and publish the difference.
   release gate on the ~40 *bundled* dists. This campaign is neither: it is an
   exhaustive, re-runnable ledger over the whole ecosystem.
 
-> **Status: P1 and P3 landed** — the harness (`scripts/ecosystem-sweep.py`), the
-> record store, and the public page (`site/ecosystem.html`) all exist. **P2, the
-> corpus sweep, is what produces the first real KPI numbers**, and until it runs
-> `ecosystem/` holds a partial set rather than a survey; see
-> [ecosystem/README.md](../ecosystem/README.md). A sweep can be run either
-> locally (§8) or from GitHub Actions (§8.1) — the numbers no longer depend on
-> having a many-core box to hand.
+> **Status: P1, P2 and P3 landed.** The corpus has been measured: [run
+> 34566091231](https://github.com/tokuhirom/mutsu/actions/runs/34566091231)
+> (2026-09-11, `scope=all`, 27/27 shards green) covers all **1624**
+> distributions at mutsu `1557d41` against rakudo 2026.07, and the headline is
+> **41.2%** dist parity — 53.6% file parity, 62.4% assertion parity. The first
+> `history.tsv` row and the chart exist as of that sweep. A sweep runs either
+> locally (§8) or from GitHub Actions (§8.1), so the numbers do not depend on
+> having a many-core box to hand. What is left is **P5**: turning the red and
+> `blocked_load` records into root-caused tickets.
 
 ## 1. What gets measured
 
@@ -387,13 +389,21 @@ dark README; browsers that ignore it get the light palette.
 | # | Deliverable | Done when |
 |---|---|---|
 | ~~**P1**~~ | ~~`scripts/ecosystem_common.py` extracted from `dist-compat-sweep.py`; `scripts/ecosystem-sweep.py` with the dep resolver, sandbox, TAP compare, `--only` / `--prefix` / `--rollup`; schema v1~~ | **done** — records round-trip, `--rollup` produces summary + history + chart, and the first eight distributions surfaced real findings |
-| **P2** | first full-corpus sweep; `ecosystem/` populated; `summary.*` + the first `history.tsv` row | `file_parity` / `assertion_parity` / `dist_parity` exist as real numbers |
-| ~~**P3**~~ | ~~`ecosystem/history.svg` linked from `README.md`; `site/ecosystem.html` + manifest generator + `pages.yml` wiring~~ | **done** — `site/ecosystem.html` is generated from the ledger by `scripts/gen-ecosystem-manifest.py`, wired into `pages.yml` and the nav, and covered by `site/e2e.test.mjs`. The README link waits on P2, which is what produces the chart |
+| ~~**P2**~~ | ~~first full-corpus sweep; `ecosystem/` populated; `summary.*` + the first `history.tsv` row~~ | **done** — run 34566091231 (2026-09-11) measured all 1624 dists at one commit with 27/27 shards green: 41.2% dist / 53.6% file / 62.4% assertion parity, and the first history row is appended. It took three attempts; the two that lost data did so silently, and what they cost is recorded in `news/2026-09/` |
+| ~~**P3**~~ | ~~`ecosystem/history.svg` linked from `README.md`; `site/ecosystem.html` + manifest generator + `pages.yml` wiring~~ | **done** — `site/ecosystem.html` is generated from the ledger by `scripts/gen-ecosystem-manifest.py`, wired into `pages.yml` and the nav, and covered by `site/e2e.test.mjs`; the README's Status section now carries the figure and links the chart, which P2 was the thing producing |
 | **P4** | the operator runbook (§8) — one entry point for a full sweep and for a shard, plus the `--rollup` + `history.tsv` append and the PR it lands as | **partly done** — `.github/workflows/ecosystem-sweep.yml` (§8.1) is that entry point for anyone with dispatch rights: it plans, builds once, measures, rolls up and opens the PR. What is left is the local `make`-level convenience wrapper |
 | **P5** | root-cause grouping of `regression` records into `todo:ticket` issues, in the shape `scripts/dist-compat-tickets.py` already produces; `docs/triage.md` picks them up | the KPI feeds the work queue |
 
-P1 and P2 are the campaign; P3-P5 make it repeatable. Do not start P2 before
-P1's `--only` round-trips a record.
+P1 and P2 are the campaign; P3-P5 make it repeatable. **P5 is the next phase**,
+and the ledger now says how to start it: of the 393 `blocked_load` records, 53
+are `raku_also_fails` (rakudo does not load them either, so they are not mutsu's
+to fix and belong outside the numerator), and the remaining 340 normalise to 133
+distinct load errors whose top ten cover a third of them (110 of 340) —
+`X::Redeclaration` on a routine, "needs parens to avoid gobbling block", `No such
+method`, a handful of parse errors, `Could not find QAST in:`, and slang
+activation. The 560 `red`/`partial` records have a much longer tail (513 with a
+recorded first failure, 336 distinct), so the cheap grouping is on the load
+axis and the file axis wants sampling rather than exhaustive triage.
 
 **There is deliberately no *scheduled* CI sweep** (ADR-0085 D9): a full sweep is
 ~20 CPU-hours, and paying a hosted runner for it weekly, on fewer cores, to

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -121,14 +121,25 @@ same distribution, and then hands over to `ecosystem-dist-fix`. A distribution
 has no issue of its own to carry a claim, which is why the lock lives on that one
 board issue's comments rather than in this tree.
 
-## Current state — a partial sweep, not the corpus
+## Current state — the corpus, measured at one commit
 
-**The corpus sweep (P2) is in progress and these records cover only part of it.**
-`site/content/ecosystem.json` carries a `coverage` figure and the page leads with
-it, so a partial sweep can never publish a parity figure that reads as the whole
-ecosystem's.
+**The whole index is in.** [Run
+34566091231](https://github.com/tokuhirom/mutsu/actions/runs/34566091231)
+(2026-09-11, `scope=all`) measured all 1624 distributions at mutsu `1557d41`
+against rakudo 2026.07, every one of its 27 shards green, and `summary.json`,
+`summary.md`, `history.tsv` and `history.svg` exist as of that sweep. The
+headline is **41.2%** dist parity (393 green of 953 graded); `file_parity` 53.6%
+and `assertion_parity` 62.4% are the metrics that actually steer the work, since
+a distribution goes green only when its last failing file does.
 
-There is deliberately still no `summary.*` or `history.tsv`: `history.tsv` takes
-**one row per full sweep** (`--rollup --history`), and appending a row for a
-third of the corpus would put a point on the KPI chart that is not comparable
-with the ones after it.
+`site/content/ecosystem.json` still carries a `coverage` figure and the page
+still leads with it. That is not vestigial: a *targeted* re-measurement
+(`--only`, `--prefix`, `--status`) leaves the rest of the ledger at whatever
+commit last measured it, so "how much of this ledger is current" stays a
+question worth answering out loud.
+
+`history.tsv` takes **one row per full sweep** (`--rollup --history`), and the
+workflow refuses to append one unless `scope=all` *and* all 27 shards
+succeeded — a row for a third of the corpus would put a point on the KPI chart
+that is not comparable with the ones after it. It refused for exactly that
+reason on the sweep before this one.

--- a/news/2026-09/ecosystem-corpus-measured.md
+++ b/news/2026-09/ecosystem-corpus-measured.md
@@ -1,0 +1,83 @@
+# The ecosystem has a number: 41.2% of 1624 distributions
+
+[Run 34566091231](https://github.com/tokuhirom/mutsu/actions/runs/34566091231)
+(`scope=all`, `history=true`) swept all 27 shards green in 78 minutes and landed
+1623 records. P2 of the parity campaign is done: every distribution in the fez
+index has been measured at one mutsu commit against one rakudo, and the ledger
+carries a `summary.json`, a `summary.md`, the first `history.tsv` row and its
+chart.
+
+```
+date        mutsu_commit  raku_version  dists  measured  baseline_files  parity_files  file_parity  assertion_parity  dist_parity
+2026-09-11  1557d41       2026.07       1624   1581      3072            1648          53.6         62.4              41.2
+```
+
+| metric | value | |
+|---|---|---|
+| `dist_parity` | **41.2%** | 393 green of 953 graded |
+| `file_parity` | **53.6%** | 1648 / 3072 files |
+| `assertion_parity` | **62.4%** | 92510 / 148161 assertions |
+
+Status over the whole index: `green` 393, `red` 307, `partial` 253,
+`no_baseline` 228, `blocked_load` 393, `blocked_dep` 43, `skipped` 7. (`green`
+and `blocked_load` both landing on 393 is a coincidence; an independent recount
+straight off the record files reproduces every field of `summary.json`.)
+
+`dist_parity` is the headline because it is the question a user asks — *does my
+module work?* — and it is brutal by construction: a distribution counts as green
+only when its **last** failing test file passes. `file_parity` and
+`assertion_parity` are the ones that move while work is in progress, which is why
+they steer the queue.
+
+## What the three attempts cost, and why the logs mattered
+
+The corpus took three runs. The first threw away shard `D`'s 128 records after 26
+minutes (`git status --porcelain` collapses a wholly-new directory into one
+entry, `cp --parents` refused it, `set -e` did the rest). The second asked for
+all 27 shards and came back with 1423 distributions — which *looks* like a
+near-complete corpus and was not:
+
+- shards `A` (154) and `S` (109) uploaded **nothing**: `upload-artifact` rejects
+  a colon and fails the whole artifact over one path, and `App:Racl` /
+  `Slang:Date` carry a single colon the `::` → `--` mapping never saw;
+- shard `C` reported **success** having died at distribution 93 of 124 on
+  `tarfile.AbsoluteLinkError`;
+- the filename rule was not injective, so distinct distributions were sharing
+  records.
+
+None of that appeared in a run's conclusion. It came out of reading 27 shard
+logs, which is the habit this campaign has to keep: **read a corpus run's logs
+even when it says success.**
+
+This run is the evidence the fixes work, and it sharpened one of them. The
+per-distribution `try/except` caught `AbsoluteLinkError` **three** times, not
+once, and each one sat in a different shard — `Collection::Plugin::Development`
+in `C`, `Gnome::Gtk3` in `G`, `Sway::PreviewKeys` in `S`. Under the old code those
+three would have truncated three shards, one of which had already lost
+everything to the colon. Seven distributions are `skipped` in total: three for
+that reason, four with no `META6.json` in the tarball.
+
+## Cost
+
+27 shards at `max-parallel: 8` is three waves: 78 minutes wall, about 5.5 hours
+of job time, with `C` the heaviest single shard at 43 minutes for 124
+distributions. That is an order of magnitude inside the design's "~20 CPU-hours,
+2.5 hours wall" estimate, and comfortably a run-it-on-demand budget.
+
+The data PR used to be the expensive part, for a reason that had nothing to do
+with sweeping: a ~1300-file records diff tripped `ci-docs-only.sh`'s 300-file
+threshold and paid for five build jobs. With completeness derived from the pull
+request's own `changed_files` instead of guessed from a count, the PR merged **26
+seconds** after it opened.
+
+## Next
+
+P5: the ledger now says where to start. Of the 393 `blocked_load` records, 53 are
+`raku_also_fails` — rakudo cannot load them either, so they are not mutsu's to
+fix — and the remaining 340 normalise to 133 distinct load errors whose top ten
+cover a third (110 of 340): `X::Redeclaration` on a routine (17), "needs parens to
+avoid gobbling block" (15), `No such method` (14), a cluster of parse errors,
+`Could not find QAST in:` (8), `Unknown function: HAS` (8), slang activation for
+a grammar rule override (8). The 560 `red`/`partial` records have a far longer
+tail — 513 first failures in 336 distinct shapes — so the load axis is where
+exhaustive grouping pays and the file axis wants sampling.


### PR DESCRIPTION
Three documents still said the first full-corpus sweep was pending. That stopped being true with [run 34566091231](https://github.com/tokuhirom/mutsu/actions/runs/34566091231) (2026-09-11, `scope=all`, 27/27 shards green), which measured all **1624** distributions at mutsu `1557d41` against rakudo 2026.07 and appended the first `history.tsv` row.

| metric | value | |
|---|---|---|
| `dist_parity` | **41.2%** | 393 green of 953 graded |
| `file_parity` | **53.6%** | 1648 / 3072 files |
| `assertion_parity` | **62.4%** | 92510 / 148161 assertions |

## What changes

- **`README.md`** — the Status section now carries the ecosystem figure beside the roast one, and links the ledger, the chart and the method. This was **P3's last deliverable**, held back on purpose because it is P2 that produces the chart. It answers a different question from roast — *does the module I use work?* rather than *does the language match its spec* — so both belong there, with the note that rakudo is the denominator and a test rakudo also fails is not counted against mutsu.
- **`ecosystem/README.md`** — "Current state: a partial sweep, not the corpus" is replaced by what the sweep found. The `coverage` figure on the site page stays and is explicitly *not* vestigial: a targeted re-measurement (`--only` / `--prefix` / `--status`) leaves the rest of the ledger at whatever commit last measured it, so "how much of this ledger is current" remains worth answering out loud.
- **`docs/ecosystem-parity.md`** — the status banner, and the P2 / P3 phase rows.
- **`PLAN.md`** — the campaign item.

## Where P5 starts

Each document now records it, because the ledger says: of the 393 `blocked_load` records, **53 are `raku_also_fails`** — rakudo cannot load them either, so they are not mutsu's to fix and do not belong in the numerator — and the remaining 340 normalise to **133 distinct load errors whose top ten cover 110** of them (`X::Redeclaration` on a routine 17, "needs parens to avoid gobbling block" 15, `No such method` 14, a cluster of parse errors, `Could not find QAST in:` 8, `Unknown function: HAS` 8, slang activation for a grammar rule override 8). The 560 `red`/`partial` records have a far longer tail — 513 first failures in 336 distinct shapes — so exhaustive grouping pays on the load axis while the file axis wants sampling.

`news/2026-09/ecosystem-corpus-measured.md` records the numbers, the three attempts the corpus took, and the habit the two silent data losses argue for: **read a corpus run's logs even when its conclusion is success.**

## Note on CI

Documentation-only (`scripts/ci-docs-only.sh --classify` over the five changed paths returns `true`), so the five build jobs report `skipped` — which counts as success for branch protection. That is correct here, not a stuck CI.

Refs #7785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164xafjtgmTPhHatdSuMR9a

---
_Generated by [Claude Code](https://claude.ai/code/session_0164xafjtgmTPhHatdSuMR9a)_