### PR TITLE
ci: avoid apt dependencies in wasm e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -676,7 +676,10 @@ jobs:
       - name: Install Playwright
         run: |
           npm install playwright
-          npx playwright install --with-deps chromium
+          # `--with-deps` is the only apt consumer in this job and can hang
+          # when the Ubuntu mirror stalls; ubuntu-latest already ships the
+          # shared libraries Chromium needs.
+          npx playwright install chromium
 
       - name: Run E2E tests
         run: node site/e2e.test.mjs

--- a/news/2026-09/wasm-e2e-playwright-no-apt.md
+++ b/news/2026-09/wasm-e2e-playwright-no-apt.md
@@ -1,0 +1,5 @@
+The WASM end-to-end job now installs Chromium without Playwright's
+`--with-deps` apt step, avoiding Ubuntu mirror stalls on runners that already
+provide the required shared libraries.
+
+Fixes #7958.


### PR DESCRIPTION
Closes #7958

## Summary
- install Playwright Chromium without `--with-deps` in the wasm-e2e job
- avoid the apt mirror dependency that can stall the 15-minute job timeout
- keep the existing mirror setup for other CI paths

## Validation
- `ci.yml` parses as YAML
- `make lint`
- `make test`
- `make roast`