### PR TITLE
fix(vm): resolve a bareword against the running module's own scope before the caller's env

### DIFF
--- a/news/2026-09/module-scope-symbol-beats-the-callers-lexical.md
+++ b/news/2026-09/module-scope-symbol-beats-the-callers-lexical.md
@@ -1,0 +1,105 @@
+# A module's own file-scope symbol now beats the caller's same-named lexical
+
+A module's routine read the wrong scope's symbol whenever the program that
+loaded it happened to have a lexical of the same name:
+
+```raku
+# lib/EKUDefs2.rakumod
+unit module EKUDefs2;
+our Str enum U2 is export(:U2) « :zz<ZZ> »;
+
+# lib/EKU4.rakumod
+unit class EKU4;
+use EKUDefs2 :U2;
+method c() { zz }      # reads the imported key by its BARE spelling
+
+# t.raku
+my $zz = 5;            # <-- unrelated caller lexical, same name
+use EKU4;
+say EKU4.c.Str;
+```
+
+`raku` prints `ZZ`. mutsu printed `Use of uninitialized value of type Any`.
+Delete the `my $zz = 5;` line and mutsu printed `ZZ`, so the caller's lexical
+was the entire difference. The same happened for an imported sigil-less
+`constant` and for a module's own file-scope `constant`, so it was never
+specific to enums.
+
+## Root cause
+
+A module body executes in the env of whatever frame loaded it, and that binding
+is undone when the load ends. The module's own routines are therefore *not*
+served from the live `env` — they read `module_scope_lexicals` /
+`module_imported_lexical_names`, or, for a unit class's own `constant`, the
+package-qualified `our` store (`EKU4::mss-own`).
+
+`exec_get_bare_word_op` consulted the first of those as its **last** resort, and
+the package-qualified store only through `package_chain_var_fallback`, which
+anchors on `current_package` — GLOBAL while a method body runs, so it declined
+for exactly the methods that needed it. Both sat *below* the generic
+`env[name]` probe, so any same-named entry the caller left behind won.
+
+Two different caller entries won, at different times. On the first call the
+module saw the `Nil` / `Package("Any")` decl-seed placeholder that a mainline
+`my $x` leaves behind, and the bareword read as `Any`. On the second call of the
+same routine the caller's *real* value had reached the module's env, and the
+bareword read as `5`. Both are wrong, and the second is why a placeholder-only
+rule would not have been enough:
+
+```
+$ mutsu -I lib -e 'my $zz = 5; use EKU4; say EKU4.c.raku; say EKU4.c.raku;'
+Any
+5                     # raku: U2::zz both times
+```
+
+## Fix
+
+`running_module_bareword`, consulted immediately above the generic `env[name]`
+probe and gated — like the variable-read twin in `get_env_with_main_alias_sym` —
+on the running routine belonging to a unit compunit. It splits the three sources
+by whether a lexical could ever collide with them:
+
+- `module_imported_lexical` and the package-qualified `our` store answer
+  **unconditionally**. Neither namespace is one a lexical of the loading scope
+  can occupy — the second because its keys carry a `::` — and
+  `module_imported_lexical`'s existing contract is already "an imported alias
+  must beat the caller's same-named env entry".
+- `module_scope_lexicals` is keyed by bare name and *can* collide with a
+  captured local of the module's own routine, which must keep the name. It
+  answers only when `env` holds nothing, or nothing but a decl-seed placeholder.
+
+The `our`-store walk (`running_package_our_var`) anchors on
+`running_package_candidates` — the running-frame package list extracted from
+`lookup_in_running_package`, so both now agree on what "the running package" is
+instead of one of them re-deriving it from the GLOBAL `current_package`.
+
+Placement matters as much as the rule. The probe sits below every type route
+(`resolve_suppressed_type`, the type-object branch, `has_type`,
+`resolve_type_in_current_package`) and below the #7914 enum-key namespace probe,
+so exactly one thing is reordered: the env-alias fallback that was serving the
+wrong scope's symbol.
+
+## Still open
+
+The **mainline** half of the collision is untouched and deliberately so: in
+
+```raku
+my $cc = 'CALLER';
+use Mix1;      # exports `constant cc = 'CCVAL'`
+say cc;        # raku: CCVAL, mutsu: CALLER
+```
+
+both symbols genuinely share the one `env` key, so no precedence rule can
+separate them — that needs a storage namespace of the kind
+[#7914](https://github.com/tokuhirom/mutsu/issues/7914) gave enum keys, and
+#7914's own "Still shared" note already records it. The frame guard means this
+change cannot reach that case; verified under a debugger rather than inferred.
+
+Pinned by `t/modules/module-scope-symbol-beats-caller-lexical.t` (10 assertions
+against the fixtures `t/lib/ModuleScopeSymbolDefs.rakumod` and
+`t/lib/ModuleScopeSymbolUser.rakumod`, output verified identical against the
+rakudo oracle), which covers all three symbol kinds on both the first and the
+second call, the captured-local case that must *not* change, and the caller's
+own lexicals still reading as themselves.
+
+Closes #7960.

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -507,27 +507,43 @@ impl Interpreter {
         table: &'a crate::runtime::PackageKeyed<V>,
         name: &str,
     ) -> Option<&'a V> {
-        let current = self.current_package();
+        for candidate in self.running_package_candidates().into_iter().flatten() {
+            if let Some(found) = Self::lookup_in_package_chain(table, candidate, name) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    /// The packages a lookup anchored on "whatever routine is running" should
+    /// try, most specific first. Split out of [`Self::lookup_in_running_package`]
+    /// so a lookup that is NOT over a [`crate::runtime::PackageKeyed`] table —
+    /// the `our`-store walk in `Interpreter::running_package_our_var`, which
+    /// builds `Pkg::name` keys instead — anchors on exactly the same packages
+    /// rather than re-deriving its own notion of "the running package".
+    ///
+    /// Why the list is needed at all: `current_package` is GLOBAL while a
+    /// method body runs (module bodies execute under GLOBAL), so the owning
+    /// package has to come from the running frame — the method's class first,
+    /// then the nearest enclosing named routine (anonymous blocks inherit that
+    /// lexical owner), then whatever package is current.
+    pub(crate) fn running_package_candidates(&self) -> [Option<&str>; 4] {
         let frame = self
             .routine_stack
             .iter()
             .rev()
             .find(|frame| !frame.is_block)
             .or_else(|| self.routine_stack.last());
-        let candidates = [
+        [
             self.method_class_stack_top_str(),
             frame.and_then(|frame| frame.lexical_package.map(|pkg| pkg.as_str())),
             frame
                 .map(|frame| frame.package.as_str())
                 .filter(|pkg| !pkg.is_empty() && *pkg != "GLOBAL"),
-            Some(current.as_str()),
-        ];
-        for candidate in candidates.into_iter().flatten() {
-            if let Some(found) = Self::lookup_in_package_chain(table, candidate, name) {
-                return Some(found);
-            }
-        }
-        None
+            // The atomic `Symbol` mirror of `current_package`, which yields a
+            // `&'static str` instead of cloning the `String` behind the lock.
+            Some(self.current_package_sym().as_str()),
+        ]
     }
 
     /// Look `name` up in a per-package table starting from a *known* owner

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -240,6 +240,31 @@ impl Interpreter {
             // symbols in Raku. This notably affects `my $foo = foo.new`, whose RHS
             // resolves `foo` before the `$foo` slot is assigned.
             Value::package(Symbol::intern(&self.type_object_name_for_bareword(name)))
+        } else if let Some(module_val) = self.running_module_bareword(name) {
+            // A file-scope symbol of the running routine's OWN compunit —
+            // an imported enum key or `constant`, or one the module declared
+            // itself — beats whatever the scope that loaded the module left
+            // under the same `env` key (#7960).
+            //
+            // A module body executes in the loading frame's env, and that
+            // binding is undone when the load ends, so the module's own
+            // routines are served from `module_scope_lexicals` instead. That
+            // table was consulted only as the LAST resort, below every
+            // live-env route, which meant the caller's unrelated same-named
+            // lexical — very often just the `Nil`/`Package("Any")` decl-seed
+            // placeholder a mainline `my $x` leaves behind — answered the
+            // module's own bareword. It is the term-resolution twin of the
+            // redirect `get_env_with_main_alias_sym` already performs for a
+            // *variable* read, and carries the same frame guard.
+            //
+            // Placed here, immediately above the generic `env[name]` probe,
+            // rather than at the top of the chain: every type route
+            // (`resolve_suppressed_type`, the type-object branch just above,
+            // `has_type`, `resolve_type_in_current_package`) and the enum-key
+            // namespace probe (#7914) keep first refusal, so this reorders
+            // exactly one thing — the env-alias fallback that was serving the
+            // wrong scope's symbol.
+            module_val
         } else if let Some(v) = self.env().get(name) {
             if matches!(v.view(), ValueView::Enum { .. } | ValueView::Nil)
                 || matches!(v.view(), ValueView::Package(pkg) if pkg.resolve() != name)
@@ -533,6 +558,105 @@ impl Interpreter {
         let val = val.into_deref();
         self.stack.push(val);
         Ok(())
+    }
+
+    /// The value a bareword takes from the running routine's OWN compunit
+    /// scope, or `None` when the name is not one of that module's file-scope
+    /// symbols (#7960).
+    ///
+    /// Three sources, with deliberately different strengths — see the inline
+    /// comments for which is which and why. The split is the whole point of the
+    /// fix: two of them live in namespaces a lexical cannot occupy and so may
+    /// answer unconditionally, while the third is keyed by bare name and may
+    /// answer only when `env` holds no real binding.
+    ///
+    /// All are gated on the running routine belonging to a unit compunit, the
+    /// same `lexical_package` guard `get_env_with_main_alias_sym` uses for the
+    /// variable-read twin of this redirect. Outside such a routine the env key
+    /// IS the right scope and nothing here applies — in particular this leaves
+    /// the MAINLINE collision (`my $c` beside an imported `constant c`, both in
+    /// `env` under the one key) exactly as it was: that one needs a storage
+    /// namespace of the kind #7914 gave enum keys, not a precedence change.
+    fn running_module_bareword(&self, name: &str) -> Option<Value> {
+        if !self
+            .routine_stack()
+            .iter()
+            .rev()
+            .any(|frame| frame.lexical_package.is_some())
+        {
+            return None;
+        }
+        // Two namespaces a lexical of the loading scope can never occupy, so
+        // nothing is displaced by letting them answer first:
+        //
+        // - `module_imported_lexical`, whose contract already is "an imported
+        //   alias must beat the caller's same-named env entry";
+        // - the package-qualified `our` store, where a module's own file-scope
+        //   `constant` lives (`ModuleScopeSymbolUser::mss-own`). Its key
+        //   carries a `::`, which no lexical name can.
+        //
+        // Both must be unconditional rather than gated on the env entry being
+        // a placeholder: the caller's REAL value does reach the module's env —
+        // on the second call of the same routine, and on the first as soon as
+        // an unrelated `use` has run in between — so a placeholder-only rule
+        // fixes one call and leaves the next one wrong.
+        if let Some(v) = self.module_imported_lexical(name) {
+            return Some(v.clone());
+        }
+        if let Some(v) = self.running_package_our_var(name) {
+            return Some(v);
+        }
+        // `module_scope_lexicals` is keyed by BARE name, so it CAN collide with
+        // a captured local of the module's own routine — and such a local must
+        // win ("a captured local in an anonymous block must beat the module's
+        // own `our $name`", `module_imported_lexical`'s doc). Let it answer
+        // only when `env` holds nothing for the name, or holds nothing but the
+        // decl-seed placeholder a `my $x` leaves behind; a real value means a
+        // real binding, and that binding keeps the name.
+        let env_entry_is_placeholder = match self.env().get(name).map(Value::view) {
+            None => true,
+            Some(ValueView::Nil) => true,
+            Some(ValueView::Package(pkg)) => pkg.resolve() == "Any" && name != "Any",
+            Some(_) => false,
+        };
+        if !env_entry_is_placeholder {
+            return None;
+        }
+        self.module_scope_lexical(name).cloned()
+    }
+
+    /// The package-qualified `our`-store entry for a bare `name`, looked up
+    /// from every package the running routine could belong to
+    /// ([`Interpreter::running_package_candidates`]), each walked up its `::`
+    /// chain.
+    ///
+    /// This is the `our`-store half of what `package_chain_var_fallback`
+    /// already does further down the bareword chain, minus its
+    /// `package_lexicals` probe (bare-keyed, so subject to the same
+    /// captured-local collision as `module_scope_lexicals`) and minus its
+    /// anchor on `current_package` — which is GLOBAL while a method body runs,
+    /// so the plain entry point declines for exactly the methods that need it.
+    fn running_package_our_var(&self, name: &str) -> Option<Value> {
+        if crate::runtime::utils::has_double_colon(name) || name.is_empty() {
+            return None;
+        }
+        for candidate in self.running_package_candidates().into_iter().flatten() {
+            let mut pkg = candidate;
+            loop {
+                if !pkg.is_empty()
+                    && pkg != "GLOBAL"
+                    && !crate::runtime::utils::has_routine_scope_marker(pkg)
+                    && let Some(v) = self.get_our_var(&format!("{pkg}::{name}"))
+                {
+                    return Some(v.clone());
+                }
+                match pkg.rsplit_once("::") {
+                    Some((parent, _)) => pkg = parent,
+                    None => break,
+                }
+            }
+        }
+        None
     }
 
     /// Whether `name` currently has a sigilless binding in scope (`my \x`,

--- a/t/lib/ModuleScopeSymbolDefs.rakumod
+++ b/t/lib/ModuleScopeSymbolDefs.rakumod
@@ -1,0 +1,7 @@
+unit module ModuleScopeSymbolDefs;
+
+# An exported enum whose key is spelled with no sigil, and an exported
+# sigil-less constant. Both are read by their BARE name from the importing
+# module's own routines (see ModuleScopeSymbolUser).
+our Str enum MSSEnum is export(:MSS) « :mssz<ZZVAL> »;
+constant mss-const is export(:MSS) = 'CONSTVAL';

--- a/t/lib/ModuleScopeSymbolUser.rakumod
+++ b/t/lib/ModuleScopeSymbolUser.rakumod
@@ -1,0 +1,17 @@
+unit class ModuleScopeSymbolUser;
+
+use ModuleScopeSymbolDefs :MSS;
+
+# The module's OWN file-scope constant, declared here rather than imported.
+constant mss-own = 'OWNVAL';
+
+method imported-enum-key() { mssz }
+method imported-constant() { mss-const }
+method own-constant()      { mss-own }
+
+# A captured local must still beat the module's own file-scope name.
+method local-shadows-own() {
+    my $mss-own = 'LOCAL';
+    my $block = { $mss-own };
+    $block()
+}

--- a/t/modules/module-scope-symbol-beats-caller-lexical.t
+++ b/t/modules/module-scope-symbol-beats-caller-lexical.t
@@ -1,0 +1,63 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# A module's routine must read its OWN file-scope symbols — an imported enum
+# key, an imported sigil-less `constant`, or one the module declared itself —
+# regardless of what the scope that loaded the module happens to have under the
+# same name.
+#
+# A module body executes in the loading frame's env and that binding is undone
+# when the load ends, so those symbols are served from `module_scope_lexicals`
+# (and, for a unit class's own `constant`, from the package-qualified `our`
+# store). Both were consulted only as the LAST resort in bareword resolution,
+# below every live-env route, so the caller's unrelated same-named lexical
+# answered instead — very often just the `Any` decl-seed placeholder a mainline
+# `my $x` leaves behind, making the module's symbol read as `Any`. See #7960;
+# #7914 is the same collision in the live-`env` store.
+#
+# The declarations live in t/lib/ModuleScopeSymbolDefs.rakumod and
+# t/lib/ModuleScopeSymbolUser.rakumod. The `my` declarations below are the
+# colliding caller lexicals; they are deliberately assigned, because an
+# ASSIGNED caller lexical is what the second and later calls of the same module
+# routine used to see (the first saw the placeholder).
+
+my $mssz      = 'CALLER-ENUM';    #OK deliberately collides
+my $mss-const = 'CALLER-CONST';   #OK deliberately collides
+my $mss-own   = 'CALLER-OWN';     #OK deliberately collides
+
+use ModuleScopeSymbolUser;
+
+plan 10;
+
+my $u = ModuleScopeSymbolUser;
+
+# --- the reported repro: an imported enum key read by its bare spelling ------
+is $u.imported-enum-key.Str, 'ZZVAL',
+    'a module reads its imported enum key, not the caller lexical';
+is $u.imported-enum-key.Str, 'ZZVAL',
+    '...and again on the second call, where the caller value is no longer a placeholder';
+is $u.imported-enum-key.raku, 'MSSEnum::mssz',
+    'the value is the enum key itself, not a look-alike string';
+
+# --- an imported sigil-less constant -----------------------------------------
+is $u.imported-constant, 'CONSTVAL',
+    'a module reads its imported constant, not the caller lexical';
+is $u.imported-constant, 'CONSTVAL', '...and again on the second call';
+
+# --- the module's own file-scope constant ------------------------------------
+is $u.own-constant, 'OWNVAL',
+    'a module reads its own file-scope constant, not the caller lexical';
+is $u.own-constant, 'OWNVAL', '...and again on the second call';
+
+# --- what must NOT change ----------------------------------------------------
+# A captured local inside the module still beats the module's own file-scope
+# name: the module-scope tables are consulted for a bare declaration only when
+# `env` holds nothing or a decl-seed placeholder, never over a real value.
+is $u.local-shadows-own, 'LOCAL',
+    'a captured local still beats the module`s own file-scope constant';
+
+# The caller's own lexicals are untouched — this is a bareword-resolution
+# change, not a change to how `$x` reads.
+is $mssz, 'CALLER-ENUM', 'the caller lexical still reads as itself';
+is $mss-own, 'CALLER-OWN', 'and so does the one colliding with the own-constant';


### PR DESCRIPTION
## The bug

A module's routine read the wrong scope's symbol whenever the program that loaded it happened to have a lexical of the same name.

```raku
# lib/EKUDefs2.rakumod
unit module EKUDefs2;
our Str enum U2 is export(:U2) « :zz<ZZ> »;

# lib/EKU4.rakumod
unit class EKU4;
use EKUDefs2 :U2;
method c() { zz }      # reads the imported key by its BARE spelling

# t.raku
my $zz = 5;            # <-- unrelated caller lexical, same name
use EKU4;
say EKU4.c.Str;
```

`raku -I lib t.raku` prints `ZZ`. mutsu printed `Use of uninitialized value of type Any in string context.` Delete the `my $zz = 5;` line and mutsu printed `ZZ`, so the caller's lexical was the entire difference. Reproduces identically for an imported sigil-less `constant` and for a module's own file-scope `constant`, so it was never enum-specific.

## Root cause

A module body executes in the env of whatever frame loaded it, and that binding is undone when the load ends. The module's own routines are therefore **not** served from the live `env` — they read `module_scope_lexicals` / `module_imported_lexical_names`, or, for a unit class's own `constant`, the package-qualified `our` store (`EKU4::mss-own`).

`exec_get_bare_word_op` consulted the first of those as its **last** resort, and reached the second only through `package_chain_var_fallback`, which anchors on `current_package` — GLOBAL while a method body runs, so it declined for exactly the methods that needed it. Both sat *below* the generic `env[name]` probe, so any same-named entry the caller left behind won.

Two different caller entries won, at different times, which matters for the shape of the fix:

```
$ mutsu -I lib -e 'my $zz = 5; use EKU4; say EKU4.c.raku; say EKU4.c.raku;'
Any                   # first call: the decl-seed placeholder a mainline `my $x` leaves behind
5                     # second call: the caller's REAL value has reached the module's env
                      # raku: U2::zz both times
```

So a "only when the env entry is a placeholder" rule would have fixed one call and left the next one wrong.

## Fix

`running_module_bareword`, consulted immediately above the generic `env[name]` probe and gated — like the variable-read twin in `get_env_with_main_alias_sym` — on the running routine belonging to a unit compunit. It splits its three sources by whether a lexical could ever collide with them:

- **`module_imported_lexical` and the package-qualified `our` store answer unconditionally.** Neither namespace is one a lexical of the loading scope can occupy — the second because its keys carry a `::` — and `module_imported_lexical`'s existing doc contract is already *"an imported alias must beat the caller's same-named env entry"*.
- **`module_scope_lexicals` is keyed by bare name** and *can* collide with a captured local of the module's own routine, which must keep the name (the other half of that same contract: *"a captured local in an anonymous block must beat the module's own `our $name`"*). It answers only when `env` holds nothing, or nothing but a decl-seed placeholder.

The `our`-store walk (`running_package_our_var`) anchors on `running_package_candidates`, the running-frame package list extracted from `lookup_in_running_package`, so both now agree on what "the running package" is instead of one of them re-deriving it from the GLOBAL `current_package`.

Placement matters as much as the rule: the probe sits below every type route (`resolve_suppressed_type`, the type-object branch, `has_type`, `resolve_type_in_current_package`) and below the #7914 enum-key namespace probe, so exactly one thing is reordered — the env-alias fallback that was serving the wrong scope's symbol. This is the narrower of the two alternatives the issue laid out, and it does not require re-keying `module_scope_lexicals` / `module_imported_lexical` everywhere they are populated and consulted.

## Deliberately still open

The **mainline** half of the collision is untouched:

```raku
my $cc = 'CALLER';
use Mix1;      # exports `constant cc = 'CCVAL'`
say cc;        # raku: CCVAL, mutsu: CALLER
```

There both symbols genuinely share the one `env` key, so no precedence rule can separate them — that needs a storage namespace of the kind #7914 gave enum keys, and #7914's own "Still shared" note already records it. I confirmed under `rust-gdb` (not by inference) that the frame guard makes this change decline before reaching any module table at mainline, so that case is byte-for-byte as it was.

## Tests

`t/modules/module-scope-symbol-beats-caller-lexical.t` — 10 assertions against two new fixtures, run on both mutsu and the rakudo oracle with identical output. Covers all three symbol kinds (imported enum key, imported constant, module's own constant) on both the first and the second call, plus the two things that must *not* change: a captured local still beating the module's own file-scope name, and the caller's own lexicals still reading as themselves.

Verified locally before publishing:

- `cargo fmt --all` — clean
- `make lint` (all four configurations) — clean
- `make test` — **PASS**, 4012 files / 42689 tests
- `make roast` — the only three red files are `roast/6.c/S32-io/file-tests.t` (`Failed: 4`), `roast/S16-filehandles/filetest.t` (`Failed: 25`) and `roast/S32-io/IO-Socket-Async.t` (exit 124), exactly the container-only failures documented in [`docs/agent-environments.md`](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) (`uid 0` and sandboxed network), with matching counts. Nothing else failed.

Closes #7960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfzzfGWMb6ED6bTZKHgjHq

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfzzfGWMb6ED6bTZKHgjHq)_