### PR TITLE
fix: find distribution metadata above deep modules

### DIFF
--- a/news/2026-09/resources-find-deep-module-meta.md
+++ b/news/2026-09/resources-find-deep-module-meta.md
@@ -1,0 +1,2 @@
+`%?RESOURCES` now finds a distribution's `META6.json` for modules nested four
+or more namespace segments below `lib/`.

--- a/src/runtime/run_dist.rs
+++ b/src/runtime/run_dist.rs
@@ -178,7 +178,7 @@ impl Interpreter {
     /// unrelated directory tree with no META6.json anywhere above it.
     pub(super) fn find_real_distribution_meta6(source_path: &Path) -> Option<Value> {
         let mut dir = source_path.parent()?;
-        for _ in 0..4 {
+        loop {
             let meta_path = dir.join("META6.json");
             if meta_path.exists()
                 && let Ok(content) = fs::read_to_string(&meta_path)
@@ -190,7 +190,6 @@ impl Interpreter {
             }
             dir = dir.parent()?;
         }
-        None
     }
 
     /// Detect a distribution (META6.json) for the given module source path.

--- a/t/lib/ResDeep/META6.json
+++ b/t/lib/ResDeep/META6.json
@@ -1,0 +1,15 @@
+{
+  "name": "ResDeep",
+  "description": "Fixture distribution whose four-segment module reads a resource",
+  "version": "0.0.1",
+  "auth": "zef:mutsu",
+  "perl": "6.d",
+  "provides": {
+    "A::B::C::D": "lib/A/B/C/D.rakumod"
+  },
+  "resources": [
+    "hello.txt"
+  ],
+  "depends": [],
+  "license": "Artistic-2.0"
+}

--- a/t/lib/ResDeep/lib/A/B/C/D.rakumod
+++ b/t/lib/ResDeep/lib/A/B/C/D.rakumod
@@ -1,0 +1,5 @@
+unit module A::B::C::D;
+
+sub deep-resource-text is export {
+    %?RESOURCES<hello.txt>.slurp(:close).trim
+}

--- a/t/lib/ResDeep/resources/hello.txt
+++ b/t/lib/ResDeep/resources/hello.txt
@@ -1,0 +1,1 @@
+hello from the deep resource

--- a/t/modules/resources-in-required-module.t
+++ b/t/modules/resources-in-required-module.t
@@ -1,8 +1,9 @@
 use v6;
-use lib 't/lib/ResCaller/lib', 't/lib/ResDist/lib', 't/lib/ResInner/lib';
+use lib 't/lib/ResCaller/lib', 't/lib/ResDist/lib', 't/lib/ResInner/lib',
+    't/lib/ResDeep/lib';
 use Test;
 
-plan 3;
+plan 4;
 
 # `%?RESOURCES` is lexically tied to the compilation unit that contains the
 # token, so a module's own mainline/`BEGIN` must see ITS distribution's
@@ -26,3 +27,7 @@ is $greeting, 'hello from the ResInner resources',
 # The plain `use` path must keep working too.
 lives-ok { EVAL 'use ResDist; ResDist.greeting' },
     '%?RESOURCES still resolves on the `use` path';
+
+use A::B::C::D;
+is deep-resource-text(), 'hello from the deep resource',
+    '%?RESOURCES finds META6.json above a four-segment module path';


### PR DESCRIPTION
## Summary

- walk upward to the filesystem root when resolving a module's META6.json
- add a four-segment module fixture that reads a resource through %?RESOURCES
- document the fix in news/

## Validation

- `prove -v -e scripts/run-t-test.sh t/modules/resources-in-required-module.t`
- `make lint`
- `make test` (4011 files, 42685 tests)
- `make roast` (1435 files, 219534 tests)

Fixes #7952.