### PR TITLE
fix: align builtin MOP ancestry queries

### DIFF
--- a/news/2026-09/builtin-mop-uses-catalog-ancestry.md
+++ b/news/2026-09/builtin-mop-uses-catalog-ancestry.md
@@ -1,0 +1,16 @@
+# Builtin MOP queries preserve concrete and parametrized ancestry
+
+`.^isa` now follows the builtin type catalog for concrete values, so queries
+such as `"x".^isa(Cool)`, `True.^isa(Int)`, and `1.5.Rat.^isa(Cool)` agree with
+Rakudo. Previously every non-package receiver returned `0` from this MOP
+entry point even though ordinary `.isa` and method dispatch already knew the
+correct ancestry.
+
+`.^mro` also now expands parametrized builtin type names through their base
+catalog row. `Array[Int].^mro` therefore includes `Array`, `List`, `Cool`,
+`Any`, and `Mu` after the parametrized head instead of stopping at
+`Array[Int]`.
+
+The regression coverage is in `t/oo/class/builtin-catalog-mro.t`.
+
+Closes #7937.

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -576,7 +576,12 @@ impl Interpreter {
                     ValueView::Package(name) => name.resolve(),
                     ValueView::Instance { class_name, .. } => class_name.resolve(),
                     ValueView::RakuAst(node) => node.class.printed_name().to_string(),
-                    _ => return Ok(Value::int(0)),
+                    // Concrete builtin values do not have a Package view, but
+                    // their dispatch owner chain carries the same nominal
+                    // ancestry as the corresponding type object.  Use that
+                    // chain instead of treating every concrete receiver as an
+                    // unrelated type.
+                    _ => self.mop_receiver_owner(&args[0]),
                 };
                 let other_name = match args[1].view() {
                     ValueView::Package(name) => name.resolve(),

--- a/src/runtime/methods_classhow_mro.rs
+++ b/src/runtime/methods_classhow_mro.rs
@@ -23,7 +23,24 @@ impl Interpreter {
             // name the catalog does not model).
             match crate::builtins::builtin_type_catalog::builtin_type_info(class_name.as_str()) {
                 Some(info) => info.mro.iter().map(|s| s.to_string()).collect(),
-                None => vec![class_name.clone()],
+                None => {
+                    // A parametrized builtin type object (for example,
+                    // `Array[Int]`) is not itself a catalog row.  Its MRO is
+                    // the parametrized name followed by the base type's
+                    // catalog chain, just as the registry and receiver
+                    // classifier already model it.
+                    if let Some((base, _)) = class_name.split_once('[')
+                        && class_name.ends_with(']')
+                        && let Some(info) =
+                            crate::builtins::builtin_type_catalog::builtin_type_info(base)
+                    {
+                        let mut mro = vec![class_name.clone()];
+                        mro.extend(info.mro.iter().map(|s| s.to_string()));
+                        mro
+                    } else {
+                        vec![class_name.clone()]
+                    }
+                }
             }
         };
         // A grammar's MRO threads through Grammar -> Match -> Capture -> Cool.

--- a/t/oo/class/builtin-catalog-mro.t
+++ b/t/oo/class/builtin-catalog-mro.t
@@ -10,7 +10,7 @@ use Test;
 #
 # Every expectation below is raku's own `.^mro` (Rakudo 2026.06).
 
-plan 20;
+plan 24;
 
 # --- the catalog rows themselves ---------------------------------------------
 
@@ -41,6 +41,16 @@ is mro-of(ArrayHeir), "ArrayHeir Array List Cool Any Mu",
 class StrHeir is Str { }
 is mro-of(StrHeir), "StrHeir Str Cool Any Mu",
     'a second heir of a different builtin gets its own tail, not the first one';
+
+# --- the MOP uses the same ancestry for values and type objects --------------
+is-deeply "x".^isa(Cool), 1,
+    'concrete Str values use the catalog for .^isa';
+is-deeply True.^isa(Int), 1,
+    'concrete Bool values use the catalog for .^isa';
+is-deeply 1.5.Rat.^isa(Cool), 1,
+    'concrete Rat values use the catalog for .^isa';
+is mro-of(Array[Int]), "Array[Int] Array List Cool Any Mu",
+    'a parametrized builtin type splices its base catalog MRO';
 
 # --- the ancestry is the one dispatch actually uses ---------------------------
 # `.^mro` could be right while the chain the method walk consults is wrong, so


### PR DESCRIPTION
## Summary

- make `.^isa` use the dispatch ancestry for concrete builtin values
- splice the base builtin catalog MRO into parametrized type names such as `Array[Int]`
- add regression coverage and a news entry

Closes #7937.

## Verification

- `make lint`
- `make test`
- `make roast`
