### PR TITLE
fix: dispatch actions for sigilless silent aliases

### DIFF
--- a/news/2026-09/sigilless-alias-silent-subrule-action.md
+++ b/news/2026-09/sigilless-alias-silent-subrule-action.md
@@ -1,0 +1,7 @@
+The sigil-prefixed `$<name>=<.subrule>` grammar capture form now preserves the
+subrule action name on its visible alias. Actions therefore populate `.ast` and
+`.made` just as they do for the equivalent `<name=.subrule>` spelling.
+
+The regression is covered by `t/grammar/grammar-sigilless-alias-silent-action.t`.
+
+Fixes #7910.

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -446,6 +446,17 @@ impl Interpreter {
                 ..Default::default()
             })
         };
+        // `$<alias>=<.subrule>` is a visible alias around a silent subrule.
+        // The silent call itself does not create a named capture, so the alias
+        // would otherwise be only a span carrier and the subrule's action would
+        // never be dispatched. Preserve the original rule name on the alias
+        // node, just as the `<alias=.subrule>` spelling does in the matcher.
+        if let RegexAtom::Named(atom_name) = &token.atom {
+            let spec = Self::parse_named_regex_lookup_spec(atom_name);
+            if spec.silent && !spec.lookup_name.is_empty() {
+                std::sync::Arc::make_mut(&mut sub).action_name = Some(spec.lookup_name);
+            }
+        }
         // A sigil-prefixed alias (`$<alias> = <rule>`) shares the subrule's
         // capture node with the original rule-name entry, just like the
         // angle-bracket form (`<alias=rule>`). Tag that shared node with the

--- a/t/grammar/grammar-sigilless-alias-silent-action.t
+++ b/t/grammar/grammar-sigilless-alias-silent-action.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+plan 5;
+
+# A sigil-prefixed alias around a silent subrule still exposes a Match under
+# the alias name, and the original subrule action must run for that Match.
+# The angle-bracket spelling (<int=.uint>) already covered the action path;
+# this pins the equivalent `$<int>=<.uint>` form.
+grammar G {
+    token uint { \d+ }
+    rule e { $<int>=<.uint> }
+}
+
+class Actions {
+    has @.calls;
+    method uint($/) {
+        @!calls.push(~$/);
+        make $/.Int;
+    }
+}
+
+my $actions = Actions.new;
+my $m = G.subparse('3', :rule<e>, :actions($actions));
+ok $m, 'the aliased silent subrule matches';
+is $m<int>.ast, 3, 'the subrule action populates the alias AST';
+is $m<int>.made, 3, 'the alias exposes the subrule action result';
+is-deeply [$m<int>.from, $m<int>.to], [0, 1], 'the alias retains the subrule span';
+is-deeply $actions.calls, ['3'], 'the subrule action fires exactly once';


### PR DESCRIPTION
## Summary

- preserve the original subrule action name on `$<name>=<.subrule>` alias captures
- add a grammar regression covering `.ast`, `.made`, span, and single dispatch
- document the compatibility fix

## Validation

- `make lint`
- `make test`
- `make roast`
- targeted grammar action tests

Closes #7910