### PR TITLE
fix(compiler): load, don't reset, the package variable for a bare `our @a;` / `our %h;`

### DIFF
--- a/news/2026-09/our-container-declaration-no-longer-resets-the-package-variable.md
+++ b/news/2026-09/our-container-declaration-no-longer-resets-the-package-variable.md
@@ -1,0 +1,73 @@
+# A bare `our @a;` / `our %h;` no longer resets the package variable
+
+`our %Store; BEGIN %Store = (a => 1); say %Store<a>;` answered `(Any)`, where
+rakudo answers `1`. The write was not lost anywhere exotic: a `BEGIN` phaser
+body runs *before* the declaration statement that precedes it in the source, and
+the declaration then overwrote the populated hash with an empty one — silently,
+with no error, which is worse than failing. The array half behaved identically
+(`our @L; BEGIN @L = (1,2)` gave `[]`), while an `our` *scalar* and a `my`
+container both survived.
+
+## Root cause
+
+The parser synthesizes a default RHS for every uninitialized declaration, and
+its shape differs by sigil: `Literal(Nil)` for `$`/`&`, an empty
+`Literal(Array)` for `@`, and an empty `Expr::Hash` for `%`. The compiler's
+`our` path recognised only the first of the three:
+
+```rust
+let is_our_redecl_nil =
+    *is_our && matches!(expr, Expr::Literal(lit) if lit.is_nil());
+```
+
+A match loaded the existing package variable (`OpCode::GetOurVar`) instead of
+the synthesized default, which is why `our $x = 3; ... our $x` preserved the 3.
+A `%`/`@` declaration failed that test, took the ordinary
+compile-RHS-and-store path, and reset the container on every execution of the
+declaration.
+
+Two things follow from "on every execution", and the `BEGIN` repro is only the
+more visible one. The reset also fired on each call of a sub containing a bare
+`our` container, so
+
+```raku
+sub bump() { our %Count; %Count<n>++ }
+bump; bump;
+our %Count; say %Count<n>;    # was 1, rakudo says 2
+```
+
+started from an empty hash every time.
+
+## Fix
+
+The `my` path already had a correct predicate for "is this the parser's
+synthesized default", including the `__has_initializer` trait check that keeps
+an explicit `our %h = ()` distinguishable from a bare `our %h;`. That predicate
+is now `Compiler::is_synthesized_decl_default`, shared by both paths, and the
+`our` test is spelled in terms of it.
+
+`GetOurVar` had to grow one matching case: it answered `Value::NIL` for a name
+with nothing stored, which is right for a scalar but would have made a
+first-ever `our %h;` declare `Nil` rather than an empty `Hash`. It now defaults
+by sigil — an empty `Array` for `@`, an empty `Hash` for `%`, `Nil` otherwise.
+
+The expression-position declaration path (`my $x = (our %h)`) carried the same
+gap in its own container branch and got the same treatment, so both paths now
+load rather than reset.
+
+## Where it was reached
+
+Found by P5 triage of the first full-corpus ecosystem sweep (#7785) while
+locating parse failures in the `blocked_load` bucket, through **`PDF::Content`**
+— `lib/PDF/Content/Ops.rakumod:248` opens `BEGIN %Store = (`, a large
+compile-time operator table. `our %H; BEGIN %H = (...)` is the standard way to
+build a lookup table once at compile time, so the construct is not obscure.
+
+Pinned by `t/modules/our-container-decl-preserves-value.t` (17 assertions,
+verified identical against the rakudo oracle): the `BEGIN` repros for `%`, `@`
+and `$`, the fresh-declaration types and emptiness, explicit initializers
+(including an explicit `= ()` clear) still running, bare redeclaration
+preserving contents, the sub-body accumulation case, expression position, and a
+`module`-scoped declaration reaching its qualified name.
+
+Closes #7953.

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -294,7 +294,19 @@ impl Compiler {
                         let tc_idx = self.code.add_constant(Value::str(String::new()));
                         self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
                     }
-                    self.compile_expr(expr);
+                    if *is_our && !has_initializer && Self::is_synthesized_decl_default(expr) {
+                        // A BARE `our` container declaration loads the package
+                        // variable rather than the synthesized empty default, so
+                        // an earlier write survives the declaration — the
+                        // expression-position twin of the statement path's
+                        // `is_our_bare_decl` (#7953). `GetOurVar` answers the
+                        // sigil's empty container when nothing is stored yet.
+                        let qualified = self.qualify_our_variable_name(name);
+                        let idx = self.code.add_constant(Value::str(qualified));
+                        self.code.emit(OpCode::GetOurVar(idx));
+                    } else {
+                        self.compile_expr(expr);
+                    }
                     // An `@` declaration whose RHS is a `$` scalar variable
                     // itemizes, exactly as the statement-position store does:
                     // `(my @i = $c)` must be one element, like `my @j = $c`.

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -1,6 +1,29 @@
 use super::*;
 
 impl Compiler {
+    /// Whether a `VarDecl`'s RHS is the *parser-synthesized* default for its
+    /// sigil rather than a user-written initializer: `Literal(Nil)` for
+    /// `$`/`&`, an empty `Literal(Array)` for `@`, and an empty `Expr::Hash`
+    /// for `%`.
+    ///
+    /// The shape alone does not settle it — `my @a = ()` parses to the same
+    /// empty `Literal(Array)` — so every caller must also check that the
+    /// declaration does NOT carry the parser's `__has_initializer` trait. What
+    /// this predicate answers is only "could this be the synthesized default",
+    /// which is what both the `my` redeclaration no-op and the `our`
+    /// value-preserving load need.
+    pub(crate) fn is_synthesized_decl_default(expr: &Expr) -> bool {
+        match expr {
+            Expr::Literal(lit) => match lit.view() {
+                crate::value::ValueView::Nil => true,
+                crate::value::ValueView::Array(ad, _) => ad.items().is_empty(),
+                _ => false,
+            },
+            Expr::Hash(pairs) => pairs.is_empty(),
+            _ => false,
+        }
+    }
+
     pub(super) fn is_dostmt_vardecl(expr: &Expr) -> bool {
         matches!(expr, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. }))
     }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1387,23 +1387,13 @@ impl Compiler {
                     let has_init = custom_traits.iter().any(|(n, _)| n == "__has_initializer");
                     // Only the default-init form (a bare `my $f;` / `my Int $f;` /
                     // `my @a;` / `my %h;`, whose RHS is the synthesized empty type
-                    // default) is a value-preserving no-op. A decl with a real RHS
-                    // expression — including internal desugared temps like
+                    // default — see `Compiler::is_synthesized_decl_default`) is a
+                    // value-preserving no-op. A decl with a real RHS expression —
+                    // including internal desugared temps like
                     // `@__destructure_tmp__` (an `Expr::ArrayLiteral`) that
                     // legitimately re-run on each `my (...)` destructure — must always
-                    // execute. The synthesized defaults are, by sigil: `Literal(Nil)`
-                    // ($ / &), an empty `Literal(Array)` (@), and an empty
-                    // `Expr::Hash` (%).
-                    let is_default_init = !has_init
-                        && match expr {
-                            Expr::Literal(lit) => match lit.view() {
-                                ValueView::Nil => true,
-                                ValueView::Array(ad, _) => ad.items().is_empty(),
-                                _ => false,
-                            },
-                            Expr::Hash(pairs) => pairs.is_empty(),
-                            _ => false,
-                        };
+                    // execute.
+                    let is_default_init = !has_init && Self::is_synthesized_decl_default(expr);
                     let already_declared = !self.my_vars_current_scope.insert(name.clone());
                     if already_declared && is_default_init {
                         return;
@@ -1456,12 +1446,23 @@ impl Compiler {
                 } else {
                     None
                 };
-                // For `our` redeclarations with no initializer (expr is Nil),
-                // load the existing package variable value instead of
-                // resetting to Nil. This makes `our $x = 3; ... our $x`
-                // preserve the value 3 in the redeclaration.
-                let is_our_redecl_nil =
-                    *is_our && matches!(expr, Expr::Literal(lit) if lit.is_nil());
+                // A bare `our` declaration (no initializer) loads the existing
+                // package variable instead of resetting it, so `our $x = 3; ...
+                // our $x` preserves the 3.
+                //
+                // Containers count too, and for them the reset is not merely a
+                // redeclaration concern: a `BEGIN` phaser body runs BEFORE the
+                // declaration statement it precedes in the source, so `our %H;
+                // BEGIN %H = (...)` wrote a populated hash that the declaration
+                // then overwrote with the parser's synthesized empty default —
+                // silently, with no error (#7953). The synthesized defaults are,
+                // by sigil: `Literal(Nil)` for `$`/`&`, an empty `Literal(Array)`
+                // for `@`, and an empty `Expr::Hash` for `%`. A real initializer
+                // — including an explicit `our %H = ()` — carries the parser's
+                // `__has_initializer` marker and must still run.
+                let is_our_bare_decl = *is_our
+                    && Self::is_synthesized_decl_default(expr)
+                    && !custom_traits.iter().any(|(n, _)| n == "__has_initializer");
                 // A scalar `:=` bind to a Positional makes the scalar a
                 // non-container alias; record it so SetLocal can mark it
                 // decontainerized (so `@a = $bound` flattens, not itemizes).
@@ -1496,7 +1497,7 @@ impl Compiler {
                 } else {
                     None
                 };
-                if is_our_redecl_nil {
+                if is_our_bare_decl {
                     let qualified = self.qualify_our_variable_name(name);
                     let idx = self.code.add_constant(Value::str(qualified));
                     self.code.emit(OpCode::GetOurVar(idx));

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -837,7 +837,22 @@ impl Interpreter {
                     .get_our_var(name)
                     .cloned()
                     .or_else(|| self.get_env_with_main_alias(name))
-                    .unwrap_or(Value::NIL);
+                    .unwrap_or_else(|| {
+                        // A never-stored `our` variable falls back to its
+                        // sigil's empty container, not `Nil`. A bare container
+                        // declaration (`our @a;` / `our %h;`) compiles to this
+                        // opcode so that an EARLIER write — a `BEGIN` phaser
+                        // body runs before the declaration statement does —
+                        // is preserved rather than reset (#7953); on the very
+                        // first declaration there is nothing stored yet and
+                        // the declaration must still install an empty
+                        // container of the right type.
+                        match name.chars().next() {
+                            Some('@') => Value::array(Vec::new()),
+                            Some('%') => Value::hash(crate::value::HashData::default()),
+                            _ => Value::NIL,
+                        }
+                    });
                 // Auto-deref ContainerRef for stack use (ContainerRef axis of
                 // the decont family — mirrors GetGlobal). `our_vars` can now
                 // hold a `ContainerRef` cell for a plain scalar `our`

--- a/t/modules/our-container-decl-preserves-value.t
+++ b/t/modules/our-container-decl-preserves-value.t
@@ -1,0 +1,106 @@
+use Test;
+
+# A bare `our @a;` / `our %h;` declaration must LOAD the package variable, not
+# reset it to the parser's synthesized empty container.
+#
+# The visible symptom was a `BEGIN` phaser: its body runs before the
+# declaration statement that precedes it in the source, so
+#
+#     our %Store; BEGIN %Store = (a => 1); say %Store<a>;
+#
+# wrote a populated hash that the declaration then silently overwrote with an
+# empty one — mutsu answered `(Any)` where rakudo answers `1`. The scalar case
+# already worked (a bare `our $x;` compiled to `GetOurVar`); only the `%`/`@`
+# halves took the reset path, because their synthesized default is an empty
+# `Hash`/`Array` literal rather than `Nil`. The same reset also made a bare
+# `our` container inside a sub start empty on every call. See #7953.
+
+plan 17;
+
+# --- the reported repro: a BEGIN write survives the declaration -------------
+{
+    our %Store;
+    BEGIN %Store = (a => 1);
+    is %Store<a>, 1, 'BEGIN write to an `our` hash survives the declaration';
+}
+
+{
+    our %Block;
+    BEGIN { %Block = (a => 2) };
+    is %Block<a>, 2, 'block-bodied BEGIN write to an `our` hash survives';
+}
+
+{
+    our @List;
+    BEGIN @List = (1, 2);
+    is @List.join(','), '1,2', 'BEGIN write to an `our` array survives';
+}
+
+# The scalar case, which always worked — pinned so it cannot regress.
+{
+    our $Scalar;
+    BEGIN $Scalar = 5;
+    is $Scalar, 5, 'BEGIN write to an `our` scalar survives';
+}
+
+# --- a fresh declaration still installs an empty container of the right type -
+{
+    our %Fresh;
+    is %Fresh.^name, 'Hash', 'a never-written `our %` declares a Hash';
+    is %Fresh.elems, 0, '...and it is empty';
+
+    our @Fresh;
+    is @Fresh.^name, 'Array', 'a never-written `our @` declares an Array';
+    is @Fresh.elems, 0, '...and it is empty';
+}
+
+# --- an explicit initializer still runs, including an empty one -------------
+{
+    our %Init = (a => 1);
+    is %Init<a>, 1, '`our %h = (...)` assigns';
+    our %Init2 = (a => 1);
+    %Init2 = ();
+    is %Init2.elems, 0, 'a later explicit empty assignment still clears';
+
+    our @Init = (1, 2);
+    is @Init.join(','), '1,2', '`our @a = (...)` assigns';
+}
+
+# --- a bare redeclaration preserves what is already there -------------------
+{
+    our %Re = (a => 1);
+    our %Re; #OK
+    is %Re<a>, 1, 'bare `our %` redeclaration preserves pairs';
+
+    our @Re = (1, 2);
+    our @Re; #OK
+    is @Re.join(','), '1,2', 'bare `our @` redeclaration preserves elements';
+}
+
+# --- a bare `our` container in a sub body accumulates across calls ----------
+{
+    sub bump() { our %Count; %Count<n>++ }
+    bump; bump;
+    our %Count;
+    is %Count<n>, 2, 'a bare `our %` in a sub body accumulates across calls';
+}
+
+# --- expression position takes the same path --------------------------------
+{
+    our %Expr;
+    BEGIN %Expr = (a => 3);
+    my $h = (our %Expr); #OK
+    is $h<a>, 3, 'expression-position bare `our %` loads the package variable';
+
+    my $fresh = (our %ExprFresh);
+    is $fresh.^name, 'Hash', 'a never-written expression-position `our %` is a Hash';
+}
+
+# --- a package-scoped declaration reaches its qualified name ----------------
+{
+    module M7953 {
+        our @T;
+        BEGIN @T = (7, 8);
+    }
+    is @M7953::T.join(','), '7,8', 'a module scope keeps its `our @` BEGIN-time value';
+}


### PR DESCRIPTION
## The bug

```
$ mutsu -e 'our %Store; BEGIN %Store = (a => 1); say %Store<a>;'
(Any)
$ raku  -e 'our %Store; BEGIN %Store = (a => 1); say %Store<a>;'
1
```

The write was not lost anywhere exotic: a `BEGIN` phaser body runs **before** the declaration statement that precedes it in the source, and the declaration then overwrote the populated container with an empty one — silently, with no error, which is worse than failing. `our @L; BEGIN @L = (1,2)` gave `[]` the same way, while an `our` *scalar* and a `my` container both survived.

## Root cause

The compiler already had the right mechanism, applied to one sigil too few. The parser synthesizes a default RHS for every uninitialized declaration, and its shape differs by sigil: `Literal(Nil)` for `$`/`&`, an empty `Literal(Array)` for `@`, and an empty `Expr::Hash` for `%`. The `our` path tested only for the first:

```rust
let is_our_redecl_nil =
    *is_our && matches!(expr, Expr::Literal(lit) if lit.is_nil());
```

A match loaded the existing package variable (`OpCode::GetOurVar`) — which is why `our $x = 3; ... our $x` preserved the 3. A `%`/`@` declaration failed that test, took the ordinary compile-RHS-and-store path, and reset the container on **every execution of the declaration**.

That second half is the wider bug, and the `BEGIN` repro is only its most visible face. The reset also fired on each call of a sub holding a bare `our` container:

```raku
sub bump() { our %Count; %Count<n>++ }
bump; bump;
our %Count; say %Count<n>;    # was 1, rakudo says 2
```

## Fix

- The `my` path already had a correct "is this the parser-synthesized default" predicate, including the `__has_initializer` trait check that keeps an explicit `our %h = ()` distinguishable from a bare `our %h;`. Extracted as `Compiler::is_synthesized_decl_default` and now shared by both paths; the `our` test is spelled in terms of it.
- `GetOurVar` needed one matching case: it answered `Value::NIL` for a name with nothing stored, which is right for a scalar but would have made a first-ever `our %h;` declare `Nil` rather than an empty `Hash`. It now defaults by sigil — an empty `Array` for `@`, an empty `Hash` for `%`, `Nil` otherwise.
- The expression-position declaration path (`my $x = (our %h)`) carried the same gap in its own container branch and gets the same treatment, so both paths load rather than reset.

No new slow-path fallback; the change is entirely in codegen plus one opcode's default.

## Where it was reached

Found by P5 triage of the first full-corpus ecosystem sweep (#7785) through **`PDF::Content`** — `lib/PDF/Content/Ops.rakumod:248` opens `BEGIN %Store = (`, a large compile-time operator table. `our %H; BEGIN %H = (...)` is the standard way to build a lookup table once at compile time, so the construct is not obscure.

## Tests

`t/modules/our-container-decl-preserves-value.t` — 17 assertions, run against the rakudo oracle and mutsu with identical output: the `BEGIN` repros for `%`, `@` and `$`; fresh-declaration type and emptiness; explicit initializers (including an explicit `= ()` clear) still running; bare redeclaration preserving contents; the sub-body accumulation case; expression position; and a `module`-scoped declaration reaching its qualified name.

Verified locally before publishing:

- `cargo fmt --all` — clean
- `make lint` (all four configurations) — clean
- `make test` — **PASS**, 4011 files / 42675 tests
- `make roast` — the only three red files are `roast/6.c/S32-io/file-tests.t` (`Failed: 4`), `roast/S16-filehandles/filetest.t` (`Failed: 25`) and `roast/S32-io/IO-Socket-Async.t` (exit 124), which are exactly the container-only failures documented in [`docs/agent-environments.md`](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) (`uid 0` and sandboxed network), with matching counts. Nothing else failed.

Closes #7953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfzzfGWMb6ED6bTZKHgjHq

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfzzfGWMb6ED6bTZKHgjHq)_