### PR TITLE
fix(vm): give enum keys their own namespace instead of the scalar key space

### DIFF
--- a/news/2026-09/enum-key-vs-scalar-namespace.md
+++ b/news/2026-09/enum-key-vs-scalar-namespace.md
@@ -1,0 +1,91 @@
+# Enum keys get their own namespace instead of sharing the scalar key space
+
+In Raku an enum's keys live in the package symbol namespace: `our Str enum U «:s<time>»`
+declares a *term* `s`, not a `$`-sigiled scalar. The two are different symbols, so `my $s`
+and the enum key `s` coexist and neither can see or clobber the other.
+
+mutsu stores a scalar `$s` sigil-stripped, under the `env` key `"s"`, and the enum
+registration installed each key under its own bare name — into that same key. The two
+namespaces were therefore one namespace, and the collision went both ways
+([#7914](https://github.com/tokuhirom/mutsu/issues/7914)):
+
+```raku
+# lib/EDefs.rakumod:  unit module EDefs;
+#                     our Str enum U is export(:U) « :ms<time> :s<time> :px<length> »;
+# lib/EUse.rakumod:   unit class EUse; use EDefs :U; method pick($x) { U::s }
+use EUse;
+my $s = 'hello';
+say "before: [$s]";        # raku & mutsu: before: [hello]
+my $r = EUse.pick(1);
+say "after: [$s] r=$r";    # raku: after: [hello] r=time
+                           # mutsu: "Use of uninitialized value ..."; after: [] r=time
+```
+
+and, in the other direction, a bare `s` term read back whatever the same-named *scalar*
+last held:
+
+```raku
+our Str enum U « :s<time> »;
+my $s = 'x'; $s = 'y';
+say s;                     # raku: s   (the enum value)   mutsu: y
+```
+
+The first shape is how it was found: `CSS::Grammar::Defs` declares
+`« … :ms<time> :s<time> … »`, so a reduction script calling into `CSS::Grammar` while
+holding a lexical `$s` silently parsed the wrong input for three iterations before
+anyone noticed.
+
+## What was actually clobbering the lexical
+
+Two separate sites wrote the enum value under the plain key. The registration loop
+(`registration_sub.rs`) did `env.insert(key, enum_val)`, and — the one that produced the
+reported `Any` — `import_module`'s exported-variable loop copied `EDefs::s` to `s` *and*
+pushed `"s"` onto `pending_rw_writeback_sources`. That list is the env→locals coherence
+channel: a name on it gets `env[name]` written through to the caller's local slot at the
+next frame reconcile. So the import of an enum key made the importing frame pull `env["s"]`
+— by then the decl-seed `Any` placeholder for its own `my $s` — over the slot holding
+`'hello'`. The first read still saw `'hello'` because the reconcile ran *after* it; every
+later read saw `Any`.
+
+## The fix
+
+A namespace, not a per-site patch. `src/runtime/enum_bare_names.rs` states the rule once:
+an enum key's bare spelling is stored under a reserved `__mutsu_enum_bare_` key prefix that
+no user symbol can spell, and only term/bareword resolution consults it
+(`Interpreter::enum_bare_value`). Variable lookup, which reaches `env` under the sigil-less
+name, can no longer see an enum key; an assignment to `$s` can no longer overwrite one.
+
+The storage stays in `env` deliberately. Enum-key visibility is *lexical*, and `env` is what
+implements that — block scopes, package-block rollback (a bare key introduced inside
+`package Foo { … }` is dropped on exit, only `::`-qualified keys survive, and the prefix
+contains no `::` precisely so an enum key keeps that behaviour), thread clones and the `our`
+store all key off it. A side table would have had to reimplement every one of those.
+
+Everything that legitimately reaches an enum key by its bare name was moved onto the new
+probe: bareword resolution, `::('name')` indirect lookup, the `Mod::EXPORT` stash, the
+`GLOBAL::`/`MY::` stash listing (which republishes the key under its bare spelling), the
+poisoned-alias check, the literal enum-value parameter constraint that makes
+`multi infix:<->(e1, e2)` dispatch (`roast/S03-operators/custom.t`), the `unit` compunit's
+package-scope rollback (#7787 — an enum value must not leak to the importer), the
+module-scope lexical snapshot, and the two in-place writes to an enum key's own binding:
+`Apple does R` and the `X::Assignment::RO` that `Alpha = 3` must raise. `OpCode::DoesVar`
+grew a `bareword` flag for the first of those, because `$Apple does R` and `Apple does R`
+used to be indistinguishable at the writeback — they shared the key — and now must be
+told apart.
+
+The probe itself is gated on a latched "any enum key has been installed" flag, so a program
+that declares no enum pays an atomic load rather than a `format!` per bareword read.
+
+`import_module` also stops recording an enum key as a pending caller-slot writeback: an
+enum key names no local slot, and that record was the half of the bug that turned `$s`
+into `Any`.
+
+## Still shared: sigil-less constants and type names
+
+The same key space is still shared by sigil-less `constant`s and type names with
+same-named scalars. This change does not move those — but it does state the rule they
+would follow, in one place, rather than leaving it implicit per declarator.
+
+Pinned by `t/types/enum-subset/enum-key-vs-same-named-scalar.t` (both directions, inline
+and through a two-module import chain), with the fixtures
+`t/lib/EnumKeyScalarDefs.rakumod` and `t/lib/EnumKeyScalarUser.rakumod`.

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -787,6 +787,7 @@ impl Compiler {
                     Expr::ArrayVar(name) => Some(format!("@{}", name)),
                     _ => None,
                 };
+                let is_bareword = matches!(left, Expr::BareWord(_));
                 if let Some(name) = var_name {
                     self.compile_expr(left);
                     // Set does-context flag so role calls with args return Pairs
@@ -796,7 +797,7 @@ impl Compiler {
                     self.code.emit(OpCode::SetDoesContext(false));
                     let slot = self.local_map.get(&name).copied();
                     let name_idx = self.code.add_constant(Value::str(name));
-                    self.code.emit(OpCode::DoesVar(name_idx, slot));
+                    self.code.emit(OpCode::DoesVar(name_idx, slot, is_bareword));
                     return;
                 }
             }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1264,8 +1264,12 @@ pub(crate) enum OpCode {
     Does,
     /// `$x does R` in-place mixin. `.0` = constant index of the target variable
     /// name; `.1` = compiler-baked local slot for that name (§1.5), `None` when the
-    /// target is not a resolvable local (falls back to the by-name writeback).
-    DoesVar(u32, Option<u32>),
+    /// target is not a resolvable local (falls back to the by-name writeback);
+    /// `.2` = the target was written as a BAREWORD (`Apple does R`), so the
+    /// in-place store may have to land in the enum-key namespace rather than under
+    /// the plain (sigil-less, hence `$`-scalar-owned) env key — see
+    /// `runtime::enum_bare_names` and #7914.
+    DoesVar(u32, Option<u32>, bool),
     /// Set/clear the in_does_rhs flag so role calls return Pairs instead of
     /// throwing X::Coerce::Impossible during `does` RHS evaluation.
     SetDoesContext(bool),

--- a/src/runtime/accessors_stash.rs
+++ b/src/runtime/accessors_stash.rs
@@ -539,6 +539,14 @@ impl Interpreter {
         {
             return value.clone();
         }
+        // `::('s')` names the TERM `s`, not the scalar `$s`. An enum key is stored
+        // in its own key namespace (#7914), so probe it before the plain `env` key
+        // — which, being sigil-less, belongs to `$s`.
+        if let Some(value) = self.enum_bare_value(name)
+            && !value.is_nil()
+        {
+            return value.clone();
+        }
         if let Some(value) = self.env.get(name)
             && !value.is_nil()
             // Skip `my`-scoped package items for indirect type lookup (::())
@@ -700,6 +708,10 @@ impl Interpreter {
                         .env
                         .get(&fq)
                         .cloned()
+                        // An enum key's bare spelling lives in its own key
+                        // namespace (#7914), so the bare `env` probe cannot see
+                        // it — ask that namespace before giving up.
+                        .or_else(|| self.enum_bare_value(name).cloned())
                         .or_else(|| self.env.get(name).cloned())
                         .unwrap_or(Value::NIL);
                     symbols.insert(name.clone(), val);
@@ -785,6 +797,15 @@ impl Interpreter {
 
         for (key, val) in self.env.iter() {
             let key_s = key.resolve();
+            // An enum key is a genuine package symbol, so it belongs in the stash
+            // under its BARE name -- but it is stored in the enum-key namespace
+            // (#7914), which the internal-key skip below would otherwise drop.
+            // Unwrap it back to the spelling the stash publishes.
+            let key_s = match key_s.strip_prefix(crate::runtime::enum_bare_names::ENUM_BARE_PREFIX)
+            {
+                Some(bare) => bare.to_string(),
+                None => key_s,
+            };
             // Internal bookkeeping markers use package-like separators (for
             // example, the inline-package prepass marker contains
             // `::Exporter::exported`). They must not appear as pseudo-package

--- a/src/runtime/enum_bare_names.rs
+++ b/src/runtime/enum_bare_names.rs
@@ -1,0 +1,123 @@
+//! The bare-name namespace for enum keys.
+//!
+//! In Raku an enum's keys live in the *package symbol* namespace: `enum U «:s<time>»`
+//! declares a term `s`, not a `$`-sigiled scalar. The two are distinct symbols, so
+//! `my $s` and the enum key `s` coexist and neither can see or clobber the other.
+//!
+//! mutsu's `env`, however, stores a scalar `$s` under the sigil-less key `"s"`, so
+//! installing an enum key under its own bare name put both symbols in ONE namespace
+//! ([#7914](https://github.com/tokuhirom/mutsu/issues/7914)). That collision went
+//! both ways:
+//!
+//! - a loaded module's `our Str enum U «… :s<time> …»` made the caller's `my $s`
+//!   read as `Any` (importing the key recorded `s` as an env write owing a
+//!   caller-slot writeback, so the next frame reconcile pulled `env["s"]` — by then
+//!   that lexical's own decl-seed placeholder — over the slot holding its value), and
+//! - a bare `s` term read back whatever the same-named *scalar* last held, instead
+//!   of the enum value.
+//!
+//! The fix is a namespace, not a per-site patch: an enum key is stored under a
+//! reserved key prefix that no user symbol can spell, and ONLY term/bareword
+//! resolution ([`Interpreter::enum_bare_value`]) consults it. Variable lookup —
+//! which reaches `env` under the sigil-less name — can no longer see it, and an
+//! assignment to `$s` can no longer overwrite it.
+//!
+//! The storage is still `env` on purpose. Enum-key visibility is *lexical*, and
+//! `env` is what implements that: block scopes, package-block rollback (a bare key
+//! introduced inside `package Foo { … }` is dropped on exit, only `::`-qualified
+//! keys survive — the prefix deliberately contains no `::` so an enum key keeps
+//! exactly that behaviour), thread clones and the `our` store all key off it. Moving
+//! the values to a side table would have had to reimplement every one of those.
+
+use crate::runtime::Interpreter;
+use crate::value::Value;
+
+/// Key prefix under which an enum key's value is stored in `env`.
+///
+/// `__mutsu_`-prefixed keys are already reserved for interpreter-internal env
+/// entries (they are excluded from `package_lexicals` snapshots and from the
+/// "plain user variable" predicates), so an enum key parked here cannot be reached
+/// by any spelling of a user variable.
+pub(crate) const ENUM_BARE_PREFIX: &str = "__mutsu_enum_bare_";
+
+/// The `env` key an enum key `name` is stored under.
+pub(crate) fn enum_bare_key(name: &str) -> String {
+    format!("{ENUM_BARE_PREFIX}{name}")
+}
+
+/// Latched once any enum key has been installed, so the probe on the bareword hot
+/// path costs an atomic load instead of a `format!` for every program that declares
+/// no enum at all. Monotonic and set strictly before any read that could observe the
+/// key, exactly like `env`'s own `*_KEY_SEEN` gates; an over-set only makes the
+/// (correct) probe run.
+static ENUM_BARE_KEY_SEEN: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// [`enum_bare_key`] for a caller that is about to INSERT under the returned key
+/// without going through [`Interpreter::insert_enum_bare_value`] — the import path
+/// shares one `env.insert` between the enum-key and the ordinary case. Latches the
+/// probe gate, which that insert would otherwise leave unset.
+pub(crate) fn enum_bare_key_for_insert(name: &str) -> String {
+    ENUM_BARE_KEY_SEEN.store(true, std::sync::atomic::Ordering::Relaxed);
+    enum_bare_key(name)
+}
+
+impl Interpreter {
+    /// Install an enum key's value in the bare-name namespace.
+    pub(crate) fn insert_enum_bare_value(&mut self, name: &str, value: Value) {
+        ENUM_BARE_KEY_SEEN.store(true, std::sync::atomic::Ordering::Relaxed);
+        self.env.insert(enum_bare_key(name), value);
+    }
+
+    /// Look an enum key up in the bare-name namespace.
+    ///
+    /// This is the ONLY way the value is reachable by its bare spelling — a plain
+    /// `env` probe under `name` deliberately misses it.
+    pub(crate) fn enum_bare_value(&self, name: &str) -> Option<&Value> {
+        // Two misses that are free to rule out before paying for the key:
+        // the program has declared no enum at all (`ENUM_BARE_KEY_SEEN`), and a
+        // QUALIFIED name (`U::s`), which the registration loop stores under its own
+        // `env` key and which is not part of this namespace. Both would otherwise
+        // cost a `format!` on every bareword resolution.
+        if !ENUM_BARE_KEY_SEEN.load(std::sync::atomic::Ordering::Relaxed)
+            || name.is_empty()
+            || crate::runtime::utils::has_double_colon(name)
+        {
+            return None;
+        }
+        self.env.get(&enum_bare_key(name))
+    }
+
+    /// Reject a bare enum-key read whose name was declared by more than one enum.
+    ///
+    /// Raku "poisons" such an alias: only the package-qualified spelling
+    /// (`Pkg::name`) may be used. Shared by the enum-key namespace probe and the
+    /// legacy `env`-hit branch of bareword resolution, which must report the same
+    /// `X::PoisonedAlias`.
+    pub(crate) fn poisoned_enum_alias_check(
+        &self,
+        name: &str,
+    ) -> Result<(), crate::value::RuntimeError> {
+        if crate::runtime::utils::has_double_colon(name) {
+            return Ok(());
+        }
+        let Some(pkg_name) = self.is_poisoned_enum_alias(name) else {
+            return Ok(());
+        };
+        let pkg_name = pkg_name.to_string();
+        let message = format!(
+            "Cannot directly use poisoned alias '{name}' because it was declared by \
+             several enums. Please access it via explicit package name like: \
+             '{pkg_name}::{name}'"
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        attrs.insert("alias".to_string(), Value::str(name.to_string()));
+        attrs.insert("package-name".to_string(), Value::str(pkg_name));
+        attrs.insert("package-type".to_string(), Value::str("enum".to_string()));
+        let ex = Value::make_instance(crate::symbol::Symbol::intern("X::PoisonedAlias"), attrs);
+        let mut err = crate::value::RuntimeError::new(message);
+        err.exception = Some(Box::new(ex));
+        Err(err)
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -596,6 +596,7 @@ mod nqp_ops_text;
 pub(crate) use class_introspection::UserMethodOrAccessor;
 pub(crate) mod cstruct_layout;
 mod decl_types;
+pub(crate) mod enum_bare_names;
 pub(crate) mod nativecall_fnptr;
 pub(crate) use self::decl_types::*;
 pub(crate) mod deprecation;

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -2194,7 +2194,11 @@ impl Interpreter {
             if !is_anonymous {
                 self.register_enum_bare_name(key, enum_type_name);
             }
-            self.env.insert(key.clone(), enum_val);
+            // The bare spelling goes into the enum-key namespace, NOT under the
+            // plain env key: `$s` is stored sigil-stripped as `"s"`, so a plain
+            // insert here would make an enum key and a same-named scalar one
+            // symbol (#7914). See `runtime::enum_bare_names`.
+            self.insert_enum_bare_value(key, enum_val);
         }
         // Register exports if `is export`
         if is_export && !is_anonymous {

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -884,21 +884,32 @@ impl Interpreter {
             self.strict_mode = saved_strict_mode;
             let imported = std::mem::replace(&mut self.module_imported_names, saved_imports);
             module_scope_names = self.collect_module_scope_names(&before_env_keys);
+            // `module_imported_names` records the ENV KEY the import landed under,
+            // because the restore loop below has to undo that exact key. For the
+            // two scope tables it feeds, the key wanted is the name the importing
+            // code SPELLS — which for an enum key is its bare form, not the
+            // enum-key namespace key the value lives at (#7914).
+            let imported_spelling = |name: &String| -> String {
+                match name.strip_prefix(crate::runtime::enum_bare_names::ENUM_BARE_PREFIX) {
+                    Some(bare) => bare.to_string(),
+                    None => name.clone(),
+                }
+            };
             // A re-import of a name an earlier module already installed adds
             // nothing to `env`, so the diff misses it even though it is part of
             // this module's scope (see `module_imported_names`).
             module_scope_names.extend(
                 imported
                     .iter()
-                    .map(|(name, value, _)| (name.clone(), value.clone())),
+                    .map(|(name, value, _)| (imported_spelling(name), value.clone())),
             );
             imported_lexical_names.extend(imported.iter().flat_map(|(name, _, _)| {
-                [
-                    name.clone(),
-                    name.strip_prefix(['$', '@', '%'])
-                        .unwrap_or(name)
-                        .to_string(),
-                ]
+                let spelled = imported_spelling(name);
+                let bare = spelled
+                    .strip_prefix(['$', '@', '%'])
+                    .unwrap_or(&spelled)
+                    .to_string();
+                [spelled, bare]
             }));
             // Module bodies execute in the caller's env for compatibility with
             // existing declaration machinery. Imported variables/constants need
@@ -979,6 +990,11 @@ impl Interpreter {
             if unit_name.is_some() {
                 for name in Self::collect_unit_package_scope_names(&stmts) {
                     self.env.remove(&name);
+                    // An enum value's bare binding lives in the enum-key namespace
+                    // (#7914), so dropping the plain key alone would leave it
+                    // resolvable in the loading scope.
+                    self.env
+                        .remove(&crate::runtime::enum_bare_names::enum_bare_key(&name));
                 }
             }
             module_type_aliases = self.module_type_aliases_of(&module_scope_names);
@@ -1386,6 +1402,13 @@ impl Interpreter {
                 continue;
             }
             let name = key.resolve();
+            // An enum key is a module-scope declaration under its BARE name; the
+            // enum-key namespace (#7914) is only where the value is *stored*, so
+            // record it the way the module's own routines will look it up.
+            let name = match name.strip_prefix(crate::runtime::enum_bare_names::ENUM_BARE_PREFIX) {
+                Some(bare) => bare.to_string(),
+                None => name.to_string(),
+            };
             // Twigils, qualified names and the `__mutsu_*` / `?FILE`-style
             // metadata keys are never plain module-scope declarations. A scalar
             // `my $x` is stored sigil-less (key `x`); `@`/`%` keep their sigil.

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -382,7 +382,7 @@ impl Interpreter {
             && let Some(ValueView::Enum {
                 enum_type: prev_type,
                 ..
-            }) = self.env.get(name).map(Value::view)
+            }) = self.enum_bare_value(name).map(Value::view)
             && prev_type.resolve() != enum_type
         {
             crate::runtime::cow_table_mut(&mut self.poisoned_enum_aliases)

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -491,6 +491,20 @@ impl Interpreter {
                 (format!("{module}::{name}"), name.clone())
             };
             if let Some(value) = self.env.get(&source).cloned() {
+                // An imported ENUM KEY is a package symbol/term, not a `$`-scalar,
+                // so it goes into the enum-key namespace rather than under its own
+                // plain `env` key — which, being sigil-less, is where a same-named
+                // `my $s` lives (#7914). Importing `:s<time>` from
+                // `CSS::Grammar::Defs` otherwise replaced the importing scope's
+                // `$s` wholesale. See `runtime::enum_bare_names`.
+                let is_enum_key = !target.contains("::")
+                    && !target.starts_with(['$', '@', '%', '&'])
+                    && matches!(value.view(), ValueView::Enum { .. });
+                let env_target = if is_enum_key {
+                    crate::runtime::enum_bare_names::enum_bare_key_for_insert(&target)
+                } else {
+                    target.clone()
+                };
                 if !target.contains("::") {
                     self.unsuppress_name(&target);
                 }
@@ -500,7 +514,12 @@ impl Interpreter {
                 // reverse env->locals pull is disabled. Record the imported
                 // name (sigil stripped to match the local-slot key) so the
                 // ImportModule opcode writes it through to the caller slot.
-                if !target.contains("::") {
+                //
+                // An enum key is skipped: it names no caller local slot, and
+                // recording it made the importing frame pull `env[<key>]` over a
+                // same-named lexical's slot on the next frame reconcile — the
+                // half of #7914 that turned the caller's `my $s` into `Any`.
+                if !target.contains("::") && !is_enum_key {
                     let slot_name = match target.chars().next() {
                         Some('$' | '@' | '%') => target[1..].to_string(),
                         _ => target.clone(),
@@ -510,12 +529,12 @@ impl Interpreter {
                 // Part of the LOADING module's own lexical scope, whether or not
                 // it is new to `env` (see `module_imported_names`).
                 if !self.module_load_stack.is_empty() && !target.contains("::") {
-                    let previous = self.env.get(&target).cloned();
+                    let previous = self.env.get(&env_target).cloned();
                     self.module_imported_names
-                        .push((target.clone(), value.clone(), previous));
+                        .push((env_target.clone(), value.clone(), previous));
                 }
-                self.record_import_env_key(&target);
-                self.env.insert(target, value);
+                self.record_import_env_key(&env_target);
+                self.env.insert(env_target, value);
             }
         }
         Ok(())

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -458,8 +458,15 @@ impl Interpreter {
                     } else if pd.name == "__type_only__"
                         && !self.is_resolvable_type(&resolved_constraint)
                     {
-                        // Bare identifier param (e.g., enum value) -- resolve from env and compare
-                        if let Some(expected_val) = self.env.get(&resolved_constraint).cloned() {
+                        // Bare identifier param (e.g., enum value) -- resolve from env and compare.
+                        // An enum key's bare spelling lives in the enum-key namespace
+                        // (#7914), so ask that first: the plain `env` key is a
+                        // same-named `$`-scalar's storage and never the enum value.
+                        if let Some(expected_val) = self
+                            .enum_bare_value(&resolved_constraint)
+                            .or_else(|| self.env.get(&resolved_constraint))
+                            .cloned()
+                        {
                             if dispatch_arg != expected_val {
                                 return false;
                             }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1282,23 +1282,22 @@ impl Interpreter {
                         return Err(RuntimeError::assignment_ro_type_object(&name));
                     }
                     // A GENUINE enum-constant reassignment (`Red = 5`) writes to
-                    // the bareword global that IS the constant's own binding, so
-                    // its name equals the currently-stored member's own `key`
-                    // (`env["Red"] == Enum { key: "Red", .. }`). Without the
-                    // `name == key` check this also fired for an ORDINARY
-                    // variable that merely holds an enum value transiently --
-                    // e.g. a for-loop's second `.kv` param (`for %h.kv -> $k, $v
-                    // {...}`) rebinding `$v` via `SetGlobal("v", ...)` when the
-                    // slot's PREVIOUS content (from the prior iteration) happened
-                    // to be an Enum member: `env.get("v")` returned
-                    // `Enum{key:"Red",..}` from iteration 1, and the unguarded
-                    // check misread iteration 2's ordinary rebind as "assigning
-                    // over the `Red` constant", raising a spurious
-                    // X::Assignment::RO (`roast/S12-enums/misc.t`'s
-                    // `X::Enum::NoValue` throws-like case, only reachable once a
-                    // hash's random iteration order put an enum value before a
-                    // later key).
-                    if let Some(ValueView::Enum { enum_type, key, .. }) = current_view
+                    // the bareword that IS the constant's own binding. That
+                    // binding lives in the ENUM-KEY namespace (#7914), not under
+                    // the plain env key — which is a same-named `$Red`'s storage
+                    // — so it is the only store this check may consult. Probing
+                    // `env[name]` instead used to need a `name == key` guard,
+                    // because an ORDINARY variable that merely held an enum value
+                    // transiently landed in the very same key: a for-loop's
+                    // second `.kv` param (`for %h.kv -> $k, $v {...}`) rebinding
+                    // `$v` via `SetGlobal("v", ...)` saw the previous iteration's
+                    // `Enum{key:"Red",..}` and misread the rebind as "assigning
+                    // over the `Red` constant" (a spurious X::Assignment::RO in
+                    // `roast/S12-enums/misc.t`). Keyed by the enum key itself,
+                    // the namespace cannot confuse the two — the guard is kept
+                    // only as a cheap assertion of that invariant.
+                    if let Some(ValueView::Enum { enum_type, key, .. }) =
+                        self.enum_bare_value(&name).map(Value::view)
                         && name == key.resolve()
                     {
                         return Err(RuntimeError::assignment_ro_typename(
@@ -2748,8 +2747,8 @@ impl Interpreter {
                 self.exec_does_op(code)?;
                 *ip += 1;
             }
-            OpCode::DoesVar(name_idx, slot) => {
-                self.exec_does_var_op(code, *name_idx, *slot)?;
+            OpCode::DoesVar(name_idx, slot, is_bareword) => {
+                self.exec_does_var_op(code, *name_idx, *slot, *is_bareword)?;
                 *ip += 1;
             }
             OpCode::SetDoesContext(flag) => {

--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -467,6 +467,7 @@ impl Interpreter {
         code: &CompiledCode,
         name_idx: u32,
         slot: Option<u32>,
+        is_bareword: bool,
     ) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
@@ -481,6 +482,15 @@ impl Interpreter {
         // Sync back: BUILD submethods may have modified closure variables.
         self.carrier_writeback_changed_aggregates(code, &pre_env);
         let name = Self::const_str(code, name_idx).to_string();
+        // `Apple does R` on an ENUM KEY mutates the key's own binding, which lives
+        // in the enum-key namespace, not under the plain `env` key (#7914 — that
+        // key belongs to `$Apple`). Only a bareword target can name an enum key;
+        // `$Apple does R` is a scalar rebind and takes the ordinary road below.
+        if is_bareword && self.enum_bare_value(&name).is_some() {
+            self.insert_enum_bare_value(&name, updated.clone());
+            self.stack.push(updated);
+            return Ok(());
+        }
         // The same by-name store an assignment uses, NOT a raw `env.insert`:
         // `set_env_with_main_alias` is what redirects a compunit lexical to its
         // own cell, logs the write into the active carrier so the carrier-return

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -202,6 +202,16 @@ impl Interpreter {
             // Pseudo-package names (MY, CORE, OUTER, CALLER, etc.) resolve to
             // Package values so that .WHO/.WHAT etc. work correctly.
             Value::package(Symbol::intern(name))
+        } else if let Some(enum_val) = self.enum_bare_value(name).cloned() {
+            // An enum key read by its bare spelling. It lives in its own key
+            // namespace (`runtime::enum_bare_names`) because `$s` and the enum key
+            // `s` are DIFFERENT symbols in Raku but share `env`'s sigil-less key
+            // space in mutsu (#7914) — so this probe, and only this probe, can see
+            // it. Ordered where the old `env[name]` Enum hit was reached: ahead of
+            // the type branch below, which the enum entry used to mask by sitting
+            // in the very env slot that branch probes.
+            self.poisoned_enum_alias_check(name)?;
+            enum_val
         } else if match self.env().get(name).map(Value::view) {
             Some(ValueView::Nil) => self.has_type(name) || Self::is_builtin_type(name),
             // A `my $Buf = Buf.new` declaration pre-seeds env["Buf"] with the
@@ -235,31 +245,8 @@ impl Interpreter {
                 || matches!(v.view(), ValueView::Package(pkg) if pkg.resolve() != name)
             {
                 // Check for poisoned enum aliases
-                if matches!(v.view(), ValueView::Enum { .. })
-                    && !crate::runtime::utils::has_double_colon(name)
-                    && let Some(pkg_name) = self.is_poisoned_enum_alias(name)
-                {
-                    let pkg_name = pkg_name.to_string();
-                    let mut attrs = std::collections::HashMap::new();
-                    attrs.insert(
-                        "message".to_string(),
-                        Value::str(format!(
-                            "Cannot directly use poisoned alias '{name}' because it \
-                             was declared by several enums. Please access it via \
-                             explicit package name like: '{pkg_name}::{name}'"
-                        )),
-                    );
-                    attrs.insert("alias".to_string(), Value::str(name.to_string()));
-                    attrs.insert("package-name".to_string(), Value::str(pkg_name.clone()));
-                    attrs.insert("package-type".to_string(), Value::str("enum".to_string()));
-                    let ex = Value::make_instance(Symbol::intern("X::PoisonedAlias"), attrs);
-                    let mut err = RuntimeError::new(format!(
-                        "Cannot directly use poisoned alias '{name}' because it was \
-                         declared by several enums. Please access it via explicit \
-                         package name like: '{pkg_name}::{name}'"
-                    ));
-                    err.exception = Some(Box::new(ex));
-                    return Err(err);
+                if matches!(v.view(), ValueView::Enum { .. }) {
+                    self.poisoned_enum_alias_check(name)?;
                 }
                 v.clone()
             } else if self.has_type(name) || Self::is_builtin_type(name) {

--- a/t/lib/EnumKeyScalarDefs.rakumod
+++ b/t/lib/EnumKeyScalarDefs.rakumod
@@ -1,0 +1,7 @@
+unit module EnumKeyScalarDefs;
+
+# Deliberately declares enum keys that collide with very common scalar names
+# (`$s`, `$r`, `$px`). mutsu stores a scalar `$s` under the sigil-less env key
+# `s`, so an enum key installed under its own bare name used to land in the very
+# same slot (#7914).
+our Str enum ColliderUnits is export(:ColliderUnits) « :ms<time> :s<time> :px<length> »;

--- a/t/lib/EnumKeyScalarUser.rakumod
+++ b/t/lib/EnumKeyScalarUser.rakumod
@@ -1,0 +1,5 @@
+unit class EnumKeyScalarUser;
+
+use EnumKeyScalarDefs :ColliderUnits;
+
+method unit-of-s() { ColliderUnits::s }

--- a/t/types/enum-subset/enum-key-vs-same-named-scalar.t
+++ b/t/types/enum-subset/enum-key-vs-same-named-scalar.t
@@ -1,0 +1,61 @@
+use lib 't/lib';
+use Test;
+
+# #7914: an enum key is a package symbol / term, not a `$`-scalar. mutsu stores a
+# scalar `$s` sigil-stripped under the env key `s`, so an enum key installed under
+# its own bare name shared one namespace with it, and the two clobbered each other
+# in both directions. `CSS::Grammar::Defs` declares exactly this shape
+# (`:ms<time> :s<time> :px<length>`), so any script that called into CSS::Grammar
+# and also used a lexical `$s` had that lexical replaced mid-call.
+
+plan 12;
+
+# --- direction 1: the enum key must not touch a same-named lexical -----------
+
+{
+    my $s = 'hello';
+    our Str enum InlineUnits « :ms<time> :s<time> »;
+    is $s, 'hello', 'an inline enum key leaves a same-named lexical alone';
+    is InlineUnits::s.Str, 'time', 'and the enum value is still reachable';
+}
+
+{
+    # The reported shape: the enum arrives through a module, is imported into a
+    # second module's scope, and the consumer merely `use`s that second module.
+    use EnumKeyScalarUser;
+    my $s = 'hello';
+    is $s, 'hello', 'a transitively imported enum key leaves `my $s` alone';
+    # Two reads: the clobber happened on a frame reconcile *after* the first one,
+    # so a single read could not see it.
+    is "[$s]", '[hello]', 'and it is still intact on the next read';
+    my $r = EnumKeyScalarUser.unit-of-s;
+    is $r.Str, 'time', 'the enum value reached through the module is right';
+    is "[$s]", '[hello]', 'a call that returns the enum value does not clobber $s';
+}
+
+{
+    use EnumKeyScalarDefs :ColliderUnits;
+    my $s = 'direct';
+    my $px = 'also direct';
+    is "$s $px", 'direct also direct',
+        'a direct tagged import leaves both colliding lexicals alone';
+    is ColliderUnits::px.Str, 'length', 'imported enum value still resolves qualified';
+}
+
+# --- direction 2: the lexical must not shadow the enum key -------------------
+
+{
+    our Str enum ShadowUnits « :sec<time> »;
+    my $sec = 'scalar';
+    is sec.Str, 'time', 'a bare enum key reads the enum, not the same-named scalar';
+    is $sec, 'scalar', 'and the scalar still reads as itself';
+    $sec = 'reassigned';
+    is sec.Str, 'time', 'reassigning the scalar does not overwrite the enum key';
+}
+
+# --- the enum key is still immutable ----------------------------------------
+
+{
+    our enum RoUnits <Alpha>;
+    dies-ok { EVAL 'Alpha = 3' }, 'assigning to an enum key is still X::Assignment::RO';
+}


### PR DESCRIPTION
## Problem

In Raku an enum's keys are package symbols: `our Str enum U «:s<time>»` declares a *term* `s`, not a `$`-sigiled scalar. `my $s` and the enum key `s` are different symbols and neither can see or clobber the other.

mutsu stores a scalar `$s` sigil-stripped under the `env` key `"s"`, and the enum registration installed each key under its own bare name — into that same key. The two namespaces were one namespace, and the collision went **both ways**:

```raku
# lib/EDefs.rakumod:  unit module EDefs;
#                     our Str enum U is export(:U) « :ms<time> :s<time> :px<length> »;
# lib/EUse.rakumod:   unit class EUse; use EDefs :U; method pick($x) { U::s }
use EUse;
my $s = 'hello';
say "before: [$s]";        # raku & mutsu: before: [hello]
my $r = EUse.pick(1);
say "after: [$s] r=$r";    # raku:  after: [hello] r=time
                           # mutsu: "Use of uninitialized value ..."; after: [] r=time
```

```raku
our Str enum U « :s<time> »;
my $s = 'x'; $s = 'y';
say s;                     # raku: s (the enum value)   mutsu: y
```

`CSS::Grammar::Defs` declares exactly that shape, so any script calling into `CSS::Grammar` while holding a lexical `$s` had it replaced mid-call.

### Root cause of the reported `Any`

Two sites wrote the enum value under the plain key. The registration loop did `env.insert(key, enum_val)`, and — the one that actually produced the `Any` — `import_module`'s exported-variable loop copied `EDefs::s` to `s` **and** pushed `"s"` onto `pending_rw_writeback_sources`. That list is the env→locals coherence channel: a name on it gets `env[name]` written through to the caller's local slot at the next frame reconcile. So importing an enum key made the importing frame pull `env["s"]` — by then the decl-seed placeholder for its own `my $s` — over the slot holding `'hello'`. The first read still saw `'hello'` because the reconcile ran *after* it; every later read saw `Any`.

## The fix

A namespace, not a per-site patch. The new `src/runtime/enum_bare_names.rs` states the rule once: an enum key's bare spelling is stored under a reserved `__mutsu_enum_bare_` key prefix that no user symbol can spell, and only term/bareword resolution (`Interpreter::enum_bare_value`) consults it. Variable lookup, which reaches `env` under the sigil-less name, can no longer see an enum key; an assignment to `$s` can no longer overwrite one.

The storage stays in `env` deliberately. Enum-key visibility is *lexical*, and `env` is what implements that — block scopes, package-block rollback (a bare key introduced inside `package Foo { … }` is dropped on exit, only `::`-qualified keys survive; the prefix contains no `::` precisely so an enum key keeps that behaviour), thread clones, the `our` store. A side table would have had to reimplement every one of those.

Every site that legitimately reaches an enum key by its bare name moves onto the new probe:

- bareword resolution (`exec_get_bare_word_op`)
- `::('name')` indirect lookup
- the `Mod::EXPORT` stash, and the `GLOBAL::`/`MY::` stash listing (which republishes the key under its bare spelling)
- the poisoned-alias (`X::PoisonedAlias`) check, extracted into a shared helper
- the literal enum-value parameter constraint behind `multi infix:<< - >>(e1, e2)` (`roast/S03-operators/custom.t`)
- the `unit` compunit's package-scope rollback (#7787 — an enum value must not leak to the importer) and the module-scope lexical snapshot
- the two in-place writes to an enum key's own binding: `Apple does R`, and the `X::Assignment::RO` that `Alpha = 3` must raise

`OpCode::DoesVar` grows a `bareword` flag for the first of those: `$Apple does R` and `Apple does R` used to be indistinguishable at the writeback — they shared the key — and now must be told apart.

`import_module` also stops recording an enum key as a pending caller-slot writeback; an enum key names no local slot.

The probe is gated on a latched "any enum key has been installed" flag (the same pattern as `env`'s `*_KEY_SEEN` gates), so a program declaring no enum pays an atomic load rather than a `format!` per bareword read.

### Still shared

Sigil-less `constant`s and type names still share the key space with same-named scalars. This PR does not move those, but it puts the rule they would follow in one place rather than leaving it implicit per declarator.

## Testing

- `t/types/enum-subset/enum-key-vs-same-named-scalar.t` (new, 12 assertions) covers both directions, inline and through a two-module import chain, plus the RO check. Fixtures: `t/lib/EnumKeyScalarDefs.rakumod`, `t/lib/EnumKeyScalarUser.rakumod`. **Verified against the rakudo v2026.07 oracle: 12/12 identical.**
- `make lint` — green (all four configurations).
- `make test` — green: 3997 files, 42522 tests, plus `cargo test`.
- `make roast` — 1433 files, 219306 tests. The only failures are the three documented container-only ones in [`docs/agent-environments.md`](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` run as `uid 0`; `S32-io/IO-Socket-Async.t` needs unsandboxed network). `roast/S03-operators/custom.t` regressed mid-work and is fixed in this PR.

Closes #7914

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHKqp6LnuNTgfZctiaSfWU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHKqp6LnuNTgfZctiaSfWU)_