### PR TITLE
fix: preserve expanded ignorecase class entries

### DIFF
--- a/news/2026-09/ignorecase-character-class-folds.md
+++ b/news/2026-09/ignorecase-character-class-folds.md
@@ -1,0 +1,11 @@
+# Ignorecase character classes preserve expanded and composed entries
+
+Character classes under `:i` now retain entries whose Unicode case fold expands
+to multiple characters, such as `ß` and `ﬀ`, without matching a partial fold.
+Base characters followed by combining escapes are also composed into one class
+entry, so the class matches the grapheme rather than its bare base character.
+
+This restores the affected `roast/S05-modifier/ignorecase.t` cases and adds
+regression coverage in `t/regex/syntax/regex-ignorecase-charclass-folds.t`.
+
+Fixes [#7907](https://github.com/tokuhirom/mutsu/issues/7907).

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -470,6 +470,7 @@ roast/S05-modifier/counted.t
 roast/S05-modifier/exhaustive.t
 roast/S05-modifier/global.t
 roast/S05-modifier/ignorecase-and-ignoremark.t
+roast/S05-modifier/ignorecase.t
 roast/S05-modifier/ignoremark.t
 roast/S05-modifier/ii.t
 roast/S05-modifier/my.t

--- a/src/runtime/regex/regex_casefold.rs
+++ b/src/runtime/regex/regex_casefold.rs
@@ -59,6 +59,13 @@ fn pattern_has_multichar_fold(pattern: &RegexPattern) -> bool {
 fn atom_has_multichar_fold(atom: &RegexAtom) -> bool {
     match atom {
         RegexAtom::Literal(ch) => has_multichar_fold(*ch),
+        RegexAtom::CharClass(class) => {
+            !class.negated
+                && class
+                    .items
+                    .iter()
+                    .any(|item| matches!(item, ClassItem::Char(ch) if has_multichar_fold(*ch)))
+        }
         RegexAtom::Group(p) | RegexAtom::CaptureGroup(p) => pattern_has_multichar_fold(p),
         RegexAtom::Alternation(alts)
         | RegexAtom::SequentialAlternation(alts)
@@ -201,6 +208,116 @@ fn casefold_atom(atom: &RegexAtom) -> CasefoldedAtom {
             negated: *negated,
             is_behind: *is_behind,
         }),
+        RegexAtom::CharClass(class) if !class.negated => {
+            CasefoldedAtom::Single(casefold_char_class(class))
+        }
         other => CasefoldedAtom::Single(other.clone()),
+    }
+}
+
+/// Turn a positive character class into folded alternatives when one of its
+/// entries expands to multiple codepoints. A character class normally consumes
+/// one character, but an entry such as `ß` has the folded spelling `ss`; in
+/// folded match space that entry must therefore be represented by a sequence,
+/// not by a single `CharClass` edge. Keeping the ordinary entries in one class
+/// preserves the class's set semantics while the expanded entries become
+/// non-capturing literal branches.
+fn casefold_char_class(class: &CharClass) -> RegexAtom {
+    let mut single_items = Vec::new();
+    let mut expanded = Vec::new();
+
+    for item in &class.items {
+        match item {
+            ClassItem::Char(ch) => {
+                let folded = casefold_char(*ch);
+                if folded.len() == 1 {
+                    single_items.push(ClassItem::Char(folded[0]));
+                } else {
+                    expanded.push(folded);
+                }
+            }
+            ClassItem::Range(start, end) => {
+                let folded_start = casefold_char(*start);
+                let folded_end = casefold_char(*end);
+                if folded_start.len() == 1 && folded_end.len() == 1 {
+                    single_items.push(ClassItem::Range(folded_start[0], folded_end[0]));
+                } else {
+                    // A range whose endpoint has a multi-character fold has
+                    // no useful one-edge representation in folded space. Keep
+                    // the original range; this fallback does not affect the
+                    // expanded-entry path.
+                    single_items.push(item.clone());
+                }
+            }
+            other => single_items.push(other.clone()),
+        }
+    }
+
+    let mut branches = Vec::new();
+    if !single_items.is_empty() {
+        branches.push(one_atom_pattern(RegexAtom::CharClass(CharClass {
+            negated: false,
+            items: single_items,
+        })));
+    }
+    branches.extend(expanded.into_iter().map(|chars| {
+        RegexPattern {
+            tokens: chars
+                .into_iter()
+                .map(|ch| RegexToken {
+                    atom: RegexAtom::Literal(ch),
+                    quant: RegexQuant::One,
+                    named_capture: None,
+                    secondary_named_capture: None,
+                    hash_capture: None,
+                    force_list_capture: false,
+                    ratchet: false,
+                    frugal: false,
+                    separator: None,
+                    from_runtime_interpolation: false,
+                })
+                .collect(),
+            anchor_start: false,
+            anchor_end: false,
+            ignore_case: false,
+            ignore_mark: false,
+        }
+    }));
+
+    match branches.len() {
+        0 => RegexAtom::CharClass(CharClass {
+            negated: false,
+            items: Vec::new(),
+        }),
+        1 => {
+            let branch = branches.pop().unwrap();
+            if branch.tokens.len() == 1 {
+                branch.tokens.into_iter().next().unwrap().atom
+            } else {
+                RegexAtom::Group(branch)
+            }
+        }
+        _ => RegexAtom::Alternation(branches),
+    }
+}
+
+fn one_atom_pattern(atom: RegexAtom) -> RegexPattern {
+    RegexPattern {
+        tokens: vec![RegexToken {
+            atom,
+            quant: RegexQuant::One,
+            named_capture: None,
+            secondary_named_capture: None,
+            hash_capture: None,
+            force_list_capture: false,
+            ratchet: false,
+            frugal: false,
+            separator: None,
+            from_runtime_interpolation: false,
+        }],
+        anchor_start: false,
+        anchor_end: false,
+        ignore_case: false,
+        ignore_mark: false,
     }
 }

--- a/src/runtime/regex_parse_charclass.rs
+++ b/src/runtime/regex_parse_charclass.rs
@@ -1,5 +1,6 @@
 use super::regex_parse::*;
 use super::*;
+use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 
 /// Result of statically folding a grammar token referenced in an enumerated
 /// char class (see `token_class_fold`).
@@ -303,9 +304,53 @@ impl Interpreter {
             negated
         };
         Some(CharClass {
-            items,
+            items: Self::compose_char_class_items(items),
             negated: final_negated,
         })
+    }
+
+    /// Raku character classes enumerate graphemes, rather than independent
+    /// codepoints. In particular, `[ a \x[308] ]` denotes the single NFG entry
+    /// `ä`, so it must not also admit the bare `a`. The parser already keeps
+    /// escaped combining marks as ordinary `Char` items; compose adjacent
+    /// exact entries here before the class is lowered to a matcher atom.
+    fn compose_char_class_items(items: Vec<ClassItem>) -> Vec<ClassItem> {
+        let mut composed = Vec::with_capacity(items.len());
+        let mut index = 0;
+        while index < items.len() {
+            let ClassItem::Char(base) = &items[index] else {
+                composed.push(items[index].clone());
+                index += 1;
+                continue;
+            };
+
+            let mut grapheme = base.to_string();
+            let mut next = index + 1;
+            while next < items.len() {
+                let ClassItem::Char(mark) = items[next] else {
+                    break;
+                };
+                if !is_combining_mark(mark) {
+                    break;
+                }
+                grapheme.push(mark);
+                next += 1;
+            }
+
+            let normalized: String = grapheme.nfc().collect();
+            let mut normalized_chars = normalized.chars();
+            match (normalized_chars.next(), normalized_chars.next()) {
+                (Some(ch), None) if next > index + 1 => {
+                    composed.push(ClassItem::Char(ch));
+                }
+                _ => {
+                    composed.push(ClassItem::Char(*base));
+                    composed.extend(items[index + 1..next].iter().cloned());
+                }
+            }
+            index = next;
+        }
+        composed
     }
 
     /// Parse bracket character class expressions like `[a..z]-[aeiou]` or `+[a..z]-[aeiou]-[y]`.

--- a/t/regex/syntax/regex-ignorecase-charclass-folds.t
+++ b/t/regex/syntax/regex-ignorecase-charclass-folds.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 10;
+
+# A character-class entry whose case fold expands to multiple characters still
+# matches the original grapheme, but not a partial fold.
+ok "\x[DF]" ~~ /:i <[ \x[DF] ]>/,
+    'a sharp-s escape in a class matches itself under :i';
+nok 's' ~~ /:i <[ \x[DF] ]>/,
+    'a sharp-s escape does not match part of its fold';
+ok "\c[LATIN SMALL LETTER SHARP S]" ~~ /:i <[ \c[LATIN SMALL LETTER SHARP S] ]>/,
+    'a named sharp-s class entry matches itself under :i';
+ok "\c[LATIN SMALL LIGATURE FF]" ~~ /:i <[ \c[LATIN SMALL LIGATURE FF] ]>/,
+    'a named ligature class entry matches itself under :i';
+nok 'f' ~~ /:i <[ \c[LATIN SMALL LIGATURE FF] ]>/,
+    'a ligature class entry does not match part of its fold';
+ok "a\x[308]" ~~ /:i <[ a \x[308] ]>/,
+    'a base plus combining escape forms one class entry';
+nok 'a' ~~ /:i <[ a \x[308] ]>/,
+    'a composed class entry does not match its bare base';
+ok 'm' ~~ /:i <[ \x[4D] ]>/,
+    'a single-character class escape still folds normally';
+nok 'm' ~~ /:i <-[ \x[4D] ]>/,
+    'a negated single-character class still rejects the other case';
+ok 'n' ~~ /:i <-[ \x[4D] ]>/,
+    'a negated single-character class still accepts another character';


### PR DESCRIPTION
## Summary

- preserve multi-character Unicode case folds in positive `:i` character classes
- compose base-plus-combining character-class entries as one grapheme
- add local regression coverage and restore `roast/S05-modifier/ignorecase.t` to the whitelist

## Validation

- `make lint`
- `make test`
- `make roast`
- targeted `roast/S05-modifier/ignorecase.t` (115/115)

Closes #7907