### PR TITLE
feat(regex): CURSOR_MORE, the walk half of the NQP cursor protocol

### DIFF
--- a/news/2026-09/cursor-more-nqp-cursor-protocol.md
+++ b/news/2026-09/cursor-more-nqp-cursor-protocol.md
@@ -1,0 +1,106 @@
+# `CURSOR_MORE`: walking every match through the NQP cursor protocol
+
+`Match.^lookup("CURSOR_MORE")` resolved to nothing, so the second half of the
+NQP cursor protocol was unavailable to ecosystem code. `String::Utils`'
+`replace-all` is written entirely in it and died with
+`No such method 'CALL-ME' for invocant of type 'Nil'`
+([#7931](https://github.com/tokuhirom/mutsu/issues/7931)). The first half —
+`!cursor_init` plus calling a `Regex` on a cursor — landed in
+[#7883](https://github.com/tokuhirom/mutsu/issues/7883); this completes it.
+
+## What the protocol asks for
+
+lizmat's house style for "walk every match without re-scanning the prefix" is
+to drive the regex engine by hand rather than through `~~`:
+
+```raku
+my constant $cursor-init = Match.^lookup("!cursor_init");
+my constant $global      = Match.^lookup("CURSOR_MORE");
+
+my $cursor := $needle($cursor-init(Match, $haystack, :0c));
+my int $pos = nqp::getattr_i($cursor, Match, '$!pos');
+while $pos >= 0 {
+    ...                                    # $!from .. $!pos is one match
+    $cursor := $global($cursor);
+    $pos = nqp::getattr_i($cursor, Match, '$!pos');
+}
+```
+
+rakudo's `Cursor.CURSOR_MORE` re-invokes the cursor's own `$!regexsub` on a
+fresh un-started cursor placed just past the last match. Two details of that
+were measured against rakudo 2026.07 and are load-bearing:
+
+- the resumption position is `$!pos`, **bumped by one when the last match was
+  zero-width** (`$!from == $!pos`). Without the bump, `/x*/` finds the same
+  empty match forever and `replace-all` never terminates.
+- the fresh cursor is un-started (`$!from == -1`), so the re-invocation *scans*
+  forward rather than anchoring, and a run that finds nothing more yields the
+  ordinary failed cursor (`$!pos == -3`) the caller's loop condition tests for.
+
+Both traces now agree with the oracle exactly, including the zero-width walk
+that is the reason the bump exists:
+
+| regex / haystack | `[$!from,$!pos]` per step |
+| --- | --- |
+| `/o/` on `"foo boo"` | `[1,2] [2,3] [5,6] [6,7] [7,-3]` |
+| `/\d+/` on `"a12b345"` | `[1,3] [4,7] [7,-3]` |
+| `/x*/` on `"axb"` | `[0,0] [1,2] [2,2] [3,3] [4,-3]` |
+
+## How mutsu remembers the regex
+
+mutsu's `Match` has no `$!regexsub` slot, so it grew one: the internal
+attribute `CURSOR_REGEXSUB_ATTR`, holding **the callable that produced the
+cursor**, stamped on the result of every cursor-protocol regex call. Storing
+the callable rather than a pattern string means `CURSOR_MORE` re-invokes it
+through the same `Regex.CALL-ME` path the original `$needle($cursor)` call
+took, so an `rx:i//`'s adverbs — and any later fix to how they are honoured —
+are inherited instead of reconstructed. The stamp preserves the `Match`
+instance id, because a cursor is handed straight to user code.
+
+The lazy `Match` node (ADR-0016 P5) answers `None` for the attribute without
+forcing, alongside the other post-hoc keys, so a probe for it on an ordinary
+match costs nothing.
+
+## The surface this deliberately does not claim
+
+`CURSOR_MORE` resumes a cursor produced by a `Regex` called on a cursor. Two
+narrower surfaces are left out, and it says so rather than guessing:
+
+- **an ordinary `"abc".match(/b/)`.** In rakudo every `Match` *is* a spent
+  `Cursor` and carries its `$!regexsub`, so `CURSOR_MORE` works on one. Here
+  the stamp would have to go on every match the engine produces, and because it
+  rebuilds the `Match` eagerly that would cost ADR-0016 P5's laziness on the
+  hottest path in the interpreter — for a surface no known consumer reaches
+  for. Making it free instead means threading the invoked regex down to the
+  engine entry points, which is the same objection the `cursor_class` stamp
+  already records, and worth its own issue if a consumer ever needs it.
+- **a grammar token method called on a cursor.** Its result feeds the
+  custom-HOW subrule side channel by instance identity, so stamping the
+  regexsub on it would perturb a path unrelated to this protocol.
+
+Also unchanged: `.^lookup`'s return value is a plain mutsu `Method`, where
+rakudo answers an `NQPRoutine` for `!cursor_init` and a
+`Method+{is-implementation-detail}` for `CURSOR_MORE`. Both are callable, which
+is all the idiom uses; mutsu has no NQP-level routine type to report.
+
+## Result
+
+The real, vendored `String::Utils` now runs its `replace-all` verbatim under
+mutsu with output identical to rakudo's:
+
+```
+replace-all("foobarfoo", /foo/, "X")   # XbarX
+replace-all("a1b22c333", /\d+/, "-")   # a-b-c-
+replace-all("aaa", /a*/, "<>")         # <><>
+```
+
+Pinned by `t/regex/match/match-cursor-more.t` (24 assertions, every
+expectation measured against rakudo 2026.07, including the verbatim
+`String::Utils::replace-all` body), next to `match-cursor-protocol.t` from
+#7883.
+
+`String::Utils`' own `t/01-basic.rakutest` is still blocked earlier than this,
+at a separate parse gap on line 33 (`is (root <abcd abce abde>), "ab", ...` — an
+imported listop followed by a `<...>` word quote, filed as
+[#7939](https://github.com/tokuhirom/mutsu/issues/7939)), so its record does
+not move yet.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -176,13 +176,15 @@ impl Interpreter {
         if let Some(err) = super::any_cool_method_gate::cool_method_not_found(&target, method) {
             return Err(err);
         }
-        // The NQP cursor protocol (#7883), both halves of it: building a
-        // cursor (`Match.!cursor_init($s, :0c)`, reached through the callable
-        // `Match.^lookup("!cursor_init")` hands back) and *calling a regex on*
-        // one (`$needle($cursor)`, which arrives here as `Regex.CALL-ME`).
-        // Gated on the method name so the common dispatch pays one comparison
-        // against an interned-length string and nothing else.
-        if method.as_bytes().first() == Some(&b'!')
+        // The NQP cursor protocol (#7883, #7931): building a cursor
+        // (`Match.!cursor_init($s, :0c)`, reached through the callable
+        // `Match.^lookup("!cursor_init")` hands back), advancing one
+        // (`CURSOR_MORE`), and *calling a regex on* one (`$needle($cursor)`,
+        // which arrives here as `Regex.CALL-ME`). Gated on the protocol's own
+        // name list so there is a single source of truth; `&str` equality
+        // compares lengths first, so the common dispatch pays two length
+        // checks and nothing else.
+        if super::regex::regex_cursor::is_cursor_protocol_method(method)
             && let Some(result) = self.try_cursor_protocol_method(&target, method, &args)
         {
             return result;

--- a/src/runtime/regex/regex_cursor.rs
+++ b/src/runtime/regex/regex_cursor.rs
@@ -12,7 +12,7 @@
 //! say $cursor.pos;   # 4
 //! ```
 //!
-//! Three pieces make that work, and this module owns all three:
+//! Four pieces make that work, and this module owns all four:
 //!
 //! 1. `Match.^lookup("!cursor_init")` must find a method whose name begins
 //!    with `!`. Those are not Raku private methods — in NQP a leading `!` is
@@ -22,6 +22,9 @@
 //! 2. `!cursor_init` itself, which builds the cursor.
 //! 3. Invoking a `Regex` (or a grammar token method) **on a cursor**, which
 //!    means "match at this cursor and report where you got to".
+//! 4. `CURSOR_MORE`, which advances a cursor that just matched to the next
+//!    match of the *same* regex — the `while` half of the idiom
+//!    (`String::Utils`'s `replace-all`, #7931).
 //!
 //! ## Cursor shape
 //!
@@ -50,15 +53,70 @@
 //! `False`, gists as `#<failed match>`) whose `$!from` is the position the
 //! attempt started at and whose `$!pos` is [`CURSOR_FAIL_POS`].
 //!
+//! ## `CURSOR_MORE`
+//!
+//! rakudo's `Cursor.CURSOR_MORE` re-invokes the cursor's own `$!regexsub` on a
+//! fresh un-started cursor placed just past the last match, so a caller can
+//! walk every match without re-scanning the prefix:
+//!
+//! ```raku
+//! my $global = Match.^lookup("CURSOR_MORE");
+//! my $c := /o/($cursor-init(Match, "foo boo", :0c));
+//! $c := $global($c) while $c.pos >= 0;   # [1,2] [2,3] [5,6] [6,7] [7,-3]
+//! ```
+//!
+//! Two details of it were measured against rakudo 2026.07 and are load-bearing:
+//!
+//! - the resumption position is `$!pos`, bumped by one when the last match was
+//!   **zero-width** (`$!from == $!pos`) — otherwise `/x*/` would find the same
+//!   empty match forever;
+//! - the fresh cursor is un-started (`$!from == -1`), so the re-invocation
+//!   *scans* forward rather than anchoring, and a run that finds nothing more
+//!   yields the ordinary failed cursor (`$!pos == -3`).
+//!
+//! mutsu therefore has to remember which callable produced a cursor. That is
+//! [`crate::value::match_view::CURSOR_REGEXSUB_ATTR`], stamped on the result of
+//! every cursor-protocol regex call and re-invoked through the same
+//! `Regex.CALL-ME` path the original call took — so an `rx:i//`'s adverbs, or
+//! any later fix to how they are honoured, are inherited rather than
+//! reconstructed from a pattern string.
+//!
 //! ## What this does NOT adopt
 //!
-//! Only the entry point the idiom needs. The rest of the protocol
+//! Only the entry points the idiom needs. The rest of the protocol
 //! (`!cursor_start`, `!cursor_pass`, `!cursor_capture`, the `$!shared` /
 //! `$!braid` state NQP threads through a parse) stays internal to mutsu's own
 //! engine: a cursor here is produced complete, never advanced step by step by
 //! user code. One consequence is that a cursor mutsu returns carries its
 //! captures, where rakudo's carries none until `!reduce` builds the Match —
 //! strictly more information, and not something the idiom reads.
+//!
+//! `CURSOR_MORE` resumes a cursor produced by **a `Regex` called on a cursor**,
+//! and only that. Two narrower surfaces are deliberately left out:
+//!
+//! - an ordinary `"abc".match(/b/)`. In rakudo every `Match` *is* a spent
+//!   `Cursor` and carries its `$!regexsub`, so `CURSOR_MORE` works on one;
+//!   here the stamp would have to go on every match the engine produces, and
+//!   since it rebuilds the Match eagerly that would cost ADR-0016 P5's
+//!   laziness on the hottest path in the interpreter for a surface no known
+//!   consumer reaches for. Making it free instead means threading the invoked
+//!   regex down to the engine entry points — the same objection the
+//!   `cursor_class` stamp records, and a change worth its own issue if a
+//!   consumer ever needs it.
+//! - a grammar *token method* called on a cursor. Its result feeds the
+//!   custom-HOW subrule side channel by instance identity
+//!   (`regex_token_method`), so stamping the regexsub on it would perturb a
+//!   path that has nothing to do with this protocol.
+//!
+//! `CURSOR_MORE` on either reports that rather than guessing — as it does for
+//! a cursor that never ran, or one whose match failed (rakudo dies with a null
+//! `$!regexsub` on both of those too).
+//!
+//! Finally, `.^lookup`'s *return value* is still a plain mutsu `Method`:
+//! rakudo answers an `NQPRoutine` for `!cursor_init` and a
+//! `Method+{is-implementation-detail}` for `CURSOR_MORE`. Both are callable
+//! and that is all the idiom uses; mutsu has no NQP-level routine type to
+//! report.
 
 use super::super::*;
 
@@ -74,7 +132,7 @@ pub(crate) const CURSOR_NOT_STARTED: i64 = -1;
 /// The cursor-protocol methods mutsu answers for. `.^lookup` / `.^find_method`
 /// consult this so `Match.^lookup("!cursor_init")` returns a callable instead
 /// of `Nil`.
-pub(crate) const CURSOR_PROTOCOL_METHODS: &[&str] = &["!cursor_init"];
+pub(crate) const CURSOR_PROTOCOL_METHODS: &[&str] = &["!cursor_init", "CURSOR_MORE"];
 
 /// Is `method_name` one of them? The receiver's own `Match`-ness is the
 /// caller's check — `Match` itself, or any grammar, since a grammar IS a
@@ -84,19 +142,31 @@ pub(crate) fn is_cursor_protocol_method(method_name: &str) -> bool {
 }
 
 impl Interpreter {
-    /// `Type.!cursor_init($target, :c($pos))` / `:p($pos)` — build a fresh
-    /// cursor over `$target`. `None` when `method` is not a cursor-protocol
-    /// method mutsu answers for, so the caller falls through to normal
-    /// dispatch.
+    /// Dispatch a cursor-protocol method. `None` when `method` is not one
+    /// mutsu answers for, or when the receiver is not the kind of thing it
+    /// applies to, so the caller falls through to normal dispatch.
     pub(crate) fn try_cursor_protocol_method(
         &mut self,
         target: &Value,
         method: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
-        if method != "!cursor_init" {
-            return None;
+        match method {
+            "!cursor_init" => self.cursor_init(target, args),
+            // `CURSOR_MORE` is an instance method on the cursor itself, so a
+            // receiver that is not a Match is somebody else's `CURSOR_MORE`.
+            "CURSOR_MORE" if target.is_match_instance() => Some(self.cursor_more(target)),
+            _ => None,
         }
+    }
+
+    /// `Type.!cursor_init($target, :c($pos))` / `:p($pos)` — build a fresh
+    /// cursor over `$target`.
+    fn cursor_init(
+        &mut self,
+        target: &Value,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
         // The receiver is the type object the cursor should have: `Match` for
         // a plain regex, the grammar's own type for a parse (rakudo: a
         // grammar's cursors are Match objects of the grammar's own type).
@@ -216,14 +286,63 @@ impl Interpreter {
         };
         let cursor = args.first()?;
         let (orig, start, anchored) = Self::cursor_call_position(cursor)?;
-        let cursor_class = cursor.match_dispatch_class().to_string();
-        Some(Ok(self.run_regex_at_cursor(
-            &pattern,
-            &orig,
-            start,
-            anchored,
-            &cursor_class,
-        )))
+        let cursor_class = Self::cursor_class_of(cursor);
+        let next = self.run_regex_at_cursor(&pattern, &orig, start, anchored, &cursor_class);
+        // Remember what produced this cursor, so `CURSOR_MORE` can resume it.
+        Some(Ok(Self::stamp_cursor_regexsub(next, regex)))
+    }
+
+    /// Record `regexsub` (rakudo's `$!regexsub`) on a cursor. Identity is
+    /// preserved: a cursor is handed straight to user code, and the rebuild
+    /// the stamp forces must not mint a new `Match` id under it.
+    fn stamp_cursor_regexsub(cursor: Value, regexsub: &Value) -> Value {
+        cursor
+            .match_with_attrs_keeping_id(vec![(
+                crate::value::match_view::CURSOR_REGEXSUB_ATTR,
+                regexsub.clone(),
+            )])
+            .unwrap_or(cursor)
+    }
+
+    /// The class a cursor reports. `match_dispatch_class` answers only for a
+    /// still-lazy Match, and a stamped cursor is an eager `Instance`, so read
+    /// the instance's own class first.
+    fn cursor_class_of(cursor: &Value) -> String {
+        match cursor.view() {
+            ValueView::Instance { class_name, .. } => class_name.resolve(),
+            _ => cursor.match_dispatch_class().to_string(),
+        }
+    }
+
+    /// `$cursor.CURSOR_MORE` — the next match of the regex that produced
+    /// `cursor`, as a new cursor. See the module doc for the two measured
+    /// details (the zero-width bump, and resuming un-started so the
+    /// re-invocation scans).
+    fn cursor_more(&mut self, cursor: &Value) -> Result<Value, RuntimeError> {
+        let from = cursor.match_from().unwrap_or(CURSOR_NOT_STARTED);
+        let pos = cursor.match_to().unwrap_or(CURSOR_FAIL_POS);
+        let Some(regexsub) = cursor.match_cursor_regexsub() else {
+            return Err(RuntimeError::new(
+                "CURSOR_MORE: no regex to resume (only a cursor a Regex was called on can be advanced)",
+            ));
+        };
+        if pos < 0 {
+            return Err(RuntimeError::new(
+                "CURSOR_MORE: cannot advance a cursor whose match failed",
+            ));
+        }
+        let orig = cursor
+            .match_orig()
+            .map(|v| v.to_string_value())
+            .unwrap_or_default();
+        // A zero-width match would otherwise be found again in the same
+        // place, forever; rakudo bumps past it by one.
+        let next = if from == pos { pos + 1 } else { pos };
+        let cursor_class = Self::cursor_class_of(cursor);
+        let fresh = Self::make_cursor_value(&cursor_class, &orig, CURSOR_NOT_STARTED, next, false);
+        // Through `CALL-ME`, i.e. the same path `$regex($cursor)` takes, so
+        // the resumed call and the original one cannot drift apart.
+        self.call_method_with_values(regexsub, "CALL-ME", vec![fresh])
     }
 
     /// Shared body of a cursor call: match `pattern` against `orig` at (or

--- a/src/runtime/regex/regex_cursor.rs
+++ b/src/runtime/regex/regex_cursor.rs
@@ -304,9 +304,12 @@ impl Interpreter {
             .unwrap_or(cursor)
     }
 
-    /// The class a cursor reports. `match_dispatch_class` answers only for a
-    /// still-lazy Match, and a stamped cursor is an eager `Instance`, so read
-    /// the instance's own class first.
+    /// The class a cursor reports (`Match`, or a grammar's own type). Every
+    /// cursor that reaches this protocol is an eager `Instance` — one
+    /// `!cursor_init` minted, or one already carrying a stamped regexsub — so
+    /// the instance's own class name is the answer. `match_dispatch_class`
+    /// answers only for a still-lazy `Match`, which is why it is the fallback
+    /// rather than the first choice.
     fn cursor_class_of(cursor: &Value) -> String {
         match cursor.view() {
             ValueView::Instance { class_name, .. } => class_name.resolve(),
@@ -319,13 +322,13 @@ impl Interpreter {
     /// details (the zero-width bump, and resuming un-started so the
     /// re-invocation scans).
     fn cursor_more(&mut self, cursor: &Value) -> Result<Value, RuntimeError> {
-        let from = cursor.match_from().unwrap_or(CURSOR_NOT_STARTED);
-        let pos = cursor.match_to().unwrap_or(CURSOR_FAIL_POS);
         let Some(regexsub) = cursor.match_cursor_regexsub() else {
             return Err(RuntimeError::new(
                 "CURSOR_MORE: no regex to resume (only a cursor a Regex was called on can be advanced)",
             ));
         };
+        let from = cursor.match_from().unwrap_or(CURSOR_NOT_STARTED);
+        let pos = cursor.match_to().unwrap_or(CURSOR_FAIL_POS);
         if pos < 0 {
             return Err(RuntimeError::new(
                 "CURSOR_MORE: cannot advance a cursor whose match failed",

--- a/src/value/match_lazy.rs
+++ b/src/value/match_lazy.rs
@@ -121,8 +121,10 @@ impl MatchNode {
             "action_name" => self.cap.action_name.clone().map(Value::str),
             // Post-hoc attributes exist only on REBUILT eager Matches (the
             // rebuild helpers produce plain Instances); a live lazy node
-            // never carries them.
+            // never carries them. Answering `None` here rather than falling
+            // through keeps a probe for one from forcing the materialization.
             "actions" | "__failed_match__" | "pos" => None,
+            crate::value::match_view::CURSOR_REGEXSUB_ATTR => None,
             _ => self.force_attrs().as_map().get(name).cloned(),
         }
     }

--- a/src/value/match_view.rs
+++ b/src/value/match_view.rs
@@ -31,6 +31,13 @@ use super::*;
 /// `__failed_match__`) and is never exposed through `.hash`/`.list`.
 pub(crate) const CURSOR_MATCH_MARKER: &str = "__grammar_cursor__";
 
+/// Internal attribute holding the callable that produced this cursor —
+/// rakudo's `$!regexsub`, which is what `CURSOR_MORE` re-invokes to find the
+/// next match (#7931). Written only by the cursor-protocol call path
+/// (`regex_cursor`), so an ordinary `~~` Match never carries it; like the
+/// other internal keys it is never exposed through `.hash`/`.list`.
+pub(crate) const CURSOR_REGEXSUB_ATTR: &str = "__cursor_regexsub__";
+
 impl Value {
     /// Is this value a `Match` instance (regex match object)? True for both
     /// the lazy repr (`ValueRepr::Match`, checked WITHOUT materializing) and
@@ -106,6 +113,12 @@ impl Value {
     /// The named-capture hash (`.hash`), a hash `Value`.
     pub(crate) fn match_named(&self) -> Option<Value> {
         self.match_attr("named")
+    }
+
+    /// The callable that produced this cursor (rakudo's `$!regexsub`), or
+    /// `None` for any Match that did not come out of a cursor-protocol call.
+    pub(crate) fn match_cursor_regexsub(&self) -> Option<Value> {
+        self.match_attr(CURSOR_REGEXSUB_ATTR)
     }
 
     /// The `make`-produced value (`.made`/`.ast`).

--- a/t/regex/match/match-cursor-more.t
+++ b/t/regex/match/match-cursor-more.t
@@ -1,0 +1,131 @@
+use v6;
+use Test;
+use nqp;
+
+# `Match.^lookup("CURSOR_MORE")` -- the second half of the NQP cursor protocol
+# (#7931): advance a cursor that just matched to the next match of the SAME
+# regex, without re-scanning the prefix. `String::Utils`'s `replace-all` is
+# written entirely in this idiom, and it is lizmat's house style for "walk
+# every match", so the shape here is what ecosystem code depends on.
+#
+# The companion file `match-cursor-protocol.t` covers `!cursor_init` and
+# calling a regex on a cursor. Every expectation below was measured against
+# rakudo 2026.07.
+
+plan 24;
+
+my $cursor-init = Match.^lookup("!cursor_init");
+my $more        = Match.^lookup("CURSOR_MORE");
+
+is Match.^can("CURSOR_MORE").elems, 1, 'Match.^can finds CURSOR_MORE';
+
+# ---- walking every match ------------------------------------------------
+# The full trace of a walk, `[$!from,$!pos]` per step, ending in the failed
+# cursor that terminates the loop.
+sub walk($needle, Str $haystack, Int $steps = 8) {
+    my $cursor := $needle($cursor-init(Match, $haystack, :0c));
+    my @trace;
+    for ^$steps {
+        @trace.push(
+            "[" ~ nqp::getattr_i($cursor, Match, '$!from')
+                ~ "," ~ nqp::getattr_i($cursor, Match, '$!pos') ~ "]"
+        );
+        last if nqp::getattr_i($cursor, Match, '$!pos') < 0;
+        $cursor := $more($cursor);
+    }
+    @trace.join(" ")
+}
+
+is walk(/o/, "foo boo"), "[1,2] [2,3] [5,6] [6,7] [7,-3]",
+    'a walk visits every match and ends in a failed cursor';
+is walk(/\d+/, "a12b345"), "[1,3] [4,7] [7,-3]",
+    'a multi-char match resumes at its own end, not one past it';
+is walk(/o/, "ooo"), "[0,1] [1,2] [2,3] [3,-3]",
+    'adjacent matches are all found';
+is walk(/z/, "abc"), "[0,-3]",
+    'a haystack with no match yields one failed cursor';
+
+# A ZERO-WIDTH match must not be found again in the same place: rakudo bumps
+# the resumption position by one when $!from == $!pos. Without that, this walk
+# never terminates.
+is walk(/x*/, "axb"), "[0,0] [1,2] [2,2] [3,3] [4,-3]",
+    'a zero-width match is bumped past, so the walk terminates';
+is walk(/\d*/, "ab"), "[0,0] [1,1] [2,2] [3,-3]",
+    'a regex that only ever matches zero-width walks one position at a time and stops';
+
+# ---- the resumed cursor is a real cursor --------------------------------
+my $first := /(\w)(\d)/($cursor-init(Match, "a1 b2", :0c));
+my $second := $more($first);
+is $second.from, 3, 'the resumed cursor reports the next match .from';
+is $second.to, 5, 'and its .to';
+is $second.Str, 'b2', 'and stringifies to the next match';
+ok ?$second, 'and is True';
+is $second.^name, 'Match', 'and is a Match';
+
+# The resumed call goes through the same path as the original, so a regex's
+# adverbs are honoured on every step, not just the first.
+is walk(rx:i/o/, "fOo"), "[1,2] [2,3] [3,-3]",
+    ':i survives the resume';
+
+# The cursor CURSOR_MORE is asked about is not disturbed by the resume.
+is $first.from, 0, 'the original cursor still reports its own .from';
+is $first.Str, 'a1', 'and its own .Str';
+
+# Positions are character positions, not bytes, on the resumed step too.
+is walk(/b/, "\c[SNOWMAN]b\c[SNOWMAN]b"), "[1,2] [3,4] [4,-3]",
+    'resumed positions count characters, not bytes';
+
+# ---- what cannot be resumed ---------------------------------------------
+# rakudo dies on both of these too (a cursor that never ran, and a failed one,
+# carry a null `$!regexsub`), so refusing is the faithful answer -- but with a
+# message that says which case it is.
+#
+# NOT pinned here: rakudo can also resume an ordinary `"abc".match(/b/)`,
+# because every rakudo Match is a spent Cursor and carries its `$!regexsub`.
+# mutsu only remembers the regex for a Match produced BY a cursor call; see
+# `regex_cursor`'s module doc for why.
+my $virgin := $cursor-init(Match, "abc", :0c);
+dies-ok { $more($virgin) }, 'a cursor that never ran cannot be advanced';
+my $failed := /z/($cursor-init(Match, "abc", :0c));
+dies-ok { $more($failed) }, 'a failed cursor cannot be advanced';
+
+# ---- the idiom this exists for ------------------------------------------
+# `String::Utils::replace-all`, verbatim (lib/String/Utils.rakumod:575).
+my sub replace-all(str $haystack, Regex:D $needle, str $replacement) {
+    my $cursor := $needle($cursor-init(Match, $haystack, :0c));
+    my int $pos = nqp::getattr_i($cursor, Match, '$!pos');
+    if $pos >= 0 {
+        my int $start;
+        my str @parts;
+        nqp::while(
+          $pos >= 0,
+          nqp::stmts(
+            nqp::push_s(@parts,
+              nqp::substr(
+                $haystack,
+                $start,
+                nqp::getattr_i($cursor, Match, '$!from') - $start
+              )
+            ),
+            nqp::push_s(@parts, $replacement),
+            $start = $pos,
+            ($cursor := $more($cursor)),
+            ($pos = nqp::getattr_i($cursor, Match, '$!pos'))
+          )
+        );
+        nqp::push_s(@parts, nqp::substr($haystack, $start));
+        nqp::join("", @parts)
+    }
+    else {
+        $haystack
+    }
+}
+
+is replace-all("foobarfoo", /foo/, "X"), "XbarX", 'replace-all replaces every match';
+is replace-all("a1b22c333", /\d+/, "-"), "a-b-c-", 'replace-all handles varying match widths';
+is replace-all("hello", /z/, "X"), "hello", 'replace-all leaves a non-matching string alone';
+is replace-all("hello world", /o/, "0"), "hell0 w0rld", 'replace-all spans the whole string';
+is replace-all("aaa", /a*/, "<>"), "<><>", 'replace-all terminates on a zero-width-capable regex';
+is replace-all("", /x/, "Y"), "", 'replace-all of an empty string is empty';
+
+done-testing;


### PR DESCRIPTION
`Match.^lookup("CURSOR_MORE")` resolved to nothing, so the second half of the NQP cursor protocol was unavailable to ecosystem code. `String::Utils`' `replace-all` is written entirely in it and died with `No such method 'CALL-ME' for invocant of type 'Nil'`. #7883 landed the first half (`!cursor_init` plus calling a `Regex` on a cursor); this completes it.

## What the protocol asks for

rakudo's `Cursor.CURSOR_MORE` re-invokes the cursor's own `$!regexsub` on a fresh un-started cursor placed just past the last match, so a caller can walk every match without re-scanning the prefix. Two details of that were measured against rakudo 2026.07 and are load-bearing:

- the resumption position is `$!pos`, **bumped by one when the last match was zero-width** (`$!from == $!pos`). Without the bump, `/x*/` finds the same empty match forever and `replace-all` never terminates.
- the fresh cursor is un-started (`$!from == -1`), so the re-invocation *scans* forward rather than anchoring, and a run that finds nothing more yields the ordinary failed cursor (`$!pos == -3`) the caller's loop condition tests for.

All traces now agree with the oracle exactly:

| regex / haystack | `[$!from,$!pos]` per step | before |
| --- | --- | --- |
| `/o/` on `"foo boo"` | `[1,2] [2,3] [5,6] [6,7] [7,-3]` | `[1,2]` forever |
| `/\d+/` on `"a12b345"` | `[1,3] [4,7] [7,-3]` | `[1,3]` forever |
| `/x*/` on `"axb"` | `[0,0] [1,2] [2,2] [3,3] [4,-3]` | `[0,0]` forever |

## How mutsu remembers the regex

mutsu's `Match` has no `$!regexsub` slot, so it grows one: the internal attribute `CURSOR_REGEXSUB_ATTR` holds **the callable that produced the cursor**, stamped on the result of every cursor-protocol regex call. Storing the callable rather than a pattern string means `CURSOR_MORE` re-invokes it through the same `Regex.CALL-ME` path the original `$needle($cursor)` call took, so an `rx:i//`'s adverbs — and any later fix to how they are honoured — are inherited instead of reconstructed.

The stamp preserves the `Match` instance id (a cursor is handed straight to user code), and the lazy `Match` node (ADR-0016 P5) answers `None` for the attribute without forcing, alongside the other post-hoc keys, so a probe for it on an ordinary match costs nothing.

## The surface this deliberately does not claim

Both are reported with a specific message rather than guessed at:

- **an ordinary `"abc".match(/b/)`.** In rakudo every `Match` *is* a spent `Cursor` and carries its `$!regexsub`, so `CURSOR_MORE` works on one. Here the stamp would have to go on every match the engine produces, and because it rebuilds the `Match` eagerly that would cost ADR-0016 P5's laziness on the hottest path in the interpreter — for a surface no known consumer reaches for. Making it free instead means threading the invoked regex down to the engine entry points, the same objection the `cursor_class` stamp already records, and worth its own issue if a consumer ever needs it.
- **a grammar token method called on a cursor.** Its result feeds the custom-HOW subrule side channel by instance identity, so stamping the regexsub on it would perturb a path unrelated to this protocol.

A cursor that never ran, and one whose match failed, are also refused — rakudo dies with a null `$!regexsub` on both of those too.

Unchanged: `.^lookup`'s return value is a plain mutsu `Method`, where rakudo answers an `NQPRoutine` for `!cursor_init` and a `Method+{is-implementation-detail}` for `CURSOR_MORE`. Both are callable, which is all the idiom uses; mutsu has no NQP-level routine type to report.

## Result

The real, vendored `String::Utils` now runs its `replace-all` verbatim under mutsu with output identical to rakudo's (`XbarX`, `a-b-c-`, `<><>`).

Its own `t/01-basic.rakutest` is still blocked *earlier* than this, at a separate parse gap on line 33 (an imported listop followed by a `<...>` word quote), filed as #7939 — so that ecosystem record does not move yet.

## Tests

New `t/regex/match/match-cursor-more.t`, 24 assertions, **every expectation first run green against `raku` 2026.07**, next to `match-cursor-protocol.t` from #7883. Covers the walk traces above, the zero-width termination, `:i` surviving the resume, the resumed cursor's `.from`/`.to`/`.Str`/`.Bool`/`.^name`, character-not-byte positions, the two refusals, and the verbatim `String::Utils::replace-all` body.

## Verification

- `cargo fmt --all` — clean
- `make lint` — green (default clippy, `jit` off, wasm32 lib, rustdoc)
- `make check-t-layout` — green
- `make test` — **3994 files / 42524 tests, all pass**
- `make roast` — 1433 files / 219306 tests; the only failures are the three documented container-only exceptions, matching their recorded signatures exactly (`roast/6.c/S32-io/file-tests.t` `Failed: 4` and `roast/S16-filehandles/filetest.t` `Failed: 25`, both because the container runs as `uid 0`; `roast/S32-io/IO-Socket-Async.t` exit 124 "planned 40 ran 17" from the sandboxed network — see `docs/agent-environments.md`)

Closes #7931

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PijqPLBuF8QM4aW9N5BULV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PijqPLBuF8QM4aW9N5BULV)_