### PR TITLE
fix: preserve block quantifier bounds on backtracking

### DIFF
--- a/news/2026-09/block-quantifier-backtracking-preserves-bounds.md
+++ b/news/2026-09/block-quantifier-backtracking-preserves-bounds.md
@@ -1,0 +1,9 @@
+# Block quantifier bounds survive backtracking
+
+Block quantifiers inside captured and separated regex repetitions now retain
+their minimum, maximum, and exact-count bounds when the matcher retries a
+candidate.
+
+Pinned by `t/regex/syntax/regex-block-quantifier-backtracking.t`.
+
+Closes #7906.

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -33,6 +33,16 @@ struct WalkCtx<'a> {
 /// variable-length alternation (mirrors the old 20k candidate bound).
 const QUANT_ALT_BUDGET: u32 = 20_000;
 
+/// Compound atoms can expose more than one end for one quantifier iteration.
+/// A quantifier over one of these must let its continuation request the next
+/// inner candidate instead of committing to the singular matcher's first end.
+fn quantifier_atom_needs_candidate_backtracking(atom: &RegexAtom) -> bool {
+    matches!(
+        atom,
+        RegexAtom::Group(_) | RegexAtom::CaptureGroup(_) | RegexAtom::CaptureIsolatedGroup(_)
+    )
+}
+
 /// A continuation invoked at every completed match of one pattern level.
 /// Returns `true` to stop the walk that produced it — the same
 /// "unwind the whole DFS" signal `walk_tokens` returns.
@@ -1223,6 +1233,18 @@ impl Interpreter {
         matches: &mut MatchSink<'_>,
     ) -> bool {
         let token = &ctx.pattern.tokens[idx];
+        if !token.ratchet && quantifier_atom_needs_candidate_backtracking(&token.atom) {
+            return self.walk_quant_group_candidates(
+                ctx,
+                idx,
+                pos,
+                min,
+                max,
+                hash_per_iter,
+                store,
+                matches,
+            );
+        }
         let pos_base = store.caps().positional.len();
         let stride = count_capture_groups(&token.atom);
         let m_quant = store.mark();
@@ -1287,6 +1309,155 @@ impl Interpreter {
         }
         store.rewind(m_quant);
         false
+    }
+
+    /// Explore every candidate of a compound atom while growing a quantifier.
+    ///
+    /// The ordinary chain path grows one iteration through the singular atom
+    /// matcher. That is sufficient when an iteration has one viable end, but a
+    /// capture group can expose several ends (for example `(. ** {2..3})`). If
+    /// the continuation rejects the greedy outer chain, the shorter inner end
+    /// must be requested before the matcher advances to the next start
+    /// position. Drive the atom through the same continuation-based producer
+    /// used by `One`/`ZeroOrOne` so those ends are tried in regex priority order.
+    #[allow(clippy::too_many_arguments)]
+    fn walk_quant_group_candidates(
+        &mut self,
+        ctx: &WalkCtx,
+        idx: usize,
+        pos: usize,
+        min: usize,
+        max: Option<usize>,
+        hash_per_iter: bool,
+        store: &mut CapStore,
+        matches: &mut MatchSink<'_>,
+    ) -> bool {
+        let token = &ctx.pattern.tokens[idx];
+        let pos_base = store.caps().positional.len();
+        let stride = count_capture_groups(&token.atom);
+        let mark = store.mark();
+        for name in Self::collect_quantified_names_for_token(token) {
+            store.insert_named_quantified(name);
+        }
+        let mut budget = QUANT_ALT_BUDGET;
+        let stop = self.walk_quant_group_candidates_dfs(
+            ctx,
+            idx,
+            pos,
+            0,
+            min,
+            max,
+            pos_base,
+            stride,
+            hash_per_iter,
+            &mut budget,
+            store,
+            matches,
+        );
+        store.rewind(mark);
+        stop
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn walk_quant_group_candidates_dfs(
+        &mut self,
+        ctx: &WalkCtx,
+        idx: usize,
+        current: usize,
+        count: usize,
+        min: usize,
+        max: Option<usize>,
+        pos_base: usize,
+        stride: usize,
+        hash_per_iter: bool,
+        budget: &mut u32,
+        store: &mut CapStore,
+        matches: &mut MatchSink<'_>,
+    ) -> bool {
+        if *budget == 0 {
+            return false;
+        }
+        let token = &ctx.pattern.tokens[idx];
+
+        // Frugal quantifiers expose the current chain before growing it.
+        if token.frugal
+            && count >= min
+            && self.descend_folded(ctx, idx, current, pos_base, stride, store, matches)
+        {
+            return true;
+        }
+        if max.is_some_and(|limit| count >= limit) {
+            return count >= min
+                && !token.frugal
+                && self.descend_folded(ctx, idx, current, pos_base, stride, store, matches);
+        }
+
+        let suppress_padding = atom_contains_alternation(&token.atom);
+        let prior_quantified = suppress_padding.then(|| {
+            super::regex_helpers::IN_QUANTIFIED_ALTERNATION_MATCH.with(|flag| flag.replace(true))
+        });
+        let mut stop = false;
+        {
+            let mut next = |interp: &mut Interpreter,
+                            store: &mut CapStore,
+                            end: usize,
+                            delta: RegexCaptures| {
+                if end == current || *budget == 0 {
+                    return false;
+                }
+                *budget -= 1;
+                let iter_pos_base = store.caps().positional.len();
+                let mark = store.mark();
+                store.merge_delta(delta);
+                Self::store_apply_named_capture(store, token, current, end, pos_base);
+                let hash_base = if hash_per_iter {
+                    iter_pos_base
+                } else {
+                    pos_base
+                };
+                Self::store_apply_hash_capture(store, ctx.chars, token, current, end, hash_base);
+                if hash_per_iter {
+                    interp.maybe_run_reduce_time_dynvar_action(token, store.caps());
+                }
+                stop = interp.walk_quant_group_candidates_dfs(
+                    ctx,
+                    idx,
+                    end,
+                    count + 1,
+                    min,
+                    max,
+                    pos_base,
+                    stride,
+                    hash_per_iter,
+                    budget,
+                    store,
+                    matches,
+                );
+                store.rewind(mark);
+                stop
+            };
+            self.for_each_atom_candidate(
+                &token.atom,
+                ctx.chars,
+                current,
+                store,
+                ctx.pkg,
+                ctx.pattern.ignore_case,
+                false,
+                &mut next,
+            );
+        }
+        if let Some(prior) = prior_quantified {
+            super::regex_helpers::IN_QUANTIFIED_ALTERNATION_MATCH.with(|flag| flag.set(prior));
+        }
+        if stop {
+            return true;
+        }
+        // Greedy quantifiers expose the current chain only after all longer
+        // chains and all higher-priority inner candidates were rejected.
+        count >= min
+            && !token.frugal
+            && self.descend_folded(ctx, idx, current, pos_base, stride, store, matches)
     }
 
     /// Full-backtracking quantifier over a variable-length alternation atom

--- a/src/runtime/regex/regex_match_sep.rs
+++ b/src/runtime/regex/regex_match_sep.rs
@@ -10,6 +10,25 @@ use super::super::*;
 use super::regex_helpers::count_capture_groups;
 
 impl Interpreter {
+    /// Resolve a separator quantifier's bounds once for the current match
+    /// state. Block quantifiers use the same evaluator as their non-separated
+    /// counterparts; treating `RepeatCode` as the fallback one-item case
+    /// silently discarded a block's minimum and maximum.
+    pub(super) fn separated_quantifier_bounds(
+        &mut self,
+        token: &RegexToken,
+        current_caps: &RegexCaptures,
+    ) -> Option<(usize, Option<usize>)> {
+        match &token.quant {
+            RegexQuant::OneOrMore => Some((1, None)),
+            RegexQuant::ZeroOrMore => Some((0, None)),
+            RegexQuant::Repeat(lo, hi) => Some((*lo, *hi)),
+            RegexQuant::RepeatCode(code) => self.eval_regex_repeat_code(code, current_caps),
+            // `?` / exact-one don't form a separator list; treat as one.
+            _ => Some((1, Some(1))),
+        }
+    }
+
     /// Match a separator quantifier at `start`. Returns `(end, delta)` pairs in
     /// LOWEST-priority-first order (the engine iterates them in reverse):
     /// shortest match first, longest (greedy) last.
@@ -33,12 +52,8 @@ impl Interpreter {
             );
         }
         let sep = token.separator.as_ref().expect("separator present");
-        let (min, max) = match &token.quant {
-            RegexQuant::OneOrMore => (1usize, None),
-            RegexQuant::ZeroOrMore => (0usize, None),
-            RegexQuant::Repeat(lo, hi) => (*lo, *hi),
-            // `?` / exact-one don't form a separator list; treat as one.
-            _ => (1usize, Some(1usize)),
+        let Some((min, max)) = self.separated_quantifier_bounds(token, current_caps) else {
+            return Vec::new();
         };
         let atom_stride = count_capture_groups(&token.atom);
         let sep_stride: usize = sep
@@ -145,12 +160,8 @@ impl Interpreter {
         current_caps: &RegexCaptures,
     ) -> Vec<(usize, RegexCaptures)> {
         let sep = token.separator.as_ref().expect("separator present");
-        let (min, max) = match &token.quant {
-            RegexQuant::OneOrMore => (1usize, None),
-            RegexQuant::ZeroOrMore => (0usize, None),
-            RegexQuant::Repeat(lo, hi) => (*lo, *hi),
-            // `?` / exact-one don't form a separator list; treat as one.
-            _ => (1usize, Some(1usize)),
+        let Some((min, max)) = self.separated_quantifier_bounds(token, current_caps) else {
+            return Vec::new();
         };
         // Frugal (`*? %`) under ratchet commits to the minimal count; greedy
         // extends to `max` (or as far as the input allows).

--- a/src/runtime/regex/regex_match_sep_lazy.rs
+++ b/src/runtime/regex/regex_match_sep_lazy.rs
@@ -102,12 +102,9 @@ impl Interpreter {
             return false;
         }
         let sep = token.separator.as_ref().expect("separator present");
-        let (min, max) = match &token.quant {
-            RegexQuant::OneOrMore => (1usize, None),
-            RegexQuant::ZeroOrMore => (0usize, None),
-            RegexQuant::Repeat(lo, hi) => (*lo, *hi),
-            // `?` / exact-one don't form a separator list; treat as one.
-            _ => (1usize, Some(1usize)),
+        let current_caps = store.caps().clone();
+        let Some((min, max)) = self.separated_quantifier_bounds(token, &current_caps) else {
+            return false;
         };
         let sep_stride: usize = sep
             .pattern

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -934,6 +934,15 @@ impl Interpreter {
         if compact.is_empty() {
             return pattern.to_string();
         }
+        // A block quantifier is match-time code, not a literal count that can
+        // be lowered by the string-based LTM expansion below. In particular,
+        // the bare `%` expansion would otherwise rewrite `** {2} % ','` before
+        // the native parser can attach the separator to its `RepeatCode` token.
+        // Leave the whole pattern for the normal parser, which evaluates the
+        // block with the current capture environment.
+        if Self::contains_block_quantifier(&compact) {
+            return pattern.to_string();
+        }
 
         static WITH_COUNT: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new(r"^(.+?)\*\*(\^?[0-9_]+(?:\^?\.\.(?:\^?[0-9_]+|\*))?)(?:(%%|%)(.+))?$")
@@ -1137,6 +1146,51 @@ impl Interpreter {
                 '(' if !in_single && !in_double => return true,
                 _ => {}
             }
+        }
+        false
+    }
+
+    /// Return whether `pattern` contains a `** { ... }` block quantifier,
+    /// including the frugal/explicit-greedy spellings `**? { ... }` and
+    /// `**! { ... }`. The input has already had insignificant whitespace
+    /// removed, so the check is deliberately small and only needs to avoid the
+    /// LTM string rewrite; the structural parser remains authoritative.
+    fn contains_block_quantifier(pattern: &str) -> bool {
+        let chars: Vec<char> = pattern.chars().collect();
+        let mut i = 0;
+        let mut escaped = false;
+        let mut quote: Option<char> = None;
+        while i < chars.len() {
+            let c = chars[i];
+            if escaped {
+                escaped = false;
+                i += 1;
+                continue;
+            }
+            if let Some(q) = quote {
+                if c == '\\' {
+                    escaped = true;
+                } else if c == q {
+                    quote = None;
+                }
+                i += 1;
+                continue;
+            }
+            if matches!(c, '\'' | '"') {
+                quote = Some(c);
+                i += 1;
+                continue;
+            }
+            if c == '*' && chars.get(i + 1) == Some(&'*') {
+                let mut j = i + 2;
+                if matches!(chars.get(j), Some('?') | Some('!')) {
+                    j += 1;
+                }
+                if chars.get(j) == Some(&'{') {
+                    return true;
+                }
+            }
+            i += 1;
         }
         false
     }

--- a/t/regex/syntax/regex-block-quantifier-backtracking.t
+++ b/t/regex/syntax/regex-block-quantifier-backtracking.t
@@ -1,0 +1,11 @@
+use Test;
+
+plan 2;
+
+is ("abcdn" ~~ /(. ** {2..3})+ n/).gist,
+    "｢abcdn｣\n 0 => ｢ab｣\n 0 => ｢cd｣",
+    'a backtracked capture keeps the block quantifier minimum';
+
+is ("a,a" ~~ /^ (a **? {2} % ",") $/).gist,
+    "｢a,a｣\n 0 => ｢a,a｣",
+    'a frugal separated block quantifier keeps its exact count';


### PR DESCRIPTION
## Summary

- drive compound quantifier iterations through inner capture candidates when backtracking
- preserve `RepeatCode` bounds for separated quantifiers and bypass unsafe LTM rewriting
- add regression coverage and release news for #7906

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`

Closes #7906
