### PR TITLE
perf(vm): closure capture keeps `__mutsu_type::` metadata only for a captured subject

### DIFF
--- a/news/2026-09/closure-capture-type-metadata-follows-its-subject.md
+++ b/news/2026-09/closure-capture-type-metadata-follows-its-subject.md
@@ -1,0 +1,97 @@
+# A closure's captured `__mutsu_type::` metadata now follows its subject
+
+The filtered closure capture (`Interpreter::capture_closure_env`) kept every
+`__mutsu_type::<name>` typed-lexical metadata key it could see, unconditionally.
+It had to, under the rule it was written to: the filter keeps a key when it is a
+free variable of the closure *or* when it is not a plain user lexical, and a
+`__mutsu_*` metadata key is never a plain user lexical. So a closure created
+anywhere in a scope inherited the type-constraint metadata of every typed lexical
+in that scope, including the ones its body cannot possibly name.
+
+That is the third of the three linear-in-import-size terms
+[#7565](https://github.com/tokuhirom/mutsu/issues/7565) decomposed. After the
+first two were fixed (#7656's END-phaser refresh, #7707's per-chunk reflective
+latch and `__mutsu_callable_id::` filter), 11 of the ~35 entries a closure still
+captured after a bare `use Test` were these keys, and they scale with the
+importing scope exactly like the routine-registration markers #7707 removed.
+
+## The rule
+
+`__mutsu_type::<name>` is *shadow metadata*: it records what `<name>` is
+constrained to, and nothing in the language can observe it except through a read
+or a write of `<name>` itself. So it belongs in a capture on exactly the same
+terms as its subject does — which is the same reasoning
+`CompiledCode::is_callee_local_sym` already applies to these keys on the
+scoped-overlay return merge. The filter now unwraps the key and decides it by
+running the rest of the predicate on the subject.
+
+Deciding it *that* way, rather than by the tempting shortcut "keep it only for a
+free variable", is what keeps a **typed dynamic** correct. `my Int $*dyn` is
+captured because its env key is a system name, never because it is a free
+variable; a free-variable test would have dropped its constraint and let
+`$*dyn = 'str'` through inside any closure. Running the real predicate on the
+subject handles dynamics, `self`, match captures and the rest for free, because
+those are precisely the names the predicate already keeps.
+
+A side effect worth noting: the metadata of a name the closure *shadows* with its
+own declaration is now dropped along with the shadowed name, instead of being
+inherited by a frame that has no such variable. That is the same cross-frame
+constraint leak `set_var_type_constraint_routine_scoped` was scoped to prevent
+(`news/2026-09/type-constraint-global-side-table-retired.md`); the capture was
+still carrying one case of it.
+
+## The unwrapping is memoized
+
+Reversing `__mutsu_type::<name>` to `<name>` meant resolving the symbol,
+re-scanning the prefix and re-interning the suffix — a string hash — every time.
+`Symbol::type_meta_subject` memoizes it in the chunked, lock-free table
+`FLAG_TABLE` established for `Symbol::flags`
+([#7856](https://github.com/tokuhirom/mutsu/issues/7856)): the mapping is a pure
+function of an immutable string and symbol ids are append-only, so an entry is
+valid for the life of the process and a racing writer stores the identical value.
+A thread-local `RefCell<FxHashMap>` was measured first and cost ~41 Ir per hit
+against one 32-bit load. Only ids that are actually metadata keys reach the
+store, so a program with no typed lexical allocates no chunk.
+
+`CompiledCode::is_callee_local_sym` — which did the same unwrapping by hand, per
+metadata key, per named call — now shares it.
+
+## Measured
+
+Instruction counts, not wall clock, per the protocol #7707 established: warm
+runs (the first run of any variant writes the precompilation cache and costs
+~300M extra instructions), `MUTSU_JIT=off MUTSU_GC=off`, release, slope between
+6 000 and 14 000 iterations of the ticket's loop. Callgrind reproduced a repeated
+baseline run to within 95 instructions on a ~480M-instruction run, so the slopes
+below are good to well under 1 Ir per iteration.
+
+| | instructions per iteration |
+| --- | --- |
+| the loop with no `use Test` (the floor) | 77 738 → 77 917 |
+| `+ use Test`, before | 106 616 |
+| `+ use Test`, after | **100 333** |
+
+The import tax is 28 878 → 22 416 per iteration (**-22%**); the loop as a whole
+is **-5.9%**. In the callgrind profile of the `use Test` variant the mechanism is
+visible directly: `Env::insert_sym`, which is the per-closure-call capture merge,
+falls 48.0M → 38.3M (-20%).
+
+The floor moves by +179 instructions per iteration (+0.23%), and that is
+optimizer drift rather than added work: an experiment that removed the new branch
+from the untyped path *entirely* — a `const` generic on
+`env_type_constraint_seen`, so the metadata arm is not even compiled for a
+program that has never declared a typed lexical — still measured +180. Two
+further shapes of the same logic (the predicate extracted to an `#[inline]`
+function; the two "drop this key" flag tests fused into one mask) measured
+between +0.1% and +0.7% *worse* on the `use Test` path, which is the sensitivity
+band to keep in mind before rearranging this filter for readability.
+
+## Pinned
+
+`t/routines/closure/closure-capture-type-constraint.t` — 12 assertions over the shapes
+where the subject *is* captured and the constraint must still bite: a typed
+scalar, a typed dynamic, a typed array's element check, a typed hash's value
+check, a subject reached only through a nested closure, an escaping closure over
+a routine-local typed lexical, and a typed `is copy` parameter; plus the two
+shapes where a closure-local redeclaration must *not* inherit an outer or
+creating-routine constraint. All twelve agree with `raku`.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -9515,10 +9515,11 @@ impl CompiledFunction {
         if sym.flags() & crate::symbol::flags::TYPE_META == 0 {
             return false;
         }
-        sym.with_str(|s| {
-            s.strip_prefix(crate::symbol::TYPE_META_PREFIX)
-                .is_some_and(|base| self.is_callee_local_sym_direct(Symbol::intern(base)))
-        })
+        // `type_meta_subject` memoizes the unwrapping: resolving the symbol,
+        // re-scanning the prefix and re-interning the suffix (a string hash)
+        // ran per metadata key per named call.
+        sym.type_meta_subject()
+            .is_some_and(|base| self.is_callee_local_sym_direct(base))
     }
 
     /// [`Self::is_callee_local_sym`] without the `__mutsu_type::` metadata-key

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cell::RefCell;
 use std::fmt;
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};
 use std::sync::{OnceLock, RwLock};
 
 /// An interned symbol — a lightweight handle that supports O(1) equality
@@ -317,6 +317,44 @@ fn store_flags(idx: usize, f: u16) {
     chunk[idx & (FLAG_CHUNK_LEN - 1)].store(f, Ordering::Relaxed);
 }
 
+/// The "not computed yet" sentinel of [`TYPE_META_SUBJECT_TABLE`]. Symbol id 0
+/// is a real symbol, so the empty state cannot be zero; no symbol can ever have
+/// id `u32::MAX` (ids are assigned from a `Vec`'s length).
+const NO_SUBJECT: u32 = u32::MAX;
+
+/// Lock-free, process-global memo of the `__mutsu_type::<name>` -> `<name>`
+/// unwrapping, indexed by the METADATA symbol's id — the same structure as
+/// [`FLAG_TABLE`], for the same reasons (the mapping is a pure function of an
+/// immutable string, ids are append-only, and a racing writer stores the
+/// identical value).
+///
+/// The thread-local `RefCell<FxHashMap>` this replaced charged ~41 Ir per hit
+/// where the answer is one 32-bit load, and the hit rate is 100% after the
+/// first ask: the closure-capture filter asks it once per visible metadata key
+/// per closure creation (#7565).
+///
+/// Only ids that are actually `__mutsu_type::` keys ever reach the store, so a
+/// program with no typed lexical allocates no chunk at all.
+static TYPE_META_SUBJECT_TABLE: [OnceLock<Box<[AtomicU32; FLAG_CHUNK_LEN]>>; FLAG_CHUNKS] =
+    [const { OnceLock::new() }; FLAG_CHUNKS];
+
+/// The already-allocated subject slot for `idx`, if any.
+#[inline]
+fn subject_slot(idx: usize) -> Option<&'static AtomicU32> {
+    let chunk = TYPE_META_SUBJECT_TABLE.get(idx >> FLAG_CHUNK_BITS)?.get()?;
+    Some(&chunk[idx & (FLAG_CHUNK_LEN - 1)])
+}
+
+/// Memoize `subject` as the type-metadata subject of symbol id `idx`.
+fn store_subject(idx: usize, subject: Symbol) {
+    let Some(cell) = TYPE_META_SUBJECT_TABLE.get(idx >> FLAG_CHUNK_BITS) else {
+        return;
+    };
+    let chunk =
+        cell.get_or_init(|| Box::new([const { AtomicU32::new(NO_SUBJECT) }; FLAG_CHUNK_LEN]));
+    chunk[idx & (FLAG_CHUNK_LEN - 1)].store(subject.raw(), Ordering::Relaxed);
+}
+
 /// Pre-interned symbols for names the VM resolves on hot paths.
 ///
 /// [`Symbol::intern`] hashes the whole string and takes a thread-local borrow,
@@ -593,6 +631,46 @@ impl Symbol {
     #[inline]
     pub(crate) fn is_code_env_entry(self) -> bool {
         self.flags() & flags::CODE_ENV_ENTRY != 0
+    }
+
+    /// The *subject* of a `__mutsu_type::<name>` metadata key: the symbol of
+    /// `<name>`, which is the env key the constraint belongs to. `None` for
+    /// any symbol that is not such a key.
+    ///
+    /// This is the inverse of
+    /// [`Interpreter::type_meta_key_for_sym`](crate::runtime::Interpreter::type_meta_key_for_sym),
+    /// and it is memoized for the same reason that one is: both directions of
+    /// the mapping are fixed for the life of the process (symbols are
+    /// append-only), and both are asked on hot paths — the closure-capture
+    /// filter asks it once per visible metadata key per closure creation, and
+    /// the scoped-overlay return merge (`CompiledCode::is_callee_local_sym`)
+    /// asks it once per metadata key per named call. Computing it meant
+    /// resolving the symbol, re-scanning the prefix, and re-interning the
+    /// suffix — a string hash — every single time.
+    #[inline]
+    pub(crate) fn type_meta_subject(self) -> Option<Symbol> {
+        if self.flags() & flags::TYPE_META == 0 {
+            return None;
+        }
+        let idx = self.0 as usize;
+        if let Some(slot) = subject_slot(idx) {
+            let raw = slot.load(Ordering::Relaxed);
+            if raw != NO_SUBJECT {
+                return Some(Symbol(raw));
+            }
+        }
+        self.compute_and_store_type_meta_subject(idx)
+    }
+
+    /// The miss half of [`Symbol::type_meta_subject`]: reached once per
+    /// metadata symbol (plus the losing side of a race), and it interns, so it
+    /// must not be inlined into the capture filter.
+    #[cold]
+    #[inline(never)]
+    fn compute_and_store_type_meta_subject(self, idx: usize) -> Option<Symbol> {
+        let subject = Symbol::intern(self.as_str().strip_prefix(TYPE_META_PREFIX)?);
+        store_subject(idx, subject);
+        Some(subject)
     }
 
     /// Resolve the symbol back to its string representation.
@@ -875,6 +953,41 @@ mod tests {
                 "flags for {name:?} drifted"
             );
         }
+    }
+
+    #[test]
+    fn type_meta_subject_round_trips_and_is_stable() {
+        // The capture filter decides a `__mutsu_type::<name>` key by running
+        // its predicate on `<name>`, so the unwrapping has to be exact -- and
+        // the memo must answer the same thing on the second ask as the first.
+        for name in [
+            "subject_probe",
+            "@subject_probe_arr",
+            "%subject_probe_hash",
+            "*subject_probe_dyn",
+            "self",
+        ] {
+            let subject = Symbol::intern(name);
+            let meta = Symbol::intern(&format!("{TYPE_META_PREFIX}{name}"));
+            assert_eq!(meta.flags() & flags::TYPE_META, flags::TYPE_META);
+            assert_eq!(meta.type_meta_subject(), Some(subject));
+            assert_eq!(meta.type_meta_subject(), Some(subject));
+            // A name that is not a metadata key has no subject, and asking does
+            // not invent one.
+            assert_eq!(subject.type_meta_subject(), None);
+        }
+    }
+
+    #[test]
+    fn type_meta_subject_is_visible_across_threads() {
+        // The memo is process-global (an `AtomicU32` table indexed by symbol
+        // id), so a subject resolved on one thread is already answered on
+        // another -- closures are captured on every thread.
+        let meta = Symbol::intern("__mutsu_type::cross_thread_subject_probe");
+        let expected = Symbol::intern("cross_thread_subject_probe");
+        assert_eq!(meta.type_meta_subject(), Some(expected));
+        let handle = std::thread::spawn(move || meta.type_meta_subject());
+        assert_eq!(handle.join().unwrap(), Some(expected));
     }
 
     #[test]

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1082,13 +1082,42 @@ impl Interpreter {
             return env;
         }
         let mut env = self.env().filtered_flat(&|k, _v| {
-            if k == callable_type_sym {
-                return false;
-            }
             // One memoized flags word answers the string questions this filter
             // asks per key (see `symbol::flags`), instead of resolving the
             // symbol and re-scanning its bytes.
-            let flags = k.flags();
+            let mut k = k;
+            let mut flags = k.flags();
+            // `__mutsu_type::<name>` is *shadow metadata*: it says what
+            // `<name>` is constrained to, and nothing can observe it except
+            // through a read or write of `<name>` itself. So it belongs in the
+            // capture on exactly the same terms as its subject, and the rest of
+            // this filter decides it by looking at that subject instead — the
+            // same metadata-key unwrapping `CompiledCode::is_callee_local_sym`
+            // already does for the return merge.
+            //
+            // Kept unconditionally (every one of them is a system name by the
+            // plain-user-lexical test below) it rode along for every typed
+            // lexical anywhere in the creating scope: 11 of the ~35 entries a
+            // closure captured after a bare `use Test`, which scale with the
+            // importer's scope exactly like the `__mutsu_callable_id::` markers
+            // below (#7565).
+            //
+            // Deciding it by its subject rather than by "is it a free
+            // variable" is what keeps a typed *dynamic* (`my Int $*x`) — a
+            // system name that is captured without ever being a free
+            // variable — constrained inside the closure.
+            if flags & crate::symbol::flags::TYPE_META != 0 {
+                // `None` cannot happen (the flag is a pure string property of
+                // the prefix), but keeping the key is the pre-#7565 behaviour.
+                let Some(subject) = k.type_meta_subject() else {
+                    return true;
+                };
+                k = subject;
+                flags = subject.flags();
+            }
+            if k == callable_type_sym {
+                return false;
+            }
             // Attribute-twigil keys (`!x`, `@!x`, `%.x`, …) are per-frame
             // materializations of `self`'s attributes, not lexicals: the
             // closure must read them through its captured `self` at RUN time.

--- a/t/routines/closure/closure-capture-type-constraint.t
+++ b/t/routines/closure/closure-capture-type-constraint.t
@@ -1,0 +1,101 @@
+use v6;
+use Test;
+
+# A closure's captured env carries the `__mutsu_type::<name>` metadata that
+# enforces a typed lexical's constraint. That metadata is *shadow meta*: it is
+# only ever observable through a read or write of its subject, so the capture
+# filter keeps it on exactly the same terms as the subject itself (#7565) --
+# dropping it for every typed lexical the closure provably cannot name.
+#
+# These are the shapes where the subject IS captured, so the constraint must
+# still bite inside the closure.
+
+plan 12;
+
+sub type-error(&code) {
+    my $hit = '';
+    try {
+        code();
+        CATCH { default { $hit = .^name } }
+    }
+    $hit;
+}
+
+# 1-2: a plain typed lexical, captured as an ordinary free variable.
+my Int $scalar = 5;
+my $write-scalar = sub { $scalar = 'nope' };
+is type-error($write-scalar), 'X::TypeCheck::Assignment',
+    'captured typed scalar keeps its constraint inside a closure';
+is $scalar, 5, 'the rejected assignment left the value alone';
+
+# 3: a typed DYNAMIC. Its env key is a system name, so it is captured without
+# ever being a free variable -- the case a naive "keep the metadata only for
+# free variables" filter would lose.
+my Int $*dyn = 1;
+my $write-dyn = sub { $*dyn = 'nope' };
+is type-error($write-dyn), 'X::TypeCheck::Assignment',
+    'captured typed dynamic keeps its constraint inside a closure';
+
+# 4: a typed array, whose element check is driven by the same metadata lane.
+my Int @arr;
+my $push-arr = sub { @arr.push('str') };
+is type-error($push-arr), 'X::TypeCheck::Assignment',
+    'captured typed array keeps its element constraint inside a closure';
+
+# 5: a typed hash.
+my Int %hash;
+my $store-hash = sub { %hash<k> = 'str' };
+is type-error($store-hash), 'X::TypeCheck::Assignment',
+    'captured typed hash keeps its value constraint inside a closure';
+
+# 6: the subject is a free variable of a NESTED closure only. The free-var set
+# a capture is filtered by covers nested closures, so the metadata must ride
+# along with it.
+my Int $nested = 3;
+my $outer = sub {
+    my $inner = sub { $nested = 'nope' };
+    inner-call($inner);
+};
+sub inner-call(&c) { c() }
+is type-error($outer), 'X::TypeCheck::Assignment',
+    'typed lexical reached only through a nested closure keeps its constraint';
+
+# 7: a closure created inside a routine, capturing that routine's own typed
+# lexical, and escaping it.
+sub make-setter() {
+    my Int $inside = 0;
+    return sub ($v) { $inside = $v; $inside };
+}
+my $setter = make-setter();
+is $setter(7), 7, 'escaping closure over a routine-local typed lexical works';
+is type-error({ $setter('str') }), 'X::TypeCheck::Assignment',
+    'escaping closure keeps the routine-local constraint';
+
+# 8: a typed lexical the closure never names must not constrain a same-named
+# lexical the closure declares for itself.
+my Int $shadowed = 1;
+my $shadow = sub { my $shadowed = 'free'; $shadowed };
+is $shadow(), 'free', 'a closure-local redeclaration is not constrained by the outer typed name';
+
+# 9: ... nor by one declared in a routine the closure is created inside.
+sub make-shadower() {
+    my Int $only-here = 1;
+    return sub { my $only-here = 'free'; $only-here };
+}
+is make-shadower()(), 'free',
+    'a closure-local redeclaration is not constrained by the creating routine typed name';
+
+# 10: an untyped capture stays untyped even when a typed lexical of another
+# name is in scope right next to it.
+my Int $typed-neighbour = 1;
+my $plain = 'anything';
+my $touch-plain = sub { $plain = 42; $plain };
+is $touch-plain(), 42, 'an untyped captured lexical is unaffected by a typed neighbour';
+
+# 11: a typed parameter's constraint is registered on the callee frame and must
+# reach a closure created in that frame.
+sub typed-param(Int $p is copy) {
+    return sub { $p = 'nope' };
+}
+is type-error(typed-param(1)), 'X::TypeCheck::Assignment',
+    'closure over a typed parameter keeps the parameter constraint';


### PR DESCRIPTION
Item 1 of the "what is left" list #7707 left on #7565.

## The problem

The filtered closure capture kept **every** `__mutsu_type::<name>` typed-lexical
metadata key it could see. It had to, under the rule it was written to: the filter
keeps a key that is a free variable of the closure **or** that is not a plain user
lexical, and a `__mutsu_*` metadata key is never a plain user lexical. So a closure
inherited the type-constraint metadata of every typed lexical in its creating
scope, including the ones its body cannot possibly name — 11 of the ~35 entries a
closure still captured after a bare `use Test`, scaling with the importing scope
exactly like the `__mutsu_callable_id::` markers #7707 removed.

## The fix

`__mutsu_type::<name>` is *shadow metadata*: nothing in the language can observe it
except through a read or a write of `<name>` itself, so it belongs in a capture on
exactly the same terms as its subject. That is the same reasoning
`CompiledCode::is_callee_local_sym` already applies to these keys on the
scoped-overlay return merge. The filter now unwraps the key and runs the rest of the
predicate on the subject.

Deciding it *that* way, rather than by the tempting shortcut "keep it only for a free
variable", is what keeps a **typed dynamic** correct — the hazard #7707 flagged.
`my Int $*dyn` is captured because its env key is a system name, never because it is
a free variable, so a free-variable test would have let `$*dyn = 'str'` through inside
any closure. Running the real predicate on the subject handles dynamics, `self`,
match captures and the rest for free, because those are precisely the names the
predicate already keeps.

`Symbol::type_meta_subject` memoizes the unwrapping in the chunked, lock-free table
established for `Symbol::flags` (#7856) — the mapping is a pure function of an
immutable string and symbol ids are append-only. A thread-local `RefCell<FxHashMap>`
was measured first and cost ~41 Ir per hit against one 32-bit load. Only ids that are
actually metadata keys reach the store, so a program with no typed lexical allocates
no chunk. `CompiledCode::is_callee_local_sym`, which did the same unwrapping by hand
per metadata key per named call, now shares it.

## Measured

Callgrind, warm runs, `MUTSU_JIT=off MUTSU_GC=off`, release, slope between 6 000 and
14 000 iterations of the ticket's loop — the protocol #7707 established. A repeated
baseline run reproduced to within 95 instructions on a ~480M-instruction run, so the
slopes are good to well under 1 Ir per iteration.

| | instructions per iteration |
| --- | --- |
| the loop with no `use Test` (the floor) | 77 738 → 77 917 |
| `+ use Test`, before | 106 616 |
| `+ use Test`, after | **100 333** |

Import tax **28 878 → 22 416 per iteration (-22%)**; the loop as a whole **-5.9%**.
The mechanism is visible directly in the profile: `Env::insert_sym` — the
per-closure-call capture merge — falls 48.0M → 38.3M (-20%).

The floor's +179 (+0.23%) is optimizer drift, not added work: an experiment that
removed the new branch from the untyped path *entirely* (a `const` generic on
`env_type_constraint_seen`, so the metadata arm is not even compiled for a program
with no typed lexical) still measured +180. Two further shapes of the same logic —
the predicate extracted to an `#[inline]` function, and the two "drop this key" flag
tests fused into one mask — measured between +0.1% and +0.7% *worse* on the
`use Test` path. Worth knowing before rearranging this filter for readability.

## Behaviour

One deliberate change beyond the capture width: the metadata of a name a closure
*shadows* with its own declaration is now dropped along with the shadowed name,
instead of being inherited by a frame that has no such variable. That is the same
cross-frame constraint leak `set_var_type_constraint_routine_scoped` was scoped to
prevent (`news/2026-09/type-constraint-global-side-table-retired.md`); the capture
was still carrying one case of it.

## Testing

- `t/routines/closure/closure-capture-type-constraint.t` — 12 new assertions over the
  shapes where the subject *is* captured and the constraint must still bite (typed
  scalar, typed dynamic, typed array element, typed hash value, a subject reached only
  through a nested closure, an escaping closure over a routine-local typed lexical, a
  typed `is copy` parameter), plus the two shapes where a closure-local redeclaration
  must *not* inherit an outer or creating-routine constraint. All twelve agree with
  `raku`.
- Two `#[test]`s pinning `Symbol::type_meta_subject`'s round trip and its
  cross-thread visibility.
- `make test`: PASS, 4000 files / 42558 tests.
- `make lint`: green in all four configurations.
- `make roast`: red only on `roast/6.c/S32-io/file-tests.t` (4) and
  `roast/S16-filehandles/filetest.t` (25) — the two `uid 0` `chmod` files
  [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md)
  records as container-only, with exactly the documented failure counts.

Refs #7565 (left open: the tax is reduced, not eliminated — items 2 and 3 of that
list remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xhWSUqaSHmPW9or22tXfi

---
_Generated by [Claude Code](https://claude.ai/code/session_017xhWSUqaSHmPW9or22tXfi)_