### PR TITLE
fix(parser): accept traits on regex declarators, and stack `so`/`not` under a tight prefix

### DIFF
--- a/news/2026-09/regex-declarator-traits-and-stacked-loose-unary.md
+++ b/news/2026-09/regex-declarator-traits-and-stacked-loose-unary.md
@@ -1,0 +1,83 @@
+# Two parse failures off the `blocked_load` index: regex-declarator traits and a prefixed whatever-curry
+
+[#7954](https://github.com/tokuhirom/mutsu/issues/7954) is the located index of the largest single
+`blocked_load` bucket from the first full-corpus ecosystem sweep: 56 distributions whose load dies
+on a hard parse error. Three of its rows were reduced to one-liners that diverge from rakudo on
+their own; one of those (`BEGIN` writing an `our`-scoped `%`/`@`) was already filed separately as
+[#7953](https://github.com/tokuhirom/mutsu/issues/7953). This entry is the other two.
+
+## 1. `my token X is export { ... }` — a regex declarator took no traits at all
+
+`Collection` (`lib/Collection/Entities.rakumod:11`) and `Number::More`
+(`lib/Number/More.rakumod:21`) both open with an exported token:
+
+```raku
+my token all-bases is export(:token-all-bases) { ... }
+```
+
+`token_decl` went straight from the (optional) signature to the `{ ... }` body, so the `is` landed
+in expression position and the whole compilation unit died with `Confused. expected statement`.
+That is the worst shape a parse gap can take: one unimplemented trait costs the entire
+distribution, not the one declaration.
+
+A regex declarator is a routine, so it now takes the routine trait grammar — the same
+`parse_sub_traits` that `sub`, `method` and `proto token` already use. `is export` is the trait with
+semantics here; every other one is accepted and dropped, which is strictly better than reinstating
+the hard failure for the next trait nobody has implemented yet.
+
+Making it *parse* is only half the row. In rakudo, `my token digits is export` exports a `Regex`
+under `&digits`, and both `&digits` and `<digits>` resolve in the importer. mutsu keeps regex
+declarators in `Registry::token_defs` rather than `Registry::functions` (ADR-0009: a token has no
+compiled body), and a *lexical* one is dropped by the block-scope restore when the module's own
+scope exits — so an export table entry alone would have imported nothing. The defs are therefore
+captured at declaration time (`Interpreter::exported_token_defs`, keyed by the module being loaded)
+and re-installed under the importing package by `import_module`. Since `&name` is a lazy by-name
+`Routine` that resolves through `resolve_token_defs`, that one registration is what makes both
+spellings work:
+
+```raku
+use ExportedRegexDeclarator;         # my token digits is export { \d+ }
+say ~("abc42" ~~ &digits);           # 42
+say so "abc42" ~~ / <digits> /;      # True
+```
+
+Tag filtering rides on the existing export machinery, so `is export(:wordy)` stays hidden from a
+plain `use` and arrives with `use Mod :wordy`.
+
+Pin: `t/grammar/token-declarator-is-export.t` (8 assertions, green under rakudo too), with the
+module fixture `t/lib/ExportedRegexDeclarator.rakumod`.
+
+## 2. `!so *` — `so` and `not` did not stack under a tighter prefix
+
+`Linux::NFTables` (`lib/Linux/NFTables.rakumod:29`) constrains a parameter with a prefixed
+whatever-curry:
+
+```raku
+multi method buffer-output(Bool $active where !so * --> Bool)
+```
+
+`so *` on its own parsed; `!so *` did not. `so` and `not` are prefix operators in Raku, and prefixes
+stack — `!so *` is one prefix chain over the term `*`, whose precedence is that of the *loosest*
+prefix in it. mutsu only knew `so` at loose-unary statement level, so `!`'s operand was parsed as an
+ordinary tight prefix expression, `so` was read as a bare term, and the `*` that followed became an
+infix multiply with nothing on its right — "expected expression after multiplicative operator".
+
+`prefix_expr` now recognises a loose `so`/`not` in operand position and parses the rest of the chain
+at loose-unary precedence. The curry then composes over the whole chain, matching rakudo:
+
+```raku
+my $c = !so *;   say $c.WHAT;   # (WhateverCode)
+say $c(False);                  # True
+say !so 1 == 2;                 # True — still !(so(1 == 2))
+```
+
+The existing reading of a non-Whatever operand is unchanged (and, if anything, tightened towards
+rakudo: the old identifier-call path swallowed its argument at list-prefix precedence, looser than
+loose unary).
+
+Pin: `t/lang/operators/prefix-stacked-loose-unary.t` (9 assertions, green under rakudo too).
+
+## Scope
+
+#7954 is an index, not one fix, and stays open: the remaining rows span roughly twenty distinct
+constructs, and the two closed here are the ones the issue had already confirmed in isolation.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1151,6 +1151,10 @@ pub(crate) enum Stmt {
         is_my: bool,
         /// `our token foo` — package scoped; a duplicate is X::Redeclaration.
         is_our: bool,
+        /// `token foo is export` — the Regex is importable under `&foo`.
+        is_export: bool,
+        /// Tags named by `is export(:TAG)`; `["DEFAULT"]` for a bare `is export`.
+        export_tags: Vec<String>,
     },
     RuleDecl {
         name: Symbol,
@@ -1158,6 +1162,10 @@ pub(crate) enum Stmt {
         param_defs: Vec<ParamDef>,
         body: Vec<Stmt>,
         multi: bool,
+        /// `rule foo is export` — the Regex is importable under `&foo`.
+        is_export: bool,
+        /// Tags named by `is export(:TAG)`; `["DEFAULT"]` for a bare `is export`.
+        export_tags: Vec<String>,
     },
     #[allow(dead_code)]
     ProtoToken {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4199,6 +4199,11 @@ pub(crate) struct CompiledTokenDeclPlan {
     /// role's deferred body, recompiled standalone at composition time with
     /// no line history — see `run_composed_role_deferred_body`).
     pub(crate) source_line: Option<i64>,
+    /// `token foo is export` — the registered Regex is also recorded as an
+    /// export of the enclosing package, so `use`-ing the module imports `&foo`.
+    pub(crate) is_export: bool,
+    /// Tags named by `is export(:TAG)`; `["DEFAULT"]` for a bare `is export`.
+    pub(crate) export_tags: Vec<String>,
 }
 
 /// Build a [`CompiledTokenDeclPlan`] from a `Stmt::TokenDecl`/`RuleDecl`.
@@ -4224,8 +4229,22 @@ fn build_token_decl_plan(stmt: &Stmt, source_line: Option<i64>) -> CompiledToken
             param_defs,
             body,
             multi,
+            ..
         } => (name, params, param_defs, body, *multi),
         _ => panic!("build_token_decl_plan expects TokenDecl/RuleDecl"),
+    };
+    let (is_export, export_tags) = match stmt {
+        Stmt::TokenDecl {
+            is_export,
+            export_tags,
+            ..
+        }
+        | Stmt::RuleDecl {
+            is_export,
+            export_tags,
+            ..
+        } => (*is_export, export_tags.clone()),
+        _ => unreachable!("build_token_decl_plan expects TokenDecl/RuleDecl"),
     };
     CompiledTokenDeclPlan {
         name: *name,
@@ -4234,6 +4253,8 @@ fn build_token_decl_plan(stmt: &Stmt, source_line: Option<i64>) -> CompiledToken
         multi,
         raw_body: body.clone(),
         source_line,
+        is_export,
+        export_tags,
     }
 }
 

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -368,7 +368,19 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
                 let (r, _) = ws(rest)?;
                 rest = r;
             }
-            let (rest, expr) = if op.parses_postfix_target() {
+            let (rest, expr) = if crate::parser::expr::precedence::is_loose_not_or_so_prefix(rest) {
+                // `so` and `not` are prefix operators in raku, and prefixes
+                // stack: `!so *` is one prefix chain over the term `*`, whose
+                // precedence is that of the LOOSEST prefix in it. Parsing the
+                // operand as an ordinary tight prefix expression left `so` to
+                // be read as a bare term, after which the `*` of `!so *` was
+                // an infix multiply with nothing on its right — a hard parse
+                // error on `sub f($a where !so *)` (Linux::NFTables).
+                crate::parser::expr::precedence::not_expr_mode(
+                    rest,
+                    crate::parser::expr::operators::ExprMode::Full,
+                )?
+            } else if op.parses_postfix_target() {
                 postfix_expr(rest)?
             } else {
                 prefix_expr(rest)?

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -73,7 +73,9 @@ pub(crate) use list_infix_top::{item_expr, list_infix_top};
 pub(crate) use logic::{
     assign_not_expr_mode, or_expr_mode, or_expr_no_assign_mode, word_logical_tail,
 };
-pub(crate) use logic2::{junctive_expr_mode, not_expr_mode, or_or_expr_mode};
+pub(crate) use logic2::{
+    is_loose_not_or_so_prefix, junctive_expr_mode, not_expr_mode, or_or_expr_mode,
+};
 pub(crate) use ternary::{comparison_nonassoc_key, structural_comparison_expr_mode};
 
 #[cfg(test)]

--- a/src/parser/stmt/class/grammar_module.rs
+++ b/src/parser/stmt/class/grammar_module.rs
@@ -79,6 +79,15 @@ pub(crate) fn token_decl(input: &str) -> PResult<'_, Stmt> {
         (rest, (Vec::new(), Vec::new()))
     };
 
+    // Traits between the signature and the body: `my token n is export { ... }`,
+    // `token n is export(:tag) { ... }`. A regex declarator is a routine, so it
+    // takes the routine trait grammar; `is export` is the one with semantics
+    // here (the Regex becomes importable under `&n`) and the rest are accepted
+    // and dropped, which is strictly better than the hard parse error a single
+    // unimplemented trait used to make of the whole compilation unit.
+    let (rest, traits) = crate::parser::stmt::parse_sub_traits_pub(rest)?;
+    let (is_export, export_tags) = (traits.is_export, traits.export_tags);
+
     let (rest, _) = ws(rest)?;
     let (rest, mut pattern) = parse_raw_braced_regex_body(rest)?;
     // An empty `token`/`regex`/`rule` body is a null regex.
@@ -110,6 +119,8 @@ pub(crate) fn token_decl(input: &str) -> PResult<'_, Stmt> {
                 param_defs,
                 body,
                 multi: is_multi,
+                is_export,
+                export_tags,
             },
         ))
     } else {
@@ -123,6 +134,8 @@ pub(crate) fn token_decl(input: &str) -> PResult<'_, Stmt> {
                 multi: is_multi,
                 is_my: false,
                 is_our: false,
+                is_export,
+                export_tags,
             },
         ))
     }

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -32,6 +32,16 @@ pub(crate) fn extract_exported_subs(
                     associativity.clone(),
                 ));
             }
+            // `token foo is export` / `rule foo is export` export a Regex under
+            // `&foo`, so they are importable names just like an exported sub.
+            Stmt::TokenDecl {
+                name, is_export, ..
+            }
+            | Stmt::RuleDecl {
+                name, is_export, ..
+            } if *is_export => {
+                names.push((name.to_string(), None, None));
+            }
             Stmt::SyntheticBlock(inner) => {
                 names.extend(extract_exported_subs(inner));
             }

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -888,6 +888,36 @@ fn collect_exported_subs(stmts: &[Stmt], exports: &mut HashMap<String, InlineMod
                         is_test_assertion: false,
                     });
             }
+            // `my token foo is export { ... }` exports a Regex under `&foo`,
+            // the same namespace a `sub foo is export` uses, so a plain
+            // `use Module` must learn the name too.
+            Stmt::TokenDecl {
+                name,
+                is_export,
+                export_tags,
+                ..
+            }
+            | Stmt::RuleDecl {
+                name,
+                is_export,
+                export_tags,
+                ..
+            } if *is_export => {
+                if export_tags
+                    .iter()
+                    .any(|t| t == "DEFAULT" || t == "MANDATORY")
+                {
+                    let resolved = name.resolve();
+                    exports
+                        .entry(resolved.clone())
+                        .or_insert(InlineModuleExport {
+                            name: resolved,
+                            precedence: None,
+                            associativity: None,
+                            is_test_assertion: false,
+                        });
+                }
+            }
             Stmt::Package { body, .. }
             | Stmt::ClassDecl { body, .. }
             | Stmt::RoleDecl { body, .. } => {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -13,6 +13,10 @@ pub(crate) type PackageLexicals = PackageKeyed<Value>;
 /// The full, specificity-sorted candidate list a multi dispatch frame carries
 /// (`push_multi_dispatch_frame`), shared between the frames that reuse it.
 pub(crate) type MultiCandidateList = std::sync::Arc<Vec<std::sync::Arc<FunctionDef>>>;
+
+/// `is export`-ed regex declarator bodies, keyed by the module that declared
+/// them and then by the declarator's name (see `Interpreter::exported_token_defs`).
+type ExportedTokenDefs = HashMap<String, HashMap<String, Vec<std::sync::Arc<FunctionDef>>>>;
 /// `(name, current package, frame lexical package) -> candidate list`: see
 /// `Interpreter::multi_dispatch_candidates_memo`.
 pub(crate) type MultiDispatchCandidatesMemo =
@@ -2669,6 +2673,17 @@ pub struct Interpreter {
     /// `is export` registration time so `import` can restore the `&name` env
     /// binding with the role mixed in, rather than just the plain FunctionDef.
     exported_sub_values: std::sync::Arc<HashMap<String, HashMap<String, Value>>>,
+    /// Regex bodies of `token`/`rule`/`regex` declarations marked `is export`,
+    /// keyed by the module being loaded and the declarator's name.
+    ///
+    /// A regex declarator does not live in `Registry::functions` like a sub —
+    /// it lives in `Registry::token_defs` (ADR-0009: no compiled body), and a
+    /// *lexical* one (`my token foo`) is dropped by the block-scope restore
+    /// when the module's own scope exits. So the defs are captured here at
+    /// registration time and re-installed under the importing package by
+    /// `import_module`, which is what makes both `&foo` and `<foo>` resolve in
+    /// the importer.
+    exported_token_defs: std::sync::Arc<ExportedTokenDefs>,
     /// Mirrored export tables for modules declared with `unit module X`
     /// when the actual runtime package registration used "GLOBAL".
     /// Populated during `load_module` so that `import_module` can perform

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1776,6 +1776,7 @@ impl Interpreter {
                 param_defs,
                 body,
                 multi,
+                ..
             } => (name, params, param_defs, body, *multi),
             _ => unreachable!("register_token_decl_from_stmt expects TokenDecl/RuleDecl"),
         };

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3063,6 +3063,7 @@ impl Interpreter {
             unit_module_packages: Default::default(),
             exported_subs: Default::default(),
             exported_sub_values: Default::default(),
+            exported_token_defs: Default::default(),
             exported_vars: Default::default(),
             unit_module_exported_subs: Default::default(),
             unit_module_loading_stack: Vec::new(),

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -49,6 +49,25 @@ impl Interpreter {
             .insert(name, val);
     }
 
+    /// Capture an `is export` regex declarator's bodies so `import_module` can
+    /// re-install them under the importing package. Keyed by the module being
+    /// loaded (any kind: unit, package-block or bare file), matching how
+    /// `register_exported_sub` attributes an export to its owner. Outside a
+    /// module load there is nothing to import into, so nothing is recorded.
+    pub(crate) fn record_exported_token_defs(
+        &mut self,
+        name: &str,
+        defs: Vec<std::sync::Arc<FunctionDef>>,
+    ) {
+        let Some(owner) = self.module_load_stack.last().cloned() else {
+            return;
+        };
+        crate::runtime::cow_table_mut(&mut self.exported_token_defs)
+            .entry(owner)
+            .or_default()
+            .insert(name.to_string(), defs);
+    }
+
     pub(crate) fn register_exported_sub(
         &mut self,
         package: String,
@@ -457,6 +476,26 @@ impl Interpreter {
             // in `proto_subs` as `GLOBAL::name` and this was invisible.)
             if imported_proto {
                 self.registry_mut().proto_subs_insert(target_single.clone());
+            }
+
+            // A `token`/`rule`/`regex` marked `is export` lives in
+            // `Registry::token_defs`, not `functions`, and a lexical one is
+            // dropped when the module's scope exits — so it is re-installed
+            // here from the defs captured at declaration time. Registering it
+            // under the importing package is what makes `&name` (a lazy
+            // by-name Routine) and `<name>` inside the importer's own regexes
+            // both resolve.
+            if let Some(defs) = self
+                .exported_token_defs
+                .get(module)
+                .and_then(|m| m.get(&name))
+                .cloned()
+            {
+                self.registry_mut()
+                    .token_defs
+                    .insert(Symbol::intern(&target_single), defs);
+                crate::runtime::regex_parse::TOKEN_DEFS_GEN
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
 
             // If this exported sub carried a trait-modified value (e.g. a role

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -702,6 +702,7 @@ impl Interpreter {
             exported_subs: self.exported_subs.clone(),
             exported_vars: self.exported_vars.clone(),
             exported_sub_values: self.exported_sub_values.clone(),
+            exported_token_defs: self.exported_token_defs.clone(),
             unit_module_exported_subs: self.unit_module_exported_subs.clone(),
             unit_module_loading_stack: Vec::new(),
             module_loading_unit_stack: Vec::new(),

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -1254,14 +1254,28 @@ impl Interpreter {
         plan_idx: u32,
     ) -> Result<(), RuntimeError> {
         let plan = &code.token_decl_plans[plan_idx as usize];
+        let name = plan.name.resolve();
         self.register_token_decl(
-            &plan.name.resolve(),
+            &name,
             &plan.params,
             &plan.param_defs,
             &plan.raw_body,
             plan.multi,
             plan.source_line,
         );
+        // `token foo is export` installs a Regex under `&foo`, exactly like a
+        // `sub foo is export` installs a Sub, so it is recorded in the same
+        // export table and `use`-ing the module imports it by name.
+        if plan.is_export && !self.suppress_exports {
+            let pkg = self.current_package().to_string();
+            let tags = plan.export_tags.clone();
+            let key = Symbol::intern(&format!("{}::{}", pkg, name));
+            let defs = self.registry().token_defs.get(&key).cloned();
+            if let Some(defs) = defs {
+                self.record_exported_token_defs(&name, defs);
+            }
+            self.register_exported_sub(pkg, name.to_string(), tags);
+        }
         Ok(())
     }
 

--- a/t/grammar/token-declarator-is-export.t
+++ b/t/grammar/token-declarator-is-export.t
@@ -1,0 +1,40 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# Regression (#7954, the `expected statement ...` parse-failure index): a
+# `token`/`regex`/`rule` declarator accepts traits, and `is export` makes the
+# Regex importable under `&name` exactly as `is export` on a sub does. Before
+# this, `my token all-bases is export { ... }` was a hard parse error that took
+# the whole compilation unit with it (Collection, Number::More).
+
+plan 8;
+
+# The declarator parses with a trait, with and without a scope declarator,
+# with and without a tag argument.
+lives-ok { EVAL 'my token t1 is export { \d+ }' }, 'my token ... is export parses';
+lives-ok { EVAL 'our token t2 is export { \d+ }' }, 'our token ... is export parses';
+lives-ok { EVAL 'token t3 is export(:tag) { \d+ }' }, 'token ... is export(:tag) parses';
+lives-ok { EVAL 'my rule t4 is export { \d+ }' }, 'my rule ... is export parses';
+lives-ok { EVAL 'my regex t5 is export { \d+ }' }, 'my regex ... is export parses';
+
+# An untagged export is NOT imported by a plain `use` — checked before any
+# tagged import, since a name stays visible once imported in this process.
+{
+    my $imported = True;
+    try {
+        $imported = EVAL q:to/CODE/;
+            use ExportedRegexDeclarator;
+            (&wordy ~~ Regex).so
+            CODE
+        CATCH { default { $imported = False } }
+    }
+    nok $imported, 'a tagged-only token is not imported by a plain use';
+}
+
+{
+    use ExportedRegexDeclarator;
+    is ~("abc42" ~~ &digits), '42', 'an exported token is importable as &name';
+    # The same import must also satisfy `<name>` inside the importer's regex.
+    ok "abc42" ~~ / <digits> /, 'an exported token resolves as <name> in a regex';
+}

--- a/t/lang/operators/prefix-stacked-loose-unary.t
+++ b/t/lang/operators/prefix-stacked-loose-unary.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# Regression (#7954, the `expected statement ...` parse-failure index): `so`
+# and `not` are prefix operators, so they stack under a tighter prefix and the
+# whole chain takes the LOOSEST prefix's precedence. Reading the operand of `!`
+# as an ordinary tight prefix expression left `so` as a bare term, after which
+# the `*` of `!so *` was an infix multiply with nothing on its right — a hard
+# parse error on `sub f($a where !so *)` (Linux::NFTables).
+
+plan 9;
+
+# The construct the index reduced to: a `where` clause holding a prefixed
+# whatever-curry.
+sub accepts-false(Bool $a where !so *) { 'ok' }
+is accepts-false(False), 'ok', 'a where clause takes a prefixed whatever-curry';
+dies-ok { accepts-false(True) }, 'and the constraint still rejects True';
+
+# The curry itself: the whole prefix chain currys, giving a WhateverCode.
+my $negated = !so *;
+isa-ok $negated, Callable, '!so * is a WhateverCode';
+is $negated(False), True, '!so * negates its argument';
+is $negated(1), False, '!so * is false for a true argument';
+is (?so *)(1), True, '?so * curries too';
+
+# The loosest prefix in the chain still owns the whole expression, so an infix
+# to the right of a non-Whatever operand is swallowed by `so`, not left to `!`.
+is (!so 1 == 2), True, '!so 1 == 2 is !(so(1 == 2))';
+is (!so 2 == 2), False, '!so 2 == 2 is !(so(2 == 2))';
+is (!not 0), False, '!not 0 stacks the same way';

--- a/t/lib/ExportedRegexDeclarator.rakumod
+++ b/t/lib/ExportedRegexDeclarator.rakumod
@@ -1,0 +1,12 @@
+unit module ExportedRegexDeclarator;
+
+# A `my token ... is export` (Collection, Number::More) — the Regex becomes
+# importable under `&name`.
+my token digits is export { \d+ }
+
+# A tagged export is hidden from a plain `use`.
+my token wordy is export(:wordy) { \w+ }
+
+# `regex` and `rule` take the same traits.
+my regex spaced-out is export { \s* }
+my rule two-words is export { \w+ \w+ }


### PR DESCRIPTION
Two of the three constructs [#7954](https://github.com/tokuhirom/mutsu/issues/7954)'s `blocked_load` parse-failure index had already confirmed in isolation. Both are hard parse errors, so each one costs the whole distribution rather than the one declaration. (The third, `BEGIN` writing an `our`-scoped `%`/`@`, is #7953 and not touched here.)

## 1. `my token X is export { ... }` — a regex declarator took no traits at all

`Collection` (`lib/Collection/Entities.rakumod:11`) and `Number::More` (`lib/Number/More.rakumod:21`) both open with an exported token. `token_decl` went straight from the (optional) signature to the `{ ... }` body, so the `is` landed in expression position and the compilation unit died with `Confused. expected statement`.

A regex declarator is a routine, so it now takes the routine trait grammar — the same `parse_sub_traits` that `sub`, `method` and `proto token` already use. `is export` is the trait with semantics here; every other one is accepted and dropped, which is strictly better than reinstating the hard failure for the next trait nobody has implemented yet.

Making it *parse* is only half the row. In rakudo `my token digits is export` exports a `Regex` under `&digits`, and both `&digits` and `<digits>` resolve in the importer. mutsu keeps regex declarators in `Registry::token_defs` rather than `Registry::functions` (ADR-0009: a token has no compiled body), and a *lexical* one is dropped by the block-scope restore when the module's own scope exits — so an export-table entry alone would have imported nothing. The defs are therefore captured at declaration time (`Interpreter::exported_token_defs`, keyed by the module being loaded) and re-installed under the importing package by `import_module`. Since `&name` is a lazy by-name `Routine` resolved through `resolve_token_defs`, that one registration is what makes both spellings work:

```raku
use ExportedRegexDeclarator;      # my token digits is export { \d+ }
say ~("abc42" ~~ &digits);        # 42
say so "abc42" ~~ / <digits> /;   # True
```

Tag filtering rides on the existing export machinery, so `is export(:wordy)` stays hidden from a plain `use` and arrives with `use Mod :wordy`.

## 2. `!so *` in a `where` clause — `so`/`not` did not stack under a tighter prefix

`Linux::NFTables` (`lib/Linux/NFTables.rakumod:29`) writes `multi method buffer-output(Bool $active where !so * --> Bool)`. `so *` alone parsed; `!so *` did not.

`so` and `not` are prefix operators in Raku, and prefixes stack — `!so *` is one prefix chain over the term `*`, whose precedence is that of the *loosest* prefix in it. mutsu only knew `so` at loose-unary statement level, so `!`'s operand was parsed as an ordinary tight prefix expression, `so` was read as a bare term, and the `*` that followed became an infix multiply with nothing on its right.

`prefix_expr` now recognises a loose `so`/`not` in operand position and parses the rest of the chain at loose-unary precedence, so the curry composes over the whole chain as rakudo does. The reading of a non-Whatever operand is unchanged (and, if anything, tightened towards rakudo: the old identifier-call path swallowed its argument at list-prefix precedence, looser than loose unary).

```raku
my $c = !so *;   say $c.WHAT;   # (WhateverCode)
say $c(False);                  # True
say !so 1 == 2;                 # True — still !(so(1 == 2))
```

## Before / after

| snippet | before | after | rakudo |
|---|---|---|---|
| `my token t is export { \d+ }` | `===SORRY!===` | parses | parses |
| `use Mod;` then `&digits` (exported token) | `Nil` | `Regex` | `Regex` |
| `sub f(Bool $a where !so *) { "ok" }; f(False)` | `===SORRY!===` | `ok` | `ok` |
| `(!so *).WHAT` | `===SORRY!===` | `(WhateverCode)` | `(WhateverCode)` |

## Tests

- `t/grammar/token-declarator-is-export.t` (8 assertions) + the module fixture `t/lib/ExportedRegexDeclarator.rakumod`
- `t/lang/operators/prefix-stacked-loose-unary.t` (9 assertions)

Both files also pass under `raku` itself, so they pin rakudo's behaviour rather than mutsu's.

## Verification

`cargo fmt --all`, `make lint`, `make test` and `make roast` were all run locally before publishing.

- `make lint`: green in all four configurations.
- `make test`: **PASS** — `Files=4013, Tests=42696`.
- `make roast`: `Files=1435, Tests=219511`, with exactly the three container-only failures `docs/agent-environments.md` documents for a remote container, matching its listed test numbers precisely: `roast/6.c/S32-io/file-tests.t` (`Failed: 4` — tests 6-8, 10, `uid 0`), `roast/S16-filehandles/filetest.t` (`Failed: 25` — tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125, `uid 0`), and `roast/S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17", sandboxed network). Nothing else failed.

## Scope

#7954 is an index, not one fix, and **stays open**: its remaining rows span roughly twenty distinct constructs. Only the two rows it had already confirmed in isolation graduate here.

Refs #7954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWWxX1ETymSN9eY5oikdqX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWWxX1ETymSN9eY5oikdqX)_