### PR TITLE
fix: preserve sequential alternation after lookahead literals

### DIFF
--- a/news/2026-09/lookahead-literal-preserves-sequential-alternation.md
+++ b/news/2026-09/lookahead-literal-preserves-sequential-alternation.md
@@ -1,0 +1,8 @@
+# Lookahead literals preserve sequential alternation
+
+Regex scanners now keep `||` visible when a quoted lookahead literal contains
+nesting punctuation such as `(`.
+
+Pinned by `t/regex/syntax/regex-lookahead-literal-seqalt.t`.
+
+Closes #7912.

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -155,28 +155,33 @@ impl Interpreter {
                 current.push(ch);
                 continue;
             }
+            // Delimiters inside an assertion belong to its nested regex, not
+            // to the outer pattern being split. This is especially important
+            // for quoted assertion literals: quote tracking is intentionally
+            // disabled while `depth_angle > 0`, so a literal `(` must still
+            // not hide a following top-level `||` from this scanner.
             match ch {
-                '(' => {
+                '(' if depth_angle == 0 => {
                     depth_paren += 1;
                     current.push(ch);
                 }
-                ')' => {
+                ')' if depth_angle == 0 => {
                     depth_paren -= 1;
                     current.push(ch);
                 }
-                '[' => {
+                '[' if depth_angle == 0 => {
                     depth_bracket += 1;
                     current.push(ch);
                 }
-                ']' => {
+                ']' if depth_angle == 0 => {
                     depth_bracket -= 1;
                     current.push(ch);
                 }
-                '{' => {
+                '{' if depth_angle == 0 => {
                     depth_brace += 1;
                     current.push(ch);
                 }
-                '}' => {
+                '}' if depth_angle == 0 => {
                     depth_brace -= 1;
                     current.push(ch);
                 }

--- a/t/regex/syntax/regex-lookahead-literal-seqalt.t
+++ b/t/regex/syntax/regex-lookahead-literal-seqalt.t
@@ -1,0 +1,15 @@
+use v6;
+use Test;
+
+plan 4;
+
+# Parentheses inside quoted lookahead literals must not affect the outer regex
+# parser's nesting depth while it finds the `||` separator.
+ok 'p' ~~ / [ [ <?before 'x'> || <?> ] \w ]+ /,
+    'a paren-free lookahead literal keeps the sequential alternation';
+ok 'p' ~~ / [ [ <?before 'xy'> || <?> ] \w ]+ /,
+    'a longer paren-free lookahead literal keeps the sequential alternation';
+ok 'p' ~~ / [ [ <?before 'x('> || <?> ] \w ]+ /,
+    'a parenthesis in a quoted lookahead literal keeps the sequential alternation';
+ok 'p' ~~ / [ [ <?before ':n'> || <?> ] \w ]+ /,
+    'a punctuation lookahead literal keeps the sequential alternation';


### PR DESCRIPTION
## Summary
- keep assertion-internal delimiters out of the outer regex nesting counters
- preserve `||` parsing when a quoted lookahead literal contains `(`
- add regression coverage for quantified sequential alternation and lookahead literals

## Validation
- focused regression and related regex tests
- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`

Closes #7912