### PR TITLE
fix: render Str enum Pair keys as colonpairs

### DIFF
--- a/news/2026-09/str-enum-pair-raku.md
+++ b/news/2026-09/str-enum-pair-raku.md
@@ -1,0 +1,4 @@
+`Pair.raku` now renders a `Str`-enum key using its string value, producing the
+same colonpair form as Rakudo instead of the qualified enum name.
+
+Fixes #7913.

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -892,15 +892,31 @@ pub fn raku_value(v: &Value) -> String {
             }
         }
         ValueView::ValuePair(key, value) => {
-            if let ValueView::Str(key_str) = key.view() {
-                let ident_like = is_adverbial_pair_key(&key_str);
+            // A Str enum is a Str value in Pair.raku's key position. Its own
+            // `.raku` remains qualified (`Sel::Alpha`), but the Pair uses its
+            // string value (`a-val`) for the colonpair/arrow decision.
+            let str_key = match key.view() {
+                ValueView::Str(key_str) => Some(key_str.to_string()),
+                ValueView::Enum {
+                    value: crate::value::EnumValue::Str(key_str),
+                    ..
+                } => Some(key_str.clone()),
+                _ => None,
+            };
+            if let Some(key_str) = str_key.as_deref() {
+                let ident_like = is_adverbial_pair_key(key_str);
                 if ident_like {
                     return match value.view() {
-                        ValueView::Bool(true) => format!(":{}", *key_str),
-                        ValueView::Bool(false) => format!(":!{}", *key_str),
-                        _ => format!(":{}({})", *key_str, raku_value(value)),
+                        ValueView::Bool(true) => format!(":{}", key_str),
+                        ValueView::Bool(false) => format!(":!{}", key_str),
+                        _ => format!(":{}({})", key_str, raku_value(value)),
                     };
                 }
+                return format!(
+                    "{} => {}",
+                    raku_value(&Value::str(key_str.to_string())),
+                    raku_value(value)
+                );
             }
             let key_repr = if raku_raw_repr(key).is_some() {
                 // A pre-rendered leaf (an instance key) is already a complete

--- a/t/types/string/str-enum-pair-raku.t
+++ b/t/types/string/str-enum-pair-raku.t
@@ -1,0 +1,19 @@
+use v6;
+use Test;
+
+# A Str enum's value is a Str in Pair.raku's key position. The enum itself
+# keeps its qualified `.raku`, but the Pair uses the string value for the
+# colonpair form, just as a Hash does.
+
+plan 3;
+
+our Str enum Sel « :Alpha<a-val> »;
+
+is (Sel::Alpha => 'x').raku, ':a-val("x")',
+    'a Str-enum Pair key uses its string value';
+is Pair.new(Sel::Alpha, 'x').raku, ':a-val("x")',
+    'Pair.new preserves the Str-enum key rendering';
+is %(Sel::Alpha => 'x').raku, '{:a-val("x")}',
+    'a Hash with a Str-enum key keeps its existing rendering';
+
+done-testing;


### PR DESCRIPTION
Fixes #7913

## Summary
- render Str-enum keys in Pair.raku from their string values
- preserve the colonpair form used by Rakudo and existing Hash rendering
- add focused regression coverage and a news entry

## Validation
- make lint
- make test
- make roast