### PR TITLE
fix: scope `sub EXPORT` per compunit so nested EXPORT modules can load

### DIFF
--- a/docs/adr/0087-runtime-export-hook-parse-time-approximation.md
+++ b/docs/adr/0087-runtime-export-hook-parse-time-approximation.md
@@ -132,3 +132,14 @@ file — and every other call shape benefits too.
 - Pinned by `t/modules/import-export/runtime-export-listop-parse.t`, which
   covers both directions: the listop call must parse, and a unit-scope routine
   the hook deliberately withholds must still be unresolvable at run time.
+- The scan detects the hook **per module file**, which is the right unit: the
+  run-time hook is per-compunit too. That invariant was not held on the run-time
+  side at first — a module body runs under `GLOBAL`, so every module's
+  `sub EXPORT` registered under the one `GLOBAL::EXPORT` key, and two modules in
+  a single load chain that each declared one collided with `X::Redeclaration`
+  ([#7947](https://github.com/tokuhirom/mutsu/issues/7947)). `load_module` now
+  hides the enclosing compunit's hook for the duration of a nested load
+  (`Interpreter::hide_export_routines`, restored only *after*
+  `apply_module_export` has consumed the nested module's own), so the two sides
+  agree on the unit. Nothing in the approximation above changes: the scan
+  already read one file at a time.

--- a/news/2026-09/nested-sub-export-per-compunit.md
+++ b/news/2026-09/nested-sub-export-per-compunit.md
@@ -1,0 +1,64 @@
+# `sub EXPORT` is scoped per compunit again
+
+A module that both `use`s another `sub EXPORT` module **and** declares its own
+hook failed to load at all:
+
+```
+$ mutsu -I lib -e 'use Outer; say outer-fn();'
+Redeclaration of routine 'EXPORT'. Did you mean to declare a multi-sub?
+  in block <unit> at lib/Inner.rakumod line 1
+```
+
+Raku scopes `sub EXPORT` to its compunit: each file may declare exactly one, and
+two files' hooks never see each other. mutsu did not hold that invariant on the
+run-time side. A module body runs under `GLOBAL`, so every module's `sub EXPORT`
+registered under the single `GLOBAL::EXPORT` key, and sub declarations are
+hoisted — entering the outer module's body registered `GLOBAL::EXPORT` before
+its `use` of the inner module ran, so the inner module's own hoisted declaration
+hit the redeclaration check in `registration_sub.rs` and killed the load.
+
+Two hooks side by side worked, because the first is consumed and recorded in
+`module_export_defs` before the second module loads. Nesting is what made the
+two live at once, and it did not need them to share a file or a scope kind: a
+`my sub EXPORT` in the outer module, or a three-deep chain, collided the same
+way.
+
+## The fix
+
+`load_module` now hides whatever `EXPORT` routine an enclosing compunit
+registered for the duration of a nested load
+(`Interpreter::hide_export_routines`), so the nested module's own declaration
+lands on a clean key, and restores it once `apply_module_export` has called and
+dropped that module's hook.
+
+The mechanism is the one `hide_toplevel_global_routines` already uses for
+ordinary package-less top-level routines — but it deliberately could **not** be
+folded into it, and the reason is the whole subtlety. That restore runs *before*
+`apply_module_export`, so including `EXPORT` in it put an outer module's stale
+hook back over the inner module's fresh one before it was ever read, which is
+exactly why `is_toplevel_global_routine_key` excludes `EXPORT` today. The new
+pair brackets `apply_module_export` instead, on both the success and the
+error path, so an aborted load cannot leave the enclosing hook hidden.
+
+Neither of the two paths the old comments warn about moves: the inherited
+`&EXPORT` handoff (the Slangify pattern) is keyed by module in
+`pending_inner_export_subs`, and the env discipline that keeps a bareword
+package bound while the hook runs is untouched.
+
+## Why it mattered
+
+Ten distributions in the ecosystem ledger were `blocked_load` on this one root
+cause — the largest single entry in that bucket, found by triage of the first
+full-corpus sweep: `Data::Generators`, `Identity::Utils`, `List::AllUtils`,
+`List::SomeUtils`, `PURL`, `SBOM::CycloneDX`, `span`, `Test::Async`,
+`User::Timezone`, `UserTimezone`. It is the dominant lizmat idiom: a small
+distribution that re-exports a dependency under a different name, with both ends
+computing their exports in `sub EXPORT`. `Test::Async` is the one that reaches
+furthest — it is a test framework, so every distribution that tests with it
+inherited the failure.
+
+Pinned by `t/modules/import-export/nested-export-sub-scoping.t`, which
+covers the nested chain, the `my sub EXPORT` variant, three levels deep, an
+outer hook that consumes the end user's `use` arguments, and the side-by-side
+shape that already worked. All six assertions were measured against `raku`
+first.

--- a/src/runtime/builtins_system_require.rs
+++ b/src/runtime/builtins_system_require.rs
@@ -354,6 +354,9 @@ impl Interpreter {
     /// module's stale `GLOBAL::EXPORT` over the inner module's fresh one
     /// before `apply_module_export` got to read it, silently breaking every
     /// `is export`/`sub EXPORT` symbol in that shape (`t/sub-export.t`).
+    /// `EXPORT` still needs per-compunit scoping -- it just needs a restore
+    /// point on the far side of `apply_module_export`, which
+    /// [`Interpreter::hide_export_routines`] provides (#7947).
     pub(crate) fn is_toplevel_global_routine_key(key: &str) -> bool {
         Self::toplevel_global_routine_name(key).is_some()
     }

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -871,6 +871,14 @@ impl Interpreter {
             // with -- or silently overwrite -- a same-named one the loading
             // scope already declared.
             let hidden_toplevel = self.hide_toplevel_global_routines();
+            // `sub EXPORT` is per-compunit: hide whatever hook an enclosing
+            // compunit already registered so this module's own (hoisted)
+            // declaration lands on a clean `GLOBAL::EXPORT` instead of tripping
+            // the redeclaration check (#7947). Restored below, *after*
+            // `apply_module_export` has run and dropped this module's own --
+            // see `hide_export_routines` for why this pair cannot share
+            // `hidden_toplevel`'s restore point.
+            let hidden_export = self.hide_export_routines();
             let result = self.run_block(&stmts);
             // Snapshot the env exactly as the module body left it, before any
             // of the restoration below (the `leaked_packages` removal, the
@@ -1060,10 +1068,18 @@ impl Interpreter {
             self.restore_toplevel_global_routines(hidden_toplevel);
             // Invalidate name-keyed resolution caches.
             self.fn_resolve_gen += 1;
-            result?;
             // If the module defined `sub EXPORT`, call it with the `use` args and
-            // install the symbols it returns into the caller's scope.
-            self.apply_module_export(export_args.unwrap_or_default(), module_body_env)?;
+            // install the symbols it returns into the caller's scope. The
+            // enclosing compunit's hook comes back either way -- an aborted
+            // load must not leave it hidden.
+            let export_result = match result {
+                Ok(()) => {
+                    self.apply_module_export(export_args.unwrap_or_default(), module_body_env)
+                }
+                Err(err) => Err(err),
+            };
+            self.restore_export_routines(hidden_export);
+            export_result?;
         }
         // Every class/role this load just registered, regardless of whether the
         // module carries distribution metadata or picked up any scope names of

--- a/src/runtime/runtime_module_export_sub.rs
+++ b/src/runtime/runtime_module_export_sub.rs
@@ -151,14 +151,86 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Take every currently-registered `EXPORT` routine out of the registry
+    /// before a compunit's own body runs, returning them for
+    /// [`Interpreter::restore_export_routines`].
+    ///
+    /// `sub EXPORT` is per-compunit in Raku: each file may declare one, and two
+    /// files' hooks never see each other. mutsu registers it under the single
+    /// `GLOBAL::EXPORT` key (the module body runs under `GLOBAL`), so without
+    /// this two modules in one load chain that each declare `sub EXPORT`
+    /// compete for that one key. Sub declarations are hoisted, so entering the
+    /// outer module's body registers `GLOBAL::EXPORT` before its `use` of the
+    /// inner one runs; the inner module's hoisted declaration then hit the
+    /// redeclaration check in `registration_sub.rs` and the whole load died
+    /// with `X::Redeclaration` (#7947 -- the dominant lizmat "re-export a
+    /// dependency under another name" idiom, 10 distributions in the ecosystem
+    /// ledger). Hiding the enclosing compunit's hook while the nested one loads
+    /// restores the per-compunit invariant with the same mechanism
+    /// `hide_toplevel_global_routines` already uses for ordinary package-less
+    /// top-level routines.
+    ///
+    /// The one thing that must not be copied from that mechanism is its
+    /// restore point. `EXPORT` is deliberately excluded from
+    /// `is_toplevel_global_routine_key` because that restore runs *before*
+    /// `apply_module_export`, which would put an outer module's stale hook back
+    /// over the inner module's fresh one before it is ever read (`t/sub-export.t`).
+    /// So this pair brackets `apply_module_export` instead -- see its caller in
+    /// `run_modules.rs`.
+    pub(super) fn hide_export_routines(
+        &mut self,
+    ) -> Vec<(crate::symbol::Symbol, Arc<FunctionDef>)> {
+        let keys: Vec<crate::symbol::Symbol> = self
+            .registry()
+            .functions
+            .keys()
+            .filter(|k| Self::is_export_routine_key(&k.resolve()))
+            .copied()
+            .collect();
+        if keys.is_empty() {
+            return Vec::new();
+        }
+        let mut hidden = Vec::with_capacity(keys.len());
+        for key in keys {
+            if let Some(def) = self.registry_mut().functions_mut().remove(&key) {
+                hidden.push((key, def));
+            }
+        }
+        // Invalidate name-keyed resolution caches.
+        self.fn_resolve_gen += 1;
+        hidden
+    }
+
+    /// Put back what [`Interpreter::hide_export_routines`] hid, once this
+    /// compunit's own `sub EXPORT` has been called and dropped.
+    pub(super) fn restore_export_routines(
+        &mut self,
+        hidden: Vec<(crate::symbol::Symbol, Arc<FunctionDef>)>,
+    ) {
+        if hidden.is_empty() {
+            return;
+        }
+        for (key, def) in hidden {
+            self.registry_mut().functions_mut().insert(key, def);
+        }
+        // Invalidate name-keyed resolution caches.
+        self.fn_resolve_gen += 1;
+    }
+
+    /// Whether a registry key names the magic `EXPORT` hook. The module body
+    /// runs under GLOBAL, so the key is normally `GLOBAL::EXPORT`; be liberal
+    /// in case a package prefix was used.
+    fn is_export_routine_key(key: &str) -> bool {
+        key == "EXPORT" || key.ends_with("::EXPORT")
+    }
+
     /// Remove any `EXPORT` routine registered by the module body (it runs under
     /// GLOBAL, so the key is `GLOBAL::EXPORT`; be liberal in case a package
     /// prefix was used) so it does not leak into the caller as `EXPORT()`.
     fn remove_export_routine(&mut self) {
-        self.registry_mut().functions_mut().retain(|key, _| {
-            let ks = key.resolve();
-            ks != "EXPORT" && !ks.ends_with("::EXPORT")
-        });
+        self.registry_mut()
+            .functions_mut()
+            .retain(|key, _| !Self::is_export_routine_key(&key.resolve()));
         // Invalidate name-keyed resolution caches.
         self.fn_resolve_gen += 1;
     }

--- a/t/lib/ChainExportArgs.rakumod
+++ b/t/lib/ChainExportArgs.rakumod
@@ -1,0 +1,7 @@
+# An outer hook that depends on its `use` arguments, so the nested load must
+# not just avoid the collision but hand the right hook the right arguments.
+use ChainExportInner;
+
+sub EXPORT(*@names) {
+    Map.new: @names.map(-> $name { "&$name" => sub () { "$name:" ~ chain-inner() } })
+}

--- a/t/lib/ChainExportInner.rakumod
+++ b/t/lib/ChainExportInner.rakumod
@@ -1,0 +1,7 @@
+# The inner half of the nested-`sub EXPORT` chain (#7947): a module whose
+# exports are computed by its own `sub EXPORT` hook.
+sub chain-inner() { "inner" }
+
+sub EXPORT() {
+    Map.new: ('&chain-inner' => &chain-inner)
+}

--- a/t/lib/ChainExportMyOuter.rakumod
+++ b/t/lib/ChainExportMyOuter.rakumod
@@ -1,0 +1,7 @@
+# Same chain, but the outer hook is a `my sub` (Identity::Utils' shape). The
+# two declarations need not share a scope kind to collide.
+use ChainExportInner;
+
+my sub EXPORT() {
+    Map.new: ('&chain-my-outer' => &chain-inner)
+}

--- a/t/lib/ChainExportOuter.rakumod
+++ b/t/lib/ChainExportOuter.rakumod
@@ -1,0 +1,9 @@
+# The outer half: a module that BOTH `use`s a `sub EXPORT` module and declares
+# its own hook -- the dominant lizmat "re-export a dependency under another
+# name" idiom. Both hooks are live at once while this compunit loads, which is
+# what used to collide on the single `GLOBAL::EXPORT` registry key (#7947).
+use ChainExportInner;
+
+sub EXPORT() {
+    Map.new: ('&chain-outer' => &chain-inner)
+}

--- a/t/lib/ChainExportTop.rakumod
+++ b/t/lib/ChainExportTop.rakumod
@@ -1,0 +1,6 @@
+# Three deep, with a hook at every level: Top -> Outer -> Inner.
+use ChainExportOuter;
+
+sub EXPORT() {
+    Map.new: ('&chain-top' => &chain-outer)
+}

--- a/t/modules/import-export/nested-export-sub-scoping.t
+++ b/t/modules/import-export/nested-export-sub-scoping.t
@@ -1,0 +1,57 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# `sub EXPORT` is per-compunit: each file may declare one, and two files'
+# hooks never see each other. mutsu registers the hook under the single
+# `GLOBAL::EXPORT` key (a module body runs under GLOBAL), so two modules in one
+# load chain that each declared `sub EXPORT` used to compete for it: sub
+# declarations are hoisted, so entering the outer module's body registered
+# `GLOBAL::EXPORT` before its `use` of the inner one ran, and the inner
+# module's own hoisted declaration then died with
+# "Redeclaration of routine 'EXPORT'" (#7947).
+#
+# That is the dominant lizmat idiom -- a small distribution that re-exports a
+# dependency under a different name, where both ends compute their exports in
+# `sub EXPORT` -- and it blocked ten distributions from loading at all.
+
+plan 6;
+
+{
+    use ChainExportOuter;
+    is chain-outer(), 'inner',
+        'a module with its own sub EXPORT can use another module with one';
+}
+
+{
+    # The inner module's own hook still works when imported directly, i.e.
+    # hiding the enclosing compunit's hook did not consume it.
+    use ChainExportInner;
+    is chain-inner(), 'inner', "the inner module's own sub EXPORT still runs";
+}
+
+{
+    use ChainExportMyOuter;
+    is chain-my-outer(), 'inner',
+        'the two declarations need not share a scope kind (`my sub EXPORT`)';
+}
+
+{
+    use ChainExportTop;
+    is chain-top(), 'inner', 'three deep, with a sub EXPORT at every level';
+}
+
+{
+    use ChainExportArgs <renamed>;
+    is renamed(), 'renamed:inner',
+        'the outer hook still receives the end user\'s use arguments';
+}
+
+{
+    # Side by side has always worked (the first hook is consumed before the
+    # second module loads); pin it so the nested fix cannot regress it.
+    use ChainExportInner;
+    use ChainExportOuter;
+    is chain-inner() ~ chain-outer(), 'innerinner',
+        'two sub EXPORT modules used side by side still both export';
+}


### PR DESCRIPTION
A module that both `use`d another `sub EXPORT` module **and** declared its own hook failed to load at all:

```
$ mutsu -I lib -e 'use Outer; say outer-fn();'
Redeclaration of routine 'EXPORT'. Did you mean to declare a multi-sub?
  in block <unit> at lib/Inner.rakumod line 1
```

## Root cause

Raku scopes `sub EXPORT` to its compunit: each file may declare exactly one, and two files' hooks never see each other. mutsu did not hold that invariant on the run-time side. A module body runs under `GLOBAL`, so every module's `sub EXPORT` registered under the single `GLOBAL::EXPORT` key — and sub declarations are hoisted, so entering the outer module's body registered `GLOBAL::EXPORT` before its `use` of the inner module ran. The inner module's own hoisted declaration then hit the redeclaration check in `registration_sub.rs` and killed the load.

Side-by-side `use` worked because the first hook is consumed and recorded in `module_export_defs` before the second module loads. Nesting is what made the two live at once, and it needed neither the same file nor the same scope kind: a `my sub EXPORT` in the outer module, or a three-deep chain, collided the same way.

## The fix

`load_module` now hides whatever `EXPORT` routine an enclosing compunit registered for the duration of a nested load (`Interpreter::hide_export_routines`) and restores it once `apply_module_export` has called and dropped that module's own hook — on both the success and the error path, so an aborted load cannot leave the enclosing hook hidden.

The mechanism is the one `hide_toplevel_global_routines` already uses for ordinary package-less top-level routines, but it deliberately **cannot** be folded into it, and that is the whole subtlety: that restore runs *before* `apply_module_export`, so including `EXPORT` in it put an outer module's stale hook back over the inner module's fresh one before it was ever read — which is exactly why `is_toplevel_global_routine_key` excludes `EXPORT` today. The new pair brackets `apply_module_export` instead.

Neither of the two paths the issue flags as must-not-regress moves: the inherited `&EXPORT` handoff (the Slangify pattern) is keyed by module in `pending_inner_export_subs`, and the env discipline that keeps a bareword package bound while the hook runs (#7806) is untouched. `t/modules/import-export/sub-export.t`, `module-inner-export-sub.t`, `module-export-sub-sees-module-scope-not-caller.t` and all 408 files under `t/modules` + `t/nativecall` pass.

## Measured against `raku`

Every row of the issue's control table, re-measured after the fix:

| shape | mutsu before | mutsu after | raku |
|---|---|---|---|
| one module with `sub EXPORT` | ok | ok | ok |
| two modules in a chain, each with `sub EXPORT` | **X::Redeclaration** | ok | ok |
| two `sub EXPORT` modules `use`d side by side | ok | ok | ok |
| only the inner module has `sub EXPORT` | ok | ok | ok |
| `my sub EXPORT` in the outer module | **X::Redeclaration** | ok | ok |
| three deep, a hook at every level | **X::Redeclaration** | ok | ok |

## Why it matters

Ten distributions in the ecosystem ledger were `blocked_load` on this one root cause — the largest single entry in that bucket: `Data::Generators`, `Identity::Utils`, `List::AllUtils`, `List::SomeUtils`, `PURL`, `SBOM::CycloneDX`, `span`, `Test::Async`, `User::Timezone`, `UserTimezone`. `Test::Async` reaches furthest: it is a test framework, so every distribution that tests with it inherited the failure. The ledger records are left for the next sweep to regenerate.

## Tests

New pin `t/modules/import-export/nested-export-sub-scoping.t` (6 assertions) with fixtures under `t/lib/ChainExport*.rakumod`: the nested chain, the `my sub EXPORT` variant, three levels deep, an outer hook that consumes the end user's `use` arguments, and the side-by-side shape that already worked. All six were run under `raku` first and match.

ADR-0087 gains a Consequences note: the parse-time scan already worked per module file, and the run-time side now agrees on that unit.

## Verification

- `cargo fmt --all`, `make lint` (all four configurations) — clean
- `make test` — **PASS**, 3997 files / 42516 tests
- `make roast` — the three container-only failures and nothing else, by name and by subtest range, per `docs/agent-environments.md`: `6.c/S32-io/file-tests.t` (6-8, 10), `S16-filehandles/filetest.t` (57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125), `S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17). `id -u` is 0 here.

Closes #7947

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pv3MLDnwMiNLsDSpqaFizx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pv3MLDnwMiNLsDSpqaFizx)_