### PR TITLE
fix: keep self-referential when matchers intact

### DIFF
--- a/news/2026-09/when-self-and-own-type-matchers.md
+++ b/news/2026-09/when-self-and-own-type-matchers.md
@@ -1,0 +1,2 @@
+`when self { ... }` and matchers using the current class or role name now
+parse correctly, including fully-qualified names in `unit class` bodies.

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -594,6 +594,10 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
         break;
     }
 
+    // A type can refer to itself from its own methods. Register its name before
+    // parsing the body so `when Name { ... }` is recognized as a type matcher
+    // instead of a bareword call that gobbles the block.
+    super::super::simple::register_user_type(&name);
     let (rest, mut body) = {
         let _pkg = super::super::simple::push_package_path(&name);
         block(r)?
@@ -625,10 +629,6 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             _ => None,
         })
     });
-    // Register the class name so the parser can disambiguate identifiers
-    // from regex/substitution operators (e.g. `S` vs `S///`).
-    super::super::simple::register_user_type(&name);
-
     // Record `is export` operator methods so `import ClassName` teaches the
     // parser the new operator symbols (`method infix:<as> is export` makes `as`
     // a usable infix in code parsed after the `import`).

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -307,6 +307,10 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                 Some(crate::ast::Expr::Literal(Value::str(kw))),
             ));
         }
+        // `stmt_list` parses the rest of a `unit class` as this declaration's
+        // body. Register the type before returning so body methods can use the
+        // fully-qualified name in a `when` matcher.
+        super::super::simple::register_user_type(&name);
         return Ok((
             r,
             with_meta_stmts(
@@ -418,6 +422,9 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
             break;
         }
         let (r, _) = opt_char(r, ';');
+        // `stmt_list` parses the rest of a `unit role` as this declaration's
+        // body, so make the declaration visible before that parsing starts.
+        super::super::simple::register_user_type(&name);
         let mut body: Vec<Stmt> = Vec::new();
         for (role_name, args) in parent_roles.into_iter().rev() {
             body.insert(
@@ -501,6 +508,8 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
             parents.push("Grammar".to_string());
         }
         let (r, _) = opt_char(r, ';');
+        // A `unit grammar` also captures the remainder of the compilation unit
+        // as its body; register its name before that body is parsed.
         super::super::simple::register_user_type(&name);
         return Ok((
             r,

--- a/src/parser/stmt/class/role_decl.rs
+++ b/src/parser/stmt/class/role_decl.rs
@@ -417,6 +417,10 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
         break;
     }
 
+    // A role can refer to itself from its own methods. Register its name before
+    // parsing the body so `when RoleName { ... }` is recognized as a type
+    // matcher instead of a bareword call that gobbles the block.
+    super::super::simple::register_user_type(&name);
     // No package path is pushed for a role body: the scope inside a role is
     // generic, so Raku refuses to install an `our`-scoped declaration there and
     // there is no composed name to register.
@@ -452,7 +456,6 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
             },
         );
     }
-    super::super::simple::register_user_type(&name);
     // `role R { ... }.^name` is one expression; see `reject_trailing_postfix`.
     super::reject_trailing_postfix(rest)?;
 

--- a/src/parser/stmt/control/given_when.rs
+++ b/src/parser/stmt/control/given_when.rs
@@ -77,6 +77,11 @@ pub(crate) fn when_stmt(input: &str) -> PResult<'_, Stmt> {
 fn bareword_names_known_term(name: &str) -> bool {
     use crate::parser::stmt::simple;
     use crate::runtime::utils;
+    // `self` is the current method invocant, never a routine call. Keep it in
+    // the known-term set so `when self { ... }` leaves the block to `when`.
+    if name == "self" {
+        return true;
+    }
     // A type smiley (`when Map:D { }`, `when Channel:U { }`) can only attach to
     // a type name, so the name is never a routine call whatever the base is —
     // an undeclared base is a different diagnostic ("Type ... is not declared").

--- a/t/control/when-undeclared-type-gobbles-block.t
+++ b/t/control/when-undeclared-type-gobbles-block.t
@@ -93,4 +93,58 @@ is $smiley, "matched", 'type smiley matcher still matches';
 lives-ok { EVAL 'given DeclaredHere { when DeclaredHere { 1 }; default { 0 } }' },
     'EVAL sees the calling unit\'s declared types as declared';
 
+# `self` is a complete term in a method and must not be mistaken for a
+# listop head that consumes the `when` body.
+class WhenSelfMatcher {
+    method describe($thing) {
+        given $thing {
+            when self { 'same object' }
+            default   { 'other' }
+        }
+    }
+}
+my $self-matcher = WhenSelfMatcher.new;
+is $self-matcher.describe($self-matcher), 'same object',
+    '`when self` keeps the matcher block in a method';
+is $self-matcher.describe(WhenSelfMatcher.new), 'other',
+    '`when self` still distinguishes a different object';
+
+# A class/role name is visible while its own body is being parsed, including
+# the fully-qualified spelling of a `unit class` whose remaining compilation
+# unit is gathered as its body.
+my role WhenOwnRole {
+    method describe($thing) {
+        given $thing {
+            when WhenOwnRole { 'wrapped' }
+            default          { 'plain' }
+        }
+    }
+}
+my class WhenOwnNode does WhenOwnRole { }
+is WhenOwnNode.new.describe(WhenOwnNode.new), 'wrapped',
+    'a role can match its own name inside its body';
+
+class WhenOwnClass {
+    method describe($thing) {
+        given $thing {
+            when WhenOwnClass { 'same type' }
+            default            { 'other type' }
+        }
+    }
+}
+is WhenOwnClass.new.describe(WhenOwnClass.new), 'same type',
+    'a class can match its own name inside its body';
+
+my $qualified-type = EVAL q:to/UNIT/;
+unit class WhenMatcher::QualifiedThing;
+method describe($thing) {
+    given $thing {
+        when WhenMatcher::QualifiedThing { 'qualified' }
+        default                          { 'plain' }
+    }
+}
+UNIT
+is $qualified-type.new.describe($qualified-type.new), 'qualified',
+    'a unit class can match its fully-qualified name in its body';
+
 done-testing;


### PR DESCRIPTION
Fixes #7949.

Summary:
- recognize `self` as a complete `when` matcher term
- register class and role names before parsing their bodies
- register `unit` declarator names before the rest of the compilation unit is captured
- add regressions for self, class/role self-reference, and fully-qualified unit-class matchers

Validation:
- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast` (all tests passed except `roast/S03-buf/write-int.t`, which hit the existing 30-second per-file timeout under `prove -j4`; the individual file passed all 2530 tests with `MUTSU_FUDGE=1` and a 120-second timeout)