### PR TITLE
perf(vm): the read-modify-write ops take their target's name symbol

### DIFF
--- a/news/2026-09/rmw-ops-take-the-name-symbol.md
+++ b/news/2026-09/rmw-ops-take-the-name-symbol.md
@@ -1,0 +1,69 @@
+# The read-modify-write ops stop re-interning their target's name
+
+`++`, `--` and the fused compound assignment `$x OP= rhs` each take their
+target's name from a constant-pool operand. Their tail then probes that name
+against four separate `Symbol`-keyed stores — the readonly registry, the env,
+the declared-type lane and the native-int constraint — and every one of those
+probes took a `&str` and re-interned it. That is a thread-local `RefCell`
+borrow plus a string hash per probe, four times per store, for a name whose
+symbol the chunk has already memoized.
+
+`CompiledCode::const_sym` has interned every constant-pool name once per chunk
+since #7736. The three op entry points now read it once and hand it down the
+whole tail, using the `_sym`/`_for` variants that already existed at the bottom
+of each lane (`is_readonly_sym`, `get_env_with_main_alias_sym`,
+`set_env_with_main_alias_sym`, `var_type_constraint_sym`). The missing links in
+the middle — `name_is_readonly_binding`, `check_readonly_for_incdec`,
+`check_incdec_type_constraint`, `maybe_wrap_native_int`,
+`wrap_native_int_arithmetic_result`, `normalize_incdec_source_with_type`,
+`store_scalar_by_name` and `store_named_scalar_rmw_result` — grew a variant
+taking `Option<Symbol>`, so a caller without a baked symbol (the slotless
+`$.attr++` accessor path, which has no constant-pool index) still works exactly
+as before.
+
+## Measured
+
+Release, callgrind, `tmp/bench-ok-2k.raku` = `use Test; plan 2000; for ^2000 {
+ok 1, "x" }` under `MUTSU_REAL_TEST=1`, warm precompilation cache, at
+`83f3ecbc`.
+
+| caller | interns/assertion before | after |
+| --- | --- | --- |
+| `types::name_is_readonly_binding` | 1.00 | 0 |
+| `vm_var_assign_typed::check_incdec_type_constraint` | 1.00 | 0 |
+| `vm_var_assign_typed::store_named_scalar_rmw_result` | 1.00 | 0 |
+| `vm_var_assign_post_incdec::exec_atomic_compound_var_op` | 1.00 | 0 |
+
+`Symbol::intern` calls 62,485 → 54,485 (−8,000, −12.8%); whole run 473.03 M →
+471.68 M Ir (−0.29%). The per-caller counts come straight out of the raw
+callgrind file rather than `callgrind_annotate --tree=caller`, which truncates
+its caller list and re-attributes across inlined copies — the annotated tree
+charged only 7,080 of the run's 62,485 interns to any named caller.
+
+The cold-cache warning in [#7766](https://github.com/tokuhirom/mutsu/issues/7766)
+is real and cost a run here: the first post-rebuild measurement read 769.84 M Ir
+and 55,048 interns, both inflated by a cold precompilation cache. Discard it and
+measure the second run.
+
+## What this is a slice of
+
+[#7766](https://github.com/tokuhirom/mutsu/issues/7766) unit 2. The issue's
+remaining four `_sym` splits — `call_compiled_function_named_inner`'s
+`fn_package`/`fn_name`, `user_method_overloads` + `has_user_method`,
+`multi_arg_type_keys`' receiver class name, and the resolution layers
+(`find_compiled_function_inner` / `resolve_function_multi_cached` /
+`fn_keys_for_base` / `push_multi_dispatch_frame_with_winner`) — are untouched
+and the issue stays open for them. Unlike this family, each of those is a `&str`
+API fed by a *further* `&str` API, so the fix is a chain grown up the call graph
+rather than a local one.
+
+## Regression cover
+
+`t/routines/signature/param-bind-symbol-keys.t` grew a section for this family.
+What a symbol mix-up produces here is not a slowdown but the *wrong name's*
+entry being read or written, so each case gives its neighbours distinguishable
+values: an `int8` that wraps beside a boxed `Int` that does not, a subset
+constraint re-checked after the mutation, a readonly parameter and a sigilless
+bind that must both reject `++`, two same-named locals in sibling scopes, an
+`our` scalar, a dynamic variable, and the topic's rw writeback. All 55
+assertions were verified against Rakudo v2026.07 first.

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -444,7 +444,17 @@ impl Interpreter {
     /// Check if a variable is readonly for increment/decrement operations.
     /// Returns Err with X::Multi::NoMatch (like Raku's postfix:<++> dispatch failure).
     pub(crate) fn check_readonly_for_increment(&self, name: &str) -> Result<(), RuntimeError> {
-        self.check_readonly_for_incdec(name, "postfix:<++>")
+        self.check_readonly_for_incdec_for(name, None, "postfix:<++>")
+    }
+
+    /// [`Self::check_readonly_for_increment`] for a caller holding `name`'s
+    /// interned form. See [`Self::name_is_readonly_binding_for`].
+    pub(crate) fn check_readonly_for_increment_for(
+        &self,
+        name: &str,
+        name_sym: Option<Symbol>,
+    ) -> Result<(), RuntimeError> {
+        self.check_readonly_for_incdec_for(name, name_sym, "postfix:<++>")
     }
 
     /// Whether `name` denotes a readonly binding, asking BOTH mechanisms that
@@ -457,7 +467,28 @@ impl Interpreter {
     /// both — `++`/`--` (below) and the rw-return container capture
     /// (`exec_capture_var_cell_op`) each regressed by consulting only one.
     pub(crate) fn name_is_readonly_binding(&self, name: &str) -> bool {
-        if self.is_readonly(name) {
+        self.name_is_readonly_binding_for(name, None)
+    }
+
+    /// [`Self::name_is_readonly_binding`] for a caller that already holds
+    /// `name`'s interned form — every in-place `++`/`--`/`OP=` op reaches this
+    /// through a constant-pool name operand, and [`CompiledCode::const_sym`]
+    /// memoizes that symbol per chunk. The `readonly_vars` registry is
+    /// `Symbol`-keyed, so the `&str` form re-hashed the name once per
+    /// read-modify-write.
+    pub(crate) fn name_is_readonly_binding_for(
+        &self,
+        name: &str,
+        name_sym: Option<Symbol>,
+    ) -> bool {
+        let readonly = match name_sym {
+            Some(sym) => {
+                debug_assert_eq!(sym, Symbol::intern(name));
+                self.is_readonly_sym(sym)
+            }
+            None => self.is_readonly(name),
+        };
+        if readonly {
             return true;
         }
         crate::env::sigilless_readonly_keys_possible()
@@ -479,6 +510,17 @@ impl Interpreter {
         name: &str,
         op: &str,
     ) -> Result<(), RuntimeError> {
+        self.check_readonly_for_incdec_for(name, None, op)
+    }
+
+    /// [`Self::check_readonly_for_incdec`] for a caller holding `name`'s
+    /// interned form. See [`Self::name_is_readonly_binding_for`].
+    pub(crate) fn check_readonly_for_incdec_for(
+        &self,
+        name: &str,
+        name_sym: Option<Symbol>,
+        op: &str,
+    ) -> Result<(), RuntimeError> {
         // A sigilless bind (`my \G = 5`) is marked via a SEPARATE mechanism
         // from `readonly_vars`/`ReadonlyKind` -- the `__mutsu_sigilless_readonly::
         // NAME` env key `Stmt::MarkSigillessReadonly` sets (see
@@ -488,7 +530,7 @@ impl Interpreter {
         // where Raku's postfix:<++> dispatch rejects it (X::Multi::NoMatch,
         // "requires mutable arguments") the same way it rejects a readonly
         // sub parameter's `++$n`.
-        if self.name_is_readonly_binding(name) {
+        if self.name_is_readonly_binding_for(name, name_sym) {
             let msg = format!(
                 "Cannot resolve caller {op}({}); the parameter requires mutable arguments",
                 name

--- a/src/vm/vm_our_package_vars.rs
+++ b/src/vm/vm_our_package_vars.rs
@@ -211,10 +211,24 @@ impl Interpreter {
     /// cell and the bare stores are skipped; otherwise the ordinary bare-name
     /// store applies, exactly as before.
     pub(crate) fn store_scalar_by_name(&mut self, name: &str, val: &Value) {
+        self.store_scalar_by_name_for(name, None, val)
+    }
+
+    /// [`Self::store_scalar_by_name`] for a caller that already holds `name`'s
+    /// interned form — the three read-modify-write ops, whose name operand is a
+    /// constant-pool index with a symbol memoized per chunk
+    /// ([`CompiledCode::const_sym`]). The env is `Symbol`-keyed, so the `&str`
+    /// form re-hashed the name on every `++`/`--`/`OP=`.
+    pub(crate) fn store_scalar_by_name_for(
+        &mut self,
+        name: &str,
+        name_sym: Option<Symbol>,
+        val: &Value,
+    ) {
         if self.our_package_scalar_write(name, val) {
             return;
         }
-        self.set_env_with_main_alias(name, val.clone());
+        self.set_env_with_main_alias_sym(name, name_sym, val.clone());
         // A compound assign / inc-dec to a package-scope free variable (`our $X`
         // or a `package { my $X }` lexical) reached from inside a named sub uses
         // the bare name; mirror the value back into the canonical package store

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -218,8 +218,19 @@ impl Interpreter {
         var_name: &str,
         value: Value,
     ) -> Value {
+        self.normalize_incdec_source_with_type_for(var_name, None, value)
+    }
+
+    /// [`Self::normalize_incdec_source_with_type`] for a caller that already
+    /// holds `var_name`'s interned form. See [`Self::maybe_wrap_native_int`].
+    pub(crate) fn normalize_incdec_source_with_type_for(
+        &mut self,
+        var_name: &str,
+        name_sym: Option<Symbol>,
+        value: Value,
+    ) -> Value {
         if value.is_nil() {
-            if let Some(tc) = loan_env!(self, var_type_constraint(var_name)) {
+            if let Some(tc) = loan_env!(self, var_type_constraint_for(var_name, name_sym)) {
                 Self::incdec_seed_for_constraint(&tc)
             } else {
                 Value::int(0)
@@ -573,11 +584,20 @@ impl Interpreter {
 
     /// If the variable has a native int type constraint, wrap the value.
     /// Used by increment/decrement to implement overflow/underflow wrapping.
-    pub(super) fn maybe_wrap_native_int(&mut self, var_name: &str, value: Value) -> Value {
+    /// `name_sym` is `var_name`'s interned form when the caller holds one — the
+    /// read-modify-write ops, whose name operand is a constant-pool index with a
+    /// symbol memoized per chunk. The constraint lane is `Symbol`-keyed, so a
+    /// `None` costs one re-hash of the name.
+    pub(super) fn maybe_wrap_native_int(
+        &mut self,
+        var_name: &str,
+        name_sym: Option<Symbol>,
+        value: Value,
+    ) -> Value {
         use crate::runtime::native_types;
         use num_traits::ToPrimitive;
 
-        let constraint = match loan_env!(self, var_type_constraint(var_name)) {
+        let constraint = match loan_env!(self, var_type_constraint_for(var_name, name_sym)) {
             Some(c) => c,
             None => return value,
         };
@@ -610,7 +630,18 @@ impl Interpreter {
         var_name: &str,
         value: Value,
     ) -> Value {
-        let Some(constraint) = loan_env!(self, var_type_constraint(var_name)) else {
+        self.wrap_native_int_arithmetic_result_for(var_name, None, value)
+    }
+
+    /// [`Self::wrap_native_int_arithmetic_result`] for a caller that already
+    /// holds `var_name`'s interned form. See [`Self::maybe_wrap_native_int`].
+    pub(crate) fn wrap_native_int_arithmetic_result_for(
+        &mut self,
+        var_name: &str,
+        name_sym: Option<Symbol>,
+        value: Value,
+    ) -> Value {
+        let Some(constraint) = loan_env!(self, var_type_constraint_for(var_name, name_sym)) else {
             return value;
         };
         Self::wrap_native_int_arithmetic_for_constraint(&constraint, value)

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -83,7 +83,11 @@ impl Interpreter {
         let rhs = self.stack.pop().unwrap();
         self.resolve_pending_alias_binds(code);
         let name = Self::const_str(code, name_idx);
-        self.check_readonly_for_increment(name)?;
+        // The name's interned form, memoized per chunk: this op's tail probes it
+        // against four Symbol-keyed stores (readonly registry, env, type
+        // constraint, native-int constraint), each of which re-hashed the string.
+        let name_sym = code.const_sym(name_idx);
+        self.check_readonly_for_increment_for(name, Some(name_sym))?;
         // Default to Nil (NOT Int(0) like `++`) so `my $w; $w ~= "z"` yields "z",
         // not "0z"; the binary op descalarizes/numifies/stringifies Nil itself.
         let raw_val = self
@@ -103,7 +107,7 @@ impl Interpreter {
             // boxed lexical's cell is authoritative and must win over a stale
             // plain `env` copy left by a prior call's return-merge.
             .or_else(|| self.package_scope_lexical(name))
-            .or_else(|| self.get_env_with_main_alias(name))
+            .or_else(|| self.get_env_with_main_alias_sym(name, name_sym))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
             .unwrap_or(Value::NIL);
@@ -140,7 +144,8 @@ impl Interpreter {
         let new_val = self.apply_compound_base_op(op, raw_val, rhs)?;
         // `AtomicCompoundVar` is only emitted for a NON-local target (the compiler
         // skips it when `local_map` has the name), so there is no baked slot here.
-        let stored = self.store_named_scalar_rmw_result(code, name, None, new_val)?;
+        let stored =
+            self.store_named_scalar_rmw_result(code, name, Some(name_sym), None, new_val)?;
         self.stack.push(stored);
         Ok(())
     }
@@ -219,6 +224,10 @@ impl Interpreter {
         // Lazily convert pending alias bind names into local_bind_pairs.
         self.resolve_pending_alias_binds(code);
         let name = Self::const_str(code, name_idx);
+        // The name's interned form, memoized per chunk: the readonly registry,
+        // the env, and the type-constraint lane are all Symbol-keyed, and this
+        // op probes each of them once per increment.
+        let name_sym = code.const_sym(name_idx);
         // Handle $CALLER::varname++ — increment through caller scope
         if let Some((bare_name, depth)) = crate::compiler::Compiler::parse_caller_prefix(name) {
             let raw_val = loan_env!(self, get_caller_var(&bare_name, depth))?;
@@ -231,7 +240,7 @@ impl Interpreter {
         if let Some(r) = self.try_slotless_attr_incdec(code, name, true, false) {
             return r;
         }
-        self.check_readonly_for_increment(name)?;
+        self.check_readonly_for_increment_for(name, Some(name_sym))?;
         if name.starts_with('!')
             && let Some(slot) = self.find_local_slot(code, name)
             && !matches!(self.locals[slot].view(), ValueView::Proxy { .. })
@@ -243,17 +252,18 @@ impl Interpreter {
                     return Ok(());
                 }
                 let inner = arc.lock().unwrap().clone();
-                let val = self.normalize_incdec_source_with_type(name, inner);
+                let val = self.normalize_incdec_source_with_type_for(name, Some(name_sym), inner);
                 let new_val = self.increment_value_smart(&val)?;
-                let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
+                let new_val =
+                    self.wrap_native_int_arithmetic_result_for(name, Some(name_sym), new_val);
                 arc.lock().unwrap().clone_from(&new_val);
                 self.stack.push(val);
                 return Ok(());
             }
             let raw_val = self.locals[slot].clone();
-            let val = self.normalize_incdec_source_with_type(name, raw_val);
+            let val = self.normalize_incdec_source_with_type_for(name, Some(name_sym), raw_val);
             let new_val = self.increment_value_smart(&val)?;
-            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
+            let new_val = self.wrap_native_int_arithmetic_result_for(name, Some(name_sym), new_val);
             self.locals[slot] = new_val.clone();
             self.flush_local_to_env(code, slot);
             // Propagate the new value along the sigilless alias chain and into
@@ -268,7 +278,7 @@ impl Interpreter {
             .per_call_anon_state_read(name, Value::int(0))
             .or_else(|| self.escaping_our_write_cell(code, name))
             .or_else(|| self.package_scope_lexical(name))
-            .or_else(|| self.get_env_with_main_alias(name))
+            .or_else(|| self.get_env_with_main_alias_sym(name, name_sym))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
             .unwrap_or(Value::int(0));
@@ -280,9 +290,9 @@ impl Interpreter {
                 return Ok(());
             }
             let inner = arc.lock().unwrap().clone();
-            let val = self.normalize_incdec_source_with_type(name, inner);
+            let val = self.normalize_incdec_source_with_type_for(name, Some(name_sym), inner);
             let new_val = self.increment_value_smart(&val)?;
-            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
+            let new_val = self.wrap_native_int_arithmetic_result_for(name, Some(name_sym), new_val);
             arc.lock().unwrap().clone_from(&new_val);
             self.stack.push(val);
             return Ok(());
@@ -294,15 +304,15 @@ impl Interpreter {
             let fetched = loan_env!(self, auto_fetch_proxy(&raw_val))?;
             let val = Self::normalize_incdec_source(fetched);
             let new_val = self.increment_value_smart(&val)?;
-            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
+            let new_val = self.wrap_native_int_arithmetic_result_for(name, Some(name_sym), new_val);
             loan_env!(self, assign_proxy_lvalue(raw_val, new_val))?;
             self.stack.push(val);
             return Ok(());
         }
-        let val = self.normalize_incdec_source_with_type(name, raw_val);
+        let val = self.normalize_incdec_source_with_type_for(name, Some(name_sym), raw_val);
         let new_val = self.increment_value_smart(&val)?;
-        let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
-        self.store_named_scalar_rmw_result(code, name, slot, new_val)?;
+        let new_val = self.wrap_native_int_arithmetic_result_for(name, Some(name_sym), new_val);
+        self.store_named_scalar_rmw_result(code, name, Some(name_sym), slot, new_val)?;
         self.stack.push(val);
         Ok(())
     }
@@ -330,10 +340,13 @@ impl Interpreter {
         slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
+        // See `exec_post_increment_op_inner`: one memoized symbol serves every
+        // Symbol-keyed probe below.
+        let name_sym = code.const_sym(name_idx);
         if let Some(r) = self.try_slotless_attr_incdec(code, name, false, false) {
             return r;
         }
-        self.check_readonly_for_increment(name)?;
+        self.check_readonly_for_increment_for(name, Some(name_sym))?;
         if name.starts_with('!')
             && let Some(slot) = self.find_local_slot(code, name)
             && !matches!(self.locals[slot].view(), ValueView::Proxy { .. })
@@ -345,17 +358,18 @@ impl Interpreter {
                     return Ok(());
                 }
                 let inner = arc.lock().unwrap().clone();
-                let val = self.normalize_incdec_source_with_type(name, inner);
+                let val = self.normalize_incdec_source_with_type_for(name, Some(name_sym), inner);
                 let new_val = self.decrement_value_smart(&val)?;
-                let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
+                let new_val =
+                    self.wrap_native_int_arithmetic_result_for(name, Some(name_sym), new_val);
                 arc.lock().unwrap().clone_from(&new_val);
                 self.stack.push(val);
                 return Ok(());
             }
             let raw_val = self.locals[slot].clone();
-            let val = self.normalize_incdec_source_with_type(name, raw_val);
+            let val = self.normalize_incdec_source_with_type_for(name, Some(name_sym), raw_val);
             let new_val = self.decrement_value_smart(&val)?;
-            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
+            let new_val = self.wrap_native_int_arithmetic_result_for(name, Some(name_sym), new_val);
             self.locals[slot] = new_val.clone();
             self.flush_local_to_env(code, slot);
             // Propagate the new value along the sigilless alias chain and into
@@ -370,7 +384,7 @@ impl Interpreter {
             .per_call_anon_state_read(name, Value::int(0))
             .or_else(|| self.escaping_our_write_cell(code, name))
             .or_else(|| self.package_scope_lexical(name))
-            .or_else(|| self.get_env_with_main_alias(name))
+            .or_else(|| self.get_env_with_main_alias_sym(name, name_sym))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
             .unwrap_or(Value::int(0));
@@ -381,17 +395,17 @@ impl Interpreter {
                 return Ok(());
             }
             let inner = arc.lock().unwrap().clone();
-            let val = self.normalize_incdec_source_with_type(name, inner);
+            let val = self.normalize_incdec_source_with_type_for(name, Some(name_sym), inner);
             let new_val = self.decrement_value_smart(&val)?;
-            let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
+            let new_val = self.wrap_native_int_arithmetic_result_for(name, Some(name_sym), new_val);
             arc.lock().unwrap().clone_from(&new_val);
             self.stack.push(val);
             return Ok(());
         }
-        let val = self.normalize_incdec_source_with_type(name, raw_val);
+        let val = self.normalize_incdec_source_with_type_for(name, Some(name_sym), raw_val);
         let new_val = self.decrement_value_smart(&val)?;
-        let new_val = self.wrap_native_int_arithmetic_result(name, new_val);
-        self.store_named_scalar_rmw_result(code, name, slot, new_val)?;
+        let new_val = self.wrap_native_int_arithmetic_result_for(name, Some(name_sym), new_val);
+        self.store_named_scalar_rmw_result(code, name, Some(name_sym), slot, new_val)?;
         self.stack.push(val);
         Ok(())
     }

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -829,10 +829,23 @@ impl Interpreter {
         name: &str,
         new_val: &Value,
     ) -> Result<(), RuntimeError> {
+        self.check_incdec_type_constraint_for(name, None, new_val)
+    }
+
+    /// [`Self::check_incdec_type_constraint`] for a caller that already holds
+    /// `name`'s interned form. The constraint lane is `Symbol`-keyed
+    /// (`var_type_constraint_sym`), so the `&str` form re-hashed the name on
+    /// every read-modify-write of any program that declares one typed lexical.
+    pub(crate) fn check_incdec_type_constraint_for(
+        &mut self,
+        name: &str,
+        name_sym: Option<Symbol>,
+        new_val: &Value,
+    ) -> Result<(), RuntimeError> {
         if name.starts_with('@') || name.starts_with('%') || name.starts_with('&') {
             return Ok(());
         }
-        if let Some(constraint) = loan_env!(self, var_type_constraint(name)) {
+        if let Some(constraint) = loan_env!(self, var_type_constraint_for(name, name_sym)) {
             if crate::runtime::native_types::is_native_int_type(&constraint)
                 || matches!(constraint.as_str(), "num" | "num32" | "num64" | "str")
             {
@@ -980,6 +993,13 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name: &str,
+        // The interned form of `name`, when the caller has one: all three
+        // read-modify-write ops reach this with a constant-pool name operand,
+        // whose symbol `CompiledCode::const_sym` memoizes per chunk. The three
+        // probes below (native-int wrap, type constraint, env store) are all
+        // Symbol-keyed underneath, so a `None` here costs three re-hashes of the
+        // same name per store.
+        name_sym: Option<Symbol>,
         // §1.5: compile-time-resolved local slot for `name`, when it is a
         // current-scope local. Drives the slot mirror + `local_bind_pairs` source
         // resolution below instead of a by-name `code.locals` search (ambiguous
@@ -987,9 +1007,9 @@ impl Interpreter {
         slot: Option<u32>,
         new_val: Value,
     ) -> Result<Value, RuntimeError> {
-        let new_val = self.maybe_wrap_native_int(name, new_val);
-        self.check_incdec_type_constraint(name, &new_val)?;
-        self.store_scalar_by_name(name, &new_val);
+        let new_val = self.maybe_wrap_native_int(name, name_sym, new_val);
+        self.check_incdec_type_constraint_for(name, name_sym, &new_val)?;
+        self.store_scalar_by_name_for(name, name_sym, &new_val);
         // Track topic mutations for the rw-map writeback (`@a.map({ $_ += 1 })`).
         // A compound assign / inc-dec to `$_` lands here via the fused
         // `AtomicCompoundVar` path; the plain-assign path (`AssignExpr`) records

--- a/t/routines/signature/param-bind-symbol-keys.t
+++ b/t/routines/signature/param-bind-symbol-keys.t
@@ -9,7 +9,7 @@ use Test;
 # share one symbol, so a mix-up would show up as a *wrong name* being bound,
 # marked or cleared rather than as a slowdown.
 
-plan 32;
+plan 55;
 
 # --- the fixed per-call keys -------------------------------------------------
 
@@ -129,3 +129,88 @@ sub container-id($bind) {
 ok container-id(True), 'the marker is set for the bound declaration';
 nok container-id(False), 'a later same-named assigned declaration clears it';
 ok container-id(True), 'and the marker is set again on the next bound declaration';
+
+# --- #7766 unit 2: the read-modify-write ops' name symbol ---------------------
+# `++`, `--` and the fused `$x OP= rhs` take their target's name from a
+# constant-pool operand, and their tail probes it against four Symbol-keyed
+# stores: the readonly registry, the env, the declared-type lane and the
+# native-int constraint. Those probes now share the one symbol
+# `CompiledCode::const_sym` memoizes per chunk instead of re-interning the
+# string at each layer. A mix-up would read or write the WRONG NAME's entry, so
+# every case below gives its neighbours distinguishable values.
+
+# the native-int constraint lane (wrapping) vs. a boxed neighbour
+my int8 $i8 = 127;
+$i8++;
+is $i8, -128, 'int8 ++ wraps at the top';
+my int8 $j8 = -128;
+$j8--;
+is $j8, 127, 'int8 -- wraps at the bottom';
+my int8 $k8 = 120;
+$k8 += 10;
+is $k8, -126, 'int8 += wraps';
+my Int $boxed = 127;
+$boxed++;
+is $boxed, 128, 'a boxed Int neighbour does not wrap';
+
+# the declared-type lane, re-checked after the mutation
+subset Even of Int where * %% 2;
+my Even $even = 2;
+dies-ok { $even++ }, 'a subset constraint rejects the incremented value';
+is $even, 2, 'the rejected increment leaves the variable untouched';
+lives-ok { $even += 2 }, 'a compound assign satisfying the constraint is accepted';
+is $even, 4, 'and stores the new value';
+
+# the readonly registry, and the separate sigilless-readonly marker
+sub ro-param($n) { $n++ }
+dies-ok { ro-param(1) }, 'a readonly parameter rejects ++';
+sub rw-copy($n is copy) { $n++; $n }
+is rw-copy(1), 2, 'an `is copy` parameter accepts ++';
+my \Gbound = 5;
+dies-ok { Gbound++ }, 'a sigilless bind to a value rejects ++';
+
+# two same-named locals in sibling scopes: one symbol, two slots
+sub branch-local($flag) {
+    if $flag { my $c = 10; $c++; return $c }
+    else     { my $c = 20; $c += 5; return $c }
+}
+is branch-local(True), 11, 'the then-branch local increments its own value';
+is branch-local(False), 25, 'the else-branch local compounds its own value';
+
+# the env store: an `our` scalar writes through its canonical cell
+our $pkg-counter = 1;
+$pkg-counter++;
+is $pkg-counter, 2, 'an `our` scalar increments through its canonical cell';
+$pkg-counter ~= "!";
+is $pkg-counter, "2!", 'an `our` scalar concatenates through the same cell';
+
+# a dynamic variable incremented from a callee
+my $*dyn-counter = 1;
+sub bump-dyn() { $*dyn-counter++ }
+bump-dyn();
+is $*dyn-counter, 2, 'a dynamic variable increments in the declaring frame';
+
+# the topic, whose store has its own writeback arm
+my @src = 1, 2, 3;
+my @mapped = @src.map({ $_ += 1 });
+is @mapped.join(","), "2,3,4", 'a compound assign to the topic yields the new value';
+is @src.join(","), "2,3,4", 'and writes back through the rw topic alias';
+for @src <-> $x { $x++ }
+is @src.join(","), "3,4,5", 'a rw loop alias writes back';
+
+# distinct names must not alias one another
+my $first = 1;
+my $second = 100;
+$first++;
+$second += 2;
+is $first, 2, 'the first name increments alone';
+is $second, 102, 'the second name compounds alone';
+
+my $chained = "a";
+$chained ~= "b";
+$chained x= 2;
+is $chained, "abab", 'string compound assignment chains on one name';
+
+my $repeated = 0;
+$repeated++ for ^5;
+is $repeated, 5, 'repeated increments accumulate on one name';


### PR DESCRIPTION
`++`, `--` and the fused compound assignment `$x OP= rhs` each take their target's name from a constant-pool operand, then probe it against four separate `Symbol`-keyed stores — the readonly registry, the env, the declared-type lane and the native-int constraint. Every one of those probes took a `&str` and re-interned it: a thread-local `RefCell` borrow plus a string hash, four times per store, for a name whose symbol the chunk has already memoized in `const_syms`.

The three op entry points now read `code.const_sym(name_idx)` once and hand it down the whole tail. The `_sym` variants at the bottom of each lane already existed (`is_readonly_sym`, `get_env_with_main_alias_sym`, `set_env_with_main_alias_sym`, `var_type_constraint_sym`); the missing links in the middle — `name_is_readonly_binding`, `check_readonly_for_incdec`, `check_incdec_type_constraint`, `maybe_wrap_native_int`, `wrap_native_int_arithmetic_result`, `normalize_incdec_source_with_type`, `store_scalar_by_name` and `store_named_scalar_rmw_result` — grew a variant taking `Option<Symbol>`, so the one caller without a baked symbol (the slotless `$.attr++` accessor path, which has no constant-pool index) keeps working unchanged.

## Measured

Release, callgrind, `tmp/bench-ok-2k.raku` = `use Test; plan 2000; for ^2000 { ok 1, "x" }` under `MUTSU_REAL_TEST=1`, warm precompilation cache, at `83f3ecbc`.

| caller | interns/assertion before | after |
| --- | --- | --- |
| `types::name_is_readonly_binding` | 1.00 | 0 |
| `vm_var_assign_typed::check_incdec_type_constraint` | 1.00 | 0 |
| `vm_var_assign_typed::store_named_scalar_rmw_result` | 1.00 | 0 |
| `vm_var_assign_post_incdec::exec_atomic_compound_var_op` | 1.00 | 0 |

`Symbol::intern` calls 62,485 → 54,485 (−8,000, −12.8%); whole run 473,028,520 → 471,676,380 Ir (−0.29%).

Two notes on the protocol, both of which cost a run here if ignored:

- The per-caller counts come straight out of the **raw** callgrind file, not `callgrind_annotate --tree=caller`, which truncates its caller list and re-attributes across inlined copies — the annotated tree charged only 7,080 of this run's 62,485 interns to any named caller. `tmp/cg-intern-callers.py` in the session is a ~50-line parser over `fn=`/`cfn=`/`calls=`; it reproduces the previous session's table exactly and is both complete and exact.
- The cold-precompilation-cache warning in #7766 is real: the first post-rebuild measurement read 769.84 M Ir and 55,048 interns. Discard it and measure the second run.

## Scope

#7766 unit 2, the assignment-path family the previous session identified as "the most self-contained slice left". The issue's four remaining `_sym` splits — `call_compiled_function_named_inner`'s `fn_package`/`fn_name`, `user_method_overloads` + `has_user_method`, `multi_arg_type_keys`' receiver class name, and the resolution layers — are untouched and the issue stays open for them. Unlike this family, each of those is a `&str` API fed by a *further* `&str` API, so the fix is a chain grown up the call graph rather than a local one.

Refs #7766 (not `Closes` — the issue tracks the four splits above).

## Regression cover

`t/routines/signature/param-bind-symbol-keys.t` grew a section for this family (32 → 55 assertions). What a symbol mix-up produces here is not a slowdown but the *wrong name's* entry being read or written, so each case gives its neighbours distinguishable values: an `int8` that wraps beside a boxed `Int` that does not, a subset constraint re-checked after the mutation, a readonly parameter and a sigilless bind that must both reject `++`, two same-named locals in sibling scopes, an `our` scalar, a dynamic variable, and the topic's rw writeback. All 55 assertions were verified against Rakudo v2026.07 before being run under mutsu.

## Verification

- `cargo fmt --all` — clean
- `make lint` — all four configurations green (default clippy, `jit` off, wasm32, rustdoc)
- `make test` — PASS, 4012 files / 42718 tests
- `make roast` — the only failures are the three documented in `docs/agent-environments.md` as container artefacts, with the counts that file records: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, runs as `uid 0`), `roast/S16-filehandles/filetest.t` (`Failed: 25`, same cause) and `roast/S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17", sandboxed network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Na39BYiPRCEMtu8bMxUqkV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Na39BYiPRCEMtu8bMxUqkV)_