### PR TITLE
fix(parser): a tag-exported routine is a routine at parse time too

### DIFF
--- a/docs/adr/0087-runtime-export-hook-parse-time-approximation.md
+++ b/docs/adr/0087-runtime-export-hook-parse-time-approximation.md
@@ -91,6 +91,21 @@ The gate on "the module declares `sub EXPORT`" is what keeps the
 over-approximation confined. A module with `is export` traits is unaffected; the
 approximation only ever applies where the scan's current answer is the empty set.
 
+> **Amended 2026-09-11 ([#7939](https://github.com/tokuhirom/mutsu/issues/7939)).**
+> The decision here is unchanged, but it now covers a second case, so the
+> sentence above no longer holds as written: a module with `is export` traits
+> *is* affected, in one bounded way. The scan used to keep only the subs whose
+> export trait carried the `DEFAULT` or `MANDATORY` tag; it now keeps every
+> `is export` sub whatever tag it carries. The tag filter could not implement
+> import semantics in the first place — `register_module_exports` is handed the
+> module name and never the importer's tag list, so it could not tell `use M`
+> (where a `:extra` sub really is not imported) from `use M :extra` (where it
+> is), and guessed wrong for every tagged import. The soundness argument above
+> carries over verbatim: the widened set is still parse-time knowledge only,
+> and a name the importer's tag list withholds still fails to resolve at run
+> time. Pinned by `t/modules/import-export/imported-listop-angle-arg.t` and
+> `t/modules/import-export/tag-export-parse-time-only.t`.
+
 ## Alternatives considered
 
 ### 1. Load modules at parse time (rakudo's model)

--- a/news/2026-09/tag-exported-listop-parse.md
+++ b/news/2026-09/tag-exported-listop-parse.md
@@ -1,0 +1,80 @@
+# A tag-exported routine is a routine at parse time too
+
+`imported-listop <a b c>` is one of Raku's most ordinary shapes, and it is
+only a call if the parser already knows the identifier names a routine. When
+it does not, `<` is taken as infix less-than and the quote-word list is a hard
+parse error — while the parenthesised `imported-listop(<a b c>)` form keeps
+working, which is the tell that the problem is the parser's knowledge rather
+than the code.
+
+mutsu answers that question with a per-module scan: every `use`d module is
+pre-parsed for the names it exports, and those names land in
+`Scope::imported_functions`. [ADR-0087](../../docs/adr/0087-runtime-export-hook-parse-time-approximation.md)
+extended the scan to modules that compute their exports through a run-time
+`sub EXPORT` hook. This entry closes the remaining hole in the same scan.
+
+## The hole
+
+The scan kept only the subs whose `is export` trait carried the `DEFAULT` or
+`MANDATORY` tag. A sub exported under a custom tag — `sub joined(*@w) is
+export(:extra)` — was dropped from the set entirely, so:
+
+```raku
+use ImportedListopAngle :extra;
+say (joined <a b c>);
+```
+
+died during the parse:
+
+```
+===SORRY!=== Error while compiling -e
+Confused. expected statement: expected expression after infix operator or ...
+------>use ImportedListopAngle :extra; say (joined <a b c>);
+                                       ^
+```
+
+against `a-b-c` from `raku`, even though `:extra` is exactly the tag that
+imports `joined`.
+
+The filter was reasonable-looking and wrong for a structural reason:
+`register_module_exports` is handed the *module name* and nothing else. It
+never sees the importer's tag list, so it cannot distinguish "plain `use M`,
+where a `:extra` sub is genuinely not imported" from "`use M :extra`, where it
+is". Filtering on the tag therefore did not implement import semantics; it
+just guessed, and guessed wrong for every tagged import.
+
+## The fix
+
+Both collection sites — the AST walk (`collect_exported_subs`) and the regex
+fallback (`extract_exported_names_fallback`) — now collect every `is export`
+sub whatever tag it carries.
+
+That is a deliberate superset, and it is sound for the same reason ADR-0087's
+approximation is: the set is parse-time knowledge only. Its every consumer is
+a parser decision about whether an identifier is a routine, while run-time
+name resolution is a separate path that still resolves against the real
+import set. So a name the importer's tag list withholds is still not callable
+— it fails as an undeclared symbol, exactly as it did before — and the cost of
+the superset is a worse diagnostic for such a name, never a change in the
+meaning of a program that runs. `tag-export-parse-time-only.t` pins that
+directly: in a unit that asks only for `:extra`, the tagged name parses and
+runs, and `EVAL 'root("abcd")'` on the module's `DEFAULT` name still throws
+`X::Undeclared::Symbols`, the same exception `raku` throws.
+
+Tag-exported *operators* were already unaffected: `sub infix:<dbl> is
+export(:ops)` reaches the parser's operator matchers through the separate
+user-operator scan, so `use TagOps :ops; 3 dbl 4` worked throughout.
+
+## Pins
+
+Two new files under `t/modules/import-export/`, both of which pass unmodified
+under `raku` as well as mutsu:
+
+- `imported-listop-angle-arg.t` — the call shapes, for an untagged export and
+  a tagged one: `<a b c>`, `<<a b c>>`, `qw{}`, a postfix on the result, and
+  the negative direction (`1 < 2` and `1 < 2 < 3` must stay comparisons). The
+  untagged half was the shape [#7939](https://github.com/tokuhirom/mutsu/issues/7939)
+  reported and had no regression test of its own; it had been fixed for the
+  `sub EXPORT` path by ADR-0087 shortly before that issue was filed, and this
+  pins it for the ordinary `is export` path.
+- `tag-export-parse-time-only.t` — the soundness half described above.

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -835,37 +835,45 @@ fn collect_exported_subs(stmts: &[Stmt], exports: &mut HashMap<String, InlineMod
             Stmt::SubDecl {
                 name,
                 is_export,
-                export_tags,
                 associativity,
                 precedence_trait,
                 is_test_assertion,
                 ..
             } if *is_export => {
-                // Only include subs that are in the DEFAULT or MANDATORY export tags.
-                // Subs tagged only with custom tags (e.g. :others) should not be
-                // imported by a plain `use Module`.
-                if export_tags
-                    .iter()
-                    .any(|t| t == "DEFAULT" || t == "MANDATORY")
-                {
-                    let precedence = precedence_trait.as_ref().and_then(|(trait_name, ref_op)| {
-                        resolve_op_precedence(ref_op).map(|ref_level| match trait_name.as_str() {
-                            "tighter" => ref_level + 5,
-                            "looser" => ref_level - 5,
-                            _ => ref_level,
-                        })
-                    });
-                    let resolved = name.resolve();
-                    exports.insert(
-                        resolved.clone(),
-                        InlineModuleExport {
-                            name: resolved,
-                            precedence,
-                            associativity: associativity.clone(),
-                            is_test_assertion: *is_test_assertion,
-                        },
-                    );
-                }
+                // Every `is export` sub is collected, whatever tag it carries.
+                // The tag decides which `use` *imports* the name; it does not
+                // decide whether the name is a routine, and this set answers
+                // only the latter question (ADR-0087): it lands in
+                // `Scope::imported_functions`, whose every consumer is a
+                // parser decision such as "is `joined <a b c>` a listop call
+                // or an infix `<`". Filtering by DEFAULT/MANDATORY here made
+                // `use M :extra; joined <a b c>` a hard parse error even
+                // though `:extra` does import `joined` -- the scan is given
+                // the module name only, never the importer's tag list, so it
+                // cannot tell that case from a plain `use M` (#7939).
+                //
+                // Run-time name resolution is a separate path that honours
+                // the tags, so a name the importer's tag list withholds still
+                // fails to resolve; the superset costs a worse diagnostic for
+                // such a name and can never change the meaning of a program
+                // that runs.
+                let precedence = precedence_trait.as_ref().and_then(|(trait_name, ref_op)| {
+                    resolve_op_precedence(ref_op).map(|ref_level| match trait_name.as_str() {
+                        "tighter" => ref_level + 5,
+                        "looser" => ref_level - 5,
+                        _ => ref_level,
+                    })
+                });
+                let resolved = name.resolve();
+                exports.insert(
+                    resolved.clone(),
+                    InlineModuleExport {
+                        name: resolved,
+                        precedence,
+                        associativity: associativity.clone(),
+                        is_test_assertion: *is_test_assertion,
+                    },
+                );
             }
             Stmt::ProtoDecl {
                 name, is_export, ..
@@ -897,7 +905,9 @@ fn extract_exported_names_fallback(source: &str) -> Vec<(String, bool)> {
     // `multi sub foo(...) is export`
     // `proto sub foo(|) is export`
     // Group 2 captures the declaration text between the name and `is export`,
-    // which may include a `is test-assertion` trait; group 3 is the export tag list.
+    // which may include a `is test-assertion` trait; group 3 is the export tag
+    // list, matched only so a tagged `is export(:foo)` is recognised as an
+    // export at all -- its contents are not consulted (see below).
     let sub_re = Regex::new(
         r"\b(?:our\s+)?(?:proto\s+|multi\s+)?sub\s+([A-Za-z_][A-Za-z0-9_'\-]*)\b([^;{]*)\bis\s+export\b(\s*\([^)]*\))?",
     )
@@ -914,9 +924,10 @@ fn extract_exported_names_fallback(source: &str) -> Vec<(String, bool)> {
     let mut names: HashMap<String, bool> = HashMap::new();
     for re in [&sub_re, &proto_re] {
         for caps in re.captures_iter(source) {
-            if let Some(name) = caps.get(1)
-                && is_default_export_from_regex_match_group(&caps, 3)
-            {
+            // Group 3 (the `is export(...)` tag list) is deliberately not
+            // consulted: like the AST walk above, this set is parse-time
+            // routine-name knowledge, not the importer's actual import set.
+            if let Some(name) = caps.get(1) {
                 let prefix = caps.get(2).map(|m| m.as_str()).unwrap_or("");
                 let is_ta = test_assertion_re.is_match(prefix);
                 let entry = names.entry(name.as_str().to_string()).or_insert(false);
@@ -928,19 +939,6 @@ fn extract_exported_names_fallback(source: &str) -> Vec<(String, bool)> {
     let mut names: Vec<(String, bool)> = names.into_iter().collect();
     names.sort();
     names
-}
-
-/// Check if an `is export(...)` match should be included in the DEFAULT import set.
-/// If no tag list is present (`is export` bare), it's DEFAULT.
-/// If a tag list is present, include only if it mentions DEFAULT or MANDATORY.
-fn is_default_export_from_regex_match_group(caps: &regex::Captures, group: usize) -> bool {
-    match caps.get(group) {
-        None => true, // bare `is export` → DEFAULT
-        Some(tag_match) => {
-            let tag_text = tag_match.as_str();
-            tag_text.contains("DEFAULT") || tag_text.contains("MANDATORY")
-        }
-    }
 }
 
 /// What `use Test` puts in scope, as a parse-time shortcut.

--- a/t/lib/ImportedListopAngle.rakumod
+++ b/t/lib/ImportedListopAngle.rakumod
@@ -1,0 +1,27 @@
+# A module in the `String::Utils` shape, exported through the ordinary
+# `is export` trait (the common case) rather than a run-time `sub EXPORT`
+# hook (pinned separately by `runtime-export-listop-parse.t`).
+#
+# `root` is String::Utils' own routine: the longest common prefix of its
+# arguments. The point of the fixture is the *call shape* the importer uses,
+# `root <abcd abce abde>` -- which only parses as a call if the parser
+# already knows the imported name is a routine.
+
+unit module ImportedListopAngle;
+
+sub root(*@strings) is export {
+    return "" unless @strings;
+    my $first = @strings[0];
+    my $len = $first.chars;
+    for @strings -> $s {
+        my $i = 0;
+        $i++ while $i < $len && $i < $s.chars
+                   && $s.substr($i, 1) eq $first.substr($i, 1);
+        $len = $i;
+    }
+    $first.substr(0, $len)
+}
+
+sub tally(*@words) is export { @words.elems }
+
+sub joined(*@words) is export(:extra) { @words.join("-") }

--- a/t/modules/import-export/imported-listop-angle-arg.t
+++ b/t/modules/import-export/imported-listop-angle-arg.t
@@ -1,0 +1,62 @@
+use v6;
+use Test;
+
+# `imported-listop <a b c>` only parses as a call if the parser already knows
+# the imported name is a routine. When it does not, `<` is taken as the infix
+# less-than and the quote-word list is a hard parse error -- while the
+# parenthesised `imported-listop(<a b c>)` form works fine, which is the tell.
+#
+# mutsu's parser pre-scans every `use`d module for the names it exports to
+# answer exactly that question. The scan used to keep only the subs whose
+# `is export` trait carried the DEFAULT or MANDATORY tag, so a sub exported
+# under a custom tag was invisible to it -- even for an importer that asked
+# for that tag, because the scan is handed the module name and never the
+# importer's tag list.
+#
+# `tag-export-parse-time-only.t` pins the other half: widening the scan is
+# parse-time knowledge only, and must not make a withheld name callable.
+#
+# https://github.com/tokuhirom/mutsu/issues/7939
+
+plan 12;
+
+use lib 't/lib';
+use ImportedListopAngle :extra, :DEFAULT;
+
+# `root` is exported untagged (DEFAULT). This half is the shape the issue
+# reported: an ordinary `is export` listop with a quote-word argument.
+is root(<abcd abce abde>), 'ab',
+    'the parenthesised call form works';
+
+is (root <abcd abce abde>), 'ab',
+    'a listop call with a quote-word argument parses';
+
+is (root <abcd abcd abcd>), 'abcd',
+    'a quote-word list of identical words parses';
+
+is (root <foo bar baz>), '',
+    'a quote-word list with no common prefix parses';
+
+is (root <foo>), 'foo',
+    'a single-element quote-word list parses';
+
+is (root <<abcd abce>>), 'abc',
+    'a double-angle quote-word argument parses';
+
+is (root qw{abcd abce}), 'abc',
+    'a qw{} argument parses';
+
+is (root <abcd abce>).chars, 3,
+    'a postfix applies to the listop call result, not to the argument';
+
+is (tally <a b c>), 3,
+    'a second untagged export parses as a listop too';
+
+# `joined` is exported only under `:extra`. Before the fix this line was a
+# parse error, not a wrong answer.
+is (joined <a b c>), 'a-b-c',
+    'a tag-exported listop with a quote-word argument parses';
+
+# The listop reading must not swallow a genuine comparison.
+ok (1 < 2), 'infix < still parses as less-than';
+ok (1 < 2 < 3), 'a chained infix < still parses';

--- a/t/modules/import-export/tag-export-parse-time-only.t
+++ b/t/modules/import-export/tag-export-parse-time-only.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+# The parser's per-module export scan now collects every `is export` sub
+# regardless of the tag it carries, because that set answers a parse-time
+# question ("is this name a routine?") and the scan is never told which tags
+# the importer actually asked for. See `imported-listop-angle-arg.t`.
+#
+# This file pins the other side of that widening: it is parse-time knowledge
+# only. Run-time name resolution still resolves against the real import set,
+# so a name the importer's tag list withholds stays uncallable. Without that,
+# the widening would silently import names raku does not.
+#
+# This unit asks for `:extra` alone, so `joined` is imported and `root`
+# (exported untagged, i.e. DEFAULT) is not.
+#
+# https://github.com/tokuhirom/mutsu/issues/7939
+
+plan 3;
+
+use lib 't/lib';
+use ImportedListopAngle :extra;
+
+is (joined <a b c>), 'a-b-c',
+    'the tag this unit asked for is imported, and parses as a listop';
+
+my $result = try EVAL 'root("abcd")';
+nok $result.defined,
+    'a DEFAULT-tag name this unit did not ask for is not callable';
+is $!.^name, 'X::Undeclared::Symbols',
+    'and it fails as an undeclared symbol, not as a call to something else';


### PR DESCRIPTION
`imported-listop <a b c>` only parses as a call if the parser already knows the identifier names a routine. When it does not, `<` is taken as the infix less-than and the quote-word list is a hard parse error — while the parenthesised `imported-listop(<a b c>)` form keeps working, which is the tell.

## What #7939 reported, and what was actually left

The issue's own repro no longer reproduces. `6741eb58` ("approximate a `sub EXPORT` module's exports at parse time", ADR-0087, closing #7881) landed at 05:26 UTC on 2026-09-11, about an hour *before* #7939 was filed; the ecosystem record it was measured against sits at `mutsu_commit: 1557d41`, which predates it. Verified against the real `String::Utils` 0.0.40 tarball: `t/01-basic.rakutest` parses and runs 121/124, no parse error at line 33.

But the same root cause survives one step over, for **tag-exported** routines:

```raku
use M :extra;            # M has: sub joined(*@w) is export(:extra) { ... }
say (joined <a b c>);
```

| | output |
|---|---|
| `raku` | `a-b-c` |
| `mutsu` (before) | `===SORRY!=== Confused. expected statement: expected expression after infix operator or ...` |

Byte-for-byte the failure mode in the issue's title.

## Root cause

The parse-time export scan kept only the subs whose `is export` trait carried the `DEFAULT` or `MANDATORY` tag, so a tag-exported sub was dropped from the set entirely.

That filter could not implement import semantics in the first place: `register_module_exports` is handed the **module name** and nothing else. It never sees the importer's tag list, so it cannot distinguish a plain `use M` (where a `:extra` sub genuinely is not imported) from `use M :extra` (where it is). It was not filtering, it was guessing — and guessed wrong for every tagged import.

## The fix

Both collection sites — the AST walk (`collect_exported_subs`) and the regex fallback (`extract_exported_names_fallback`) — now collect every `is export` sub whatever tag it carries.

A deliberate superset, sound for the same reason ADR-0087's approximation is: the set is **parse-time knowledge only**. It lands in `Scope::imported_functions`, whose every consumer is a parser decision about whether an identifier is a routine, while run-time name resolution is a separate path that still resolves against the real import set. A name the importer's tag list withholds therefore stays uncallable — it fails as `X::Undeclared::Symbols`, exactly as `raku` does. The cost of the superset is a worse diagnostic for such a name, never a change in the meaning of a program that runs.

Tag-exported *operators* were already unaffected: `sub infix:<dbl> is export(:ops)` reaches the operator matchers through the separate user-operator scan, so `use TagOps :ops; 3 dbl 4` worked throughout.

## Tests

Two new files under `t/modules/import-export/`, **both of which pass unmodified under `raku` as well as mutsu**:

- `imported-listop-angle-arg.t` — the call shapes for an untagged export and a tagged one: `<a b c>`, `<<a b c>>`, `qw{}`, a postfix on the result, and the negative direction (`1 < 2` and `1 < 2 < 3` must stay comparisons). The untagged half is the shape #7939 literally names; it had been fixed for the `sub EXPORT` path by ADR-0087 but had no regression test of its own for the ordinary `is export` path.
- `tag-export-parse-time-only.t` — the soundness half: in a unit asking only for `:extra`, the tagged name parses and runs, and `EVAL 'root("abcd")'` on the module's `DEFAULT` name still throws `X::Undeclared::Symbols`.

ADR-0087 gets a dated amendment: the decision is unchanged, but it now covers this second case, so its "a module with `is export` traits is unaffected" sentence no longer held as written.

## Verification

- `make test` — **PASS**, 4013 files / 42694 tests, all successful.
- `make roast` — 1435 files / 219511 tests. The only failures are the three documented container-only ones from `docs/agent-environments.md`, matching their recorded shapes exactly: `6.c/S32-io/file-tests.t` (Failed: 4) and `S16-filehandles/filetest.t` (Failed: 25) because the container runs as `uid 0`, and `S32-io/IO-Socket-Async.t` (exit 124, ran 17) because of the sandboxed network.
- `make lint` — clean across all four configurations (default clippy, `jit` off, wasm32, rustdoc).
- `String::Utils` unchanged at 121/124 on `01-basic`, and `02-selective-importing.rakutest` — the dist's own selective-import file — still passes in full.

Closes #7939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CLSteRVgVA9qXRM4muga5

---
_Generated by [Claude Code](https://claude.ai/code/session_017CLSteRVgVA9qXRM4muga5)_