### PR TITLE
fix(parser): a paren-less zero-arg builtin call is a call, not a bareword

### DIFF
--- a/news/2026-09/paren-less-zero-arg-builtin-call.md
+++ b/news/2026-09/paren-less-zero-arg-builtin-call.md
@@ -72,7 +72,10 @@ position.
 
 This also removes the raciness the finding was hit through: a child spawned as
 `Proc::Async.new: $*EXECUTABLE, "-e", "sleep"` now blocks, so a parent's `.kill`
-no longer races the child's own 20ms exit.
+no longer races the child's own 20ms exit. That in turn exposed two real
+`Proc::Async` deadlocks in `roast/S17-procasync/kill.t`, which the 20ms exit had
+been hiding; they are fixed alongside and written up in
+`proc-async-ready-kill-cross-thread.md`.
 
 Pinned by `t/lang/parsing/bare-zero-arg-builtin-call.t`, which checks all three
 directions — the zero-arg call really happens, `sleep;` really blocks (measured

--- a/news/2026-09/paren-less-zero-arg-builtin-call.md
+++ b/news/2026-09/paren-less-zero-arg-builtin-call.md
@@ -1,0 +1,81 @@
+# A paren-less zero-arg builtin call is a call, not a bareword
+
+`sleep;` returned instantly instead of sleeping forever, and `my $x = exit;` bound
+the *string* `"exit"` and let execution carry on:
+
+```raku
+sub f() { my $x = exit; say "STILL RUNNING, x=$x.raku()"; }
+f();
+say "AND HERE TOO";
+```
+
+Rakudo prints nothing and exits 0. mutsu printed both lines.
+
+## Root cause
+
+Neither `builtin_sleep` nor `builtin_exit` was at fault — the call never reached
+them. `sleep` is registered as a listop, but the listop parse needs at least one
+argument to follow it. With nothing after the identifier the parse fell through
+to the last resort at the end of `parse_identifier_call`, which turns an
+unrecognised word into `Expr::BareWord(name)` — the string `"sleep"`.
+
+That fallback had grown an ad-hoc allowlist of names rescued from it one at a
+time (`await`/`slip`/`slurp`, then `callframe`/`caller`, then
+`return`/`return-rw`, each added after a bug report — the last because
+Text::CSV's `$error and return;` guard kept executing the rest of the sub). The
+allowlist growing one name per bug report was the actual defect: every core
+routine whose parameters are *all* optional was affected in paren-less zero-arg
+position, and `sleep`, `exit`, `get` and `prompt` simply had not been reported
+yet.
+
+## Fix
+
+The three hardcoded arms are replaced by one table,
+`is_zero_arg_callable_builtin()` in `src/parser/primary/ident/predicates.rs`.
+Membership is measured against Rakudo rather than guessed: a name belongs there
+iff `raku -e 'my $x = NAME;'` compiles. Rakudo rejects a bare
+argument-requiring routine at compile time — either with
+`Unsupported use of bare "say"` (the Perl 5 unary carve-out) or with
+`Calling elems() will never work with signature of the proto ($, *%)` — so a
+name that compiles there is one whose signature really does accept zero
+arguments. Sweeping mutsu's builtin and listop name tables through that oracle
+produced the 38 entries now in the table; everything else (`say`, `ord`,
+`elems`, `floor`, `map`, `set`, `bag`, `sleep-until`, ...) keeps falling through
+to the bareword/`X::Obsolete` path unchanged.
+
+Two names Rakudo accepts are deliberately excluded because mutsu has no zero-arg
+routine behind them, so compiling them to a call would trade a wrong value for a
+worse error: `take-rw` (reachable only with an argument, so a zero-arg call is an
+"Undeclared routine" *parse* error) and `parse-names` (implemented only as a
+method bypass, so a zero-arg call is "Unknown function").
+
+`callframe`/`caller`/`return`/`return-rw` keep their own arm, merged into one:
+they must compile to a call even when what follows is not a statement
+terminator, which the table's gate does not allow.
+
+## Result
+
+| code | before | after (= raku) |
+| --- | --- | --- |
+| `sleep;` | returned immediately | sleeps indefinitely |
+| `my $x = exit;` | `Str "exit"`, execution continued | exits |
+| `my $x = get;` | `Str "get"` | `Any` (reads `$*IN`) |
+| `my $x = prompt;` | `Str "prompt"` | `Any` |
+| `my $x = join;` | `Str "join"` | `Str ""` |
+| `my $x = sum;` | `Str "sum"` | `0` |
+
+Beyond the four names in the report this also corrects `cross`, `flat`, `hash`,
+`item`, `join`, `lines`, `max`, `min`, `minmax`, `note`, `repeated`, `repl`,
+`roundrobin`, `run`, `sleep-timer`, `sort`, `squish`, `succeed`, `sum`, `take`,
+`undefine`, `unique`, `val`, `warn`, `words`, `zip` and `chdir` in the same
+position.
+
+This also removes the raciness the finding was hit through: a child spawned as
+`Proc::Async.new: $*EXECUTABLE, "-e", "sleep"` now blocks, so a parent's `.kill`
+no longer races the child's own 20ms exit.
+
+Pinned by `t/lang/parsing/bare-zero-arg-builtin-call.t`, which checks all three
+directions — the zero-arg call really happens, `sleep;` really blocks (measured
+in a child process, where only a *broken* `sleep` can fail the assertion),
+`exit` really exits, argument-requiring routines still report
+`Unsupported use of bare ...`, and calls with arguments are untouched.

--- a/news/2026-09/proc-async-ready-kill-cross-thread.md
+++ b/news/2026-09/proc-async-ready-kill-cross-thread.md
@@ -1,0 +1,55 @@
+# Proc::Async `.ready` and `.kill` work from a thread that did not call `.start`
+
+`roast/S17-procasync/kill.t` uses this shape twice:
+
+```raku
+start { await $p.ready; $p.kill }
+await $p.start
+```
+
+Under mutsu neither half worked, and the file only stayed green because its
+children were spawned as `$*EXECUTABLE, "-e", "sleep"` — and a bare `sleep` fell
+through the parser as a bareword, so the child exited in 20ms on its own,
+whatever the parent did. Fixing that parse (see
+`paren-less-zero-arg-builtin-call.md`) made the children block and exposed both
+bugs at once as a hard deadlock.
+
+## `.ready` handed out a promise nobody held
+
+The `ready` handler built a fresh `SharedPromise` and stored it into the
+instance attributes as `ready_promise`, expecting `.start` to keep it. But the
+handler stores through *its own copy* of those attributes, so the write is only
+visible to whoever runs next on that thread. With `.ready` called from a `start`
+block and `.start` from the parent, `.start` saw no `ready_promise` and kept
+nothing; `await $p.ready` then waited forever on a promise with no other
+reference to it.
+
+The promise is now created by the constructor
+(`build_native_proc_async_value`), so `.ready` and `.start` share one promise no
+matter which thread reaches which first, and `.ready` only has to hand it back.
+A `Proc::Async` built by some other path still falls back to the old lazy
+construction.
+
+## `.kill` reported a running process as not started
+
+`.kill` needs two facts — `started` and `pid` — and `.start` writes both through
+the same per-thread copy. From another thread, `.kill` therefore saw
+`started = False` and raised `X::Proc::Async::MustBeStarted` against a process
+that was demonstrably running.
+
+The ready promise is shared by reference and `.start` keeps it *with the pid*,
+so it is the one piece of cross-thread truth already available: `.kill` now
+takes the pid from it when the instance attributes do not carry one, and treats
+a kept ready promise as proof the process started.
+
+This is a targeted fix for `Proc::Async`, not a general one. Instance-attribute
+mutations still do not propagate across threads — `.write`, `.close-stdin` and
+the other `MustBeStarted` gates have the same latent problem, and the real
+answer is for a `Proc::Async`'s live process state to live outside the
+per-thread attribute copies altogether.
+
+Pinned by `t/concurrency/thread-lock/proc-async-ready-cross-thread-kill.t`, which checks
+that `.kill` before `.start` is still `X::Proc::Async::MustBeStarted`, that
+`.ready` resolves with the pid on the starting thread, and that
+`start { await $p.ready; $p.kill }` ends a child blocked in a bare `sleep` —
+which it can only do if both halves work cross-thread.

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -19,8 +19,8 @@ use crate::parser::primary::ident::listop::{
 use crate::parser::primary::ident::predicates::{
     balanced_paren_text, is_expr_listop, is_infix_word_op, is_keyword, is_listop,
     is_require_terminator, is_stmt_modifier_ahead, is_unspace_before_postfix,
-    keyword_as_function_error, looks_like_binding, parens_then_block, starts_with_term_keyword,
-    try_extend_colon_name,
+    is_zero_arg_callable_builtin, keyword_as_function_error, looks_like_binding, parens_then_block,
+    starts_with_term_keyword, try_extend_colon_name,
 };
 use crate::parser::primary::ident::supply::supply_method_call;
 use crate::parser::primary::misc::{
@@ -2094,8 +2094,15 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         return Ok((rest, make_call_expr(name, input, args)));
     }
 
-    // Functions that can be called with no arguments as bare words
-    if matches!(name.as_str(), "await" | "slip" | "slurp") && is_terminator_or_dot {
+    // A core routine whose parameters are ALL optional is a real zero-arg call
+    // when nothing follows it, not a bare word: `sleep;` must sleep forever and
+    // `my $x = exit;` must exit rather than binding the string "exit" and
+    // letting execution carry on. A following `.` counts as "nothing follows"
+    // because it is a method call on the result (`slurp.lines`). Routines that
+    // genuinely need an argument are absent from the table and keep falling
+    // through to the bareword/X::Obsolete path below. See
+    // [`is_zero_arg_callable_builtin`] for how the table was measured.
+    if is_terminator_or_dot && is_zero_arg_callable_builtin(&name) {
         return Ok((rest, make_call_expr(name, input, vec![])));
     }
 
@@ -2116,22 +2123,20 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         return Ok((rest, make_call_expr(name, input, vec![])));
     }
 
-    // callframe and caller are term-like functions: always a zero-arg call
-    if matches!(name.as_str(), "callframe" | "caller") {
-        return Ok((rest, make_call_expr(name, input, vec![])));
-    }
-
-    // A bare `return` in EXPRESSION position (`$err and return;`) transfers
-    // control with Nil: compile it as the zero-arg `return` call (which raises
-    // the return control exception), not an inert BareWord — that resolved to
-    // the `&return` routine object and fell through, so Text::CSV's
-    // `$error and return;` guard kept executing the rest of the sub. A
-    // user-declared `\return` term never reaches this fallback (term_literals
-    // resolves it first).
-    // `return-rw` gets the same treatment: a bare `return-rw` returns Nil from
-    // the enclosing routine rather than resolving to an inert BareWord (which
-    // stringified to "return-rw" and let the rest of the sub keep running).
-    if name == "return" || name == "return-rw" {
+    // The same rescue, but UNGATED: these four must compile to a zero-arg call
+    // even when what follows is not a statement terminator.
+    //
+    // `callframe`/`caller` are term-like functions. A bare `return` in
+    // EXPRESSION position (`$err and return;`) transfers control with Nil, so it
+    // has to raise the return control exception rather than resolve to an inert
+    // BareWord — that resolved to the `&return` routine object and fell through,
+    // so Text::CSV's `$error and return;` guard kept executing the rest of the
+    // sub. `return-rw` gets the same treatment. A user-declared `\return` term
+    // never reaches this fallback (term_literals resolves it first).
+    if matches!(
+        name.as_str(),
+        "callframe" | "caller" | "return" | "return-rw"
+    ) {
         return Ok((rest, make_call_expr(name, input, vec![])));
     }
 

--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -153,6 +153,80 @@ pub(crate) fn is_prefix_pseudo_op(name: &str) -> bool {
     )
 }
 
+/// Core routines whose signature is *entirely optional parameters*, so a
+/// paren-less, argument-less use (`sleep;`, `my $x = exit;`) is a real zero-arg
+/// call rather than a bare word.
+///
+/// The identifier-call parser's final fallback turns an unrecognised word into
+/// `Expr::BareWord(name)`, i.e. the *string* `"sleep"`. For a routine that
+/// genuinely requires an argument that is the right shape (the caller then
+/// raises `Unsupported use of bare "..."`), but for one whose parameters are
+/// all optional it silently drops the call: `sleep;` returned instantly instead
+/// of sleeping forever, and `my $x = exit;` left `$x` as `Str "exit"` while
+/// execution carried on. This table is the general answer, replacing the
+/// ad-hoc arms that were rescuing one name per bug report.
+///
+/// Membership is measured against Rakudo, not guessed: a name belongs here iff
+/// `raku -e 'my $x = NAME;'` compiles. Rakudo rejects a bare argument-requiring
+/// routine at compile time — either with `Unsupported use of bare "say"`
+/// (the Perl 5 unary carve-out) or with `Calling elems() will never work with
+/// signature of the proto ($, *%)` — so a name that compiles there is one whose
+/// signature really does accept zero arguments. Names that fail that check
+/// (`say`, `ord`, `elems`, `floor`, `map`, `set`, `bag`, `sleep-until`, ...)
+/// are deliberately absent and keep falling through to the bareword path.
+///
+/// Two names Rakudo accepts are still excluded because mutsu has no zero-arg
+/// routine behind them — compiling them to a call would trade a wrong value for
+/// a worse error: `take-rw` (only reachable with an argument, so a zero-arg call
+/// is an "Undeclared routine" *parse* error) and `parse-names` (implemented only
+/// as a method bypass, so a zero-arg call is "Unknown function").
+///
+/// `callframe`/`caller`/`return`/`return-rw` also take no arguments but are
+/// handled by their own *ungated* arm at the call site, because they must
+/// compile to a call even when what follows is not a statement terminator.
+pub(crate) fn is_zero_arg_callable_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "await"
+            | "chdir"
+            | "cross"
+            | "die"
+            | "dir"
+            | "exit"
+            | "fail"
+            | "flat"
+            | "get"
+            | "hash"
+            | "item"
+            | "join"
+            | "lines"
+            | "max"
+            | "min"
+            | "minmax"
+            | "note"
+            | "prompt"
+            | "repeated"
+            | "repl"
+            | "roundrobin"
+            | "run"
+            | "sleep"
+            | "sleep-timer"
+            | "slip"
+            | "slurp"
+            | "sort"
+            | "squish"
+            | "succeed"
+            | "sum"
+            | "take"
+            | "undefine"
+            | "unique"
+            | "val"
+            | "warn"
+            | "words"
+            | "zip"
+    )
+}
+
 /// Check if a name is a listop (can take args without parens).
 pub(crate) fn is_listop(name: &str) -> bool {
     matches!(

--- a/src/runtime/methods_object_native_ctors_io.rs
+++ b/src/runtime/methods_object_native_ctors_io.rs
@@ -323,6 +323,17 @@ impl Interpreter {
             "supply".to_string(),
             Value::make_instance(Symbol::intern("Supply"), merged_supply_attrs),
         );
+        // `.ready` must hand out the SAME promise that `.start` keeps, so it is
+        // created here rather than lazily by the `ready` handler. A lazily
+        // created one is stored through the handler's own copy of the instance
+        // attributes, which is lost whenever `.ready` and `.start` do not run in
+        // that order on the same thread: `start { await $p.ready }; await
+        // $p.start` then awaited a promise nobody ever kept and deadlocked
+        // (roast/S17-procasync/kill.t, whose child is a bare `sleep`).
+        attrs.insert(
+            "ready_promise".to_string(),
+            Value::promise(SharedPromise::new()),
+        );
         if w_flag {
             attrs.insert("w".to_string(), Value::TRUE);
         }

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -961,19 +961,39 @@ impl Interpreter {
                 Ok((ret, attrs))
             }
             "kill" => {
-                let started = attrs.get("started").is_some_and(|v| v.truthy());
-                let has_pid = attrs.contains_key("pid");
+                // `started` and `pid` are written into `.start`'s own copy of
+                // the instance attributes, so a thread that did not call
+                // `.start` never sees them -- `start { await $p.ready; $p.kill }`
+                // raised X::Proc::Async::MustBeStarted against a running
+                // process (roast/S17-procasync/kill.t). The ready promise is
+                // shared by reference and `.start` keeps it with the pid, so it
+                // is the cross-thread source of truth for both facts.
+                let ready_pid = match attrs.get("ready_promise").map(Value::view) {
+                    Some(ValueView::Promise(ready)) if ready.status() == "Kept" => {
+                        match ready.result_blocking().view() {
+                            ValueView::Int(pid) => Some(pid),
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                };
+                let started =
+                    attrs.get("started").is_some_and(|v| v.truthy()) || ready_pid.is_some();
+                let pid = match attrs.get("pid").map(Value::view) {
+                    Some(ValueView::Int(pid)) => Some(pid),
+                    _ => ready_pid,
+                };
                 if !started {
                     return Err(proc_async_error(
                         "X::Proc::Async::MustBeStarted",
                         &[("method", Value::str_from("kill"))],
                     ));
                 }
-                if !has_pid {
+                if pid.is_none() {
                     return Ok((Value::NIL, attrs));
                 }
                 #[cfg(feature = "native")]
-                if let Some(ValueView::Int(pid)) = attrs.get("pid").map(Value::view) {
+                if let Some(pid) = pid {
                     let sig = args
                         .first()
                         .and_then(|v| match v.view() {
@@ -1153,15 +1173,26 @@ impl Interpreter {
                     promise.break_with(err, String::new(), String::new());
                     return Ok((Value::promise(promise), attrs));
                 }
-                // Returns a Promise that resolves with the PID when the process
-                // has been started. If already started, resolves immediately.
-                let promise = SharedPromise::new();
+                // Returns the Promise `.start` keeps with the PID once the
+                // process has been spawned. It is built by the constructor, not
+                // here: creating it lazily stored it through this handler's own
+                // copy of the instance attributes, so `start { await $p.ready }`
+                // running before (or on another thread from) `.start` awaited a
+                // promise nobody held and deadlocked.
+                let ready = match attrs.get("ready_promise").map(Value::view) {
+                    Some(ValueView::Promise(p)) => p.clone(),
+                    // A Proc::Async built by some other path still gets a working
+                    // promise, kept immediately when the process already runs.
+                    _ => {
+                        let p = SharedPromise::new();
+                        attrs.insert("ready_promise".to_string(), Value::promise(p.clone()));
+                        p
+                    }
+                };
                 if let Some(ValueView::Int(pid)) = attrs.get("pid").map(Value::view) {
-                    promise.keep(Value::int(pid), String::new(), String::new());
+                    ready.try_keep(Value::int(pid)).ok();
                 }
-                // Store the ready promise so start can resolve it
-                attrs.insert("ready_promise".to_string(), Value::promise(promise.clone()));
-                Ok((Value::promise(promise), attrs))
+                Ok((Value::promise(ready), attrs))
             }
             "stdout" | "stderr" => {
                 if attrs

--- a/t/concurrency/thread-lock/proc-async-ready-cross-thread-kill.t
+++ b/t/concurrency/thread-lock/proc-async-ready-cross-thread-kill.t
@@ -1,0 +1,52 @@
+use Test;
+
+# `.ready` and `.kill` have to work from a thread other than the one that
+# called `.start`, which is the shape roast/S17-procasync/kill.t uses:
+#
+#     start { await $p.ready; $p.kill }
+#     await $p.start
+#
+# Both facts `.kill` needs -- "has it started" and "what is the pid" -- used to
+# be written only into `.start`'s own copy of the instance attributes, which the
+# other thread never sees: `await $p.ready` waited on a promise nobody held, and
+# reaching `.kill` anyway raised X::Proc::Async::MustBeStarted against a running
+# process. The ready promise is now built by the constructor, so `.ready` and
+# `.start` share one promise, and `.kill` reads the pid back out of it.
+#
+# This was invisible while a bare `sleep` fell through the parser as a bareword
+# and the child exited in 20ms on its own.
+
+plan 4;
+
+# `.kill` before `.start` is still an error, from any thread.
+{
+    my $proc = Proc::Async.new($*EXECUTABLE, '-e', 'sleep');
+    throws-like { $proc.kill }, X::Proc::Async::MustBeStarted,
+        '.kill before .start is X::Proc::Async::MustBeStarted';
+}
+
+# `.ready` resolves with the pid for the thread that started the process.
+{
+    my $proc = Proc::Async.new($*EXECUTABLE, '-e', 'sleep');
+    my $run = $proc.start;
+    my $pid = await $proc.ready;
+    ok $pid ~~ Int && $pid > 0, '.ready resolves with the pid on the starting thread';
+    $proc.kill;
+    await Promise.anyof(Promise.in(15), $run);
+    ok $run.status != Planned, '.kill on the starting thread ends the child';
+}
+
+# The roast shape: ready + kill on a thread that did not call `.start`. The
+# child blocks forever, so it can only end if BOTH halves work cross-thread.
+{
+    my $proc = Proc::Async.new($*EXECUTABLE, '-e', 'sleep');
+    start {
+        await $proc.ready;
+        $proc.kill;
+    }
+    my $run = $proc.start;
+    await Promise.anyof(Promise.in(15), $run);
+    my $ended = $run.status != Planned;
+    $proc.kill unless $ended;
+    ok $ended, '`start { await $p.ready; $p.kill }` ends a child blocked in `sleep`';
+}

--- a/t/lang/parsing/bare-zero-arg-builtin-call.t
+++ b/t/lang/parsing/bare-zero-arg-builtin-call.t
@@ -1,0 +1,78 @@
+use lib 'roast/packages/Test-Helpers/lib';
+use Test;
+use Test::Util;
+
+# A core routine whose parameters are ALL optional, used paren-less with no
+# argument, is a real zero-arg call -- not the bareword *string*.
+#
+# The identifier-call parser's last resort turns an unrecognised word into
+# `Expr::BareWord(name)`, so `sleep;` evaluated to the Str "sleep" and returned
+# instantly, and `my $x = exit;` bound "exit" and let execution carry on. See
+# `is_zero_arg_callable_builtin()` in src/parser/primary/ident/predicates.rs:
+# membership is measured against Rakudo, which rejects a bare
+# argument-requiring routine at compile time.
+#
+# Routines that genuinely need an argument must keep falling through to the
+# bareword/X::Obsolete path, and calls with arguments must be untouched.
+
+plan 36;
+
+# --- the zero-arg call really happens ---------------------------------------
+
+for <join sum min max minmax unique squish repeated flat zip cross roundrobin
+     hash item slip sort undefine val> -> $name {
+    my $got = EVAL("my \$x = $name; \$x");
+    nok ($got ~~ Str:D && $got eq $name),
+        "bare `$name` compiles to a zero-arg call, not the bareword string";
+}
+
+is (my $j = join), '', 'bare `join` returns join()\'s empty string';
+is (my $s = sum), 0, 'bare `sum` returns sum()\'s 0';
+is (my $h = hash).elems, 0, 'bare `hash` returns an empty Hash';
+nok (my $m = min).defined, 'bare `min` returns an undefined value';
+
+# --- `sleep;` blocks, it does not fall through ------------------------------
+
+# `sleep` is `sub sleep($seconds = Inf --> Nil)`, so a bare `sleep` sleeps
+# indefinitely. Run it in a child and assert it has NOT finished: a slow or
+# loaded machine can only make this pass, never fail.
+{
+    my $prog = Proc::Async.new($*EXECUTABLE.absolute, '-e', 'sleep; print "RETURNED"');
+    my $out = '';
+    $prog.stdout.tap: { $out ~= $^a };
+    my $promise = $prog.start;
+    await Promise.anyof(Promise.in(5), $promise);
+    my $finished = $promise.status == Kept;
+    $prog.kill unless $finished;
+    nok $finished, 'bare `sleep;` blocks instead of returning the word "sleep"';
+}
+
+# --- `exit` in expression position really exits -----------------------------
+
+is_run 'sub f() { my $x = exit; print "STILL RUNNING" }; f(); print "AND HERE"',
+    %(:out(''), :err(''), :status(0)),
+    'bare `exit` in expression position exits instead of continuing';
+
+# --- argument-requiring routines are unaffected -----------------------------
+
+# `say` is checked as a bare statement and the Perl 5 unaries in expression
+# position, which is where each of them is diagnosed today.
+for 'say;', 'my $x = ord;', 'my $x = chr;', 'my $x = lc;', 'my $x = uc;',
+    'my $x = abs;' -> $code {
+    my $message;
+    try {
+        EVAL $code;
+        CATCH { default { $message = .message } }
+    }
+    ok $message.defined && $message.contains('Unsupported use of bare'),
+        "`$code` still reports Unsupported use of bare";
+}
+
+# --- real calls are unaffected ----------------------------------------------
+
+is join('-', 1, 2, 3), '1-2-3', 'join with arguments still works';
+is (join '-', 1, 2, 3), '1-2-3', 'join as a listop still works';
+is min(3, 1, 2), 1, 'min with arguments still works';
+is sum(1, 2, 3), 6, 'sum with arguments still works';
+is sort(3, 1, 2).join(','), '1,2,3', 'sort with arguments still works';
+is (flat 1, 2, 3).elems, 3, 'flat as a listop still works';

--- a/t/lang/parsing/bare-zero-arg-builtin-call.t
+++ b/t/lang/parsing/bare-zero-arg-builtin-call.t
@@ -36,12 +36,16 @@ nok (my $m = min).defined, 'bare `min` returns an undefined value';
 # `sleep` is `sub sleep($seconds = Inf --> Nil)`, so a bare `sleep` sleeps
 # indefinitely. Run it in a child and assert it has NOT finished: a slow or
 # loaded machine can only make this pass, never fail.
+#
+# Two seconds, not more: a `sleep` that falls through as a bareword returns in
+# about 20ms, so this is already a hundredfold margin, and the wait is paid in
+# full by the serial `prove t/` of the gc-stress and jit-stress jobs.
 {
     my $prog = Proc::Async.new($*EXECUTABLE.absolute, '-e', 'sleep; print "RETURNED"');
     my $out = '';
     $prog.stdout.tap: { $out ~= $^a };
     my $promise = $prog.start;
-    await Promise.anyof(Promise.in(5), $promise);
+    await Promise.anyof(Promise.in(2), $promise);
     my $finished = $promise.status == Kept;
     $prog.kill unless $finished;
     nok $finished, 'bare `sleep;` blocks instead of returning the word "sleep"';


### PR DESCRIPTION
Closes #7936

`sleep;` returned instantly instead of sleeping forever, and `my $x = exit;` bound the *string* `"exit"` and let execution carry on.

## Root cause

Neither builtin was at fault — the call never reached them. `sleep` is registered as a listop, but the listop parse needs at least one argument to follow it. With nothing after the identifier the parse fell through to the last resort at the end of `parse_identifier_call`, which turns an unrecognised word into `Expr::BareWord(name)`.

That fallback had grown an ad-hoc allowlist of names rescued from it one at a time (`await`/`slip`/`slurp`, then `callframe`/`caller`, then `return`/`return-rw`, each added after a bug report). As the ticket says, the allowlist growing one name per bug report *is* the defect: every core routine whose parameters are all optional was affected in paren-less zero-arg position.

## Fix

The three hardcoded arms are replaced by one table, `is_zero_arg_callable_builtin()` in `src/parser/primary/ident/predicates.rs`.

Membership is **measured against Rakudo rather than guessed**: a name belongs there iff `raku -e 'my $x = NAME;'` compiles. Rakudo rejects a bare argument-requiring routine at compile time — either with `Unsupported use of bare "say"` (the Perl 5 unary carve-out) or with `Calling elems() will never work with signature of the proto ($, *%)` — so a name that compiles there is one whose signature really does accept zero arguments. Sweeping mutsu's builtin and listop name tables through that oracle produced the 38 entries; everything else (`say`, `ord`, `elems`, `floor`, `map`, `set`, `bag`, `sleep-until`, …) keeps falling through to the bareword/`X::Obsolete` path unchanged.

`take-rw` and `parse-names` are deliberately excluded even though Rakudo accepts them, because mutsu has no zero-arg routine behind either: compiling them to a call would trade a wrong value for a worse error (`Undeclared routine` at parse time, and `Unknown function`).

`callframe`/`caller`/`return`/`return-rw` keep their own arm, now merged into one: they must compile to a call even when what follows is not a statement terminator, which the table's gate does not allow.

| code | before | after (= raku) |
| --- | --- | --- |
| `sleep;` | returned immediately | sleeps indefinitely |
| `my $x = exit;` | `Str "exit"`, execution continued | exits |
| `my $x = get;` | `Str "get"` | `Any` (reads `$*IN`) |
| `my $x = prompt;` | `Str "prompt"` | `Any` |
| `my $x = join;` | `Str "join"` | `Str ""` |
| `my $x = sum;` | `Str "sum"` | `0` |

Beyond the four names in the report this also corrects `chdir`, `cross`, `flat`, `hash`, `item`, `join`, `lines`, `max`, `min`, `minmax`, `note`, `repeated`, `repl`, `roundrobin`, `run`, `sleep-timer`, `sort`, `squish`, `succeed`, `sum`, `take`, `undefine`, `unique`, `val`, `warn`, `words` and `zip` in the same position.

## Second commit: two Proc::Async deadlocks the old parse was hiding

`roast/S17-procasync/kill.t` is whitelisted and went red, because it uses this shape twice:

```raku
start { await $p.ready; $p.kill }
await $p.start
```

Neither half worked under mutsu. The file only stayed green because its children are spawned as `$*EXECUTABLE, "-e", "sleep"` — and the bareword `sleep` made them exit in 20ms whatever the parent did. Making the children block turned both bugs into a hard deadlock, so they are fixed here:

- **`.ready` handed out a promise nobody held.** It built a fresh `SharedPromise` and stored it into the instance attributes for `.start` to keep — but a handler stores through *its own copy* of those attributes, so with `.ready` on one thread and `.start` on another, `.start` saw no `ready_promise` and kept nothing. The promise is now built by the constructor, so both share one whichever thread reaches which first.
- **`.kill` reported a running process as not started.** `started` and `pid` are written through that same per-thread copy, so from another thread `.kill` raised `X::Proc::Async::MustBeStarted` against a demonstrably running process. The ready promise is shared by reference and `.start` keeps it *with the pid*, so `.kill` now takes the pid from it and treats a kept ready promise as proof the process started.

This is targeted at `Proc::Async`, not general — instance-attribute mutations still do not propagate across threads, and the news entry records that `.write`/`.close-stdin` have the same latent problem.

## Tests

- `t/lang/parsing/bare-zero-arg-builtin-call.t` (36 tests) — the zero-arg call really happens; `sleep;` really blocks, measured in a child process so that only a *broken* `sleep` can fail the assertion; `exit` really exits; argument-requiring routines still report `Unsupported use of bare …`; calls with arguments are untouched.
- `t/concurrency/thread-lock/proc-async-ready-cross-thread-kill.t` (4 tests) — `.kill` before `.start` is still `X::Proc::Async::MustBeStarted`, `.ready` resolves with the pid, and `start { await $p.ready; $p.kill }` ends a child blocked in a bare `sleep`.

## Verification

- `cargo fmt --all`, `make lint` (all four configurations) — green
- `make test` — 3995 files, 42540 tests, **PASS**
- `make roast` — 1433 files, 219306 tests; the only red files are `S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64/69-72/77-80/101…125) and `S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17), which are exactly the container-environment failures documented in `docs/agent-environments.md` (`id -u` is `0` here; the network is sandboxed). `S17-procasync/kill.t` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oPv2zBwaykmuKMvY14mPz

---
_Generated by [Claude Code](https://claude.ai/code/session_018oPv2zBwaykmuKMvY14mPz)_