### PR TITLE
fix(parser): preserve enum export value lists

### DIFF
--- a/news/2026-09/enum-export-space-and-slip.md
+++ b/news/2026-09/enum-export-space-and-slip.md
@@ -1,0 +1,4 @@
+Enum declarations now preserve value lists after `is export`, including the
+space-separated form and literal names supplied through `slip`.
+
+Fixes #7948.

--- a/src/parser/stmt/decl/enum_decl.rs
+++ b/src/parser/stmt/decl/enum_decl.rs
@@ -25,6 +25,56 @@ fn register_enum_values(variants: &[(String, Option<Expr>)]) {
     }
 }
 
+/// Collect literal names supplied by top-level `slip` entries in a dynamic
+/// parenthesized enum body. The runtime still evaluates the complete body, but
+/// the parser needs these names before the following statements are parsed so
+/// they are treated as complete enum-value terms.
+pub(in crate::parser::stmt) fn collect_dynamic_enum_value_names(
+    body: &Expr,
+    out: &mut Vec<String>,
+) {
+    let Expr::ArrayLiteral(items) = body.peel_parens() else {
+        return;
+    };
+    for item in items {
+        let Expr::Call { name, args } = item.peel_parens() else {
+            continue;
+        };
+        if name.resolve() != "slip" {
+            continue;
+        }
+        for arg in args {
+            collect_literal_enum_value_names(arg, out);
+        }
+    }
+}
+
+fn collect_literal_enum_value_names(expr: &Expr, out: &mut Vec<String>) {
+    match expr.peel_parens() {
+        Expr::Literal(value) | Expr::LiteralSrc(value, _) => {
+            if let Some(name) = value.as_str()
+                && !out.iter().any(|existing| existing == name)
+            {
+                out.push(name.to_string());
+            }
+        }
+        Expr::ArrayLiteral(items) | Expr::BracketArray(items, _) => {
+            for item in items {
+                collect_literal_enum_value_names(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn register_dynamic_enum_values(body: &Expr) {
+    let mut names = Vec::new();
+    collect_dynamic_enum_value_names(body, &mut names);
+    for name in names {
+        super::super::simple::register_user_enum_value(&name);
+    }
+}
+
 /// Skip a balanced `[...]` role-parameterization argument. Returns the input
 /// past the closing `]`, or `None` when the input does not start with `[`.
 fn skip_balanced_brackets(input: &str) -> Option<&str> {
@@ -397,6 +447,7 @@ pub(super) fn parse_enum_decl_body_with_type(
             None => {
                 // Computed body (operators like `X~`, `Z=>`, `|`, a `%hash`, …):
                 // keep the whole expression and let the runtime build the enum.
+                register_dynamic_enum_values(&body);
                 return Ok((
                     r,
                     Stmt::EnumDecl {

--- a/src/parser/stmt/decl/helpers.rs
+++ b/src/parser/stmt/decl/helpers.rs
@@ -102,10 +102,10 @@ pub(super) fn parse_export_trait_tags(input: &str) -> PResult<'_, Vec<String>> {
 /// parentheses, so `is export (A => 1)` and `is export (:A(1))` must be left
 /// for the enum parser.
 pub(super) fn has_export_tag_argument(input: &str) -> bool {
-    let Ok((rest, _)) = ws(input) else {
-        return false;
-    };
-    let Some(mut inner) = rest.strip_prefix('(') else {
+    // Whitespace is significant here. `is export(:tag)` is a trait argument,
+    // while `is export (:value, ...)` starts the enum's value list. Consuming
+    // the whitespace would make those two spellings indistinguishable.
+    let Some(mut inner) = input.strip_prefix('(') else {
         return false;
     };
     inner = inner.trim_start_matches(|c: char| c.is_whitespace() || c == ',');

--- a/src/parser/stmt/decl/mod.rs
+++ b/src/parser/stmt/decl/mod.rs
@@ -13,6 +13,7 @@ mod use_decl;
 // Re-export public items that were previously accessible from the flat `decl` module.
 pub(in crate::parser) use constant_subset::inline_subset_term;
 pub(in crate::parser::stmt) use constant_subset::{constant_decl, constant_stmt, subset_decl};
+pub(in crate::parser::stmt) use enum_decl::collect_dynamic_enum_value_names;
 pub(crate) use enum_decl::{anon_enum_decl, enum_decl};
 pub(in crate::parser::stmt) use handles::parse_handle_specs;
 pub(in crate::parser::stmt) use has_decl::has_decl;

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -723,6 +723,12 @@ fn collect_module_enum_values(stmts: &[Stmt], out: &mut Vec<String>) {
                         .map(|(name, _)| name.clone())
                         .filter(|name| name != "__DYNAMIC__" && !name.is_empty()),
                 );
+                if variants.len() == 1
+                    && variants[0].0 == "__DYNAMIC__"
+                    && let Some(body) = variants[0].1.as_ref()
+                {
+                    super::super::decl::collect_dynamic_enum_value_names(body, out);
+                }
             }
             Stmt::ClassDecl { body, .. }
             | Stmt::RoleDecl { body, .. }

--- a/t/lib/EnumExportSpaceAndSlipFixture.rakumod
+++ b/t/lib/EnumExportSpaceAndSlipFixture.rakumod
@@ -1,0 +1,3 @@
+unit module EnumExportSpaceAndSlipFixture;
+
+our enum ImportedSlip is export (:30IMPORTED_A, slip <IMPORTED_B IMPORTED_C>);

--- a/t/modules/import-export/enum-export-space-and-slip.t
+++ b/t/modules/import-export/enum-export-space-and-slip.t
@@ -1,0 +1,42 @@
+use lib 't/lib';
+use Test;
+
+use EnumExportSpaceAndSlipFixture;
+
+# A space after `is export` means that the following parenthesized expression
+# is the enum value list, not the export trait's own argument list. A `slip`
+# in that list is evaluated at runtime, but its literal names must still be
+# known while parsing the statements that follow it.
+enum SpacedExport is export (:10SPACED_A, :11SPACED_B);
+enum SpacedSlip is export (:20LOCAL_A, slip <LOCAL_B LOCAL_C>);
+
+plan 11;
+
+is SPACED_A.value, 10, 'space after is export keeps the first enum value';
+is SPACED_B.value, 11, 'space after is export keeps later enum values';
+
+my $spaced-match = 'not matched';
+given SPACED_B {
+    when SPACED_B { $spaced-match = 'matched' }
+}
+is $spaced-match, 'matched', 'spaced export enum values are complete parse-time terms';
+
+is LOCAL_A.value, 20, 'a dynamic enum keeps its explicit value';
+is LOCAL_B.value, 21, 'a slipped enum value follows the explicit value';
+is LOCAL_C.value, 22, 'later slipped enum values auto-increment';
+
+my $local-match = 'not matched';
+given LOCAL_B {
+    when LOCAL_B { $local-match = 'matched' }
+}
+is $local-match, 'matched', 'slipped local values are known to the parser';
+
+is IMPORTED_A.value, 30, 'an imported dynamic enum keeps its explicit value';
+is IMPORTED_B.value, 31, 'an imported slipped enum value is registered';
+is IMPORTED_C.value, 32, 'an imported slipped enum value auto-increments';
+
+my $imported-match = 'not matched';
+given IMPORTED_B {
+    when IMPORTED_B { $imported-match = 'matched' }
+}
+is $imported-match, 'matched', 'imported slipped values are known to the parser';


### PR DESCRIPTION
Closes #7948

## Summary
- preserve the whitespace distinction between `is export(:tag)` and `is export (:value, ...)`
- pre-register literal names supplied through dynamic enum `slip` expressions for parse-time bareword matching
- cover local and imported enum values with regression tests

## Validation
- `make check-t-layout`
- `make lint`
- `make test`
- `make roast`