### PR TITLE
feat(ci): sweep the whole ecosystem nightly at 03:20 JST

### DIFF
--- a/.agents/skills/ecosystem-dist-fix/SKILL.md
+++ b/.agents/skills/ecosystem-dist-fix/SKILL.md
@@ -213,7 +213,7 @@ The change goes where `CLAUDE.md` says it goes: implement in `compiler/` and `vm
 
 **Every fix commits a focused regression test under `t/`** — the §4 reduction, placed by
 [docs/t-directory-layout.md](../../../docs/t-directory-layout.md) (by what it would catch, not by
-the syntax it uses). The ecosystem sweep is operator-run and not in CI, so this `t/` file is the
+the syntax it uses). The ecosystem sweep only measures, and nightly at that, so this `t/` file is the
 *only* thing standing between your fix and a silent regression. Name it after the capability, and
 say in a comment which distribution it came from.
 

--- a/.github/workflows/ecosystem-sweep.yml
+++ b/.github/workflows/ecosystem-sweep.yml
@@ -15,12 +15,21 @@ name: Ecosystem sweep
 # Decisions: docs/adr/0085-ecosystem-testsuite-parity-measurement.md (D9 + its
 # 2026-09-10 amendment, which is what allows this workflow to exist).
 #
-# Deliberately `workflow_dispatch` ONLY -- there is no `schedule:`. ADR-0085 D9
-# rejected a periodic sweep and that still stands: a full corpus run is ~20
-# CPU-hours to track a number that moves at the speed of interpreter fixes, so
-# it happens when someone decides the numbers are worth refreshing. What the
-# amendment adds is that "someone" no longer needs a 12-core box and a local
-# `bwrap` -- one dispatch does it.
+# Two entry points: a nightly `schedule:` that measures the whole corpus, and
+# `workflow_dispatch` for anything else (one shard, a named distribution, a
+# status). The schedule was added by ADR-0085 D9's SECOND amendment
+# (2026-09-11), which reversed the original "operator-run only" decision on
+# measured cost: the rejection assumed ~20 CPU-hours per sweep, and the first
+# real corpus run took 78 minutes of wall time and about 5.5 hours of job time
+# across 27 shards. Read that amendment before changing the cadence.
+#
+# IMPORTANT for anyone editing this file: on a `schedule:` event `inputs.*` are
+# ALL EMPTY -- a workflow_dispatch default does not apply. Every input is
+# therefore read as `inputs.x || <default>`, and the two booleans as
+# `inputs.x || github.event_name == 'schedule'`, so the nightly run is a full
+# `scope: all` sweep that rolls up and appends a history row. Adding a new input
+# means adding its fallback too, or the nightly run silently gets the empty
+# value.
 #
 # Three things it does NOT compromise on, because they are what make the number
 # mean anything (ADR-0085 D8):
@@ -40,6 +49,12 @@ name: Ecosystem sweep
 # lands its records but is refused a `history.tsv` row.
 
 on:
+  # 18:20 UTC = 03:20 JST, every day. JST has no daylight saving, so the local
+  # time does not drift. Twenty past rather than on the hour: GitHub queues
+  # scheduled jobs hardest at :00, and a 27-shard matrix waiting for runners is
+  # the one delay this run cannot shorten.
+  schedule:
+    - cron: '20 18 * * *'
   workflow_dispatch:
     inputs:
       scope:
@@ -143,14 +158,14 @@ jobs:
           # `run:` body: the planner is what decides they are safe to word-split
           # into an argv, and it can only do that if the shell never sees them
           # first.
-          SCOPE: ${{ inputs.scope }}
+          SCOPE: ${{ inputs.scope || 'all' }}
           PREFIX: ${{ inputs.prefix }}
           ONLY: ${{ inputs.only }}
-          STATUS: ${{ inputs.status }}
-          SHARDS: ${{ inputs.shards }}
-          JOBS: ${{ inputs.jobs }}
-          ATTEMPTS: ${{ inputs.attempts }}
-          FILE_TIMEOUT: ${{ inputs.file_timeout }}
+          STATUS: ${{ inputs.status || 'partial' }}
+          SHARDS: ${{ inputs.shards || 'auto' }}
+          JOBS: ${{ inputs.jobs || '4' }}
+          ATTEMPTS: ${{ inputs.attempts || '3' }}
+          FILE_TIMEOUT: ${{ inputs.file_timeout || '120' }}
         run: |
           set -euo pipefail
           for pair in "jobs:$JOBS" "attempts:$ATTEMPTS" "file_timeout:$FILE_TIMEOUT"; do
@@ -237,7 +252,7 @@ jobs:
 
       - name: Summary
         env:
-          SCOPE: ${{ inputs.scope }}
+          SCOPE: ${{ inputs.scope || 'all' }}
         run: |
           {
             echo "## Ecosystem sweep plan"
@@ -333,9 +348,9 @@ jobs:
       - name: Measure
         env:
           SWEEP_ARGS: ${{ matrix.chunk.args }}
-          JOBS: ${{ inputs.jobs }}
-          ATTEMPTS: ${{ inputs.attempts }}
-          FILE_TIMEOUT: ${{ inputs.file_timeout }}
+          JOBS: ${{ inputs.jobs || '4' }}
+          ATTEMPTS: ${{ inputs.attempts || '3' }}
+          FILE_TIMEOUT: ${{ inputs.file_timeout || '120' }}
           MUTSU_BIN: target/release/mutsu
         run: |
           set -euo pipefail
@@ -506,10 +521,10 @@ jobs:
       # KPI chart that is not comparable with its neighbours.
       - name: Roll the numbers up
         id: rollup
-        if: ${{ inputs.rollup && steps.apply.outputs.changed != '0' }}
+        if: ${{ (inputs.rollup || github.event_name == 'schedule') && steps.apply.outputs.changed != '0' }}
         env:
           FULL_CORPUS: ${{ needs.build.outputs.full-corpus }}
-          WANT_HISTORY: ${{ inputs.history }}
+          WANT_HISTORY: ${{ inputs.history || github.event_name == 'schedule' }}
           ALL_SHARDS_OK: ${{ needs.sweep.result == 'success' }}
           UNIFORM: ${{ steps.provenance.outputs.uniform }}
         run: |
@@ -556,7 +571,7 @@ jobs:
             echo ""
             echo "| | |"
             echo "|---|---|"
-            echo "| scope | \`${{ inputs.scope }}\` |"
+            echo "| scope | \`${{ inputs.scope || 'all' }}\` (${{ github.event_name }}) |"
             echo "| mutsu | \`${{ needs.build.outputs.mutsu-commit }}\` |"
             echo "| rakudo | ${{ needs.build.outputs.raku-version }} |"
             echo "| shards | ${{ needs.build.outputs.count }} (\`${{ needs.sweep.result }}\`) |"
@@ -594,11 +609,11 @@ jobs:
           cat /tmp/report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Push the branch and open the pull request
-        if: ${{ inputs.publish != 'none' && steps.apply.outputs.changed != '0' }}
+        if: ${{ (inputs.publish || 'pull-request') != 'none' && steps.apply.outputs.changed != '0' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
-          PUBLISH: ${{ inputs.publish }}
-          SCOPE: ${{ inputs.scope }}
+          PUBLISH: ${{ inputs.publish || 'pull-request' }}
+          SCOPE: ${{ inputs.scope || 'all' }}
           HAVE_APP_TOKEN: ${{ steps.app-token.outputs.token != '' }}
         run: |
           set -euo pipefail

--- a/PLAN.md
+++ b/PLAN.md
@@ -113,8 +113,10 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
       operations manual and phases (P1-P5, one PR each):
       [docs/ecosystem-parity.md](docs/ecosystem-parity.md);
       tracking issue [#7785](https://github.com/tokuhirom/mutsu/issues/7785).
-      The sweep is *dispatched*, never scheduled (ADR-0085 D9), so it does **not** close B1's
-      "working-module regression CI" — that stays a separate item.
+      The sweep runs **nightly at 03:20 JST** (`schedule:` in `ecosystem-sweep.yml`, ADR-0085 D9's
+      second amendment) and can also be dispatched for one shard or one distribution. It is a
+      measurement, not a gate, so it still does **not** close B1's "working-module regression CI" —
+      that stays a separate item.
 - [ ] **★Real-dist compatibility sweep** — run real fez dists under mutsu and fix the general bugs
       they surface. Ledger: [docs/dist-compat-sweep.md](docs/dist-compat-sweep.md). **The `--run-tests`
       axis is the sharper frontier**: running each loading dist's own suite with raku as the baseline.

--- a/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
+++ b/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
@@ -1,6 +1,6 @@
 # ADR-0085 — The ecosystem KPI is per-distribution test-suite parity against rakudo
 
-- Status: Accepted (design confirmed 2026-09-10; P1 implemented — see "Implementation status"; D9 amended 2026-09-10 to allow an operator-dispatched CI sweep)
+- Status: Accepted (design confirmed 2026-09-10; P1-P3 implemented — see "Implementation status"; D9 amended 2026-09-10 to allow an operator-dispatched CI sweep, and again 2026-09-11 to schedule it nightly on measured cost)
 - Date: 2026-09-10
 - Issue: [#7785](https://github.com/tokuhirom/mutsu/issues/7785)
 - Operations manual (the "how"): [docs/ecosystem-parity.md](../ecosystem-parity.md)
@@ -235,7 +235,7 @@ the harness at startup, not left to the operator:
   sweep that cannot confirm it aborts rather than publishing a flattered
   number.
 
-### D9. The sweep is operator-run, not CI-scheduled
+### D9. The sweep is operator-run, not CI-scheduled  *(superseded by the two amendments below: it is CI-dispatched and nightly-scheduled)*
 
 A full sweep is ~20 CPU-hours. It runs **on the maintainer's box, started by
 hand**, and its results reach `main` as an ordinary pull request. There is no
@@ -314,6 +314,62 @@ timing difference lands in `no_baseline` rather than being charged to mutsu); an
 a pull request opened with the default `GITHUB_TOKEN` does not start CI, so the
 workflow uses the repository's GitHub App token when it is configured and says
 so in the run summary when it is not.
+
+#### Second amendment, 2026-09-11: the sweep IS scheduled now, nightly
+
+The first amendment said adding a `schedule:` "needs a new decision, not an edit
+here". This is that decision, and it reverses D9's original answer: the workflow
+now carries `schedule: - cron: '20 18 * * *'` — 03:20 JST every day — measuring
+the whole corpus.
+
+What changed is the **cost**, which D9 had estimated rather than measured. Its
+rejection rested on "20 CPU-hours of Actions time every week". The first real
+corpus run on hosted runners ([run
+34566091231](https://github.com/tokuhirom/mutsu/actions/runs/34566091231)) took
+**78 minutes of wall time and about 5.5 hours of job time** across 27 shards at
+`max-parallel: 8`, with the heaviest single shard at 43 minutes. That is a
+quarter of the assumed figure, it is free on a public repository, and it fits
+inside a night. An estimate that is wrong by 4x is the whole reason the original
+trade-off came out the way it did.
+
+The second half of D9's argument — "a number that moves on the timescale of
+interpreter fixes rather than of pushes" — argued for *less* frequency than
+pushes, and nightly is exactly that: mutsu takes several merges a day, so a
+daily sweep is already coarser than the thing it measures, while being fine
+enough that a regression is attributable to one day's merges instead of to
+however long it had been since someone remembered to run it. It also turns
+`history.tsv` into a real series rather than a handful of irregular points, which
+is what makes the KPI chart worth drawing (and retires this document's own note
+about index-vs-time spacing being needed for "operator-run and irregular"
+sweeps — the reason still holds for a dispatched run in between).
+
+D9's first consequence is therefore **retired**: the KPI no longer updates "only
+when someone runs it". Its second stands unchanged — this is still a
+*measurement*, not a gate, so PLAN.md §1 B1's "working-module regression CI"
+remains a separate, unstarted item. Nothing about a nightly sweep fails a build
+or blocks a merge; a red shard produces a warning, fewer records, and a refused
+history row.
+
+Three mechanics this required, each a place a scheduled run differs from a
+dispatched one:
+
+- **`inputs.*` are empty on a `schedule` event** — a `workflow_dispatch` default
+  does not apply — so every input is read as `inputs.x || <default>` and the two
+  booleans as `inputs.x || github.event_name == 'schedule'`. Without that the
+  nightly run would plan an empty scope. This is the trap for whoever adds the
+  next input.
+- **`concurrency: ecosystem-sweep` with `cancel-in-progress: false`** already
+  existed and now earns its keep: a dispatched sweep and the nightly one queue
+  instead of racing the same records, and a cancelled sweep would throw away
+  hours of measurement.
+- **A no-change night is silent.** `changed == 0` skips the rollup and opens no
+  pull request, so an unchanged corpus costs runner time and nothing else — no
+  empty PR, no history row.
+
+The cadence is a knob, not a principle: if the daily data PR or the runner time
+turns out not to pay for itself, the cron moves to weekly with no other change.
+What must not change quietly is the `scope: all` + all-shards-green condition on
+the history row, which is what keeps the series comparable.
 
 ## Consequences
 

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -375,8 +375,9 @@ which is why this is a separate script rather than a flag on that one:
 
 - **The x axis is time, not sample index.** `HISTORY.tsv` gets a row on every
   main push, so evenly-spaced samples are honest there. Ecosystem sweeps are
-  operator-run and irregular (ADR-0085 D9), so index spacing would draw a
-  six-week gap and a same-day re-run the same width.
+  nightly *plus* whatever is dispatched in between (ADR-0085 D9's second
+  amendment), so index spacing would still draw a skipped night and a same-day
+  re-run the same width.
 - **A rakudo change is drawn as a labelled vertical rule.** It re-bases every
   baseline, so the series is not comparable across it — the step at that point
   is the denominator moving, not news, and the chart has to say so or it lies.
@@ -457,9 +458,29 @@ and the KPI is not comparable across that boundary.
 
 ### 8.1 From GitHub Actions
 
-`.github/workflows/ecosystem-sweep.yml`, **Run workflow** (or
+**The corpus is measured for you every night**: `ecosystem-sweep.yml` carries
+`schedule: - cron: '20 18 * * *'` — 03:20 JST — and a scheduled run is a full
+`scope: all` sweep that rolls up and appends a `history.tsv` row (ADR-0085 D9's
+second amendment; the cost that justifies it is 78 minutes of wall time and ~5.5
+hours of job time). So nobody has to remember to refresh the numbers, and the
+question worth asking about a stale-looking figure is "did last night's run go
+red", not "when did someone last run it".
+
+Dispatch it by hand for anything *other* than the whole corpus — one shard, one
+distribution, one status — or to re-measure immediately rather than waiting for
+the night: `.github/workflows/ecosystem-sweep.yml`, **Run workflow** (or
 `gh workflow run ecosystem-sweep.yml -f scope=…`). One dispatch does the whole
 runbook: plan, build, measure, roll up, open the pull request.
+
+A dispatched run and the nightly one never overlap (`concurrency:
+ecosystem-sweep`, queued rather than cancelled — a cancelled sweep throws away
+hours of measurement), and a night that changes nothing opens no pull request.
+
+> **Editing the workflow's inputs:** on a `schedule` event `inputs.*` are **all
+> empty** — a `workflow_dispatch` default does not apply to it. Every input is
+> read as `inputs.x || <default>`, and `rollup`/`history` as
+> `inputs.x || github.event_name == 'schedule'`. Add a new input without its
+> fallback and the nightly run silently gets the empty value.
 
 | input | what it selects | maps to |
 |---|---|---|

--- a/news/2026-09/ecosystem-sweep-from-github-actions.md
+++ b/news/2026-09/ecosystem-sweep-from-github-actions.md
@@ -65,6 +65,12 @@ regression CI" remains a separate, unstarted item. The ADR records this as a
 dated amendment to D9 rather than a rewrite, because the decision was extended
 (who needs the hardware), not reversed (when it runs).
 
+> **Reversed the next day.** The sweep is scheduled nightly as of 2026-09-11 —
+> the "~20 CPU-hours" above was an estimate, and the first real corpus run cost
+> 78 minutes of wall time and ~5.5 hours of job time, a quarter of it. See
+> `news/2026-09/ecosystem-sweep-runs-nightly.md` and ADR-0085 D9's second
+> amendment. The paragraph stands as what was believed when this was written.
+
 ## Also in this change
 
 `scripts/ecosystem-ci.py` holds the two decisions the workflow has to make —

--- a/news/2026-09/ecosystem-sweep-runs-nightly.md
+++ b/news/2026-09/ecosystem-sweep-runs-nightly.md
@@ -1,0 +1,63 @@
+# The ecosystem sweep runs itself now, at 03:20 JST
+
+`ecosystem-sweep.yml` has a `schedule:` — `20 18 * * *`, which is 03:20 JST every
+day — and a scheduled run measures the whole corpus, rolls up, appends a
+`history.tsv` row and lands the records as a pull request that auto-merges. The
+parity KPI stops being something a person has to remember to refresh.
+
+## The decision this reverses, and why
+
+ADR-0085 D9 said the sweep was operator-run and explicitly *not* CI-scheduled,
+and its 2026-09-10 amendment — which added the `workflow_dispatch` entry point —
+reaffirmed that half: "there is no `schedule:` in the workflow, and adding one
+needs a new decision, not an edit here."
+
+The new decision rests on a number D9 had estimated rather than measured. Its
+rejection was costed at "20 CPU-hours of Actions time every week". The first real
+corpus run on hosted runners took **78 minutes of wall time and about 5.5 hours
+of job time** across 27 shards at `max-parallel: 8`, heaviest shard 43 minutes.
+That is a quarter of the assumed figure, free on a public repository, and it fits
+inside a night. A trade-off decided on an estimate that was wrong by 4x deserved
+to be re-decided once the estimate became a measurement.
+
+D9's other argument — that the number "moves on the timescale of interpreter
+fixes rather than of pushes" — was an argument for *less often than pushes*, and
+nightly is that: mutsu takes several merges a day, so a daily sweep is already
+coarser than what it measures, while being fine enough to attribute a regression
+to one day's merges instead of to however long it had been since somebody ran it.
+It also turns `history.tsv` into a series rather than a few irregular points,
+which is what makes the KPI chart worth drawing at all.
+
+One of D9's two stated consequences is retired by this — "the KPI updates only
+when someone runs it" — and the other stands untouched: this is a *measurement*,
+not a gate. A nightly sweep fails no build and blocks no merge, so PLAN.md's
+"working-module regression CI" is still a separate, unstarted item. A red shard
+produces a warning, fewer records and a refused history row.
+
+## The trap a scheduled workflow sets
+
+**On a `schedule` event, `inputs.*` are all empty.** A `workflow_dispatch`
+default does not apply to a scheduled run — it is not a dispatch. A workflow
+written for the dispatch path alone therefore plans an *empty scope* the first
+night, and would have quietly measured nothing.
+
+Every input is now read as `inputs.x || <default>`, and the two booleans as
+`inputs.x || github.event_name == 'schedule'`, so the nightly run is a full
+`scope: all` sweep with `rollup` and `history` on while a dispatch keeps its
+declared defaults (`scope: stale`, `history: false`). That is the thing to
+remember when adding the next input: without its fallback, the nightly run gets
+the empty value and nothing says so. The workflow header, ADR-0085 and
+`docs/ecosystem-parity.md` §8.1 all carry the warning, because it is invisible in
+the diff of whoever adds input number eleven.
+
+Two other mechanics matter and were already in place. `concurrency:
+ecosystem-sweep` with `cancel-in-progress: false` now earns its keep: a
+dispatched sweep and the nightly one queue instead of racing the same records,
+and queueing rather than cancelling is right because a cancelled sweep throws
+away hours of measurement. And a night that changes nothing skips the rollup and
+opens no pull request, so an unchanged corpus costs runner time and nothing else.
+
+The cadence is a knob, not a principle. If a daily data PR turns out not to pay
+for itself the cron moves to weekly and nothing else changes. What must not move
+quietly is the `scope: all` *and* all-shards-green condition on the history row —
+that is what keeps the series comparable from one point to the next.


### PR DESCRIPTION
`ecosystem-sweep.yml` gets `schedule: - cron: '20 18 * * *'` — **03:20 JST every day** — and a scheduled run measures the whole corpus, rolls up, appends a `history.tsv` row and lands the records as a pull request that auto-merges. The parity KPI stops being something a person has to remember to refresh.

Twenty past rather than on the hour: GitHub queues scheduled jobs hardest at `:00`, and a 27-shard matrix waiting for runners is the one delay this run cannot shorten. JST has no daylight saving, so the local time does not drift.

## This reverses a recorded decision, so it is recorded as one

ADR-0085 **D9** decided the sweep was operator-run and explicitly *not* CI-scheduled. Its 2026-09-10 amendment, which added `workflow_dispatch`, reaffirmed that half in as many words: *"there is no `schedule:` in the workflow, and adding one needs a new decision, not an edit here."* This PR is that decision, written as a **second dated amendment** rather than an edit to D9.

What changed is a number D9 estimated rather than measured:

| | |
|---|---|
| D9's assumption | "20 CPU-hours of Actions time every week" |
| First real corpus run ([34566091231](https://github.com/tokuhirom/mutsu/actions/runs/34566091231)) | **78 min wall, ~5.5 h job time**, 27 shards at `max-parallel: 8`, heaviest shard 43 min |

A quarter of the assumed figure, free on a public repository, and it fits inside a night. A trade-off decided on an estimate that was wrong by 4x deserved re-deciding once the estimate became a measurement.

D9's other argument — the number "moves on the timescale of interpreter fixes rather than of pushes" — argued for *less often than pushes*, and nightly is exactly that: mutsu takes several merges a day, so a daily sweep is already coarser than what it measures, while being fine enough to attribute a regression to one day's merges instead of to however long it had been since somebody ran it. It also turns `history.tsv` into a series rather than a handful of irregular points, which is what makes the KPI chart worth drawing.

One of D9's two stated consequences is **retired** — "the KPI updates only when someone runs it". The other stands untouched: this is a *measurement*, not a gate. Nothing here fails a build or blocks a merge, so PLAN.md's "working-module regression CI" remains a separate, unstarted item.

## The trap, and why this is not a one-line diff

**On a `schedule` event, `inputs.*` are all empty.** A `workflow_dispatch` default does not apply to a run that is not a dispatch. Written for the dispatch path alone, the first night would have planned an **empty scope** and measured nothing — with a green run to show for it.

Every input is now read as `inputs.x || <default>`, and the two booleans as `inputs.x || github.event_name == 'schedule'`, so a scheduled run is a full `scope: all` sweep with `rollup` and `history` on, while a dispatch keeps its declared defaults (`scope: stale`, `history: false`). Fourteen sites. The workflow header, the ADR amendment and `docs/ecosystem-parity.md` §8.1 all carry the warning, because it is invisible in the diff of whoever adds input number eleven.

Two mechanics that already existed and now earn their keep: `concurrency: ecosystem-sweep` with `cancel-in-progress: false` keeps a dispatched sweep and the nightly one queueing instead of racing the same records (queue, not cancel — a cancelled sweep throws away hours of measurement), and a night that changes nothing skips the rollup and opens no pull request.

## Verification

- `scripts/ecosystem-ci.py plan --scope all --shards auto` — the scheduled configuration yields `count=27`, `full-corpus=true`, shards `A`…`Z` plus `_`
- YAML parses; triggers are `['schedule', 'workflow_dispatch']`, cron `20 18 * * *`
- `scripts/ci-docs-only.sh --self-test` (60 checks), and this diff classifies as documentation-only — `ecosystem-sweep.yml` is a non-`ci.yml` workflow, so the build jobs correctly report `skipped`

## Also

The four documents that asserted the sweep is never scheduled are updated (`PLAN.md`, `docs/ecosystem-parity.md` §8.1 and its chart-axis note, the `ecosystem-dist-fix` skill). The earlier news entry's now-false paragraph gets a **dated forward pointer rather than a rewrite** — it records what was believed when it was written.

The cadence is a knob, not a principle: if a daily data PR turns out not to pay for itself, the cron moves to weekly and nothing else changes. What must not move quietly is the `scope: all` *and* all-shards-green condition on the history row, which is what keeps the series comparable.

Refs #7785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164xafjtgmTPhHatdSuMR9a

---
_Generated by [Claude Code](https://claude.ai/code/session_0164xafjtgmTPhHatdSuMR9a)_