### PR TITLE
fix(site): the ecosystem page listed 400 of 1625 distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ target-local/
 # e2e suite) from the bench-data branch's history.
 /site/bench-trend.html
 /site/.bench-history.e2e.tsv
+# Copied out of ecosystem/ at deploy time by pages.yml (and transiently by the
+# e2e suite) for the ecosystem page's parity chart.
+/site/history.svg
 # Compatibility numbers counted at deploy time by pages.yml (the landing page
 # falls back to a baked-in figure when it is absent).
 /site/content/stats.json

--- a/news/2026-09/ecosystem-page-showed-400-of-1625-distributions.md
+++ b/news/2026-09/ecosystem-page-showed-400-of-1625-distributions.md
@@ -1,0 +1,47 @@
+# The ecosystem page showed 400 of 1625 distributions and claimed all of them
+
+`site/ecosystem.html` rendered `matches.slice(0, 400)` — a cap added when the
+corpus sweep had measured a couple of hundred distributions and the table was
+never expected to reach it. The sweep has since measured the whole corpus (1625
+records under `ecosystem/dists/`), so the cap became the page's dominant
+behaviour, and a bad one, because the rows are sorted worst-first
+(`STATUS_ORDER` in `scripts/gen-ecosystem-manifest.py`: red, partial,
+blocked_load, blocked_dep, green, no_baseline, skipped).
+
+With today's ledger that puts the cut 94 rows into `partial`:
+
+| status | records | rows rendered before |
+| --- | --- | --- |
+| red | 306 | 306 |
+| partial | 271 | 94 |
+| blocked_load | 360 | 0 |
+| blocked_dep | 43 | 0 |
+| green | 403 | 0 |
+| no_baseline | 235 | 0 |
+| skipped | 7 | 0 |
+
+So the page that exists to answer "does my module work on mutsu?" could not
+display a single working module in its default view — every one of the 403 green
+distributions fell past the cap — while the count above the table read
+`1625 件中 1625 件`, because it counted matches rather than rendered rows. The
+status filter and the search box both still reached the hidden rows, which is
+why this survived: any query narrow enough to matter came back correct.
+
+The cap is gone; the table renders every match. A full 1625-row render measures
+~1.1s to `body[data-ready]` on a cold load and ~90ms to re-render on a keystroke
+in the search box, so nothing needed chunking or virtualizing to pay for it.
+
+Two things now keep it fixed. `site/e2e.test.mjs` asserts the row count equals
+the manifest's distribution count outright instead of `min(count, 400)`, and
+asserts that filtering yields exactly the matching rows rather than "at most the
+full count" — an assertion a truncating table also satisfied. And the committed
+`site/content/ecosystem.json` snapshot was regenerated: it had been left at the
+251-row shard-C measurement from 2026-09-10 while `ecosystem/dists/` grew to
+1625, so the e2e suite had been exercising a corpus far too small to ever reach
+the cap. (The deployed page never read that snapshot — `pages.yml` regenerates
+it at deploy time — which is exactly why the staleness went unnoticed.)
+
+The same regeneration flipped the manifest's `has_chart` to true, so the e2e
+suite now stages `ecosystem/history.svg` into `site/` the way `pages.yml` does
+for the deploy, and asserts the chart's visibility follows `has_chart`. That
+wiring had no coverage before.

--- a/site/content/ecosystem.json
+++ b/site/content/ecosystem.json
@@ -1,22 +1,13 @@
 {
  "counts": {
-  "corpus": 1623,
-  "distributions": 251,
-  "graded": 127,
-  "green": 61
+  "corpus": 1625,
+  "distributions": 1625,
+  "graded": 980,
+  "green": 403
  },
- "coverage": 15.5,
- "dist_parity": 48.0,
+ "coverage": 100.0,
+ "dist_parity": 41.1,
  "distributions": [
-  {
-   "axis": "pure",
-   "baseline": 1,
-   "dist": "AccountableBagHash",
-   "passed": 0,
-   "reason": "No such method 'STORE' for invocant of type 'AccountableBagHash'",
-   "status": "red",
-   "version": "0.0.7"
-  },
   {
    "axis": "pure",
    "baseline": 1,
@@ -54,6 +45,15 @@
    "version": "0.0.7"
   },
   {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "Algorithm::KDimensionalTree",
+   "passed": 0,
+   "reason": "No such method 'assuming' for invocant of type 'Method'",
+   "status": "red",
+   "version": "0.1.2"
+  },
+  {
    "axis": "pure",
    "baseline": 1,
    "dist": "Algorithm::Kruskal",
@@ -82,6 +82,15 @@
   },
   {
    "axis": "pure",
+   "baseline": 1,
+   "dist": "App::ShowPath",
+   "passed": 0,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
    "baseline": 2,
    "dist": "App::Stouch",
    "passed": 0,
@@ -103,7 +112,7 @@
    "baseline": 1,
    "dist": "are",
    "passed": 0,
-   "reason": "Unsupported nqp:: op: nqp::getattr",
+   "reason": "Unsupported nqp:: op: nqp::shift",
    "status": "red",
    "version": "0.0.1"
   },
@@ -121,7 +130,7 @@
    "baseline": 1,
    "dist": "Array::Rounded",
    "passed": 0,
-   "reason": "is 1 ok on Array::Rounded",
+   "reason": "is 1.5:p ok on Array::Rounded",
    "status": "red",
    "version": "0.0.3"
   },
@@ -182,15 +191,6 @@
   {
    "axis": "pure",
    "baseline": 1,
-   "dist": "Chatnik",
-   "passed": 0,
-   "reason": "circular module dependency detected: Chatnik -> LLM::Functions -> Hash::Merge -> LLM::Function -> LLM::Function",
-   "status": "red",
-   "version": "0.0.7"
-  },
-  {
-   "axis": "pure",
-   "baseline": 1,
    "dist": "Chinese",
    "passed": 0,
    "reason": "Unknown function: 且",
@@ -238,7 +238,7 @@
    "baseline": 1,
    "dist": "Commands",
    "passed": 0,
-   "reason": "Cannot bind to %!commands",
+   "reason": "Type check failed in binding; expected Associative but got List",
    "status": "red",
    "version": "0.0.9"
   },
@@ -280,6 +280,1482 @@
   },
   {
    "axis": "pure",
+   "baseline": 2,
+   "dist": "Concurrent::Trie",
+   "passed": 0,
+   "reason": "Unknown function: entry-walk",
+   "status": "red",
+   "version": "1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Config::Netrc",
+   "passed": 0,
+   "reason": "Type Array does not support associative indexing.",
+   "status": "red",
+   "version": "1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Config::Parser::NetRC",
+   "passed": 0,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Config::Parser::toml",
+   "passed": 0,
+   "reason": "Could not find file at",
+   "status": "red",
+   "version": "1.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Configuration",
+   "passed": 0,
+   "reason": "Configuration module can be use-d ok",
+   "status": "red",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Cookie::Jar",
+   "passed": 0,
+   "reason": "Could not find symbol '&to-json' in 'GLOBAL::JSON::Fast'",
+   "status": "red",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Crypt::RC4",
+   "passed": 0,
+   "reason": "No such method 'RC4' for invocant of type 'Test::X::SubtestsSkipped'",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "CSS::Grammar",
+   "passed": 0,
+   "reason": "Cannot resolve caller json-eqv(Hash:D); none of these signatures matches",
+   "status": "red",
+   "version": "0.4.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "CSS::Module::CSS3::Selectors",
+   "passed": 0,
+   "reason": "css3x-selectors simple-selector warnings",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "CSS::Selector::To::XPath",
+   "passed": 0,
+   "reason": "Cannot resolve caller xpath(CSS::Selector::To::XPath:D: Array:D); none of these signatures matches:",
+   "status": "red",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "CustomImporting",
+   "passed": 0,
+   "reason": "Confused. expected statement: expected use statement or import statement or no statement or need statement or unit statement or ...",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Dan",
+   "passed": 0,
+   "reason": "DataSlice[0..2]",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Dan::Pandas",
+   "passed": 0,
+   "reason": ".map.map",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Data::Importers",
+   "passed": 0,
+   "reason": "Type check failed in binding to parameter '$url'; expected Str but got Any",
+   "status": "red",
+   "version": "0.1.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Data::StaticTable",
+   "passed": 0,
+   "reason": "Can not create Data::StaticTables with repeated header names",
+   "status": "red",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Data::UkraineWar::MoD",
+   "passed": 0,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Date::Discordian",
+   "passed": 0,
+   "reason": "takes a Date",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Date::WorkdayCalendar",
+   "passed": 0,
+   "reason": "Confused. expected statement: expected expression statement or ')'",
+   "status": "red",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "DateTime::Monotonic",
+   "passed": 0,
+   "reason": "Syscall",
+   "status": "red",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Dawa",
+   "passed": 0,
+   "reason": "No such method 'wrap' for invocant of type 'Sub'",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "DB::ORM::Quicky",
+   "passed": 0,
+   "reason": "1",
+   "status": "red",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Deepgrep",
+   "passed": 0,
+   "reason": "Unknown function: ?ROUTINE",
+   "status": "red",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Definitely",
+   "passed": 0,
+   "reason": "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter 'value'; expected ::T, got Int",
+   "status": "red",
+   "version": "2.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Directory",
+   "passed": 0,
+   "reason": "X::IO::Dir with no message",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "DOSH::CLI",
+   "passed": 0,
+   "reason": "DOSH::CLI module can be use-d ok",
+   "status": "red",
+   "version": "7.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "DSL::Entity::Foods",
+   "passed": 0,
+   "reason": "chocolate chip cookie ice creams",
+   "status": "red",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "DSL::Entity::Jobs",
+   "passed": 0,
+   "reason": "mobile application development",
+   "status": "red",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "DSL::Examples",
+   "passed": 0,
+   "reason": "Cannot resolve caller dsl-examples(); none of these signatures matches:",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "EBNF::Grammar",
+   "passed": 0,
+   "reason": "equivalence",
+   "status": "red",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "ECMA262Regex",
+   "passed": 0,
+   "reason": "No such method 'ident' for invocant of type 'Match'",
+   "status": "red",
+   "version": "1.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Edit::Files",
+   "passed": 0,
+   "reason": "did edit-files get exported",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "eigenstates",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::p6bindattrinvres",
+   "status": "red",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Email::MessageID",
+   "passed": 0,
+   "reason": "No such method 'hostname' for invocant of type 'Kernel'",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Env",
+   "passed": 0,
+   "reason": "did we find %*ENV<ACCEPT_EULA> as ACCEPT_EULA",
+   "status": "red",
+   "version": "0.99"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Env::Dotenv",
+   "passed": 0,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "envy",
+   "passed": 0,
+   "reason": "crc32_hex(12345678901234567890123456789012345678901234567890123456789012345678901234567890) => expect:7ca94a72,got:FFFFFFFF",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Fasta",
+   "passed": 0,
+   "reason": "Cannot resolve caller prefix:<++>(...); the parameter requires mutable arguments",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "File::Find",
+   "passed": 0,
+   "reason": "Unknown function: checkrules",
+   "status": "red",
+   "version": "0.2.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "FiniteFields",
+   "passed": 0,
+   "reason": "not ok 38 -",
+   "status": "red",
+   "version": "0.3.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "FixedInt",
+   "passed": 0,
+   "reason": "Confused. expected statement: expected expression statement or ')'",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Fortran::Grammar",
+   "passed": 0,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "ForwardIterables",
+   "passed": 0,
+   "reason": "do we get a good first value",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "French",
+   "passed": 0,
+   "reason": "Unknown function: et",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "from",
+   "passed": 0,
+   "reason": "Unknown function: plan",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "FStrings",
+   "passed": 0,
+   "reason": "general g small",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Function::Validation",
+   "passed": 0,
+   "reason": "not ok 5 -",
+   "status": "red",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Geo::Coordinates::UTM",
+   "passed": 0,
+   "reason": "Confused. expected statement: expected use statement or import statement or no statement or need statement or unit statement or ...",
+   "status": "red",
+   "version": "0.9.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Geo::WellKnownBinary",
+   "passed": 0,
+   "reason": "from GA buildingpoints table",
+   "status": "red",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "GeoIP2",
+   "passed": 0,
+   "reason": "Odd number of elements found where hash initializer expected: found 1 element(s); last element seen: 0",
+   "status": "red",
+   "version": "1.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "German",
+   "passed": 0,
+   "reason": "Unknown function: und",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Getopt::Type",
+   "passed": 0,
+   "reason": "not ok 7 -",
+   "status": "red",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Grammar::Extractor",
+   "passed": 0,
+   "reason": "X::Assignment::RO: cannot assign through .bool on non-instance",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Grammar::Message",
+   "passed": 0,
+   "reason": "Invalid attribute name 'blue'",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Grammar::Profiler::Simple",
+   "passed": 0,
+   "reason": "test consistency of ''",
+   "status": "red",
+   "version": "0.05"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Grammar::Tracer::Compact",
+   "passed": 0,
+   "reason": "grammar.parse(...) with the tracer works",
+   "status": "red",
+   "version": "1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Grid",
+   "passed": 0,
+   "reason": "grid",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Hash-with",
+   "passed": 0,
+   "reason": "does lower case give right answer",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Hash::Consistent",
+   "passed": 0,
+   "reason": "basic instantiation",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Hash::int",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::hash",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Hash::LRU",
+   "passed": 0,
+   "reason": "No such method 'keyof' for invocant of type 'Hash'",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Hash::Ordered",
+   "passed": 0,
+   "reason": "in sub keys at /home/runner/.cache/mutsu-ecosystem/deps/Hash__Agnostic/Hash-Agnostic-0.0.20/lib/Hash/Agnostic.rakumod line 22",
+   "status": "red",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Hash::Restricted",
+   "passed": 0,
+   "reason": "Unknown prefix operator: (-)",
+   "status": "red",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Hash::str",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::hash",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 6,
+   "dist": "Hash::Util",
+   "passed": 0,
+   "reason": "is &all_ref_keys externally accessible?",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Heap",
+   "passed": 0,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "HexDump::Tiny",
+   "passed": 0,
+   "reason": "Not enough elements for map block arity",
+   "status": "red",
+   "version": "0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "hide-methods",
+   "passed": 0,
+   "reason": "No such method 'wrap' for invocant of type 'Method+{MethodWrapped}'",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "HTML::Entity::Fast",
+   "passed": 0,
+   "reason": "encoding with entities",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "HTML::Functional",
+   "passed": 0,
+   "reason": "Unknown function: h1",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "HTML::Strip",
+   "passed": 0,
+   "reason": "basic tag strip",
+   "status": "red",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "HTML::Tag",
+   "passed": 0,
+   "reason": "HTML::Tag::p works ok",
+   "status": "red",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "HTTP::Server::Async::Plugins::Router::Simple",
+   "passed": 0,
+   "reason": "Got to the end",
+   "status": "red",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "HTTP::Server::Middleware::JSON",
+   "passed": 0,
+   "reason": "Not parsed",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "HTTP::Tiny",
+   "passed": 0,
+   "reason": "X::Undeclared::Symbols: Undeclared name:",
+   "status": "red",
+   "version": "0.2.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Identity::Utils",
+   "passed": 0,
+   "reason": "Did 'api' get exported?",
+   "status": "red",
+   "version": "0.0.29"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "IDNA::Punycode",
+   "passed": 0,
+   "reason": "Unknown function: digit_value",
+   "status": "red",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "if",
+   "passed": 0,
+   "reason": "a bare use still works",
+   "status": "red",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "immutable",
+   "passed": 0,
+   "reason": "Ambiguous call to 'new(ValueList\u00005: )'; these signatures all match:",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "inode-dev-devtype",
+   "passed": 0,
+   "reason": "No such method 'FILETEST-E' for invocant of type 'Rakudo::Internals'",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "InterceptAllMethods",
+   "passed": 0,
+   "reason": "No such method 'foo' for invocant of type 'Foo'",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Interval",
+   "passed": 0,
+   "reason": "next value ok",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Intl::Format::Number",
+   "passed": 0,
+   "reason": "Count of minimum integer digits is correct",
+   "status": "red",
+   "version": "0.4.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "IO::Dir",
+   "passed": 0,
+   "reason": "X::IO::Dir with no message",
+   "status": "red",
+   "version": "1.001004"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "IO::Maildir",
+   "passed": 0,
+   "reason": "No such method 'truncate' for invocant of type 'Instant'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "IO::Stem",
+   "passed": 0,
+   "reason": "Basic IO::Path instantiation",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 9,
+   "dist": "IP::Addr",
+   "passed": 0,
+   "reason": "X::Method::NotFound: Unknown method value dispatch (fallback disabled): parse",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "JobQueue",
+   "passed": 0,
+   "reason": "Unknown function: uuid-v4",
+   "status": "red",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "JSON::Fast::Hyper",
+   "passed": 0,
+   "reason": "is array ok",
+   "status": "red",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "JSON::Mask",
+   "passed": 0,
+   "reason": "'self' used where no object is available",
+   "status": "red",
+   "version": "1.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "JSON::Native",
+   "passed": 0,
+   "reason": "thread 'mutsu-main' (3) has overflowed its stack",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "JSON::RepositoryEvent",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::p6bindattrinvres",
+   "status": "red",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "JSON::RPC",
+   "passed": 0,
+   "reason": "rpc call with invalid Batch",
+   "status": "red",
+   "version": "1.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Karabiner::CompModGenerator",
+   "passed": 0,
+   "reason": "generates files without dying",
+   "status": "red",
+   "version": "0.0.20"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Keyring",
+   "passed": 0,
+   "reason": "Can never assign default value Array to attribute '$!backend-priority', it expects: Keyring::Backend:U",
+   "status": "red",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "Kind",
+   "passed": 0,
+   "reason": "No such method 'kind' for invocant of type 'Perl6::Metamodel::ClassHOW'",
+   "status": "red",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Kind::Subset::Parametric",
+   "passed": 0,
+   "reason": "can mark a subset as being parametric",
+   "status": "red",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Kubernetes",
+   "passed": 0,
+   "reason": "kind: Test",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::AF",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::CY",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::DE",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::EN",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::EO",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::FR",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::HU",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::IT",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::JA",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::NL",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::PT",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "L10N::TLH",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 9,
+   "dist": "L10N::ZH",
+   "passed": 0,
+   "reason": "No such method 'AST' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Lang::JA::Kana",
+   "passed": 0,
+   "reason": "Basic Hiragana to Katakana conversion",
+   "status": "red",
+   "version": "1.2.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "LibraryMake",
+   "passed": 0,
+   "reason": "Unknown VM; don't know how to build",
+   "status": "red",
+   "version": "1.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Lingua::Stem::Portuguese",
+   "passed": 0,
+   "reason": "Could not find Lingua::Stem::Portuguese in:",
+   "status": "red",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Lingua::Stem::Russian",
+   "passed": 0,
+   "reason": "Could not find Lingua::Stem::Russian in:",
+   "status": "red",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "List::Allmax",
+   "passed": 0,
+   "reason": "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '&by'; expected Callable[Callable] but got WhateverCode (WhateverCode.new)",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "List::Divvy",
+   "passed": 0,
+   "reason": "No such method 'CALL-ME' for invocant of type 'Nil'",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 60,
+   "dist": "List::MoreUtils",
+   "passed": 0,
+   "reason": "is &bsearch_index externally accessible?",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 15,
+   "dist": "List::UtilsBy",
+   "passed": 0,
+   "reason": "is &nmax_by externally accessible?",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Listicles",
+   "passed": 0,
+   "reason": ".flatten should return a Seq (like .flat)",
+   "status": "red",
+   "version": "1.6.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "LLM::Functions",
+   "passed": 0,
+   "reason": "Odd number of elements found where hash initializer expected: found 2 element(s); last element seen:",
+   "status": "red",
+   "version": "0.5.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "LLM::Graph",
+   "passed": 0,
+   "reason": "No such method 'attribute_table' for invocant of type 'Perl6::Metamodel::ClassHOW'",
+   "status": "red",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Locale::Codes::Country",
+   "passed": 0,
+   "reason": "codeToCountry country=BANGLADESH",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Locale::US",
+   "passed": 0,
+   "reason": "No such method 'uc' for invocant of type 'Any'",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Map::Match",
+   "passed": 0,
+   "reason": "value for \\d >> :k",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Map::Ordered",
+   "passed": 0,
+   "reason": "Cannot dispatch to method STORE on Hash::Agnostic because it is not inherited or done by Map::Ordered",
+   "status": "red",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "Markdown::Grammar",
+   "passed": 0,
+   "reason": "'self' used where no object is available",
+   "status": "red",
+   "version": "0.6.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Math::Combinatorics",
+   "passed": 0,
+   "reason": "Cannot resolve caller multicombinations(List:D, Int:D); none of these signatures matches",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Math::Constants",
+   "passed": 0,
+   "reason": "Undeclared name:",
+   "status": "red",
+   "version": "0.2.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "Math::DistanceFunctions",
+   "passed": 0,
+   "reason": "Could not use native implementation.",
+   "status": "red",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Math::Fitting",
+   "passed": 0,
+   "reason": "Cannot resolve caller Math::Fitting::LinearRegression::Fit(Array:D); none of these signatures matches:",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Math::Handy",
+   "passed": 0,
+   "reason": "memory allocation of 269168 bytes failed",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Math::Interval",
+   "passed": 0,
+   "reason": "R+R",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Math::Polynomial::Chebyshev",
+   "passed": 0,
+   "reason": "Same result with function over data and data argument",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Math::SalvoCombatModeling",
+   "passed": 0,
+   "reason": "Unsupported language 'Bulgarian'. Expected one of:",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Math::Vector",
+   "passed": 0,
+   "reason": "Runtime error: Unsupported use of -> as postfix. In Raku please use: either . to call a method, or whitespace to delimit a pointy block.",
+   "status": "red",
+   "version": "0.6.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "MergeOrderedSeqs",
+   "passed": 0,
+   "reason": "not ok 1 -",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "MermaidJS::Grammar",
+   "passed": 0,
+   "reason": "sample 2 parses",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "META::constants",
+   "passed": 0,
+   "reason": "is NAME ok",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "META::verauthapi",
+   "passed": 0,
+   "reason": ":ver on A at compile-time",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Method::Also",
+   "passed": 0,
+   "reason": "No such method 'bar' for invocant of type 'A'",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Method::Misspelt",
+   "passed": 0,
+   "reason": "No such method 'FOO-baz' for invocant of type 'B'",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Method::Protected",
+   "passed": 0,
+   "reason": "",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "ML::Clustering",
+   "passed": 0,
+   "reason": "No such method 'assuming' for invocant of type 'Method'",
+   "status": "red",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "MoarVM::Remote",
+   "passed": 0,
+   "reason": "No such method 'share' for invocant of type 'Supply'",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "mod-div-specs",
+   "passed": 0,
+   "reason": "div dies with dispatch error if non-int",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Moneys",
+   "passed": 0,
+   "reason": "Confused. expected statement: expected known call arguments or first call argument or positional argument expression or reduction operator or expression stateme",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Moonphase",
+   "passed": 0,
+   "reason": "test1",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "MQTT::Client",
+   "passed": 0,
+   "reason": "4.7.2.1, '$SYS/monitor/Clients' should not match '+/monitor/Clients'",
+   "status": "red",
+   "version": "*"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Native::Overflow",
+   "passed": 0,
+   "reason": "",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Net::IP::Parse",
+   "passed": 0,
+   "reason": "Confused. expected statement: expected expression statement or listop argument expression or expected statement: expected expression statement or listop argumen",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Net::netent",
+   "passed": 0,
+   "reason": "Cannot resolve caller; none of the candidates match",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Net::Netmask",
+   "passed": 0,
+   "reason": "Default constructor for 'Net::Netmask' only takes named arguments",
+   "status": "red",
+   "version": "0.2.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Net::NetRC",
+   "passed": 0,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Net::protoent",
+   "passed": 0,
+   "reason": "Cannot resolve caller; none of the candidates match",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Net::servent",
+   "passed": 0,
+   "reason": "Cannot resolve caller; none of the candidates match",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Number::Denominate",
+   "passed": 0,
+   "reason": "No such method 'value' for invocant of type 'List'",
+   "status": "red",
+   "version": "2.002002"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Object::Delayed",
+   "passed": 0,
+   "reason": "Too few positionals passed; expected 1 argument but got 0",
+   "status": "red",
+   "version": "0.0.13"
+  },
+  {
+   "axis": "guts",
+   "baseline": 3,
+   "dist": "Object::Trampoline",
+   "passed": 0,
+   "reason": "Default constructor for 'Object::Trampoline' only takes named arguments",
+   "status": "red",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "ObjectCache",
+   "passed": 0,
+   "reason": "Could not instantiate role 'ObjectCache' because it died with X::AdHoc; exception details:",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "OneSeq",
+   "passed": 0,
+   "reason": "Confused. expected statement: expected right-hand expression after '=' or expression after hyper operator or '.' or digits or generic radix literal or ...",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "OO::Actors",
+   "passed": 0,
+   "reason": "No such method 'add_role' for invocant of type 'MetamodelX::ActorHOW'",
+   "status": "red",
+   "version": "0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "OrderedHash",
+   "passed": 0,
+   "reason": "No matching candidates for method: !index",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "overload::constant",
+   "passed": 0,
+   "reason": "can overload integer",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5-X",
+   "passed": 0,
+   "reason": "is -e 'r' ok",
+   "status": "red",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
    "baseline": 1,
    "dist": "P5caller",
    "passed": 0,
@@ -289,12 +1765,1020 @@
   },
   {
    "axis": "pure",
+   "baseline": 3,
+   "dist": "P5chomp",
+   "passed": 0,
+   "reason": "chomp without args dies",
+   "status": "red",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5each",
+   "passed": 0,
+   "reason": "SWEEP-TIMEOUT",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5fileno",
+   "passed": 0,
+   "reason": "is fileno STDIN 0",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "P5localtime",
+   "passed": 0,
+   "reason": "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '@t'; expected Positional but got Str (Fri Sep 11 21:31:54 2026)",
+   "status": "red",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "P5math",
+   "passed": 0,
+   "reason": "Cannot resolve caller; none of the candidates match",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5print",
+   "passed": 0,
+   "reason": "Cannot assign to a readonly variable or a value",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5quotemeta",
+   "passed": 0,
+   "reason": "Codepoint 0 [0]  \\# using $_",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "P5readlink",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::const::STAT_EXISTS",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5reset",
+   "passed": 0,
+   "reason": "was $a reset",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5reverse",
+   "passed": 0,
+   "reason": "did we get a good implicit 3 2 1",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5sleep",
+   "passed": 0,
+   "reason": "Could not find symbol '&sleep-timer' in 'GLOBAL::CORE'",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5substr",
+   "passed": 0,
+   "reason": "Cannot modify an immutable Str ()",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "P5times",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::getrusage",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5unlink",
+   "passed": 0,
+   "reason": "does \"bar\" no longer exist",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Path::Map",
+   "passed": 0,
+   "reason": "lookup('date/2012/12/25')",
+   "status": "red",
+   "version": "0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "paths",
+   "passed": 0,
+   "reason": "Did 'is-regular-file' get exported?",
+   "status": "red",
+   "version": "10.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "PDF::ISO_32000",
+   "passed": 0,
+   "reason": "interface role missing method - dies",
+   "status": "red",
+   "version": "0.0.13"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "PDF::ISO_32000_2",
+   "passed": 0,
+   "reason": "interface role missing method - dies",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Pinterest::URL::Normalizer",
+   "passed": 0,
+   "reason": "The host is not an exact Pinterest domain",
+   "status": "red",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Pod::EOD",
+   "passed": 0,
+   "reason": "rearrangement should be successful for feature 'sub example {}'",
+   "status": "red",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "Pod::Load",
+   "passed": 0,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "red",
+   "version": "0.7.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Pod::To::Man",
+   "passed": 0,
+   "reason": "first pod renders ok",
+   "status": "red",
+   "version": "1.2.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Point",
+   "passed": 0,
+   "reason": "Type check failed in assignment to $!x; expected num but got Int (2)",
+   "status": "red",
+   "version": "1.2.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Portuguese",
+   "passed": 0,
+   "reason": "Confused. expected statement: expected expression statement or listop argument expression or expression after infix operator or '.' or digits or ...",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "POSIX::PWDENT",
+   "passed": 0,
+   "reason": "User 'root' exists",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Proc::Easier",
+   "passed": 0,
+   "reason": "get calling line number",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Prompt",
+   "passed": 0,
+   "reason": "'prompt' exported specifically",
+   "status": "red",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "Rainbow",
+   "passed": 0,
+   "reason": "/home/runner/.cache/mutsu-ecosystem/run/ecosweep-u2gpu5tg/dist/dist/t/test-data/rakudoc-lang",
+   "status": "red",
+   "version": "0.4.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Rake",
+   "passed": 0,
+   "reason": "number of values out of range. Is: 2, should be in 0..0",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "raku-RandomColor",
+   "passed": 0,
+   "reason": "Cannot assign to an immutable value",
+   "status": "red",
+   "version": "v0.12"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "RakuAST::Utils",
+   "passed": 0,
+   "reason": "No such method 'from-identifier-parts' for invocant of type 'RakuAST::Name'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Rakudo::Version",
+   "passed": 0,
+   "reason": "An exception occurred while evaluating a CHECK",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 3,
+   "dist": "rakudoc",
+   "passed": 0,
+   "reason": "Use of Nil in string context",
+   "status": "red",
+   "version": "0.2.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "rakudoc2man",
+   "passed": 0,
+   "reason": "Use of Nil in string context",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "RakuDoc::Load",
+   "passed": 0,
+   "reason": "No such method 'config' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "RakuDoc::Test::Files",
+   "passed": 0,
+   "reason": "No such method 'INCLUDE' for invocant of type 'Rakudo::Internals'",
+   "status": "red",
+   "version": "0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Random::Names",
+   "passed": 0,
+   "reason": "No such method 'set_why' for invocant of type 'Str'",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "Rat::Precise",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::islt_I",
+   "status": "red",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "RedFactory",
+   "passed": 0,
+   "reason": "Failed to parse module 'Red': Unexpected block in infix position (missing statement control word before the expression?)",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "RepositoryEvent",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::p6bindattrinvres",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "ReverseIterables",
+   "passed": 0,
+   "reason": "do we get a good first value",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Router::Right",
+   "passed": 0,
+   "reason": "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter 'argh'; expected Hash, got Nil",
+   "status": "red",
+   "version": "0.0.61"
+  },
+  {
+   "axis": "guts",
+   "baseline": 3,
+   "dist": "SelectiveImporting",
+   "passed": 0,
+   "reason": "Unknown function: package",
+   "status": "red",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 3,
+   "dist": "Sequence::Generator",
+   "passed": 0,
+   "reason": "is &infix:<...> imported?",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "SHAI",
+   "passed": 0,
+   "reason": "SHAI::CLI module can be use-d ok",
+   "status": "red",
+   "version": "5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Shell::Command",
+   "passed": 0,
+   "reason": "Unknown function: checkrules",
+   "status": "red",
+   "version": "*"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "silently",
+   "passed": 0,
+   "reason": "ERR captured ok (1)",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Slang::Subscripts",
+   "passed": 0,
+   "reason": "does it work with sigilless entities",
+   "status": "red",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Smooth::Numbers",
+   "passed": 0,
+   "reason": "thread 'mutsu-main' (3) has overflowed its stack",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "snip",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::push",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "SOAP::Client",
+   "passed": 0,
+   "reason": "Failed to resolve 'www.w3schools.com:443': failed to lookup address information: Temporary failure in name resolution",
+   "status": "red",
+   "version": "1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "sourcery",
+   "passed": 0,
+   "reason": "does Str.Numeric give 1 location",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "span",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::push",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Spanish",
+   "passed": 0,
+   "reason": "Unknown function: y",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Sparky-Job-Api",
+   "passed": 0,
+   "reason": "Unknown function: tags",
+   "status": "red",
+   "version": "0.0.13"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "String::Fields",
+   "passed": 0,
+   "reason": "did $foo become a String::Fields object",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "String::Splice",
+   "passed": 0,
+   "reason": "No matching candidates for method: splice",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Sub::Memoized",
+   "passed": 0,
+   "reason": "is memoized: positional, did we not execute the body this time",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Sub::Name",
+   "passed": 0,
+   "reason": "did we get the right name?",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Sub::Util",
+   "passed": 0,
+   "reason": "is &set_subname NOT imported?",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "subs",
+   "passed": 0,
+   "reason": "Redeclaration of routine 'foo'. Did you mean to declare a multi-sub?",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Sys::Hostname",
+   "passed": 0,
+   "reason": "No such method 'hostname' for invocant of type 'Kernel'",
+   "status": "red",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Tee",
+   "passed": 0,
+   "reason": "'\"\\$one\"' cannot be used as a source",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Terminal::Boxer",
+   "passed": 0,
+   "reason": "Seq objects are not valid endpoints for Ranges",
+   "status": "red",
+   "version": "0.3.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Terminal::Tests",
+   "passed": 0,
+   "reason": "Invalid attribute name 'bold'",
+   "status": "red",
+   "version": "0.0.18"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Terminal::WCWidth",
+   "passed": 0,
+   "reason": "Type check failed in binding to parameter '$ucs'; expected Int:D but got NFC",
+   "status": "red",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Terminal::Width",
+   "passed": 0,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "red",
+   "version": "1.001002"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Test::Builder",
+   "passed": 0,
+   "reason": "Created object isn't existing global singleton",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 10,
+   "dist": "Test::Mock",
+   "passed": 0,
+   "reason": "No such method 'get-all-yaks' for invocant of type 'Any'",
+   "status": "red",
+   "version": "1.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Test::Script",
+   "passed": 0,
+   "reason": "Environment",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Test::Time",
+   "passed": 0,
+   "reason": "Preceding context expects a term, but found infix => instead.",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Testo",
+   "passed": 0,
+   "reason": "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter 'test'; expected Testo::Test::Result:D, got Junction",
+   "status": "red",
+   "version": "1.003009"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::LDIF",
+   "passed": 0,
+   "reason": "Confused. expected statement: expected expression statement or listop argument expression after ',' or expected statement: expected expression statement or list",
+   "status": "red",
+   "version": "1.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::Markov",
+   "passed": 0,
+   "reason": "SWEEP-TIMEOUT",
+   "status": "red",
+   "version": "2.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::MathematicalCase",
+   "passed": 0,
+   "reason": "Type check failed in binding to parameter '$needle'; expected int but got NFD",
+   "status": "red",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Time::Duration",
+   "passed": 0,
+   "reason": "Calling _render(Array, Array) will never work with declared signature (Str $direction, @approximate, @separate)",
+   "status": "red",
+   "version": "2.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 3,
+   "dist": "Time::gmtime",
+   "passed": 0,
+   "reason": "Cannot resolve caller; none of the candidates match",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "native",
+   "baseline": 3,
+   "dist": "Time::localtime",
+   "passed": 0,
+   "reason": "Cannot resolve caller; none of the candidates match",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "TimeBomb",
+   "passed": 0,
+   "reason": "Routine",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Timer::Stopwatch",
+   "passed": 0,
+   "reason": "No such private method 'stop' for invocant of type 'Timer::Stopwatch'",
+   "status": "red",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "TimeUnit",
+   "passed": 0,
+   "reason": "Calling minutes() will never work with declared signature (Numeric() $n)",
+   "status": "red",
+   "version": "1.3.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Today",
+   "passed": 0,
+   "reason": "does 'today' work?",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "TOML::Thumb",
+   "passed": 0,
+   "reason": "No such method '' for invocant of type 'IO::Path'",
+   "status": "red",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Trap",
+   "passed": 0,
+   "reason": "No such method 'text' for invocant of type 'Trap(Any)'",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Tuple",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::push",
+   "status": "red",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "UML::Translators",
+   "passed": 0,
+   "reason": "Cannot load name space MyPackageClass.",
+   "status": "red",
+   "version": "0.1.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Unicode",
+   "passed": 0,
+   "reason": "Cannot resolve caller version(Unicode\u00003:U: ); none of these signatures matches:",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "URI::Encode",
+   "passed": 0,
+   "reason": "Decode to \"   \"",
+   "status": "red",
+   "version": "1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "URI::Query::FromHash",
+   "passed": 0,
+   "reason": "empty string",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "User::grent",
+   "passed": 0,
+   "reason": "Cannot resolve caller; none of the candidates match",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "User::pwent",
+   "passed": 0,
+   "reason": "Cannot resolve caller; none of the candidates match",
+   "status": "red",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "ValueList",
+   "passed": 0,
+   "reason": "Unsupported nqp:: op: nqp::push",
+   "status": "red",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "ValueMap",
+   "passed": 0,
+   "reason": "Unknown function: new",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "ValuePair",
+   "passed": 0,
+   "reason": "thread 'mutsu-main' (3) has overflowed its stack",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "ValueType",
+   "passed": 0,
+   "reason": "is the basic .WHICH ok",
+   "status": "red",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "ValueTypeCache",
+   "passed": 0,
+   "reason": "Could not instantiate role 'ValueTypeCache' because it died with X::AdHoc; exception details:",
+   "status": "red",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "VERS",
+   "passed": 0,
+   "reason": "No such method 'Version' for invocant of type 'VERS::Type(VERS::raku)'",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Version::Conan",
+   "passed": 0,
+   "reason": "Cannot resolve caller raku(Version::Conan:U: ); none of these signatures matches:",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Version::Nginx",
+   "passed": 0,
+   "reason": "Default constructor for 'Version::Nginx' only takes named arguments",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Version::Raku",
+   "passed": 0,
+   "reason": "Default constructor for 'Version::Raku' only takes named arguments",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Version::RubyGems",
+   "passed": 0,
+   "reason": "Cannot resolve caller raku(Version::RubyGems:U: ); none of these signatures matches:",
+   "status": "red",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Version::Semver",
+   "passed": 0,
+   "reason": "Cannot resolve caller raku(Version::Semver:U: ); none of these signatures matches:",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Version::Semverish",
+   "passed": 0,
+   "reason": "Cannot resolve caller raku(Version::Semverish:U: ); none of these signatures matches:",
+   "status": "red",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "W3C::DOM",
+   "passed": 0,
+   "reason": "Method 'publicId' must be implemented by Dtd because it is required by roles: W3C::DOM::DocumentType.",
+   "status": "red",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Web::Scraper",
+   "passed": 0,
+   "reason": "tarray hash equality",
+   "status": "red",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "WebService::GitHub",
+   "passed": 0,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "red",
+   "version": "0.2.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "WhereList",
+   "passed": 0,
+   "reason": "Confused. expected statement: expected ')'",
+   "status": "red",
+   "version": "1.001002"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "WriteOnceHash",
+   "passed": 0,
+   "reason": "No such method 'BIND-KEY' for invocant of type 'Hash'",
+   "status": "red",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "XDG::GuaranteedResources",
+   "passed": 0,
+   "reason": "thread 'mutsu-main' (3) has overflowed its stack",
+   "status": "red",
+   "version": "2.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "XML::Entity::HTML",
+   "passed": 0,
+   "reason": "decode-html-entities works",
+   "status": "red",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "xxirakup6-RandomColor",
+   "passed": 0,
+   "reason": "Cannot assign to an immutable value",
+   "status": "red",
+   "version": "v0.11"
+  },
+  {
+   "axis": "pure",
    "baseline": 10,
    "dist": "ABC",
    "passed": 3,
    "reason": "\"_D,5/4\" has base note D",
    "status": "partial",
    "version": "0.6.13"
+  },
+  {
+   "axis": "native",
+   "baseline": 4,
+   "dist": "AccessorFacade",
+   "passed": 2,
+   "reason": "Type check failed for return value; expected Bool but got Whatever (*)",
+   "status": "partial",
+   "version": "0.1.2"
   },
   {
    "axis": "pure",
@@ -337,7 +2821,7 @@
    "baseline": 6,
    "dist": "Algorithm::Evolutionary::Simple",
    "passed": 2,
-   "reason": "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '@chromosome'; expected Positional but got Hash ({10 => (Any), 9 => (Any)})",
+   "reason": "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '@chromosome1'; expected Positional but got Str (Seq|True True True True True True T",
    "status": "partial",
    "version": "0.0.8"
   },
@@ -424,6 +2908,15 @@
   },
   {
    "axis": "native",
+   "baseline": 2,
+   "dist": "Audio::Encode::LameMP3",
+   "passed": 1,
+   "reason": "An exception occurred while evaluating a CHECK",
+   "status": "partial",
+   "version": "0.0.15"
+  },
+  {
+   "axis": "native",
    "baseline": 3,
    "dist": "Audio::Fingerprint::Chromaprint",
    "passed": 2,
@@ -468,6 +2961,15 @@
    "version": "0.2.3"
   },
   {
+   "axis": "guts",
+   "baseline": 3,
+   "dist": "Backtrace::Files",
+   "passed": 2,
+   "reason": "Did 'add-source-lines' get exported?",
+   "status": "partial",
+   "version": "0.0.4"
+  },
+  {
    "axis": "pure",
    "baseline": 2,
    "dist": "Bench",
@@ -481,7 +2983,7 @@
    "baseline": 2,
    "dist": "Benchmark",
    "passed": 1,
-   "reason": "Type check failed for return value; expected Hash:D[Duration:D] but got Hash (max\t-0.00004673004150390625",
+   "reason": "Type check failed for return value; expected Hash:D[Duration:D] but got Hash (max\t-0.000012874603271484375",
    "status": "partial",
    "version": "2.1"
   },
@@ -532,12 +3034,21 @@
   },
   {
    "axis": "pure",
-   "baseline": 7,
+   "baseline": 8,
    "dist": "Cache::Async",
    "passed": 6,
-   "reason": "Cache entry should never be older than .5s",
+   "reason": "Unknown function: atomic-fetch-sub",
    "status": "partial",
    "version": "0.3.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "CellularAutomata",
+   "passed": 1,
+   "reason": "rule 73",
+   "status": "partial",
+   "version": "0.0.1"
   },
   {
    "axis": "pure",
@@ -586,12 +3097,1929 @@
   },
   {
    "axis": "pure",
+   "baseline": 3,
+   "dist": "Concurrent::Iterator",
+   "passed": 1,
+   "reason": "SWEEP-TIMEOUT",
+   "status": "partial",
+   "version": "1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Concurrent::Stack",
+   "passed": 1,
+   "reason": "No such method 'Failure' for invocant of type 'X::Concurrent::Stack::Empty'",
+   "status": "partial",
+   "version": "1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 19,
+   "dist": "Config::TOML",
+   "passed": 14,
+   "reason": "Type check failed in binding to parameter '$container'; expected Associative:D but got Str",
+   "status": "partial",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "CoreHackers::Sourcery",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "2.001006"
+  },
+  {
+   "axis": "pure",
+   "baseline": 15,
+   "dist": "Crane",
+   "passed": 4,
+   "reason": "not ok 5 -",
+   "status": "partial",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 9,
+   "dist": "Cro::Core",
+   "passed": 8,
+   "reason": "Internal error: failed to spawn worker thread: Os { code: 11, kind: WouldBlock, message: \"Resource temporarily unavailable\" }",
+   "status": "partial",
+   "version": "0.8.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Cro::WebSocket",
+   "passed": 2,
+   "reason": "Hello",
+   "status": "partial",
+   "version": "0.8.10"
+  },
+  {
+   "axis": "native",
+   "baseline": 9,
+   "dist": "Crypt::LibGcrypt",
+   "passed": 4,
+   "reason": "Cannot locate native library 'libgcrypt.so': libgcrypt.so.2: dlopen failed",
+   "status": "partial",
+   "version": "1.0.11"
+  },
+  {
+   "axis": "native",
+   "baseline": 4,
+   "dist": "Crypt::LibScrypt",
+   "passed": 1,
+   "reason": "An exception occurred while evaluating a CHECK",
+   "status": "partial",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 9,
+   "dist": "Data::Dump",
+   "passed": 5,
+   "reason": "got expected data structure",
+   "status": "partial",
+   "version": "0.0.18"
+  },
+  {
+   "axis": "pure",
+   "baseline": 26,
+   "dist": "Data::MessagePack",
+   "passed": 11,
+   "reason": "Double packed correcly",
+   "status": "partial",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Data::Transformers",
+   "passed": 3,
+   "reason": "X::TypeCheck::Argument: Calling rescale(Array, Array, Array) will never work with proto signature (Numeric:D x, _capture)",
+   "status": "partial",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Data::TypeSystem",
+   "passed": 2,
+   "reason": "not ok 3 -",
+   "status": "partial",
+   "version": "0.1.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Date::Calendar::Armenian",
+   "passed": 2,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Date::Calendar::Bahai",
+   "passed": 2,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Date::Calendar::FrenchRevolutionary",
+   "passed": 2,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Date::Calendar::Gregorian",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Date::Calendar::MayaAztec",
+   "passed": 3,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Date::Calendar::Persian",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Date::Calendar::Strftime",
+   "passed": 2,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Date::Easter",
+   "passed": 1,
+   "reason": "Ambiguous call to 'etype(Date::Event: )'; these signatures all match:",
+   "status": "partial",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Date::Event",
+   "passed": 2,
+   "reason": "Use of Nil in string context",
+   "status": "partial",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "pure",
+   "baseline": 19,
+   "dist": "Date::Names",
+   "passed": 18,
+   "reason": "Runtime error: X::Syntax::Malformed: Malformed initializer",
+   "status": "partial",
+   "version": "2.3.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "DateTime::Format",
+   "passed": 2,
+   "reason": "RFC 2822 format with UTC",
+   "status": "partial",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "DateTime::TimeZone",
+   "passed": 1,
+   "reason": "Correct offset with lastSun rule and first day of month == Sunday (day before)",
+   "status": "partial",
+   "version": "0.10.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 6,
+   "dist": "DAWG",
+   "passed": 5,
+   "reason": "DAWG minimized: 1 nodes, 0 edges",
+   "status": "partial",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "DB::Migration::Declare",
+   "passed": 1,
+   "reason": "Confused. expected statement: expected expression statement or listop argument expression or expected statement: expected expression statement or '.' or digits ",
+   "status": "partial",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 9,
+   "dist": "DB::Xoos",
+   "passed": 4,
+   "reason": "join sql",
+   "status": "partial",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 8,
+   "dist": "DB::Xoos::SQLite",
+   "passed": 4,
+   "reason": "Could not find symbol 'Concurrent::Stack'",
+   "status": "partial",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Die",
+   "passed": 1,
+   "reason": "STDERR",
+   "status": "partial",
+   "version": "1.001002"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Digest",
+   "passed": 3,
+   "reason": "SWEEP-TIMEOUT",
+   "status": "partial",
+   "version": "1.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "DirHandle",
+   "passed": 1,
+   "reason": "Undeclared routine:",
+   "status": "partial",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Display::Listings",
+   "passed": 1,
+   "reason": "Signature constraint check failed in binding to parameter '&include-row'; expected :(Str:D $pref, Regex $pat, Str:D $k, Str:D @f, %r) but got :(Str:D $prefix, R",
+   "status": "partial",
+   "version": "0.1.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Distribution::Resources::Menu",
+   "passed": 1,
+   "reason": "Type check failed in assignment to $!resources; expected Distribution::Resources but got Hash",
+   "status": "partial",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Docker::File",
+   "passed": 1,
+   "reason": "Cannot resolve caller Str(Docker::File::Label:D: ); none of these signatures matches:",
+   "status": "partial",
+   "version": "1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "DSL::Entity::Metadata",
+   "passed": 1,
+   "reason": "No such method 'word-value' for invocant of type 'Match'",
+   "status": "partial",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "DSL::Entity::WeatherData",
+   "passed": 1,
+   "reason": "F0664",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "DSL::Shared",
+   "passed": 1,
+   "reason": "not ok 6 -",
+   "status": "partial",
+   "version": "0.2.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 11,
+   "dist": "EERPG",
+   "passed": 4,
+   "reason": "thread 'mutsu-main' (3) has overflowed its stack",
+   "status": "partial",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "Email::Valid",
+   "passed": 6,
+   "reason": "Type check failed in assignment to $desc; expected Email but got Str (\"test@valid.com\")",
+   "status": "partial",
+   "version": "1.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "EuclideanRhythm",
+   "passed": 2,
+   "reason": "SWEEP-TIMEOUT",
+   "status": "partial",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Event::Emitter",
+   "passed": 4,
+   "reason": "'Event::Emitter::Role::Node::Event::Emitter[Any]+{Event::Emitter::Supply}' cannot inherit from 'Event::Emitter::Role::Node::Event::Emitter[Any]' because it is u",
+   "status": "partial",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "FEN::Grammar",
+   "passed": 3,
+   "reason": "Cannot resolve caller active-color(FEN::Actions:D: FEN::Grammar:D); none of these signatures matches:",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "File::Ignore",
+   "passed": 6,
+   "reason": "Unknown function: recurse",
+   "status": "partial",
+   "version": "1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "File::Utils",
+   "passed": 1,
+   "reason": "Type check failed in binding to parameter '$ucs'; expected Int:D but got NFC",
+   "status": "partial",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "flow",
+   "passed": 2,
+   "reason": "Too many positionals passed; expected 0 arguments but got more",
+   "status": "partial",
+   "version": "v0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 11,
+   "dist": "Form",
+   "passed": 4,
+   "reason": "Simple centred block field parses",
+   "status": "partial",
+   "version": "1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 32,
+   "dist": "Format::Lisp",
+   "passed": 31,
+   "reason": "single directive, no ornamentation",
+   "status": "partial",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 18,
+   "dist": "FunctionalParsers",
+   "passed": 6,
+   "reason": "Runtime error: X::Syntax::Malformed: Malformed initializer",
+   "status": "partial",
+   "version": "0.1.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 8,
+   "dist": "Games::TauStation::DateTime",
+   "passed": 3,
+   "reason": "No such method 'DateTime::later' for invocant of type 'Games::TauStation::DateTime::GCT'",
+   "status": "partial",
+   "version": "1.001006"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Geo::Basic",
+   "passed": 3,
+   "reason": "encoded Ireland, most of England and Wales, small part of Scotland to gc",
+   "status": "partial",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 11,
+   "dist": "Geo::Ellipsoid",
+   "passed": 10,
+   "reason": "not ok 5 -",
+   "status": "partial",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Geo::Region",
+   "passed": 2,
+   "reason": "World (001) superregion",
+   "status": "partial",
+   "version": "*"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Git::File::History",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "native",
+   "baseline": 24,
+   "dist": "Gnome::Gio",
+   "passed": 10,
+   "reason": "Type check failed in binding to parameter '$argc'; expected int-ptr but got Any",
+   "status": "partial",
+   "version": "0.11.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 10,
+   "dist": "Gnome::Glib",
+   "passed": 2,
+   "reason": "Package 'GQuark' is insufficiently type-like to qualify a variable.  Did you mean 'class'?",
+   "status": "partial",
+   "version": "0.21.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 4,
+   "dist": "Gnome::GObject",
+   "passed": 3,
+   "reason": "(process:2): GLib-GObject-CRITICAL **: 21:10:38.207: g_value_init: assertion 'value != NULL' failed",
+   "status": "partial",
+   "version": "0.20.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 4,
+   "dist": "Gnome::N",
+   "passed": 3,
+   "reason": "Invalid typename 'GType' in parameter declaration.",
+   "status": "partial",
+   "version": "0.22.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Grammar::Common",
+   "passed": 4,
+   "reason": "Could not instantiate role 'Grammar::Common::Expression::Infix' because it died with X::Redeclaration; exception details:",
+   "status": "partial",
+   "version": "0.3.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 9,
+   "dist": "Grammar::Modelica",
+   "passed": 2,
+   "reason": "No such method 'S-CHAR' for invocant of type 'Match'",
+   "status": "partial",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "Grammar::PrettyErrors",
+   "passed": 2,
+   "reason": "nice report",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 24,
+   "dist": "Graph",
+   "passed": 9,
+   "reason": "Required named parameter '!n' not passed",
+   "status": "partial",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "H2O::Client",
+   "passed": 4,
+   "reason": "list positional access preserves selector order",
+   "status": "partial",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "has-word",
+   "passed": 1,
+   "reason": "Unsupported nqp:: op: nqp::indexic",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Hash::Agnostic",
+   "passed": 1,
+   "reason": "test basic stuff after initialization",
+   "status": "partial",
+   "version": "0.0.20"
+  },
+  {
+   "axis": "pure",
+   "baseline": 8,
+   "dist": "HTML::Parser::XML",
+   "passed": 7,
+   "reason": "SWEEP-TIMEOUT",
+   "status": "partial",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 8,
+   "dist": "HTTP::Server::Async",
+   "passed": 1,
+   "reason": "HTTP Status Code: 200",
+   "status": "partial",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 16,
+   "dist": "Humming-Bird",
+   "passed": 4,
+   "reason": "No such method 'path' for invocant of type 'Any'",
+   "status": "partial",
+   "version": "4.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "Humming-Bird::Core",
+   "passed": 3,
+   "reason": "No such method 'path' for invocant of type 'Any'",
+   "status": "partial",
+   "version": "2.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Implementation::Loader",
+   "passed": 2,
+   "reason": "Type WithRoleTest does not do role TestRole",
+   "status": "partial",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Inline::Brainfuck",
+   "passed": 2,
+   "reason": "Calling test() will never work with declared signature (Str:D $output-type, Str:D $op-name, Str:D $routine-name, &code, $expected, Str $test-name)",
+   "status": "partial",
+   "version": "1.001001"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "IO::CatHandle::AutoLines",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "1.001004"
+  },
+  {
+   "axis": "pure",
+   "baseline": 10,
+   "dist": "IO::MiddleMan",
+   "passed": 3,
+   "reason": "Expected IO::Handle",
+   "status": "partial",
+   "version": "1.001004"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "IP::Random",
+   "passed": 3,
+   "reason": "No such method 'value' for invocant of type 'Hash'",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 33,
+   "dist": "Iter::Able",
+   "passed": 1,
+   "reason": "Cannot resolve caller group-conseq(Array:D); none of these signatures matches",
+   "status": "partial",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 9,
+   "dist": "Java::Generate",
+   "passed": 4,
+   "reason": "Type check failed in assignment to $!op; expected Op but got Str (\"+\")",
+   "status": "partial",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "JSON::Class",
+   "passed": 2,
+   "reason": "Cannot look up attributes in a Outer type object. Did you forget a '.new'?",
+   "status": "partial",
+   "version": "0.0.21"
+  },
+  {
+   "axis": "guts",
+   "baseline": 14,
+   "dist": "JSON::Fast",
+   "passed": 13,
+   "reason": "Hash: Int keys",
+   "status": "partial",
+   "version": "0.20.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "JSON::Hjson",
+   "passed": 1,
+   "reason": "not ok 1 -",
+   "status": "partial",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "JSON::Infer",
+   "passed": 2,
+   "reason": "Type check failed for return value; expected Attribute but got Any (JSON::Infer::Attribute())",
+   "status": "partial",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 14,
+   "dist": "JSON::Marshal",
+   "passed": 10,
+   "reason": "marshalled-by trait with Method name",
+   "status": "partial",
+   "version": "0.0.25"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "JSON::Path",
+   "passed": 3,
+   "reason": "Correct value result",
+   "status": "partial",
+   "version": "1.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 11,
+   "dist": "JSON::Unmarshal",
+   "passed": 7,
+   "reason": "Type check failed for an element of @!dogs; expected Dog but got Array",
+   "status": "partial",
+   "version": "0.18"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "JSONL",
+   "passed": 1,
+   "reason": "No such method 'set' for invocant of type 'SetHash'",
+   "status": "partial",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 6,
+   "dist": "Jupyter::Kernel",
+   "passed": 3,
+   "reason": "Unsupported nqp:: op: nqp::getcomp",
+   "status": "partial",
+   "version": "1.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "LaTeX::Grammar",
+   "passed": 1,
+   "reason": "MathJSON shape for: \\sqrt{x}",
+   "status": "partial",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "LEB128",
+   "passed": 1,
+   "reason": "Cannot resolve caller encode-leb128-unsigned(Int:D, Any:D); none of these signatures matches:",
+   "status": "partial",
+   "version": "1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 9,
+   "dist": "Lingua::EN::Numbers",
+   "passed": 4,
+   "reason": "No such method '' for invocant of type 'Int'",
+   "status": "partial",
+   "version": "2.8.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Lingua::EN::Stem::Porter",
+   "passed": 2,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "v1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 18,
+   "dist": "Lingua::NumericWordForms",
+   "passed": 17,
+   "reason": "εννιακόσια ογδόντα δισεκατομμύρια επτακόσια τριάντα έξι εκατομμύρια εκατόν τριάντα οκτώ χιλιάδες οκτακόσια τριάντα εννέα",
+   "status": "partial",
+   "version": "0.6.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Linux::Cpuinfo",
+   "passed": 2,
+   "reason": "Default constructor for 'Linux::Cpuinfo::Cpu::X86_64' only takes named arguments",
+   "status": "partial",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "Linux::Fuser",
+   "passed": 1,
+   "reason": "Unknown function: do_tests",
+   "status": "partial",
+   "version": "0.0.16"
+  },
+  {
+   "axis": "native",
+   "baseline": 4,
+   "dist": "Linux::NFTables",
+   "passed": 2,
+   "reason": "Cannot locate native library 'resources/libraries/libnfthelper.so': resources/libraries/libnfthelper.so: dlopen failed",
+   "status": "partial",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 14,
+   "dist": "List::Util",
+   "passed": 1,
+   "reason": "List::Util doesn't know how to export: any, all, notall, none",
+   "status": "partial",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 14,
+   "dist": "LLM::Character",
+   "passed": 8,
+   "reason": "No such method 'key' for invocant of type 'Hash'",
+   "status": "partial",
+   "version": "0.2.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 13,
+   "dist": "LLM::Chat",
+   "passed": 10,
+   "reason": "chat-completion returns canned response",
+   "status": "partial",
+   "version": "0.10.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "LLM::Chat::Backend",
+   "passed": 6,
+   "reason": "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter 'node'; expected Set, got Any",
+   "status": "partial",
+   "version": "0.2.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 13,
+   "dist": "LLM::Data::Inference",
+   "passed": 11,
+   "reason": "Missing variable dies",
+   "status": "partial",
+   "version": "0.10.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 4,
+   "dist": "LLM::RetrievalAugmentedGeneration",
+   "passed": 1,
+   "reason": "The argument $num-type is expected to be one of the strings \"num32\" or \"num64\" or one of the types num32 or num64.",
+   "status": "partial",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "LN",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "1.001002"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Locale::Dates",
+   "passed": 1,
+   "reason": "is weekday 0 correct",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "LocalTime",
+   "passed": 4,
+   "reason": "subtest B",
+   "status": "partial",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 15,
+   "dist": "Log::Async",
+   "passed": 12,
+   "reason": "not severe",
+   "status": "partial",
+   "version": "0.0.17"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Log::Dispatch",
+   "passed": 1,
+   "reason": "Type check failed in assignment to $!level; expected LOG-LEVEL:D but got Str (\"INFO\")",
+   "status": "partial",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Log::Reader",
+   "passed": 1,
+   "reason": "Month out of range. Is: 0, should be in 1..12",
+   "status": "partial",
+   "version": "1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Log::Timeline",
+   "passed": 2,
+   "reason": "Unexpected character in JSON: (",
+   "status": "partial",
+   "version": "0.5.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Logger",
+   "passed": 5,
+   "reason": "changed timestamp",
+   "status": "partial",
+   "version": "0.4.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "LogP6::Writer::StackDriver",
+   "passed": 1,
+   "reason": "Could not find symbol '&trace' in 'Level'",
+   "status": "partial",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 8,
+   "dist": "LWP::Simple",
+   "passed": 4,
+   "reason": "SWEEP-TIMEOUT",
+   "status": "partial",
+   "version": "0.109"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Manifesto",
+   "passed": 4,
+   "reason": "got what we expected",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Map::Mapnik",
+   "passed": 1,
+   "reason": "Type check failed for an element of @!parameters; expected Parameter but got Any",
+   "status": "partial",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Math::Angle",
+   "passed": 2,
+   "reason": "new from degree string",
+   "status": "partial",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Math::ConvergenceMethods",
+   "passed": 4,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.6.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 16,
+   "dist": "Math::FFT::Libfftw3",
+   "passed": 3,
+   "reason": "No such method 'allocate' for invocant of type 'NativeCall::Types::CArray[num64]'",
+   "status": "partial",
+   "version": "0.3.5"
+  },
+  {
+   "axis": "native",
+   "baseline": 16,
+   "dist": "Math::FFT::Libfftw3::C2C",
+   "passed": 3,
+   "reason": "No such method 'allocate' for invocant of type 'NativeCall::Types::CArray[num64]'",
+   "status": "partial",
+   "version": "0.3.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 5,
+   "dist": "Math::Nearest",
+   "passed": 1,
+   "reason": "No such method 'assuming' for invocant of type 'Method'",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 19,
+   "dist": "Math::NumberTheory",
+   "passed": 8,
+   "reason": "SWEEP-TIMEOUT",
+   "status": "partial",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Math::PascalTriangle",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Math::Polygons",
+   "passed": 3,
+   "reason": "Cannot dispatch to method Writer::serialize on XML because it is not inherited or done by SVG",
+   "status": "partial",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Math::Root",
+   "passed": 2,
+   "reason": "square root 2 ridiculous precision ok",
+   "status": "partial",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Math::SpecialFunctions",
+   "passed": 1,
+   "reason": "not ok 1 -",
+   "status": "partial",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Math::Splines",
+   "passed": 2,
+   "reason": "Cannot resolve caller b-spline-basis-value(); none of these signatures matches:",
+   "status": "partial",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Math::Trig",
+   "passed": 5,
+   "reason": "great-circle-bearing is exported by :great-circle",
+   "status": "partial",
+   "version": "0.5.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 10,
+   "dist": "MCP",
+   "passed": 2,
+   "reason": "Unknown function: LATEST_PROTOCOL_VERSION",
+   "status": "partial",
+   "version": "0.33.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 24,
+   "dist": "MCP::Client",
+   "passed": 6,
+   "reason": "one event",
+   "status": "partial",
+   "version": "0.5.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 23,
+   "dist": "MCP::Server",
+   "passed": 3,
+   "reason": "Type check failed for return value; expected Hash but got List (content\ttext\tType check failed for return value; expected Hash but got List (content\ttext\thello ",
+   "status": "partial",
+   "version": "0.6.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "MCP::Server::Tool::Ask",
+   "passed": 1,
+   "reason": "Type check failed for return value; expected Hash but got List (content\ttext\tType check failed for return value; expected Hash but got List (content\ttext\t{\"answ",
+   "status": "partial",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 11,
+   "dist": "MCP::Server::Tool::Shell",
+   "passed": 1,
+   "reason": "Type check failed in assignment to $!failure-prefix; expected Str but got Any (Any)",
+   "status": "partial",
+   "version": "0.4.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Memoize",
+   "passed": 1,
+   "reason": "':pure(False) disables implicit 'is pure'",
+   "status": "partial",
+   "version": "*"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Menu::Simple",
+   "passed": 1,
+   "reason": "Undeclared name:",
+   "status": "partial",
+   "version": "0.17"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "MessagePack::Class",
+   "passed": 2,
+   "reason": "No such method 'string' for invocant of type 'Any'",
+   "status": "partial",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "Monad",
+   "passed": 3,
+   "reason": "Confused. expected statement: expected use statement or import statement or no statement or need statement or unit statement or ...",
+   "status": "partial",
+   "version": "0.2.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 4,
+   "dist": "MongoDB::Fast",
+   "passed": 3,
+   "reason": "SWEEP-TIMEOUT",
+   "status": "partial",
+   "version": "0.2.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 5,
+   "dist": "MQ::Posix",
+   "passed": 2,
+   "reason": "No such method 'max-messages' for invocant of type 'Any'",
+   "status": "partial",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 37,
+   "dist": "MVC::Keayl",
+   "passed": 31,
+   "reason": "No such method '' for invocant of type 'HeartbeatChannel'",
+   "status": "partial",
+   "version": "0.9.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 6,
+   "dist": "Native::FindVersion",
+   "passed": 2,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 4,
+   "dist": "NativeHelpers::Blob",
+   "passed": 2,
+   "reason": "Can only handle",
+   "status": "partial",
+   "version": "0.1.13"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Net::Whois",
+   "passed": 3,
+   "reason": "IP address with number > 255",
+   "status": "partial",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Net::Whois::Async",
+   "passed": 4,
+   "reason": "invalid IP rejected by IP subset",
+   "status": "partial",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 9,
+   "dist": "Notcurses::Native",
+   "passed": 8,
+   "reason": "notcurses: has non-null 'name'",
+   "status": "partial",
+   "version": "0.6.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Object::Permission",
+   "passed": 2,
+   "reason": "set $*AUTH-USER ok",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Oyatul",
+   "passed": 2,
+   "reason": "No such method 'to-hash' for invocant of type 'Any'",
+   "status": "partial",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "P5chr",
+   "passed": 2,
+   "reason": "ord without args dies",
+   "status": "partial",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "P5getgrnam",
+   "passed": 1,
+   "reason": "NativeCall: symbol '_getgrgid' not found in 'this process': dlsym failed",
+   "status": "partial",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "P5getnetbyname",
+   "passed": 1,
+   "reason": "NativeCall: symbol '_getnetent' not found in 'this process': dlsym failed",
+   "status": "partial",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "P5getpriority",
+   "passed": 1,
+   "reason": "NativeCall: symbol '_getpriority' not found in 'this process': dlsym failed",
+   "status": "partial",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "P5getprotobyname",
+   "passed": 1,
+   "reason": "NativeCall: symbol '_getprotobyname' not found in 'this process': dlsym failed",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "P5getpwnam",
+   "passed": 1,
+   "reason": "NativeCall: symbol '_getpwuid' not found in 'this process': dlsym failed",
+   "status": "partial",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "P5getservbyname",
+   "passed": 1,
+   "reason": "NativeCall: symbol '_getservbyname' not found in 'this process': dlsym failed",
+   "status": "partial",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "P5pack",
+   "passed": 6,
+   "reason": "Cannot modify an immutable Str (a)",
+   "status": "partial",
+   "version": "0.0.16"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Parameterizable",
+   "passed": 1,
+   "reason": "Ultimate cannot be parameterized",
+   "status": "partial",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "PatternMatching",
+   "passed": 1,
+   "reason": "Confused. expected statement: expected right-hand expression after '=' or '.' or digits or generic radix literal or unicode numeric literal or ...",
+   "status": "partial",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 8,
+   "dist": "PB-Lottery",
+   "passed": 6,
+   "reason": "good read of existing data",
+   "status": "partial",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 10,
+   "dist": "PDF::Grammar",
+   "passed": 3,
+   "reason": "normal block tricky terminators image-block",
+   "status": "partial",
+   "version": "0.3.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Pluggable",
+   "passed": 1,
+   "reason": "No such method 'distribution' for invocant of type 'CompUnit::Repository::FileSystem'",
+   "status": "partial",
+   "version": "0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Pod::Contents",
+   "passed": 1,
+   "reason": "Runtime error: X::Syntax::Adverb: You can't adverb @@contents_without_indentation.",
+   "status": "partial",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 15,
+   "dist": "Pod::To::HTML",
+   "passed": 11,
+   "reason": "not ok 2 -",
+   "status": "partial",
+   "version": "v0.8.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 11,
+   "dist": "Pod::To::Markdown",
+   "passed": 8,
+   "reason": "Converts declarators to Markdown correctly",
+   "status": "partial",
+   "version": "0.2.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Pod::TreeWalker",
+   "passed": 2,
+   "reason": "pod comment",
+   "status": "partial",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 15,
+   "dist": "Pod::Utils",
+   "passed": 5,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "POFile",
+   "passed": 1,
+   "reason": "msgid, msgstr with source reference comment",
+   "status": "partial",
+   "version": "0.9"
+  },
+  {
+   "axis": "pure",
    "baseline": 4,
    "dist": "Prime::Factor",
    "passed": 1,
    "reason": "divisors() not defined for Int parameters. Coerce to Int before calling.",
    "status": "partial",
    "version": "0.4.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Printing::Jdf",
+   "passed": 2,
+   "reason": "DateTime.new requires arguments",
+   "status": "partial",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 4,
+   "dist": "Prompt::Hidden",
+   "passed": 1,
+   "reason": "a numeric line still comes back an allomorph",
+   "status": "partial",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "PURL",
+   "passed": 1,
+   "reason": "is the type correct",
+   "status": "partial",
+   "version": "0.0.15"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Pythonic::Str",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "1.001001"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "QueryOS",
+   "passed": 1,
+   "reason": "Unknown function: os-version-parts",
+   "status": "partial",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "RakudoPrereq",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "1.001005"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Range::SetOps",
+   "passed": 1,
+   "reason": "Runtime error: Unable to parse expression in array composer; couldn't find final ']' (corresponding starter was at line 1)",
+   "status": "partial",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "RegexUtils",
+   "passed": 3,
+   "reason": "No such method 'ident' for invocant of type 'Match'",
+   "status": "partial",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Retry",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "guts",
+   "baseline": 9,
+   "dist": "Scalar::Util",
+   "passed": 1,
+   "reason": "Scalar::Util doesn't know how to export: blessed",
+   "status": "partial",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Scientist",
+   "passed": 2,
+   "reason": "use is required",
+   "status": "partial",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "SeqSplitter",
+   "passed": 1,
+   "reason": "Type check failed in binding to parameter '$orig-seq'; expected Sequence:D but got Seq",
+   "status": "partial",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "SION",
+   "passed": 1,
+   "reason": "Your printf-style directives specify 0 arguments, but 1 argument was",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "Sort-Fast",
+   "passed": 1,
+   "reason": "Type check failed in binding; expected Positional but got Any",
+   "status": "partial",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 11,
+   "dist": "SQL::Builder",
+   "passed": 1,
+   "reason": "Type check failed in binding $s: expected Str, got Any",
+   "status": "partial",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Staticish",
+   "passed": 2,
+   "reason": "'Foo' cannot inherit from 'Static' because it is unknown.",
+   "status": "partial",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "guts",
+   "baseline": 3,
+   "dist": "String::Utils",
+   "passed": 2,
+   "reason": "is SHA1 ok",
+   "status": "partial",
+   "version": "0.0.40"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "SupplyTimeWindow",
+   "passed": 1,
+   "reason": "SWEEP-TIMEOUT",
+   "status": "partial",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 32,
+   "dist": "Syndicate",
+   "passed": 5,
+   "reason": "Use of Nil in string context",
+   "status": "partial",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Sys::OsRelease",
+   "passed": 5,
+   "reason": "Defaults are ok",
+   "status": "partial",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "System::Passwd",
+   "passed": 2,
+   "reason": "get root user by uid",
+   "status": "partial",
+   "version": "0.05"
+  },
+  {
+   "axis": "pure",
+   "baseline": 60,
+   "dist": "Template::HAML",
+   "passed": 28,
+   "reason": "X::HAML::ParseFail()",
+   "status": "partial",
+   "version": "0.9.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 24,
+   "dist": "Template::Jinja2",
+   "passed": 8,
+   "reason": "X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter 'node'; expected Set, got Any",
+   "status": "partial",
+   "version": "0.3.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 8,
+   "dist": "Template::Nest::XS",
+   "passed": 1,
+   "reason": "No such method 'deref' for invocant of type 'NativeCall::Types::Pointer[Str]'",
+   "status": "partial",
+   "version": "0.1.10"
+  },
+  {
+   "axis": "native",
+   "baseline": 3,
+   "dist": "Termbox2",
+   "passed": 2,
+   "reason": "Bare use imports every symbol, and nothing else",
+   "status": "partial",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Terminal::ANSIParser",
+   "passed": 1,
+   "reason": "Index out of bounds",
+   "status": "partial",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Terminal::Graphing::BarChart",
+   "passed": 1,
+   "reason": "bad bare graph",
+   "status": "partial",
+   "version": "2.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "Terminal::MultiProgress",
+   "passed": 3,
+   "reason": "start becomes Started",
+   "status": "partial",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Terminal::QuickCharts",
+   "passed": 4,
+   "reason": "pick-color Seq: --> ~Int",
+   "status": "partial",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Test::Grammar",
+   "passed": 3,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Test::Notice",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "1.001005"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Test::Output",
+   "passed": 1,
+   "reason": "Calling test() will never work with declared signature (Str:D $output-type, Str:D $op-name, Str:D $routine-name, &code, $expected, Str $test-name)",
+   "status": "partial",
+   "version": "1.001006"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Test::Run",
+   "passed": 1,
+   "reason": "Runtime error: X::Redeclaration: Redeclaration of symbol '@'",
+   "status": "partial",
+   "version": "0.2.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Test::Scheduler",
+   "passed": 2,
+   "reason": "Promise in 0 seconds is not scheduled immediately",
+   "status": "partial",
+   "version": "1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Test::Script::Output",
+   "passed": 1,
+   "reason": "No such method 'say' for invocant of type 'Str'",
+   "status": "partial",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Test::When",
+   "passed": 1,
+   "reason": "<smoke>",
+   "status": "partial",
+   "version": "2.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Text::Caesar",
+   "passed": 1,
+   "reason": "not ok 1 -",
+   "status": "partial",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Text::Calendar",
+   "passed": 1,
+   "reason": "Use of uninitialized value of type Any in string context.",
+   "status": "partial",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 6,
+   "dist": "Text::CodeProcessing",
+   "passed": 1,
+   "reason": "Unsupported nqp:: op: nqp::getcomp",
+   "status": "partial",
+   "version": "0.6.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 32,
+   "dist": "Text::CSV",
+   "passed": 31,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.022"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Text::Diff",
+   "passed": 1,
+   "reason": "X::TypeCheck::Argument: Calling _longestCommonSubsequence(Array, Array, Int, Nil) will never work with proto signature (@a, __ANON_STATE__, counting, &fcn, %arg",
+   "status": "partial",
+   "version": "1.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Text::Markdown",
+   "passed": 3,
+   "reason": "Slurped link correctly",
+   "status": "partial",
+   "version": "1.1.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 4,
+   "dist": "Text::MiscUtils",
+   "passed": 2,
+   "reason": "An exception occurred while evaluating a CHECK",
+   "status": "partial",
+   "version": "0.0.13"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Text::SubParsers",
+   "passed": 3,
+   "reason": "not ok 6 -",
+   "status": "partial",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Text::Template",
+   "passed": 1,
+   "reason": "nothing returned after exception",
+   "status": "partial",
+   "version": "1.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 17,
+   "dist": "Text::Utils",
+   "passed": 14,
+   "reason": "keep tabs",
+   "status": "partial",
+   "version": "4.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Text::Wrap",
+   "passed": 2,
+   "reason": "keep paragraphs",
+   "status": "partial",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Timer",
+   "passed": 1,
+   "reason": "Returns a reasonable value",
+   "status": "partial",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 8,
+   "dist": "Tinky",
+   "passed": 2,
+   "reason": "Type check failed in assignment to $!workflow; expected Workflow but got Str (\"Workflow\")",
+   "status": "partial",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Tinky::Declare",
+   "passed": 2,
+   "reason": "No Transitions defined in workflow",
+   "status": "partial",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 12,
+   "dist": "Trait::Env",
+   "passed": 1,
+   "reason": "thread 'mutsu-main' (3) has overflowed its stack",
+   "status": "partial",
+   "version": "1.1.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "Trait::IO",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "1.001001"
   },
   {
    "axis": "pure",
@@ -603,13 +5031,175 @@
    "version": "0.0.1"
   },
   {
+   "axis": "pure",
+   "baseline": 8,
+   "dist": "Ujumla",
+   "passed": 2,
+   "reason": "simple config",
+   "status": "partial",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Understitch",
+   "passed": 3,
+   "reason": "Confused. expected statement: expected expression statement or listop argument expression or expected statement: expected known call arguments or first call arg",
+   "status": "partial",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "UpRooted",
+   "passed": 3,
+   "reason": "UpRooted::Table",
+   "status": "partial",
+   "version": "1.8.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "URI",
+   "passed": 5,
+   "reason": "query param foo - el 2",
+   "status": "partial",
+   "version": "v0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "URI::FetchFile",
+   "passed": 3,
+   "reason": "No such method 'is-available' for invocant of type 'HTTP::UserAgent'",
+   "status": "partial",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 8,
+   "dist": "URI::Template",
+   "passed": 5,
+   "reason": "Level 3 Examples",
+   "status": "partial",
+   "version": "0.0.11"
+  },
+  {
    "axis": "native",
-   "baseline": 0,
-   "dist": "AccessorFacade",
-   "passed": 0,
-   "reason": "AccessorFacade: Runtime error: Failed to parse module 'AccessorFacade': X::Undeclared::Symbols: Undeclared routine:",
-   "status": "blocked_load",
+   "baseline": 3,
+   "dist": "User::Timezone",
+   "passed": 2,
+   "reason": "Unknown function: override-user-timezone",
+   "status": "partial",
+   "version": "0.3.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "UserTimezone",
+   "passed": 2,
+   "reason": "Unknown function: override-user-timezone",
+   "status": "partial",
+   "version": "0.3.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Uxmal",
+   "passed": 2,
+   "reason": "No such method 'max_threads' for invocant of type 'ThreadPoolScheduler'",
+   "status": "partial",
+   "version": "1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "vCard::Parser",
+   "passed": 3,
+   "reason": "Unsupported use of ${:group(\"MyGroup\")}. In Raku please use: $(:group(\"MyGroup\")) for hard ref or $::(:group(\"MyGroup\")) for symbolic ref.",
+   "status": "partial",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "Version::Repology",
+   "passed": 1,
+   "reason": "Cannot resolve caller raku(Version::Repology:U: ); none of these signatures matches:",
+   "status": "partial",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "WebService::Nominatim",
+   "passed": 1,
+   "reason": "Eiffel is in the url",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "WebService::Overpass",
+   "passed": 2,
+   "reason": "Got args",
+   "status": "partial",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 9,
+   "dist": "WebService::Soundcloud",
+   "passed": 7,
+   "reason": "new Playlist object from JSON",
+   "status": "partial",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "WebService::TMDB",
+   "passed": 2,
+   "reason": "Use of Nil in string context",
+   "status": "partial",
    "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "WWW",
+   "passed": 1,
+   "reason": "Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "partial",
+   "version": "1.005007"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "WWW::DuckDuckGo",
+   "passed": 1,
+   "reason": "Type Array does not support associative indexing.",
+   "status": "partial",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "XDG::BaseDirectory",
+   "passed": 3,
+   "reason": "Default constructor for 'XDG::BaseDirectory' only takes named arguments",
+   "status": "partial",
+   "version": "0.0.15"
+  },
+  {
+   "axis": "pure",
+   "baseline": 15,
+   "dist": "XML::Class",
+   "passed": 2,
+   "reason": "Can't use unknown trait 'is' -> 'xml-element' in an attribute declaration.",
+   "status": "partial",
+   "version": "0.0.11"
   },
   {
    "axis": "native",
@@ -657,15 +5247,6 @@
    "version": "0.1.1"
   },
   {
-   "axis": "native",
-   "baseline": 0,
-   "dist": "Algorithm::KDimensionalTree",
-   "passed": 0,
-   "reason": "Algorithm::KDimensionalTree: circular module dependency detected: Algorithm::KDimensionalTree -> Math::DistanceFunctions -> Math::DistanceFunctionish -> Math::D",
-   "status": "blocked_load",
-   "version": "0.1.2"
-  },
-  {
    "axis": "guts",
    "baseline": 0,
    "dist": "annotations",
@@ -688,7 +5269,7 @@
    "baseline": 0,
    "dist": "APISports::Football",
    "passed": 0,
-   "reason": "APISports::Football::Club: Unknown role: CustomUnmarshaller",
+   "reason": "APISports::Football::Club: Failed to parse module 'APISports::Football::Types': X::Syntax::CannotMeta: Cannot negate . because it is too fiddly",
    "status": "blocked_load",
    "version": "0.2.3"
   },
@@ -706,7 +5287,7 @@
    "baseline": 0,
    "dist": "App::Ebread",
    "passed": 0,
-   "reason": "App::Ebread::Epub: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-ho3pu70h/dist/dist/lib/App/Ebread/Epub.rakumod",
+   "reason": "App::Ebread::Epub: expected statement: expected expected statement: expected expected statement: expected expression statement or expected statement: expected e",
    "status": "blocked_load",
    "version": "0.2.3"
   },
@@ -715,7 +5296,7 @@
    "baseline": 0,
    "dist": "App::Ecosystems",
    "passed": 0,
-   "reason": "App::Ecosystems: Runtime error: Failed to parse module 'Ecosystem': Precedence of , is too loose to use inside ?? !!; please parenthesize",
+   "reason": "App::Ecosystems: An exception occurred while evaluating a CHECK",
    "status": "blocked_load",
    "version": "0.0.9"
   },
@@ -738,20 +5319,11 @@
    "version": "3.0.9"
   },
   {
-   "axis": "pure",
-   "baseline": 0,
-   "dist": "App::MoarVM::Debug",
-   "passed": 0,
-   "reason": "App::MoarVM::Debug: An exception occurred while evaluating a CHECK",
-   "status": "blocked_load",
-   "version": "0.2"
-  },
-  {
    "axis": "guts",
    "baseline": 0,
    "dist": "App::MoarVM::HeapAnalyzer::Model",
    "passed": 0,
-   "reason": "App::MoarVM::HeapAnalyzer::Model: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-otoeptq0/dist/App-MoarVM-HeapAnalyzer-Model-0.2/l",
+   "reason": "App::MoarVM::HeapAnalyzer::Model: Failed to parse module 'App::MoarVM::HeapAnalyzer::Model': Unsupported use of do...for. In Raku please use: repeat...while or ",
    "status": "blocked_load",
    "version": "0.2"
   },
@@ -778,7 +5350,7 @@
    "baseline": 0,
    "dist": "App::Prove6",
    "passed": 0,
-   "reason": "App::Prove6: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-uyycyxb8/dist/App-Prove6-0.0.18/lib/App/Prove6.rakumod",
+   "reason": "App::Prove6: expected statement: expected ')'",
    "status": "blocked_load",
    "version": "0.0.18"
   },
@@ -801,15 +5373,6 @@
    "version": "2.0.2"
   },
   {
-   "axis": "pure",
-   "baseline": 0,
-   "dist": "App::ShowPath",
-   "passed": 0,
-   "reason": "App::ShowPath: Runtime error: Failed to parse module 'Term::Choose::Constant': Unable to parse expression in array composer; couldn't find final ']' (correspond",
-   "status": "blocked_load",
-   "version": "0.0.2"
-  },
-  {
    "axis": "native",
    "baseline": 0,
    "dist": "Archive::SimpleZip",
@@ -823,7 +5386,7 @@
    "baseline": 0,
    "dist": "Arithmetic::PaperAndPencil",
    "passed": 0,
-   "reason": "Arithmetic::PaperAndPencil: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-0dvb_o2s/dist/dist/lib/Arithmetic/PaperAndPencil/Number",
+   "reason": "Arithmetic::PaperAndPencil: expected statement: expected expected statement: expected use statement or import statement or no statement or need statement or uni",
    "status": "blocked_load",
    "version": "0.0.1"
   },
@@ -832,7 +5395,7 @@
    "baseline": 0,
    "dist": "Array::Agnostic",
    "passed": 0,
-   "reason": "Array::Agnostic: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-boklcnl1/dist/Array-Agnostic-0.0.18/lib/Array/Agnostic.rakumod",
+   "reason": "Array::Agnostic: expected statement: expected expected statement: expected expected statement: expected expression statement or '.' or digits or generic radix l",
    "status": "blocked_load",
    "version": "0.0.18"
   },
@@ -859,7 +5422,7 @@
    "baseline": 0,
    "dist": "Array::Sparse",
    "passed": 0,
-   "reason": "Array::Sparse: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-99es008r/dist/Array-Sparse-0.0.13/lib/Array/Sparse.rakumod",
+   "reason": "Array::Sparse: unparsed input, column 1: \"}\\n\\n# vim: expandtab shiftwidth=4\"",
    "status": "blocked_load",
    "version": "0.0.13"
   },
@@ -886,7 +5449,7 @@
    "baseline": 0,
    "dist": "ASTQuery",
    "passed": 0,
-   "reason": "ASTQuery::Match: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-o04cxcg8/dist/ASTQuery-0.0.7/lib/ASTQuery/Match.rakumod",
+   "reason": "ASTQuery::Match: expected statement: expected expected statement: expected expression statement or expected statement: expected use statement or import statemen",
    "status": "blocked_load",
    "version": "0.0.7"
   },
@@ -895,7 +5458,7 @@
    "baseline": 0,
    "dist": "Astro::Utils",
    "passed": 0,
-   "reason": "Astro::Utils: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/deps/Math__FractionalPart/Math-FractionalPart-0.0.6/lib/Math/FractionalPart.rakumo",
+   "reason": "Astro::Utils: expected statement: expected expected statement: expected expected statement: expected expected statement: expected use statement or import statem",
    "status": "blocked_load",
    "version": "0.0.3"
   },
@@ -904,7 +5467,7 @@
    "baseline": 0,
    "dist": "Async::Workers",
    "passed": 0,
-   "reason": "Async::Workers: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-m8t4iyyr/dist/Async-Workers-v0.3.1/lib/Async/Workers.rakumod",
+   "reason": "Async::Workers: expected statement: expected expected statement: expected expected statement: expected expression statement or '.' or digits or generic radix li",
    "status": "blocked_load",
    "version": "0.3.1"
   },
@@ -918,20 +5481,11 @@
    "version": "1.0.10"
   },
   {
-   "axis": "native",
-   "baseline": 0,
-   "dist": "Audio::Encode::LameMP3",
-   "passed": 0,
-   "reason": "Audio::Encode::LameMP3: Runtime error: Failed to parse module 'AccessorFacade': X::Undeclared::Symbols: Undeclared routine:",
-   "status": "blocked_load",
-   "version": "0.0.15"
-  },
-  {
    "axis": "pure",
    "baseline": 0,
    "dist": "Audio::Hydrogen",
    "passed": 0,
-   "reason": "Audio::Hydrogen: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/deps/XML__Class/XML-Class-0.0.11/lib/XML/Class.rakumod",
+   "reason": "Audio::Hydrogen: Can't use unknown trait 'is' -> 'xml-element' in an attribute declaration.",
    "status": "blocked_load",
    "version": "0.0.7"
   },
@@ -940,18 +5494,9 @@
    "baseline": 0,
    "dist": "Audio::Icecast",
    "passed": 0,
-   "reason": "Audio::Icecast: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/deps/XML__Class/XML-Class-0.0.11/lib/XML/Class.rakumod",
+   "reason": "Audio::Icecast: Can't use unknown trait 'is' -> 'xml-element' in an attribute declaration.",
    "status": "blocked_load",
    "version": "0.0.6"
-  },
-  {
-   "axis": "native",
-   "baseline": 0,
-   "dist": "Audio::Libshout",
-   "passed": 0,
-   "reason": "Audio::Libshout: Runtime error: Failed to parse module 'AccessorFacade': X::Undeclared::Symbols: Undeclared routine:",
-   "status": "blocked_load",
-   "version": "0.0.15"
   },
   {
    "axis": "pure",
@@ -961,15 +5506,6 @@
    "reason": "Audio::Playlist::JSPF: Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
    "status": "blocked_load",
    "version": "0.0.6"
-  },
-  {
-   "axis": "guts",
-   "baseline": 0,
-   "dist": "Backtrace::Files",
-   "passed": 0,
-   "reason": "Backtrace::Files: No such method 'key' for invocant of type 'PseudoStash'",
-   "status": "blocked_load",
-   "version": "0.0.4"
   },
   {
    "axis": "guts",
@@ -994,7 +5530,7 @@
    "baseline": 0,
    "dist": "BigRoot",
    "passed": 0,
-   "reason": "BigRoot: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-eq5c77qc/dist/BigRoot-0.1.1/lib/BigRoot.rakumod",
+   "reason": "BigRoot: expected statement: expected expected statement: expected angle index key or expression statement",
    "status": "blocked_load",
    "version": "0.1.1"
   },
@@ -1021,7 +5557,7 @@
    "baseline": 0,
    "dist": "Blogin",
    "passed": 0,
-   "reason": "Blogin: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-ldtfot8g/dist/dist/lib/Blogin/Markdown.rakumod",
+   "reason": "Blogin: expected statement: expected expected statement: expected use statement or import statement or no statement or need statement or unit statement or ...",
    "status": "blocked_load",
    "version": "0.9.1"
   },
@@ -1037,18 +5573,18 @@
   {
    "axis": "pure",
    "baseline": 0,
-   "dist": "CellularAutomata",
+   "dist": "Chatnik",
    "passed": 0,
-   "reason": "CellularAutomata: circular module dependency detected: CellularAutomata -> CellularAutomata::Scan -> Data::Transformers -> Data::TypeSystem::Predicates -> Data:",
+   "reason": "Chatnik: Failed to slurp '(Any)': No such file or directory (os error 2)",
    "status": "blocked_load",
-   "version": "0.0.1"
+   "version": "0.0.7"
   },
   {
    "axis": "pure",
    "baseline": 0,
    "dist": "Chemistry::Stoichiometry",
    "passed": 0,
-   "reason": "Chemistry::Stoichiometry: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/deps/Math__Matrix/dist/lib/Math/Matrix.rakumod",
+   "reason": "Chemistry::Stoichiometry: expected statement: expected expression statement or expression after infix operator or '.' or digits or generic radix literal or ...",
    "status": "blocked_load",
    "version": "0.1.10"
   },
@@ -1057,7 +5593,7 @@
    "baseline": 0,
    "dist": "Clu",
    "passed": 0,
-   "reason": "Clu::Ingester: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/deps/TOML/lib/TOML/NQP.rakumod",
+   "reason": "Clu::Ingester: expected statement: expected expected statement: expected use statement or import statement or no statement or need statement or unit statement o",
    "status": "blocked_load",
    "version": "1.0.1"
   },
@@ -1066,7 +5602,7 @@
    "baseline": 0,
    "dist": "Code::Coverable",
    "passed": 0,
-   "reason": "Code::Coverable: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-7wqvi8lf/dist/Code-Coverable-0.0.13/lib/Code/Coverable.rakumod",
+   "reason": "Code::Coverable: Failed to parse module 'Code::Coverable': Unexpected block in infix position (missing statement control word before the expression?)",
    "status": "blocked_load",
    "version": "0.0.13"
   },
@@ -1075,7 +5611,7 @@
    "baseline": 0,
    "dist": "Code::Coverage",
    "passed": 0,
-   "reason": "Code::Coverage: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/deps/Code__Coverable/Code-Coverable-0.0.13/lib/Code/Coverable.rakumod",
+   "reason": "Code::Coverage: Failed to parse module 'Code::Coverable': Unexpected block in infix position (missing statement control word before the expression?)",
    "status": "blocked_load",
    "version": "0.0.8"
   },
@@ -1084,7 +5620,7 @@
    "baseline": 0,
    "dist": "Collection",
    "passed": 0,
-   "reason": "Collection: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/deps/PrettyDump/dist/lib/PrettyDump.rakumod",
+   "reason": "Collection: expected statement: expected expected statement: expected expected statement: expected use statement or import statement or no statement or need sta",
    "status": "blocked_load",
    "version": "0.18.0"
   },
@@ -1102,7 +5638,7 @@
    "baseline": 0,
    "dist": "Color::Palette",
    "passed": 0,
-   "reason": "Color::Palette: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-rar5otge/dist/dist/lib/Color/Palette.rakumod",
+   "reason": "Color::Palette: Failed to parse module 'Color::Palette': Unexpected block in infix position (missing statement control word before the expression?)",
    "status": "blocked_load",
    "version": "0.0.2"
   },
@@ -1116,6 +5652,51 @@
    "version": "0.0.2"
   },
   {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Config::BINDish",
+   "passed": 0,
+   "reason": "Config::BINDish: An exception occurred while evaluating a CHECK",
+   "status": "blocked_load",
+   "version": "0.0.18"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Contact",
+   "passed": 0,
+   "reason": "Contact: Variable $.name used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cooklang",
+   "passed": 0,
+   "reason": "Cooklang: An exception occurred while evaluating a CHECK",
+   "status": "blocked_load",
+   "version": "1.1.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "CoreHackers::NfaChainsaw",
+   "passed": 0,
+   "reason": "CoreHackers::NfaChainsaw::Extractor: Could not find Perl6::Grammar in:",
+   "status": "blocked_load",
+   "version": "0.0.1.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "CoreHackers::Q",
+   "passed": 0,
+   "reason": "CoreHackers::Q: thread 'mutsu-main' (3) panicked at src/parser/stmt/simple_expr_stmt/core.rs:194:30:",
+   "status": "blocked_load",
+   "version": "1.003000"
+  },
+  {
    "axis": "pure",
    "baseline": 0,
    "dist": "CRDT",
@@ -1127,20 +5708,47 @@
   {
    "axis": "pure",
    "baseline": 0,
-   "dist": "CSS::Font::Resources",
+   "dist": "cro",
    "passed": 0,
-   "reason": "CSS::Font::Resources::Source: expected statement: expected expression statement or expression after infix operator or '.' or digits or generic radix literal or ",
+   "reason": "Cro::Tools::Template::Common: Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
    "status": "blocked_load",
-   "version": "0.0.11"
+   "version": "0.8.10"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Cro::RPC::JSON",
+   "passed": 0,
+   "reason": "Cro::RPC::JSON::Message: Failed to parse module 'Cro::RPC::JSON::Utils': X::Comp::Group: Function 'Metamodel::ClassHOW' needs parens to avoid gobbling block (or",
+   "status": "blocked_load",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Crypt::SodiumPasswordHash",
+   "passed": 0,
+   "reason": "Crypt::SodiumPasswordHash: Error while importing from 'NativeCall': no such tag 'TEST' declared",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Crypt::SodiumScrypt",
+   "passed": 0,
+   "reason": "Crypt::SodiumScrypt: Error while importing from 'NativeCall': no such tag 'TEST' declared",
+   "status": "blocked_load",
+   "version": "0.0.5"
   },
   {
    "axis": "pure",
    "baseline": 0,
-   "dist": "CSS::Grammar",
+   "dist": "CSS::Font::Resources",
    "passed": 0,
-   "reason": "CSS::Grammar::AST: Error while importing from 'CSS::Grammar::Defs': no such tag 'CSSTrait' declared",
+   "reason": "CSS::Font::Resources: Runtime error: Failed to parse module 'CSS::Properties::Calculator': Regex not terminated.",
    "status": "blocked_load",
-   "version": "0.4.3"
+   "version": "0.0.11"
   },
   {
    "axis": "pure",
@@ -1156,18 +5764,9 @@
    "baseline": 0,
    "dist": "CSS::Module",
    "passed": 0,
-   "reason": "CSS::Module: Inconsistent class hierarchy for CSS::Grammar::CSS21",
+   "reason": "CSS::Module: No such method 'key' for invocant of type 'Str'",
    "status": "blocked_load",
    "version": "0.7.7"
-  },
-  {
-   "axis": "pure",
-   "baseline": 0,
-   "dist": "CSS::Module::CSS3::Selectors",
-   "passed": 0,
-   "reason": "CSS::Module::CSS3::Selectors: Inconsistent class hierarchy for CSS::Grammar::CSS21",
-   "status": "blocked_load",
-   "version": "0.0.6"
   },
   {
    "axis": "pure",
@@ -1183,25 +5782,16 @@
    "baseline": 0,
    "dist": "CSS::Properties",
    "passed": 0,
-   "reason": "CSS::Font: expected statement: expected expression statement or expression after infix operator or '.' or digits or generic radix literal or ...",
+   "reason": "CSS::Box: Failed to parse module 'CSS::Box': Unrecognized regex metacharacter - (must be quoted to match literally)",
    "status": "blocked_load",
    "version": "0.10.9"
   },
   {
    "axis": "pure",
    "baseline": 0,
-   "dist": "CSS::Selector::To::XPath",
-   "passed": 0,
-   "reason": "CSS::Selector::To::XPath: Inconsistent class hierarchy for CSS::Grammar::CSS21",
-   "status": "blocked_load",
-   "version": "0.0.9"
-  },
-  {
-   "axis": "pure",
-   "baseline": 0,
    "dist": "CSS::Specification",
    "passed": 0,
-   "reason": "CSS::Specification: Inconsistent class hierarchy for CSS::Grammar::CSS21",
+   "reason": "CSS::Specification::AST: 'CSS::Specification::AST' cannot inherit from 'CSS::Grammar::AST' because it is unknown.",
    "status": "blocked_load",
    "version": "0.5.3"
   },
@@ -1210,7 +5800,7 @@
    "baseline": 0,
    "dist": "CSS::Stylesheet",
    "passed": 0,
-   "reason": "CSS::Media: ===SORRY!=== Error while compiling /root/.cache/mutsu-ecosystem/run/ecosweep-sjpdjvb0/dist/CSS-Stylesheet-0.1.5/lib/CSS/Media.rakumod",
+   "reason": "CSS::AtPageRule: Failed to parse module 'CSS::Properties': Cannot interpolate attribute in a regex",
    "status": "blocked_load",
    "version": "0.1.5"
   },
@@ -1219,7 +5809,7 @@
    "baseline": 0,
    "dist": "CSS::TagSet",
    "passed": 0,
-   "reason": "CSS::TagSet::XHTML: Could not instantiate role 'CSS::TagSet' because it died with X::AdHoc; exception details:",
+   "reason": "CSS::TagSet::Pango: expected statement: expected expected statement: expected right-hand expression after '=' or expected statement: expected expression stateme",
    "status": "blocked_load",
    "version": "0.1.4"
   },
@@ -1228,18 +5818,2628 @@
    "baseline": 0,
    "dist": "CSS::Writer",
    "passed": 0,
-   "reason": "CSS::Writer: Inconsistent class hierarchy for CSS::Grammar::CSS21",
+   "reason": "CSS::Writer: No such method 'key' for invocant of type 'Str'",
    "status": "blocked_load",
    "version": "0.3.3"
   },
   {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Dan::Polars",
+   "passed": 0,
+   "reason": "Dan::Polars: Failed to parse module 'Dan::Polars::Containers': X::Syntax::Missing: Missing block",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Data::Cryptocurrencies",
+   "passed": 0,
+   "reason": "Data::Cryptocurrencies: Failed to slurp '(Any)': No such file or directory (os error 2)",
+   "status": "blocked_load",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Data::Dump::Tree",
+   "passed": 0,
+   "reason": "Data::Dump::Tree::Horizontal: expected statement: expected expected statement: expected expected statement: expected right-hand expression after '=' or expected",
+   "status": "blocked_load",
+   "version": "2.9.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Data::ExampleDatasets",
+   "passed": 0,
+   "reason": "Data::ExampleDatasets: Failed to slurp '(Any)': No such file or directory (os error 2)",
+   "status": "blocked_load",
+   "version": "0.2.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Data::Generators",
+   "passed": 0,
+   "reason": "Data::Generators: No such method 'instance' for invocant of type 'Int'",
+   "status": "blocked_load",
+   "version": "0.1.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Data::RandomKeep",
+   "passed": 0,
+   "reason": "Data::RandomKeep: expected statement: expected expected statement: expected expression statement or expected statement: expected expected statement: expected ex",
+   "status": "blocked_load",
+   "version": "0.1.1"
+  },
+  {
    "axis": "guts",
    "baseline": 0,
-   "dist": "String::Utils",
+   "dist": "Data::Record",
    "passed": 0,
-   "reason": "String::Utils: An exception occurred while evaluating a CHECK",
+   "reason": "Data::Record: expected statement: expected expression statement or expression after infix operator or '.' or digits or generic radix literal or ...",
    "status": "blocked_load",
-   "version": "0.0.40"
+   "version": "1.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Data::Reshapers",
+   "passed": 0,
+   "reason": "Data::Reshapers: X::Comp::Trait::Duplicate: attribute 'min-width' already exists in class 'Pretty::Table' (possibly from role composition)",
+   "status": "blocked_load",
+   "version": "0.3.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Data::Summarizers",
+   "passed": 0,
+   "reason": "Data::Summarizers: X::Comp::Trait::Duplicate: attribute 'min-width' already exists in class 'Pretty::Table' (possibly from role composition)",
+   "status": "blocked_load",
+   "version": "0.2.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Data::Translators",
+   "passed": 0,
+   "reason": "Data::Translators: Runtime error: Failed to parse module 'Data::Translators': X::Redeclaration: Redeclaration of symbol '$s'",
+   "status": "blocked_load",
+   "version": "0.1.18"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Date::Calendar::Hebrew",
+   "passed": 0,
+   "reason": "Date::Calendar::Hebrew: List::MoreUtils doesn't know how to export: before",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Date::Calendar::Hijri",
+   "passed": 0,
+   "reason": "Date::Calendar::Hijri: Unknown function: make-fct",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Date::Calendar::Julian",
+   "passed": 0,
+   "reason": "Date::Calendar::Julian: List::MoreUtils doesn't know how to export: last_index",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Date::Utils",
+   "passed": 0,
+   "reason": "Date::Utils: Runtime error: No return arguments allowed when return value UInt # range 0..6 is already specified in the signature",
+   "status": "blocked_load",
+   "version": "0.7.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DateTime::Julian",
+   "passed": 0,
+   "reason": "DateTime::Julian: expected statement: expected expected statement: expected expected statement: expected expected statement: expected use statement or import st",
+   "status": "blocked_load",
+   "version": "1.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DateTime::strftime",
+   "passed": 0,
+   "reason": "DateTime::strftime: 'DateTime' cannot inherit from itself.",
+   "status": "blocked_load",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DateTime::Timezones",
+   "passed": 0,
+   "reason": "DateTime::Timezones: Cannot modify an immutable value",
+   "status": "blocked_load",
+   "version": "0.4.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DateTime::US",
+   "passed": 0,
+   "reason": "DateTime::US: Runtime error: No return arguments allowed when return value UInt # range 0..6 is already specified in the signature",
+   "status": "blocked_load",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DB::Xoos::Pg",
+   "passed": 0,
+   "reason": "DB::Xoos::Pg: expected statement: expected expected statement: expected use statement or import statement or no statement or need statement or unit statement or",
+   "status": "blocked_load",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DBIish::Pool",
+   "passed": 0,
+   "reason": "DBIish::Pool: Failed to parse module 'DBIish::Pool': Unexpected block in infix position (missing statement control word before the expression?)",
+   "status": "blocked_load",
+   "version": "1.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Ddt",
+   "passed": 0,
+   "reason": "Ddt::Distribution: Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "0.8.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Deps",
+   "passed": 0,
+   "reason": "Deps: expected statement: expected expected statement: expected expression statement or expression after infix operator or '.' or digits or generic radix litera",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "deredere",
+   "passed": 0,
+   "reason": "deredere: Variable $.original_name used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Dev::ContainerizedService",
+   "passed": 0,
+   "reason": "Dev::ContainerizedService::Spec::ClickHouse: Attribute $!port:8123 not declared in class Dev::ContainerizedService::Spec::ClickHouse",
+   "status": "blocked_load",
+   "version": "0.3.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Digest::xxHash",
+   "passed": 0,
+   "reason": "Digest::xxHash: expected statement: expected ')'",
+   "status": "blocked_load",
+   "version": "1.8.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Dist::META",
+   "passed": 0,
+   "reason": "Dist::META: Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Distribution::Extension::Updater",
+   "passed": 0,
+   "reason": "Distribution::Extension::Updater: Runtime error: Failed to parse module 'Distribution::Extension::Updater': X::Redeclaration: Redeclaration of symbol '$d'",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Doc::Executable",
+   "passed": 0,
+   "reason": "Doc::Executable: Type check failed in assignment to $!resources; expected Distribution::Resources but got Hash",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "dosh",
+   "passed": 0,
+   "reason": "DOSH::CLI: Failed to slurp '(Any)': No such file or directory (os error 2)",
+   "status": "blocked_load",
+   "version": ".0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::Bulgarian",
+   "passed": 0,
+   "reason": "DSL::Bulgarian::ClassificationWorkflows::Grammar: Could not instantiate role 'DSL::Shared::Roles::English::PipelineCommand' because it died with X::Redeclaratio",
+   "status": "blocked_load",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::English::ClassificationWorkflows",
+   "passed": 0,
+   "reason": "DSL::English::ClassificationWorkflows: Could not instantiate role 'DSL::Entity::MachineLearning::Grammar::EntityNames' because it died with X::Undeclared::Symbo",
+   "status": "blocked_load",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::English::DataAcquisitionWorkflows",
+   "passed": 0,
+   "reason": "DSL::English::DataAcquisitionWorkflows::Actions::Bulgarian::Standard: Could not instantiate role 'DSL::Shared::Roles::English::PipelineCommand' because it died ",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::English::EpidemiologyModelingWorkflows",
+   "passed": 0,
+   "reason": "DSL::English::EpidemiologyModelingWorkflows: Could not instantiate role 'DSL::Shared::Roles::English::CommonSpeechParts' because it died with X::Redeclaration; ",
+   "status": "blocked_load",
+   "version": "0.5.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::English::FoodPreparationWorkflows",
+   "passed": 0,
+   "reason": "DSL::English::FoodPreparationWorkflows::Actions::Bulgarian::Standard: Could not instantiate role 'DSL::Entity::Geographics::Grammar::EntityNames' because it die",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::Entity::AddressBook",
+   "passed": 0,
+   "reason": "DSL::Entity::AddressBook::Actions::SQL::Standard: Could not instantiate role 'DSL::Shared::Roles::English::PipelineCommand' because it died with X::Redeclaratio",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::Entity::Geographics",
+   "passed": 0,
+   "reason": "DSL::Entity::Geographics: Could not instantiate role 'DSL::Entity::Geographics::Grammar::EntityNames' because it died with X::Undeclared::Symbols; exception det",
+   "status": "blocked_load",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::Entity::MachineLearning",
+   "passed": 0,
+   "reason": "DSL::Entity::MachineLearning: Could not instantiate role 'DSL::Entity::MachineLearning::Grammar::EntityNames' because it died with X::Undeclared::Symbols; excep",
+   "status": "blocked_load",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::FiniteStateMachines",
+   "passed": 0,
+   "reason": "DSL::FiniteStateMachines::AddressBookCaller: X::Comp::Trait::Duplicate: attribute 'min-width' already exists in class 'Pretty::Table' (possibly from role compos",
+   "status": "blocked_load",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "EC",
+   "passed": 0,
+   "reason": "ed25519: expected statement: expected expected statement: expected expected statement: expected expression statement or expression after infix operator or '.' o",
+   "status": "blocked_load",
+   "version": "0.6.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Ecosystem",
+   "passed": 0,
+   "reason": "Ecosystem: An exception occurred while evaluating a CHECK",
+   "status": "blocked_load",
+   "version": "0.0.33"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Ecosystem::Cache",
+   "passed": 0,
+   "reason": "Ecosystem::Cache: An exception occurred while evaluating a CHECK",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Email::MIME",
+   "passed": 0,
+   "reason": "Email::MIME: X::Comp::Trait::Duplicate: attribute 'headers' already exists in class 'Email::Simple::Header' (possibly from role composition)",
+   "status": "blocked_load",
+   "version": "2.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Email::Simple",
+   "passed": 0,
+   "reason": "Email::Simple: X::Comp::Trait::Duplicate: attribute 'headers' already exists in class 'Email::Simple::Header' (possibly from role composition)",
+   "status": "blocked_load",
+   "version": "2.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Encoding::Emacs",
+   "passed": 0,
+   "reason": "Encoding::Emacs::Generator: Redeclaration of routine 'regex'. Did you mean to declare a multi-sub?",
+   "status": "blocked_load",
+   "version": "0.1.5.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "FatRatStr",
+   "passed": 0,
+   "reason": "FatRatStr: You tried to augment class NumStr, but it does not exist",
+   "status": "blocked_load",
+   "version": "0.0.14"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "FDF",
+   "passed": 0,
+   "reason": "FDF::Annot: Invalid typename 'IndRef' in parameter declaration.",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "fez",
+   "passed": 0,
+   "reason": "Fez::API: Runtime error: No return arguments allowed when return value Fez::Types::api-response is already specified in the signature",
+   "status": "blocked_load",
+   "version": "100.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "FFmpegProgressBar",
+   "passed": 0,
+   "reason": "FFmpegProgressBar: expected statement: expected expected statement: expected expected statement: expected expected statement: expected return value expression o",
+   "status": "blocked_load",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "FHIR",
+   "passed": 0,
+   "reason": "FHIR::JsonSerdes: Failed to parse module 'FHIR::JsonSerdes': X::Comp::Group: Function 'Base64Binary' needs parens to avoid gobbling block (or perhaps it's a cla",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "File::ExtendedAttributes",
+   "passed": 0,
+   "reason": "File::ExtendedAttributes: Cannot convert value to native integer type 'int'",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "File::Name::Editor",
+   "passed": 0,
+   "reason": "File::Name::Editor: Failed to parse module 'File::Name::Editor': Unexpected block in infix position (missing statement control word before the expression?)",
+   "status": "blocked_load",
+   "version": "0.2.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "FINALIZER",
+   "passed": 0,
+   "reason": "FINALIZER: 'LeavePhaser' cannot inherit from 'RakuAST::StatementPrefix::Phaser::Leave' because it is unknown.",
+   "status": "blocked_load",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Font::AFM",
+   "passed": 0,
+   "reason": "Font::Metrics::courier: 'Font::Metrics::courier' cannot inherit from 'Font::AFM' because it is unknown.",
+   "status": "blocked_load",
+   "version": "1.24.10"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Font::FreeType",
+   "passed": 0,
+   "reason": "Font::FreeType: Could not find NativeCall::Types in:",
+   "status": "blocked_load",
+   "version": "0.5.16"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "FontConfig",
+   "passed": 0,
+   "reason": "FontConfig: Failed to parse module 'FontConfig::Raw': X::Comp::Group: Function 'FcTypeUnknown' needs parens to avoid gobbling block (or perhaps it's a class tha",
+   "status": "blocked_load",
+   "version": "0.1.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Functional::LinkedList",
+   "passed": 0,
+   "reason": "Functional::LinkedList: Runtime error: Failed to parse module 'Functional::LinkedList': X::Parameter::Default::TypeCheck: Default value type 'Any' does not sati",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Functional::Queue",
+   "passed": 0,
+   "reason": "Functional::Queue: 'ValueClass::Attribute' cannot inherit from 'Attribute' because it is unknown.",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Functional::Stack",
+   "passed": 0,
+   "reason": "Functional::Stack: 'ValueClass::Attribute' cannot inherit from 'Attribute' because it is unknown.",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Game::Entities",
+   "passed": 0,
+   "reason": "Game::Entities: expected statement: expected expected statement: expected expected statement: expected expected statement: expected expression statement or ']'",
+   "status": "blocked_load",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Gauge",
+   "passed": 0,
+   "reason": "Gauge: Runtime error: Failed to parse module 'Gauge': X::InvalidType: role 'Iterator' cannot compose itself",
+   "status": "blocked_load",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "GD",
+   "passed": 0,
+   "reason": "GD: Error while importing from 'NativeCall': no such tag 'TEST' declared",
+   "status": "blocked_load",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "GD::Raw",
+   "passed": 0,
+   "reason": "GD::Raw: Variable $.red0 used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.8"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Grammar::BNF",
+   "passed": 0,
+   "reason": "Slang::ABNF: Could not find QAST in:",
+   "status": "blocked_load",
+   "version": "v0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Grammar::Editor",
+   "passed": 0,
+   "reason": "Grammar::Editor::Pane::Input: Invalid typename 'CrossAlign' in parameter declaration.",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Grammar::TokenProcessing",
+   "passed": 0,
+   "reason": "Grammar::TokenProcessing: Failed to parse module 'Grammar::TokenProcessing': Unmatched ( in regex",
+   "status": "blocked_load",
+   "version": "0.1.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Graph::RandomMaze",
+   "passed": 0,
+   "reason": "Graph::RandomMaze: No such method 'instance' for invocant of type 'Int'",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Graphviz::DOT::Grammar",
+   "passed": 0,
+   "reason": "Graphviz::DOT::Actions::Raku: Inconsistent class hierarchy for Graphviz::DOT::Actions::Raku",
+   "status": "blocked_load",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Green",
+   "passed": 0,
+   "reason": "Green: Runtime error: Failed to parse module 'Green': X::Syntax::Missing: Missing block",
+   "status": "blocked_load",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Grok",
+   "passed": 0,
+   "reason": "Grok: Variable $!thing used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "GUI::Editors",
+   "passed": 0,
+   "reason": "GUI::Editors: 'GUI::Editors::Editors' cannot inherit from 'GUI::Editors::BasePaths' because it is unknown.",
+   "status": "blocked_load",
+   "version": "0.1.18"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "HarfBuzz",
+   "passed": 0,
+   "reason": "HarfBuzz: Variable $!var used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.1.7"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "HarfBuzz::Font::FreeType",
+   "passed": 0,
+   "reason": "HarfBuzz::Font::FreeType: Variable $!var used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "HarfBuzz::Subset",
+   "passed": 0,
+   "reason": "HarfBuzz::Subset: Variable $!var used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Hash2Class",
+   "passed": 0,
+   "reason": "Hash2Class: Unsupported nqp:: op: nqp::hash",
+   "status": "blocked_load",
+   "version": "0.1.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Hash::MutableKeys",
+   "passed": 0,
+   "reason": "Hash::MutableKeys: Unknown role: Hash",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Hash::Sorted",
+   "passed": 0,
+   "reason": "Hash::Sorted: Unsupported nqp:: op: nqp::list",
+   "status": "blocked_load",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Hey",
+   "passed": 0,
+   "reason": "Hey::Interruption: X::Comp::Trait::Duplicate: attribute 'min-width' already exists in class 'Prettier::Table' (possibly from role composition)",
+   "status": "blocked_load",
+   "version": "1.0.0-beta.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Holidays::Miscellaneous",
+   "passed": 0,
+   "reason": "Holidays::Miscellaneous: Runtime error: No return arguments allowed when return value UInt # range 0..6 is already specified in the signature",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Holidays::US::Federal",
+   "passed": 0,
+   "reason": "Holidays::US::Federal: Runtime error: No return arguments allowed when return value UInt # range 0..6 is already specified in the signature",
+   "status": "blocked_load",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "HomoGlypher",
+   "passed": 0,
+   "reason": "HomoGlypher: expected statement: expected expected statement: expected use statement or import statement or no statement or need statement or unit statement or ",
+   "status": "blocked_load",
+   "version": "1.8.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "HTML::Canvas",
+   "passed": 0,
+   "reason": "HTML::Canvas::Gradient: Failed to parse module 'CSS::Properties': Cannot interpolate attribute in a regex",
+   "status": "blocked_load",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "HTML::Component",
+   "passed": 0,
+   "reason": "HTML::Component::Boilerplate: Unknown role: HTML",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "HTTP::UserAgent::Strict",
+   "passed": 0,
+   "reason": "HTTP::Cookies::Strict: Failed to parse module 'HTTP::Message::Strict': X::Syntax::InfixInTermPosition: Preceding context expects a term, but found infix , inste",
+   "status": "blocked_load",
+   "version": "0.9.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Igo",
+   "passed": 0,
+   "reason": "Igo: Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Image::Libexif",
+   "passed": 0,
+   "reason": "Image::Libexif: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Image::Resize",
+   "passed": 0,
+   "reason": "Image::Resize: Variable $.red0 used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Injector",
+   "passed": 0,
+   "reason": "Injector: No such method 'loaded' for invocant of type 'CompUnit::Repository::FileSystem'",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Inline::BASIC",
+   "passed": 0,
+   "reason": "Inline::BASIC: Runtime error: Failed to parse module 'Inline::BASIC': Unrecognized regex metacharacter ] (must be quoted to match literally)",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Inline::J",
+   "passed": 0,
+   "reason": "Inline::J::Conversion: Cannot resolve caller trait_mod:<is>(Sub:D); none of these signatures matches:",
+   "status": "blocked_load",
+   "version": "0.5.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Inline::Python3",
+   "passed": 0,
+   "reason": "Inline::Python3: An exception occurred while evaluating a CHECK",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Intl::CLDR",
+   "passed": 0,
+   "reason": "Intl::CLDR::Types::AppendItems: Can't use unknown trait 'is' -> 'aliased-by' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "0.7.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Intl::Format::DateTime",
+   "passed": 0,
+   "reason": "Intl::Format::DateTime::MetazoneNames: Can't use unknown trait 'is' -> 'aliased-by' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "0.3.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Intl::LanguageTaggish",
+   "passed": 0,
+   "reason": "Intl::LanguageTaggish: Unimplemented multi method from role",
+   "status": "blocked_load",
+   "version": "0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "IO::Path::Mode",
+   "passed": 0,
+   "reason": "IO::Path::Mode: No such method 'wrap' for invocant of type 'Method'",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "IO::String",
+   "passed": 0,
+   "reason": "IO::String: expected statement: expected expected statement: expected expected statement: expected right-hand expression after '=' or '.' or digits or generic r",
+   "status": "blocked_load",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "IRC::Channel::Log",
+   "passed": 0,
+   "reason": "IRC::Channel::Log: Unsupported nqp:: op: nqp::list",
+   "status": "blocked_load",
+   "version": "0.0.43"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "JavaScript::D3",
+   "passed": 0,
+   "reason": "JavaScript::D3: No such method 'IO' for invocant of type 'Any'",
+   "status": "blocked_load",
+   "version": "0.3.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Jupyter::Chatbook",
+   "passed": 0,
+   "reason": "Jupyter::Chatbook::Magics: Failed to slurp '(Any)': No such file or directory (os error 2)",
+   "status": "blocked_load",
+   "version": "0.3.9"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "kazmath",
+   "passed": 0,
+   "reason": "kazmath: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "KHPH",
+   "passed": 0,
+   "reason": "KHPH: Type check failed for return value; expected int32 but got Whatever (*)",
+   "status": "blocked_load",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "L10N",
+   "passed": 0,
+   "reason": "L10N: Failed to parse module 'L10N': X::Syntax::Missing: Missing block",
+   "status": "blocked_load",
+   "version": "0.1.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Lang::Transliterate",
+   "passed": 0,
+   "reason": "Lang::Transliterate::En::TolkienRunic: expected statement: expected expected statement: expected expected statement: expected expected statement: expected expec",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "LibraryCheck",
+   "passed": 0,
+   "reason": "LibraryCheck: Error while importing from 'NativeCall': no such tag 'TEST' declared",
+   "status": "blocked_load",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "LibXML",
+   "passed": 0,
+   "reason": "LibXML::Raw::DOM::Document: Cannot declare our-scoped enum inside of a role",
+   "status": "blocked_load",
+   "version": "0.11.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "LibXML::Class",
+   "passed": 0,
+   "reason": "LibXML::Class::Types: 'LibXML::Class::Types::NOT-SET' cannot inherit from 'LibXML::Class::Types::Nil' because it is unknown.",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "License::SPDX",
+   "passed": 0,
+   "reason": "License::SPDX: Can't use unknown trait 'is' -> 'unmarshalled-by' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "3.28.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "List::Agnostic",
+   "passed": 0,
+   "reason": "List::Agnostic: expected statement: expected expected statement: expected expected statement: expected expression statement or '.' or digits or generic radix li",
+   "status": "blocked_load",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "List::AllUtils",
+   "passed": 0,
+   "reason": "List::AllUtils: No such method 'key' for invocant of type 'Stash'",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "List::Operator::DoublePlus",
+   "passed": 0,
+   "reason": "List::Operator::DoublePlus: Variable '&infix:\u0001(\"\\c[DOUBLE PLUS]\")\u0001' is not declared",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "List::SomeUtils",
+   "passed": 0,
+   "reason": "List::SomeUtils: No such method 'key' for invocant of type 'Stash'",
+   "status": "blocked_load",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "LLM::Agent",
+   "passed": 0,
+   "reason": "LLM::Agent: expected statement: expected expression statement or listop argument expression or '.' or digits or generic radix literal or ...",
+   "status": "blocked_load",
+   "version": "0.6.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "LLM::DWIM",
+   "passed": 0,
+   "reason": "LLM::DWIM: Failed to slurp '(Any)': No such file or directory (os error 2)",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "LLM::Prompts",
+   "passed": 0,
+   "reason": "LLM::Prompts: Failed to slurp '(Any)': No such file or directory (os error 2)",
+   "status": "blocked_load",
+   "version": "0.2.15"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "LLM::Resources",
+   "passed": 0,
+   "reason": "LLM::Resources::DSLTranslation: Unknown function: openai-base-url",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Logic::Ternary",
+   "passed": 0,
+   "reason": "Logic::Ternary: X::InvalidType: Invalid typename 'Enumeration'",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Lumberjack",
+   "passed": 0,
+   "reason": "Lumberjack: Unknown role: role",
+   "status": "blocked_load",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Lumberjack::Config::JSON",
+   "passed": 0,
+   "reason": "Lumberjack::Config::JSON: Unknown role: role",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Lumberjack::Dispatcher::EventSource",
+   "passed": 0,
+   "reason": "Lumberjack::Dispatcher::EventSource: Unknown role: role",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Lumberjack::Dispatcher::Syslog",
+   "passed": 0,
+   "reason": "Lumberjack::Dispatcher::Syslog: Unknown role: role",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Lumberjack::Message::JSON",
+   "passed": 0,
+   "reason": "Lumberjack::Message::JSON: Unknown role: role",
+   "status": "blocked_load",
+   "version": "0.1.11"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "MagickWand",
+   "passed": 0,
+   "reason": "MagickWand: Error while importing from 'NativeCall': no such tag 'TEST' declared",
+   "status": "blocked_load",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Manifest::StopWar",
+   "passed": 0,
+   "reason": "Manifest::StopWar: Calling private method 'jonathanstowe' must be fully qualified with the package containing that private method.",
+   "status": "blocked_load",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Map::Leaflet",
+   "passed": 0,
+   "reason": "Map::Leaflet: Runtime error: Failed to parse module 'Map::Leaflet': X::Redeclaration: Redeclaration of symbol '@'",
+   "status": "blocked_load",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Markdown::Lex",
+   "passed": 0,
+   "reason": "Markdown::Lex: expected statement: expected expected statement: expected use statement or import statement or no statement or need statement or unit statement o",
+   "status": "blocked_load",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Markup::Calendar",
+   "passed": 0,
+   "reason": "Markup::Calendar: Runtime error: Failed to parse module 'Data::Translators': X::Redeclaration: Redeclaration of symbol '$s'",
+   "status": "blocked_load",
+   "version": "0.2.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Marpa",
+   "passed": 0,
+   "reason": "Marpa: Runtime error: Failed to parse module 'Marpa': X::Undeclared::Symbols: Undeclared routine:",
+   "status": "blocked_load",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Marrow",
+   "passed": 0,
+   "reason": "API::Db: expected statement: expected expected statement: expected use statement or import statement or no statement or need statement or unit statement or ...",
+   "status": "blocked_load",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Math::FractionalPart",
+   "passed": 0,
+   "reason": "Math::FractionalPart: expected statement: expected expected statement: expected expected statement: expected expected statement: expected use statement or impor",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Math::GameTheory",
+   "passed": 0,
+   "reason": "Math::GameTheory: expected statement: expected expected statement: expected expression statement or ')'",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::BLAS",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::BLAS: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::Complex",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::Complex: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::DigitalFiltering",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::DigitalFiltering: Variable $.vector used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::Eigensystem",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::Eigensystem: Variable $.vector used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::Interpolation",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::Interpolation: Variable $.interp used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::LinearAlgebra",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::LinearAlgebra: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::Matrix",
+   "passed": 0,
+   "reason": "Math::Libgsl::Block: Variable $.vector used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.6.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::MovingWindow",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::MovingWindow: Variable $.vector used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::Permutation",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::Permutation: Variable $.vector used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::Polynomial",
+   "passed": 0,
+   "reason": "Math::Libgsl::Polynomial: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::RunningStatistics",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::RunningStatistics: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::Sort",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::Sort: Variable $.vector used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::Wavelet",
+   "passed": 0,
+   "reason": "Math::Libgsl::Raw::Wavelet: Variable $.vector used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Math::Matrix",
+   "passed": 0,
+   "reason": "Math::Matrix: expected statement: expected expression statement or expression after infix operator or '.' or digits or generic radix literal or ...",
+   "status": "blocked_load",
+   "version": "0.4.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Math::Quaternion",
+   "passed": 0,
+   "reason": "Math::Quaternion: Variable $.r used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.2.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Math::Sequences",
+   "passed": 0,
+   "reason": "Math::Sequences::Integer: X::Method::NotFound: Unknown method value dispatch (fallback disabled): new on Range",
+   "status": "blocked_load",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Math::SparseMatrix",
+   "passed": 0,
+   "reason": "Math::SparseMatrix: Variable $.csr-struct used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.15"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Math::Symbolic",
+   "passed": 0,
+   "reason": "Math::Symbolic: expected statement: expected expected statement: expected expected statement: expected expression statement or '.' or digits or generic radix li",
+   "status": "blocked_load",
+   "version": "*"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MCP::Server::Tool::Web",
+   "passed": 0,
+   "reason": "MCP::Server::Tool::Web::Addr: Unknown function: parse-cidr",
+   "status": "blocked_load",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "META6",
+   "passed": 0,
+   "reason": "META6: Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "0.0.31"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "MetamodelX::Dataclass",
+   "passed": 0,
+   "reason": "MetamodelX::Dataclass: expected statement: expected expected statement: expected expected statement: expected right-hand expression after '=' or expression afte",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Mi6::Helper",
+   "passed": 0,
+   "reason": "Mi6::Helper: X::InvalidType: Invalid typename 'TAP::Entry::Handler'",
+   "status": "blocked_load",
+   "version": "1.2.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MIDI::Make",
+   "passed": 0,
+   "reason": "MIDI::Make: expected statement: expected expected statement: expected ')'",
+   "status": "blocked_load",
+   "version": "0.11.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "ML::AssociationRuleLearning",
+   "passed": 0,
+   "reason": "ML::AssociationRuleLearning: X::Comp::Trait::Duplicate: attribute 'min-width' already exists in class 'Pretty::Table' (possibly from role composition)",
+   "status": "blocked_load",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "ML::FindTextualAnswer",
+   "passed": 0,
+   "reason": "ML::FindTextualAnswer: Unknown function: openai-base-url",
+   "status": "blocked_load",
+   "version": "0.2.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "ML::LatentSemanticAnalyzer",
+   "passed": 0,
+   "reason": "ML::LatentSemanticAnalyzer: expected statement: expected expected statement: expected expected statement: expected expression statement or '.' or digits or gene",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "ML::NLPTemplateEngine",
+   "passed": 0,
+   "reason": "ML::NLPTemplateEngine::Core: Unknown function: openai-base-url",
+   "status": "blocked_load",
+   "version": "0.1.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "ML::SparseMatrixRecommender",
+   "passed": 0,
+   "reason": "ML::SparseMatrixRecommender: expected statement: expected expected statement: expected expected statement: expected right-hand expression after '=' or '.' or di",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "ML::TriesWithFrequencies",
+   "passed": 0,
+   "reason": "ML::TriesWithFrequencies: Redeclaration of routine 'leafQ'. Did you mean to declare a multi-sub?",
+   "status": "blocked_load",
+   "version": "0.6.7"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Mmap::Native",
+   "passed": 0,
+   "reason": "Mmap::Native: Could not find NativeCall::Types in:",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MoarVM::Bytecode",
+   "passed": 0,
+   "reason": "MoarVM::Bytecode: expected statement: expected expected statement: expected expected statement: expected expression statement or '.' or digits or generic radix ",
+   "status": "blocked_load",
+   "version": "0.0.27"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Monad-Result",
+   "passed": 0,
+   "reason": "Monad::Result: Redeclaration of routine 'ok'. Did you mean to declare a multi-sub?",
+   "status": "blocked_load",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Monitor::Monit",
+   "passed": 0,
+   "reason": "Monitor::Monit: Can't use unknown trait 'is' -> 'xml-element' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "MUGS::Core",
+   "passed": 0,
+   "reason": "MUGS::App::Admin: Error while importing from 'NativeCall': no such tag 'TEST' declared",
+   "status": "blocked_load",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MUGS::Games",
+   "passed": 0,
+   "reason": "MUGS::Server::Game::Adventure: Error while importing from 'NativeCall': no such tag 'TEST' declared",
+   "status": "blocked_load",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MUGS::UI::CLI",
+   "passed": 0,
+   "reason": "MUGS::UI::CLI: Variable $.dwSize used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MUGS::UI::TUI",
+   "passed": 0,
+   "reason": "MUGS::App::TUI::A11yMenu: Variable $.dwSize used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Mux",
+   "passed": 0,
+   "reason": "Mux: X::Comp::Trait::Duplicate: attribute 'channels' already exists in class 'Mux' (possibly from role composition)",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Native::Packing",
+   "passed": 0,
+   "reason": "Native::Packing: Runtime error: Failed to parse module 'Native::Packing': X::InvalidType: role 'Native::Packing' cannot compose itself",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Net::BGP",
+   "passed": 0,
+   "reason": "Net::BGP::AS-List: Runtime error: Failed to parse module 'Net::BGP::Conversions': X::Undeclared::Symbols: Undeclared routine:",
+   "status": "blocked_load",
+   "version": "0.9.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Net::Ethereum",
+   "passed": 0,
+   "reason": "Net::Ethereum: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.0.185"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Net::IMAP",
+   "passed": 0,
+   "reason": "Net::IMAP::Message: X::Comp::Trait::Duplicate: attribute 'headers' already exists in class 'Email::Simple::Header' (possibly from role composition)",
+   "status": "blocked_load",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Net::Netmask::Fast",
+   "passed": 0,
+   "reason": "Net::Netmask::Fast: Unsupported nqp:: op: nqp::coerce_is",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Net::Postgres",
+   "passed": 0,
+   "reason": "Net::Postgres: expected statement: expected expected statement: expected expression statement or expression after infix operator or '.' or digits or generic rad",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Node::Ethereum::Keccak256::Native",
+   "passed": 0,
+   "reason": "Node::Ethereum::Keccak256::Native: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Node::Ethereum::KZG",
+   "passed": 0,
+   "reason": "Node::Ethereum::KZG::Blob: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.0.33"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Object::Permission::Group",
+   "passed": 0,
+   "reason": "Object::Permission::Group: Dynamic variable $*AUTH-USER not found",
+   "status": "blocked_load",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "octans",
+   "passed": 0,
+   "reason": "Octans::CLI: Runtime error: Failed to parse module 'Octans::CLI': Unsupported use of -> as postfix. In Raku please use: either . to call a method, or whitespace",
+   "status": "blocked_load",
+   "version": "0.2.5"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "OO::Plugin",
+   "passed": 0,
+   "reason": "OO::Plugin: Runtime error: Failed to parse module 'OO::Plugin::Class': Variable '$.stage' of type 'Str:D' must be initialized",
+   "status": "blocked_load",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "ORM::ActiveRecord",
+   "passed": 0,
+   "reason": "ORM::ActiveRecord::Model::Relations: Unknown function: of",
+   "status": "blocked_load",
+   "version": "0.9.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "ORM::Factory",
+   "passed": 0,
+   "reason": "ORM::Factory::DSL: Redeclaration of routine 'define'. Did you mean to declare a multi-sub?",
+   "status": "blocked_load",
+   "version": "0.9.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Pakku",
+   "passed": 0,
+   "reason": "Pakku: expected statement: expected expected statement: expected condition expression after 'if' or listop argument expression or '.' or digits or generic radix",
+   "status": "blocked_load",
+   "version": "celastrina.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "ParaSeq",
+   "passed": 0,
+   "reason": "ParaSeq: No such method 'cpu-cores-but-one' for invocant of type 'Kernel'",
+   "status": "blocked_load",
+   "version": "0.2.7"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "PDF",
+   "passed": 0,
+   "reason": "PDF::COS::Array: Invalid typename 'IndRef' in parameter declaration.",
+   "status": "blocked_load",
+   "version": "0.6.15"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::Class",
+   "passed": 0,
+   "reason": "PDF::AcroForm: Invalid typename 'IndRef' in parameter declaration.",
+   "status": "blocked_load",
+   "version": "0.5.30"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "PDF::Content",
+   "passed": 0,
+   "reason": "PDF::Content::API: Invalid typename 'IndRef' in parameter declaration.",
+   "status": "blocked_load",
+   "version": "0.9.11"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "PDF::Font::Loader",
+   "passed": 0,
+   "reason": "PDF::Font::Loader::Dict: Invalid typename 'IndRef' in parameter declaration.",
+   "status": "blocked_load",
+   "version": "0.8.15"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::Font::Loader::HarfBuzz",
+   "passed": 0,
+   "reason": "PDF::Font::Loader::HarfBuzz: Variable $!var used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "PDF::Native",
+   "passed": 0,
+   "reason": "PDF::Native::COS: Could not instantiate role 'PDF::Native::COS::COSType' because it died with X::AdHoc; exception details:",
+   "status": "blocked_load",
+   "version": "0.1.14"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Physics::Error",
+   "passed": 0,
+   "reason": "Physics::Error: Failed to parse module 'Physics::Error': X::Syntax::Missing: Missing block",
+   "status": "blocked_load",
+   "version": "0.1.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Physics::Unit",
+   "passed": 0,
+   "reason": "Physics::Unit: You tried to augment class NumStr, but it does not exist",
+   "status": "blocked_load",
+   "version": "2.0.31"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Pod::To::PDF",
+   "passed": 0,
+   "reason": "Pod::To::Cairo::Style: Failed to parse module 'FontConfig::Raw': X::Comp::Group: Function 'FcTypeUnknown' needs parens to avoid gobbling block (or perhaps it's ",
+   "status": "blocked_load",
+   "version": "0.1.14"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Pod::To::PDF::Lite",
+   "passed": 0,
+   "reason": "Pod::To::PDF::Lite::Style: Invalid typename 'IndRef' in parameter declaration.",
+   "status": "blocked_load",
+   "version": "0.1.16"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Polyglot::Regexen",
+   "passed": 0,
+   "reason": "Polyglot::Regex::ECMA262::Actions-Mixin: Could not find QAST in:",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Pop",
+   "passed": 0,
+   "reason": "Pop: Runtime error: Failed to parse module 'Pop::Graphics': Regex not terminated.",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "POSIX::getaddrinfo",
+   "passed": 0,
+   "reason": "POSIX::getaddrinfo: Failed to parse module 'POSIX::getaddrinfo': X::Undeclared::Symbols: Undeclared routine:",
+   "status": "blocked_load",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Pray",
+   "passed": 0,
+   "reason": "Pray::Geometry::Sphere: expected statement: expected expected statement: expected return value expression or '.' or digits or generic radix literal or unicode n",
+   "status": "blocked_load",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Prettier::Table",
+   "passed": 0,
+   "reason": "Prettier::Table: X::Comp::Trait::Duplicate: attribute 'min-width' already exists in class 'Prettier::Table' (possibly from role composition)",
+   "status": "blocked_load",
+   "version": "1.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PrettyDump",
+   "passed": 0,
+   "reason": "PrettyDump: expected statement: expected expected statement: expected expected statement: expected use statement or import statement or no statement or need sta",
+   "status": "blocked_load",
+   "version": "1.2.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Proc::Q",
+   "passed": 0,
+   "reason": "Proc::Q: Proc::Q module requires Rakudo v2017.06 or newer",
+   "status": "blocked_load",
+   "version": "1.001003"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Prompt::Expand",
+   "passed": 0,
+   "reason": "Prompt::Expand: 'DateTime' cannot inherit from itself.",
+   "status": "blocked_load",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Protocol",
+   "passed": 0,
+   "reason": "MetamodelX::Protocol: 'MetamodelX::Protocol' cannot inherit from 'Metamodel::SubsetHOW' because it is unknown.",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Protocol::MQTT",
+   "passed": 0,
+   "reason": "Net::MQTT: Invalid typename 'EncodeBuffer' in parameter declaration.",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Protocol::Postgres",
+   "passed": 0,
+   "reason": "Protocol::Postgres: expected statement: expected expected statement: expected expression statement or expression after infix operator or '.' or digits or generi",
+   "status": "blocked_load",
+   "version": "0.0.13"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Proxee",
+   "passed": 0,
+   "reason": "Proxee: expected statement: expected expected statement: expected expression statement or '{'",
+   "status": "blocked_load",
+   "version": "1.001004"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PublicSuffix",
+   "passed": 0,
+   "reason": "PublicSuffix: Runtime error: Failed to parse module 'PublicSuffix': Unsupported use of bare \"lc\". In Raku please use: .lc if you meant to call it as a method on",
+   "status": "blocked_load",
+   "version": "0.1.20250910"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "python::itertools",
+   "passed": 0,
+   "reason": "python::itertools: expected statement: expected expected statement: expected expression statement or expected statement: expected use statement or import statem",
+   "status": "blocked_load",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Qt::QtWidgets",
+   "passed": 0,
+   "reason": "Qt::QtWidgets::Callbacks: 'QSize' cannot inherit from 'QtObject' because it is unknown.",
+   "status": "blocked_load",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Qwiratry",
+   "passed": 0,
+   "reason": "Qwiratry::Walker: Failed to parse module 'Qwiratry::Walker::Capabilities': X::Syntax::InfixInTermPosition: Preceding context expects a term, but found infix => ",
+   "status": "blocked_load",
+   "version": "0.10.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "raku-mailgun",
+   "passed": 0,
+   "reason": "Mailgun: expected statement: expected expected statement: expected expression statement or ')'",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "raku-pod-extraction",
+   "passed": 0,
+   "reason": "PodExtraction: Unknown function: returns",
+   "status": "blocked_load",
+   "version": "0.3.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Raku::Pod::Render",
+   "passed": 0,
+   "reason": "Pod::To::HTML2: Unknown function: returns",
+   "status": "blocked_load",
+   "version": "4.10.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "RakuConfig",
+   "passed": 0,
+   "reason": "RakuConfig: expected statement: expected expected statement: expected expected statement: expected use statement or import statement or no statement or need sta",
+   "status": "blocked_load",
+   "version": "0.8.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Rakudo-Type-Introspection",
+   "passed": 0,
+   "reason": "Rakudo-Type-Introspection: expected statement: expected expected statement: expected expected statement: expected expected statement: expected use statement or ",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Rakudo::CORE::META",
+   "passed": 0,
+   "reason": "Rakudo::CORE::META: An exception occurred while evaluating a CHECK",
+   "status": "blocked_load",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Rakudo::Options",
+   "passed": 0,
+   "reason": "Rakudo::Options: An exception occurred while evaluating a CHECK",
+   "status": "blocked_load",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Raylib::Bindings",
+   "passed": 0,
+   "reason": "Raylib::Bindings: Variable $.texture used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.20"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Red",
+   "passed": 0,
+   "reason": "MetamodelX::Red::Comparate: expected statement: expected expected statement: expected expected statement: expected expression statement or expected statement: e",
+   "status": "blocked_load",
+   "version": "0.2.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "RedX::HashedPassword",
+   "passed": 0,
+   "reason": "RedX::HashedPassword: expected statement: expected expected statement: expected expected statement: expected expression statement or expected statement: expecte",
+   "status": "blocked_load",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "REPL",
+   "passed": 0,
+   "reason": "REPL: 'DateTime' cannot inherit from itself.",
+   "status": "blocked_load",
+   "version": "0.0.26"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "roundrobin-slip",
+   "passed": 0,
+   "reason": "roundrobin-slip: Unsupported nqp:: op: nqp::list",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "RPi::Device::DHT11",
+   "passed": 0,
+   "reason": "RPi::Device::DHT11: Unknown function: HAS",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "RPi::Device::ST7036",
+   "passed": 0,
+   "reason": "RPi::Device::ST7036: Default constructor for 'Any' only takes named arguments",
+   "status": "blocked_load",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Russian",
+   "passed": 0,
+   "reason": "Russian: expected statement: expected expected statement: expected anonymous sub parameter list/body or expected statement: expected expression statement or '.'",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "SBOM::CycloneDX",
+   "passed": 0,
+   "reason": "SBOM: X::Undeclared::Symbols: Undeclared name:",
+   "status": "blocked_load",
+   "version": "0.0.16"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Selkie",
+   "passed": 0,
+   "reason": "Selkie::App: expected statement: expected expression statement or ')'",
+   "status": "blocked_load",
+   "version": "0.16.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Selkie::UI",
+   "passed": 0,
+   "reason": "Selkie::UI::AppBuilder: Invalid typename 'CrossAlign' in parameter declaration.",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Services::PortMapping",
+   "passed": 0,
+   "reason": "Services::PortMapping: SWEEP-TIMEOUT",
+   "status": "blocked_load",
+   "version": "v0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Set::Equality",
+   "passed": 0,
+   "reason": "Implementation: Unsupported nqp:: op: nqp::p6bindattrinvres",
+   "status": "blocked_load",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Shell::DSL",
+   "passed": 0,
+   "reason": "Shell::DSL: Runtime error: Failed to parse module 'Shell::DSL': Confused. Two terms in a row",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "SixPM",
+   "passed": 0,
+   "reason": "App::six-pm::Meta6: Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::Date",
+   "passed": 0,
+   "reason": "Slang::Date: Runtime error: slang activation for 'Slang::Date' failed: Slang activation NYI: grammar rule override 'value:sym<date>' is not supported by this im",
+   "status": "blocked_load",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::Emoji",
+   "passed": 0,
+   "reason": "Slang::Emoji: Runtime error: slang activation for 'Slang::Emoji' failed: Slang activation NYI: grammar rule override 'sigilless-variable' is not supported by th",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::Forgiven",
+   "passed": 0,
+   "reason": "Slang::Forgiven: Could not find QAST in:",
+   "status": "blocked_load",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::Kazu",
+   "passed": 0,
+   "reason": "Slang::Kazu: Could not find QAST in:",
+   "status": "blocked_load",
+   "version": "1.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::Lambda",
+   "passed": 0,
+   "reason": "Slang::Lambda: Runtime error: slang activation for 'Slang::Lambda' failed: Slang activation NYI: grammar rule override 'lambda' is not supported by this impleme",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::Mosdef",
+   "passed": 0,
+   "reason": "Slang::Mosdef: Runtime error: slang activation for 'Slang::Mosdef' failed: Slang activation NYI: grammar rule override 'routine_declarator:sym<method>' is not s",
+   "status": "blocked_load",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::Nogil",
+   "passed": 0,
+   "reason": "Slang::Nogil: Runtime error: slang activation for 'Slang::Nogil' failed: Slang activation NYI: grammar rule override 'sigilless-variable' is not supported by th",
+   "status": "blocked_load",
+   "version": "1.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::NumberBase",
+   "passed": 0,
+   "reason": "Slang::NumberBase: Runtime error: slang activation for 'Slang::NumberBase' failed: Slang activation NYI: grammar rule override 'number:sym<base>' is not support",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::Otherwise",
+   "passed": 0,
+   "reason": "Slang::Otherwise: Runtime error: slang activation for 'Slang::Otherwise' failed: Slang activation NYI: grammar rule override 'vetPerlForSyntax' is not supported",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::Roman",
+   "passed": 0,
+   "reason": "Slang::Roman: Runtime error: slang activation for 'Slang::Roman' failed: Slang activation NYI: grammar rule override 'number:sym<roman>' is not supported by thi",
+   "status": "blocked_load",
+   "version": "0.6.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::SQL",
+   "passed": 0,
+   "reason": "Slang::SQL: Could not find QAST in:",
+   "status": "blocked_load",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang:Date",
+   "passed": 0,
+   "reason": "Slang::Date: Could not find QAST in:",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Sparrow6",
+   "passed": 0,
+   "reason": "Sparrow6::RakuTask: Runtime error: Failed to parse module 'Sparrow6::RakuTask': Null regex not allowed",
+   "status": "blocked_load",
+   "version": "0.0.94"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "SQL::Abstract",
+   "passed": 0,
+   "reason": "SQL::Abstract: Invalid typename 'Column::List(Any)' in parameter declaration.",
+   "status": "blocked_load",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "SSH::LibSSH",
+   "passed": 0,
+   "reason": "SSH::LibSSH: Error while importing from 'NativeCall': no such tag 'types' declared",
+   "status": "blocked_load",
+   "version": "0.10.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "SSH::LibSSH::Tunnel",
+   "passed": 0,
+   "reason": "SSH::LibSSH::Tunnel: Error while importing from 'NativeCall': no such tag 'types' declared",
+   "status": "blocked_load",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Statistics::Distributions",
+   "passed": 0,
+   "reason": "Statistics::Distributions: expected statement: expected expected statement: expected expression statement or ')'",
+   "status": "blocked_load",
+   "version": "0.1.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Stomp",
+   "passed": 0,
+   "reason": "Stomp: 'Stomp::Client' cannot inherit from itself.",
+   "status": "blocked_load",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "String::Color",
+   "passed": 0,
+   "reason": "String::Color: Unsupported nqp:: op: nqp::list",
+   "status": "blocked_load",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Sway::Config",
+   "passed": 0,
+   "reason": "Sway::Config::CLI: Constraint type check failed in binding to parameter '$pod'; expected PodOrArrayOfPod but got Nil (Nil)",
+   "status": "blocked_load",
+   "version": "0.2.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "T",
+   "passed": 0,
+   "reason": "T: Could not find QAST in:",
+   "status": "blocked_load",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "TAP",
+   "passed": 0,
+   "reason": "TAP: X::InvalidType: Invalid typename 'TAP::Entry::Handler'",
+   "status": "blocked_load",
+   "version": "0.3.15"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "TCP::LowLevel",
+   "passed": 0,
+   "reason": "TCP::LowLevel: Variable $.in used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Terminal-API",
+   "passed": 0,
+   "reason": "Terminal::API: Variable $.dwSize used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "1.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Terminal-Widgets-Plugins-Anolis",
+   "passed": 0,
+   "reason": "Terminal::Widgets::Plugins::Anolis: Failed to parse module 'Terminal::Widgets::Widget': Unexpected block in infix position (missing statement control word befor",
+   "status": "blocked_load",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Terminal::LineEditor",
+   "passed": 0,
+   "reason": "Terminal::LineEditor::RawTerminalInput: Variable $.dwSize used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.0.23"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Terminal::Print",
+   "passed": 0,
+   "reason": "Terminal::Print: Variable $.dwSize used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.978"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Terminal::Widgets",
+   "passed": 0,
+   "reason": "Terminal::Widgets::App: Variable $.dwSize used where no 'self' is available",
+   "status": "blocked_load",
+   "version": "0.3.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Test::Async",
+   "passed": 0,
+   "reason": "Test::Async: 'Test::Async::Metamodel::BundleHOW' cannot inherit from 'Metamodel::ParametricRoleHOW' because it is unknown.",
+   "status": "blocked_load",
+   "version": "0.1.17"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Test::Coverage",
+   "passed": 0,
+   "reason": "Test::Coverage: Failed to parse module 'Code::Coverable': Unexpected block in infix position (missing statement control word before the expression?)",
+   "status": "blocked_load",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Test::Declare",
+   "passed": 0,
+   "reason": "Test::Declare: Runtime error: Failed to parse module 'Test::Declare::Callable': Confused. Two terms in a row",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Test::Describe",
+   "passed": 0,
+   "reason": "Test::Describe: Failed to parse module 'Test::Describe::It': Unexpected block in infix position (missing statement control word before the expression?)",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Test::META",
+   "passed": 0,
+   "reason": "Test::META: Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "0.0.20"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Test::Stream",
+   "passed": 0,
+   "reason": "Test::Predicates: Redeclaration of routine 'instance'. Did you mean to declare a multi-sub?",
+   "status": "blocked_load",
+   "version": "0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Text::Emoji",
+   "passed": 0,
+   "reason": "Text::Emoji: X::Hash::Store::OddNumber with no message",
+   "status": "blocked_load",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Text::Flags",
+   "passed": 0,
+   "reason": "Text::Flags: Unknown function: constant",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Timezone::Simple",
+   "passed": 0,
+   "reason": "Timezone::Simple: Cannot modify an immutable value",
+   "status": "blocked_load",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Timezones::ZoneInfo",
+   "passed": 0,
+   "reason": "CX::Warn::Timezones::UnknownID: 'UnknownID' cannot inherit from 'CX::Warn' because it is unknown.",
+   "status": "blocked_load",
+   "version": "0.5.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Tinky::JSON",
+   "passed": 0,
+   "reason": "Tinky::JSON: Can't use unknown trait 'is' -> 'unmarshalled-by' in an attribute declaration.",
+   "status": "blocked_load",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "TOML",
+   "passed": 0,
+   "reason": "TOML: expected statement: expected expected statement: expected use statement or import statement or no statement or need statement or unit statement or ...",
+   "status": "blocked_load",
+   "version": "3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Tomtit",
+   "passed": 0,
+   "reason": "Tomtit::Completion: Redeclaration of routine 'scenario-list'. Did you mean to declare a multi-sub?",
+   "status": "blocked_load",
+   "version": "0.1.37"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Tomty",
+   "passed": 0,
+   "reason": "Tomty::Completion: Redeclaration of routine 'test-list'. Did you mean to declare a multi-sub?",
+   "status": "blocked_load",
+   "version": "0.0.22"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "TooLoo",
+   "passed": 0,
+   "reason": "TooLoo::Asciicaster: X::Comp::Trait::Duplicate: attribute 'min-width' already exists in class 'Prettier::Table' (possibly from role composition)",
+   "status": "blocked_load",
+   "version": "2.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Tree::Binary",
+   "passed": 0,
+   "reason": "Tree::Binary: 'Tree::Binary::Iterator' cannot inherit from itself.",
+   "status": "blocked_load",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "UI::HTMLWindow",
+   "passed": 0,
+   "reason": "UI::HTMLWindow: expected statement: expected expected statement: expected expected statement: expected expression statement or ')'",
+   "status": "blocked_load",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "uniname-words",
+   "passed": 0,
+   "reason": "uniname-words: Unsupported nqp:: op: nqp::hash",
+   "status": "blocked_load",
+   "version": "10.0.16"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "uniprop",
+   "passed": 0,
+   "reason": "uniprop: An exception occurred while evaluating a CHECK",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Universal::Errno",
+   "passed": 0,
+   "reason": "Universal::Errno: Cannot convert value to native integer type 'int'",
+   "status": "blocked_load",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Unix::errno",
+   "passed": 0,
+   "reason": "Unix::errno: Cannot convert value to native integer type 'int'",
+   "status": "blocked_load",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Usage::Utils",
+   "passed": 0,
+   "reason": "Usage::Utils: Runtime error: No return arguments allowed when return value True is already specified in the signature",
+   "status": "blocked_load",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "ValueClass",
+   "passed": 0,
+   "reason": "ValueClass: 'ValueClass::Attribute' cannot inherit from 'Attribute' because it is unknown.",
+   "status": "blocked_load",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WAT",
+   "passed": 0,
+   "reason": "WAT::CLI: Failed to slurp '(Any)': No such file or directory (os error 2)",
+   "status": "blocked_load",
+   "version": "1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WAT--CLI",
+   "passed": 0,
+   "reason": "WAT::CLI: Failed to slurp '(Any)': No such file or directory (os error 2)",
+   "status": "blocked_load",
+   "version": "1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WebDriver2",
+   "passed": 0,
+   "reason": "WebDriver2::Driver::Provider: expected statement: expected expected statement: expected expression statement or '{'",
+   "status": "blocked_load",
+   "version": "0.1.12"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WebService::Slack::Webhook",
+   "passed": 0,
+   "reason": "WebService::Slack::Webhook: expected statement: expected expected statement: expected expression statement or ')'",
+   "status": "blocked_load",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::HorizonsEphemerisSystem",
+   "passed": 0,
+   "reason": "WWW::HorizonsEphemerisSystem: Cannot convert string to number: base-10 number must begin with valid digits or '.' in '⏏AngularDegrees' (indicated by ⏏)",
+   "status": "blocked_load",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "X11::libxdo",
+   "passed": 0,
+   "reason": "X11::libxdo: Attribute $!xkey not declared in class X11::Xlib::Raw::XEvent",
+   "status": "blocked_load",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "X::Intl",
+   "passed": 0,
+   "reason": "CX::Warn::Intl: Unknown role: CX",
+   "status": "blocked_load",
+   "version": "0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "YAML::Parser::LibYAML",
+   "passed": 0,
+   "reason": "YAML::Parser::LibYAML: Unknown VM; don't know how to build",
+   "status": "blocked_load",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "YAMLScript",
+   "passed": 0,
+   "reason": "YAMLScript: Shared library file 'libys.so.0.2.30' not found",
+   "status": "blocked_load",
+   "version": "0.2.30"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "YAMLStar",
+   "passed": 0,
+   "reason": "YAMLStar: Shared library file 'libyamlstar.so' not found",
+   "status": "blocked_load",
+   "version": "0.1.18"
   },
   {
    "axis": "",
@@ -1350,6 +8550,285 @@
    "version": "0.0.7"
   },
   {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Digest::PSHA1",
+   "passed": 0,
+   "reason": "missing dependency: Digest::SHA",
+   "status": "blocked_dep",
+   "version": "1.0.2"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Draku",
+   "passed": 0,
+   "reason": "missing dependency: Unicode::UTF8, git",
+   "status": "blocked_dep",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "EcosystemMakerFaker",
+   "passed": 0,
+   "reason": "missing dependency: shorten",
+   "status": "blocked_dep",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Elucid8::Build",
+   "passed": 0,
+   "reason": "missing dependency: RakuAST::Deparse::Highlight",
+   "status": "blocked_dep",
+   "version": "0.12.11"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Ethelia",
+   "passed": 0,
+   "reason": "missing dependency: Dossier, Dossier::TelegramBot, Dossier::Transport::Request",
+   "status": "blocked_dep",
+   "version": "0.0.154"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "FeiShuBot",
+   "passed": 0,
+   "reason": "missing dependency: Digest::SHA",
+   "status": "blocked_dep",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Files::Containing",
+   "passed": 0,
+   "reason": "missing dependency: has",
+   "status": "blocked_dep",
+   "version": "0.0.17"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Git::Files",
+   "passed": 0,
+   "reason": "missing dependency: path",
+   "status": "blocked_dep",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "highlighter",
+   "passed": 0,
+   "reason": "missing dependency: has",
+   "status": "blocked_dep",
+   "version": "0.0.23"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "IRC::Client::Plugin::Rakkable",
+   "passed": 0,
+   "reason": "missing dependency: as, has, path",
+   "status": "blocked_dep",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "IRC::Log",
+   "passed": 0,
+   "reason": "missing dependency: has",
+   "status": "blocked_dep",
+   "version": "0.0.26"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "IRC::Log::Colabti",
+   "passed": 0,
+   "reason": "missing dependency: has",
+   "status": "blocked_dep",
+   "version": "0.0.53"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "IRC::Log::Perlgeek",
+   "passed": 0,
+   "reason": "missing dependency: has",
+   "status": "blocked_dep",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "IRC::Log::Textual",
+   "passed": 0,
+   "reason": "missing dependency: has",
+   "status": "blocked_dep",
+   "version": "0.0.18"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Learn::Raku::With",
+   "passed": 0,
+   "reason": "missing dependency: CORE",
+   "status": "blocked_dep",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Lines::Containing",
+   "passed": 0,
+   "reason": "missing dependency: has",
+   "status": "blocked_dep",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Lumberjack::Application",
+   "passed": 0,
+   "reason": "missing dependency: Digest::SHA",
+   "status": "blocked_dep",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Needle::Compile",
+   "passed": 0,
+   "reason": "missing dependency: has",
+   "status": "blocked_dep",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "orion",
+   "passed": 0,
+   "reason": "missing dependency: Digest::SHA",
+   "status": "blocked_dep",
+   "version": "0.2.3"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "P5built-ins",
+   "passed": 0,
+   "reason": "missing dependency: P5",
+   "status": "blocked_dep",
+   "version": "0.0.31"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Pheix",
+   "passed": 0,
+   "reason": "missing dependency: JSON",
+   "status": "blocked_dep",
+   "version": "1.1.3"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "rak",
+   "passed": 0,
+   "reason": "missing dependency: path",
+   "status": "blocked_dep",
+   "version": "0.0.67"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Rakuast::RakuDoc::Render",
+   "passed": 0,
+   "reason": "missing dependency: RakuAST::Deparse::Highlight",
+   "status": "blocked_dep",
+   "version": "1.0.18"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Rakudo::Cache",
+   "passed": 0,
+   "reason": "missing dependency: path",
+   "status": "blocked_dep",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "shorten-sub-commands",
+   "passed": 0,
+   "reason": "missing dependency: as",
+   "status": "blocked_dep",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "taurus",
+   "passed": 0,
+   "reason": "missing dependency: Unicode::UTF8",
+   "status": "blocked_dep",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Terminal::UI",
+   "passed": 0,
+   "reason": "missing dependency: Unicode::UTF8",
+   "status": "blocked_dep",
+   "version": "0.1.14"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Touch",
+   "passed": 0,
+   "reason": "missing dependency: v6",
+   "status": "blocked_dep",
+   "version": "0.7.0"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Type-Relations-Digraph",
+   "passed": 0,
+   "reason": "missing dependency: Rakudo",
+   "status": "blocked_dep",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Zeco",
+   "passed": 0,
+   "reason": "missing dependency: Humming, raku",
+   "status": "blocked_dep",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Zef::Configuration",
+   "passed": 0,
+   "reason": "missing dependency: shorten",
+   "status": "blocked_dep",
+   "version": "0.0.13"
+  },
+  {
    "axis": "pure",
    "baseline": 9,
    "dist": "Abbreviations",
@@ -1357,6 +8836,15 @@
    "reason": "",
    "status": "green",
    "version": "2.2.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "AccountableBagHash",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
   },
   {
    "axis": "pure",
@@ -1595,6 +9083,15 @@
   {
    "axis": "pure",
    "baseline": 1,
+   "dist": "App::MoarVM::Debug",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
    "dist": "App::pack.raku",
    "passed": 1,
    "reason": "",
@@ -1717,6 +9214,15 @@
    "reason": "",
    "status": "green",
    "version": "0.0.6"
+  },
+  {
+   "axis": "native",
+   "baseline": 3,
+   "dist": "Audio::Libshout",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.15"
   },
   {
    "axis": "pure",
@@ -1846,9 +9352,108 @@
   },
   {
    "axis": "pure",
+   "baseline": 3,
+   "dist": "Config::INI",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "*"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Config::Ini",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "content-storage-cli",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 10,
+   "dist": "CortexJS",
+   "passed": 10,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
    "baseline": 1,
    "dist": "CPAN::Uploader::Tiny",
    "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Cro::FCGI",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Cro::HTTP",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "0.8.13"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Cro::HTTP::BodyParser::JSONClass",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Cro::HTTP::BodySerializerJSONClass",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Crypt::AnyPasswordHash",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 3,
+   "dist": "Crypt::Libcrypt",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "CSV-AutoClass",
+   "passed": 2,
    "reason": "",
    "status": "green",
    "version": "0.1.0"
@@ -1861,15 +9466,6 @@
    "reason": "",
    "status": "green",
    "version": "0.2.0"
-  },
-  {
-   "axis": "pure",
-   "baseline": 2,
-   "dist": "CSV-AutoClass",
-   "passed": 2,
-   "reason": "",
-   "status": "green",
-   "version": "0.1.0"
   },
   {
    "axis": "pure",
@@ -1896,6 +9492,2976 @@
    "passed": 9,
    "reason": "",
    "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Curry",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Data::DPath",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Data::TextOrBinary",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "DataStar",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Datastar::SDK",
+   "passed": 5,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Date::Calendar::CopticEthiopic",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Date::Christian::Advent",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Date::YearDay",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "DateTime::Grammar",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Datetime::Math",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.6.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "DateTime::Posix",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.9.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "DateTime::React",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "DB::Migration::Simple",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "DB::Xoos::MySQL",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 36,
+   "dist": "DBIish",
+   "passed": 36,
+   "reason": "",
+   "status": "green",
+   "version": "0.6.8"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "Desktop::Notify",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Desktop::Notify::Progress",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Devel::ExecRunnerGenerator",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 3,
+   "dist": "Device::Velleman::K8055",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "DFM::Parser",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Dice::Roller",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Digest::FNV",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Digest::HMAC",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.7"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "Digest::SHA1::Native",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Digest::SHA256::Native",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Distribution::Builder::Cmake",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Doc::TypeGraph",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "2.3.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "Doublephone",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Duck::CSV",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Duckie",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Email::Notmuch",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Encoding::Huffman::PP6",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "English",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Env::File",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Event::Emitter::Inter-Process",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "EventSource::Client",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "EventSource::Server",
+   "passed": 5,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "FastCGI",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.9.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "FastCGI::NativeCall",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "FastCGI::NativeCall::Async",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "FastCGI::NativeCall::PSGI",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "File-Path-Copy",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.18"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "File::Copy",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "File::file",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "File::Metadata::Libextractor",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "File::Path::Copy",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.14"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "File::Tudo",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.03"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "FontConverter",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "FontFactory::Type1",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "1.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Foo::Bar",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "fornax",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Fortune",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Game::Covid19",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Game::Sudoku",
+   "passed": 5,
+   "reason": "",
+   "status": "green",
+   "version": "1.1.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "GDBM",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Geo::Coder::OpenCage",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Geo::Geometry",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Geo::Location",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Geo::Polyline",
+   "passed": 6,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Getopt::Long::Grammar",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Gherkin::Grammar",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Git::Add",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Git::Blame::File",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Git::Log",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Git::Status",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "GitHub::Actions",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Github::PublicKeys",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Glob::Grammar",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Gnome::Gtk4",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "GNU::Time",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "GOTO",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 3,
+   "dist": "Grammar::Debugger",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Gray::Code::RBC",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 3,
+   "dist": "GTK::Simple",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.3.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "GUI::Wings",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Gzz::Prompt",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Gzz::Text::Utils",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.23"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Hash::Timeout",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "head-skip-tail",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Highlight::Terminal",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Hilite",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Hilite::Simple",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "HowToUseModuleResources",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "HTML::EscapeUtils",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "HTTP::Easy",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "HTTP::HPACK",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "HTTP::Roles",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "HTTP::Server::Logger",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "HTTP::Status",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "HTTP::Tinyish",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.4.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 23,
+   "dist": "HTTP::UserAgent",
+   "passed": 23,
+   "reason": "",
+   "status": "green",
+   "version": "1.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "hyperize",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "IdClass",
+   "passed": 6,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Iec104Parser",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Ikoko",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Image::Draft::Review",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Image::PNG::Portable",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "*"
+  },
+  {
+   "axis": "native",
+   "baseline": 3,
+   "dist": "Image::QRCode",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Image::Reference::Audit",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Int::polydiv",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "IO-Archive",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "IO::Capture::Simple",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "v0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "IO::Path::AutoDecompress",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "IO::Path::ChildSecure",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.001011"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "IO::Prompt",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "IRC::Utils",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "IUP",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "v0.5.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Japanese",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "JSON::Name",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "JSON::OptIn",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "JSON::Pretty",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Jupyter::Converter",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Kivuli",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Korean",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Lang::ZH::Palladius",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "LeftistHeap",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "lemmatize",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Lingua::Conjunction",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.001001"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Lingua::EN::Conjugate",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Lingua::EN::Syllable",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Lingua::Translation::DeepL",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Lingy",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Linux::Joystick",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "LLM::Data::ContentTag",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "LLM::Data::Pipeline",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.7.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 3,
+   "dist": "Log::Syslog::Native",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "MacOS::AudioDevices",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "MacOS::NativeLib",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Map::Agnostic",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.14"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Map::DeckGL",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Math::Arrow",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Math::BijectiveBase",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Math::Libgsl::Combination",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Math::Libgsl::Elementary",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Math::Libgsl::Function",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Math::Libgsl::Histogram",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Math::Libgsl::Multiset",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Math::Libgsl::QuasiRandom",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Math::Libgsl::Random",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Math::Libgsl::RandomDistribution",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Math::Libgsl::Series",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "Math::Libgsl::Statistics",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Math::Random",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Math::Zeckendorf",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Mathematica::Serializer",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Metropolis",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Migration::RTtoGithub",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "MIME::Base64",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "1.2.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "MIME::Types",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "ML::ROCFunctions",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Modf",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Module2Rpm",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Module::Does",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "mv2d",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.333"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "MVC::Keayl::Admin",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.9.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "nano",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 3,
+   "dist": "NativeHelpers::Array",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "native",
+   "baseline": 4,
+   "dist": "NativeLibs",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 6,
+   "dist": "Net::DNS",
+   "passed": 6,
+   "reason": "",
+   "status": "green",
+   "version": "1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Net::Gemini",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Net::Snapcast",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Netstring",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Node::Ethereum::RLP",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.15"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Noise::Simplex",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Notify",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Number::Bytes::Human",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 11,
+   "dist": "Number::More",
+   "passed": 11,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.12"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "NYI",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 5,
+   "dist": "OO::Monitors",
+   "passed": 5,
+   "reason": "",
+   "status": "green",
+   "version": "1.1.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 7,
+   "dist": "OpenRouter::API",
+   "passed": 7,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Operator::feq",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5__FILE__",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5chdir",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5defined",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5fc",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "P5hex",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "P5index",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5lc",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "P5lcfirst",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5length",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "guts",
+   "baseline": 2,
+   "dist": "P5opendir",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5push",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5ref",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5seek",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5shift",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5study",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "P5tie",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.17"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Parse::Paths",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "path-utils",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.25"
+  },
+  {
+   "axis": "native",
+   "baseline": 4,
+   "dist": "Pg::Notify",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Physics::Constants",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Physics::Measure",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "2.0.26"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Physics::Navigation",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Pod::From::Cache",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.6.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Pod::To::Raku",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Pod::Usage",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "PostCocoon::Url",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Proc::Easy",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Proc::Editor",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "PSGI",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "1.2.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "PSpec",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "4.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Qwiratry::Format::JSON",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Qwiratry::Format::XML",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Qwiratry::Format::YAML",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Raku::Elements",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "RakupodObject",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Random::Choice",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Rat::Power",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "rawstr4c",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "ReadWriteLock",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.3.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 19,
+   "dist": "Recipe::Parser",
+   "passed": 19,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 16,
+   "dist": "Redis",
+   "passed": 16,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Repository::Precomp::Cleanup",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Resource::Wrangler",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "2.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Rmv::JIRA",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Roaring::Tags",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "RPi::ButtonWatcher",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "RPi::Device::DS18B20",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "RPi::Device::PiGlow",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "RPi::Device::SMBus",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "RSV",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Ryml",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "SantaClaus::Utils",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "SCGI",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "2.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Script::Hash",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Shareable",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "sigpipe",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Slang::Piersing",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Slang::Tuxic",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Slangify",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "SnowFlake",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "sortuk",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Sparky",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.2.32"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Sparky::Minimal",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Sparrow6::Rakudo::Install",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "SparrowCI",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Sparrowdo",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.57"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "Spreadsheet::Libxlsxio",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Statistics::LinearRegression",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Storable::Lite",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "String::FuzzyIndex",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "String::Rotate",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Subset::Helper",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.001002"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Subsets::Common",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Syntax::Highlighters",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Sys::Domainname",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Sys::IP",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "Sys::Lastlog",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Sys::Utmp",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Syslog::Parse",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "System::Query",
+   "passed": 5,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Teddy Bear",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 12,
+   "dist": "Template6",
+   "passed": 12,
+   "reason": "",
+   "status": "green",
+   "version": "0.16.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Template::Mojo",
+   "passed": 5,
+   "reason": "",
+   "status": "green",
+   "version": "v0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 13,
+   "dist": "Template::Mustache",
+   "passed": 13,
+   "reason": "",
+   "status": "green",
+   "version": "1.2.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 10,
+   "dist": "Template::Nest::Fast",
+   "passed": 10,
+   "reason": "",
+   "status": "green",
+   "version": "0.3.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Template::Protone",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "Term::Choose",
+   "passed": 5,
+   "reason": "",
+   "status": "green",
+   "version": "2.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Term::Choose::Util",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "1.4.8"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Term::ReadKey",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Term::Size",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Term::TablePrint",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "1.6.9"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Term::termios",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "*"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Terminal-MakeRaw",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Terminal::ANSIColor",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.14"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Terminal::Capabilities",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.21"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Terminal::Gauge",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Terminal::Getpass",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.11"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Terminal::ReadKey",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "Terminal::Size",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Test::Assertion",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Test::Class",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Test::ContainerizedService",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Test::Differences",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Test::HTTP::Server",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.5.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Test::IO::Socket::Async",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Test::NoTabs",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Test::Util::ServerPort",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::Center",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::Chart",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "Text::Diff::Sift4",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "2.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::Homoglyph::ASCII",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::Homoglyph::Cyrillic",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::Levenshtein",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "v0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::Lorem",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 4,
+   "dist": "Text::Plot",
+   "passed": 4,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::Sorensen",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::Spintax",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::T9",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "*"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Text::Tabs",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Tie::Array",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Tie::Hash",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Tie::StdArray",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Tie::StdHash",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Time::Duration::Parser",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Timezones::US",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "TinyFloats",
+   "passed": 5,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "TinyID",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Tomtit::Profile::Python",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Trove",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.41"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "UK::Sort",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "UNICODE-VERSION",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Unicode::UTF8-Parser",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "*"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Unix::Groups",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "native",
+   "baseline": 2,
+   "dist": "UNIX::Privileges",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.6"
+  },
+  {
+   "axis": "guts",
+   "baseline": 1,
+   "dist": "unprint",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "URL::Find",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "v0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "User::Language",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.5.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Util::Bitfield",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "Util::Uuencode",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "UUID::V4",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "vars",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Video::Prompt::Brief",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 3,
+   "dist": "Wasm::Emitter",
+   "passed": 3,
+   "reason": "",
+   "status": "green",
+   "version": "0.9.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Web::App",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.9.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Web::Template",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "3.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 1,
+   "dist": "Win32::Registry",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "Windows::Test",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "wordfinder",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "WWW::Gemini",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.25"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "WWW::Ollama",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "WWW::Playwright",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.9.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 15,
+   "dist": "XML",
+   "passed": 15,
+   "reason": "",
+   "status": "green",
+   "version": "0.3.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "XML::Canonical",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "XML::Fast",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 1,
+   "dist": "XML::Query",
+   "passed": 1,
+   "reason": "",
+   "status": "green",
+   "version": "1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 2,
+   "dist": "YakShave",
+   "passed": 2,
+   "reason": "",
+   "status": "green",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 5,
+   "dist": "YAMLish",
+   "passed": 5,
+   "reason": "",
+   "status": "green",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 5,
+   "dist": "zef",
+   "passed": 5,
+   "reason": "",
+   "status": "green",
+   "version": "1.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "_",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
    "version": "0.0.2"
   },
   {
@@ -2135,6 +12701,15 @@
   {
    "axis": "pure",
    "baseline": 0,
+   "dist": "caelum",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
    "dist": "Calendar",
    "passed": 0,
    "reason": "",
@@ -2185,6 +12760,15 @@
    "reason": "",
    "status": "no_baseline",
    "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "cmark::Simple",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.3"
   },
   {
    "axis": "pure",
@@ -2241,6 +12825,105 @@
    "version": "0.0.4"
   },
   {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Console::Blackjack",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Contact::Name",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cro-HTTP-Middleware-GoatCounter",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cro::CBOR",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cro::HTTP::RouterUtils",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cro::HTTP::Session::MySQL",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cro::HTTP::Session::SQLite",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cro::OpenAPI::RoutesFromDefinition",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cro::TLS",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.8.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cro::WebApp",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.10.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cro::WebApp::Evaluate",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
    "axis": "native",
    "baseline": 0,
    "dist": "CRoaring",
@@ -2248,6 +12931,42 @@
    "reason": "",
    "status": "no_baseline",
    "version": "0.2.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Crolite",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cromponent",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.14"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Cromtit",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.21"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Crypt::Argon2",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.3.0"
   },
   {
    "axis": "pure",
@@ -2266,15 +12985,1662 @@
    "reason": "",
    "status": "no_baseline",
    "version": "v0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Data::Geographics",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Data::Tree",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "DB::MySQL",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Debugging::Tool",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.3.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "delete-old-until-size",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "DirsOfInterest",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Discogs::API",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::English::DataQueryWorkflows",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.6.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::English::LatentSemanticAnalysisWorkflows",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.8.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::English::QuantileRegressionWorkflows",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.8.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::English::RecommenderWorkflows",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.6.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::English::SearchEngineQueries",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.5.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "DSL::Translators",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Ecosystem::Archive",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Ecosystem::Archive::Update",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.29"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Elucid8::Run-locally",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.51.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Email::SendGrid",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "ERK",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Exportable",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "File-TreeBuilder",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "File::Directory::Bubble",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "File::Directory::Tree",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "*"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "File::Stat",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "File::Temp",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.12"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "File::TreeBuilder",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Filetype::Magic",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Games::BubbleBreaker",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "*"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Geo::Valhalla",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Geo::WellKnownText",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "GEOS",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "GLFW",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "GlotIO",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "2.0.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Gnome::Gdk4",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.23"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Gnome::GdkPixbuf",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Gnome::Graphene",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.11"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Gnome::Gsk4",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Gnome::Pango",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.14"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "GnomeTools",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.8.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Graphviz::DOT::Chessboard",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "GtkLayerShell",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "HarfBuzz::Shaper::Cairo",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Hiker",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "HTML::Canvas::To::PDF",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.13"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "HTML::Parser",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "HTTP::Server::Router",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "HTTP::Server::Router::YAML",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "HuggingFace::API",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Image::Markup::Utilities",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Inline::Scheme::Gambit",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Intl::Format::List",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.6.0+"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Intl::LanguageTag",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.12.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Intl::Regex::CharClass",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Intl::Token::Number",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.6"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Intl::UserLanguage",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.4.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "IO-Socket-TLSViaAsync",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "IO::Notification::Recursive",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "IO::Socket::Async::SSL",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.8.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "IO::Socket::SSL",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "IRC::Client",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "4.0.15"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "IRC::Client::Plugin::Logger",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.13"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "JavaScript::Google::Charts",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "JSON-CSV",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "JSON-Simd",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "JSON::Collector",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "JSON::JWT",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "JSON::Webhook",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "L10N::Complete",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "lacerta",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "LibXML::Writer",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "LibXSLT",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Linenoise",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Lingua::EN::Fathom",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Lingua::EN::Sentence",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "LLM::Classifiers::Emotions",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "LLM::Containerization",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "LR1",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Mac::Applications::List",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.14"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Mac::Battery::Alerter",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::DistanceFunctions::Edit",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::DistanceFunctions::Native",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::Libgsl::Constants",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.13"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Math::SparseMatrix::Native",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "MCP::Server::Tool::FileSystem",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "MeCab",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.19"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MessageStream",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MoarVM::Profile",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MongoDB::Queue",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MUGS",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "MUGS::UI::WebSimple",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Net::Google::Sheets",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Net::LibIDN2",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Net::Postgres::Abstract",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Net::SMTP",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.2.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Node::Ethereum::KeyStore::V3",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.27"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Noise::Simplex::Native",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "NotoFonts-OT",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.3.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "ONNX::Native",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.0"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "ONNX::Runtime",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "OpenMPT::Bindings",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "OpenSSL",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Overwatch",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Pastebin::Gist",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.004002"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Pastebin::Shadowcat",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "2.001003"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Path::Finder",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.4.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::API6",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::Combiner",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::Document",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.10"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::Extract",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::Font::Loader::CSS",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::Lite",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.15"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::NameTags",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::Tags",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::Tags::Reader",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.18"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "PDF::To::Cairo",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Physics::Vector",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Pleroma",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Polyglot::Brainfuck",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Proc::ZMQed",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Progress::Bar",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.0.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Pyrint",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Qwiratry--Location--HTTP",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Qwiratry::Location::HTTP",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Qwiratry::Test",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "RakudoContainerfileBuilder",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.0.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "RakuRename",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Raygui::Bindings",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "RealDentalCosts::API",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Resend",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "RKDS",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "2.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "SBOM::Raku",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.13"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "SDL2-ttf",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Shodan",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Sitemap",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "Slang::Comments",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Slangify::Tutorial",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "SOD",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Sort::Naturally",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "v0.2.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "SparrowCI - super fun and flexible CI system with many programming languages support",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "SparrowCI-SandBox",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Spreadsheet::ODS",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Spreadsheet::XLSX",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.3.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "SQL::Builder::ExecuteWithDBIish",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Statistics",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.6"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "sublist",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Subsets::IO",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "1.001003"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Sys::Chown",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Sys::HostAddr",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Test::Selector",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.4.2"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Text::CSV::LibCSV",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Text::FriBidi",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Tokenizers",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.3.0"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "TOP",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.7"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "TreeSitter::Native",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "under-version-control",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Unicode::Security",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Updown",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "native",
+   "baseline": 0,
+   "dist": "Vips::Native",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.6.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Web::App::MVC",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WebDriver",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WebService::AWS::Auth::V4",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WebService::HashiCorp::Vault",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.0"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "Wikidata::API",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW--CloudHosting--Hetzner",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.1"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::CloudHosting::Hetzner",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "guts",
+   "baseline": 0,
+   "dist": "WWW::GCloud",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.8"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::GCloud::API::Storage",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.5"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::GCloud::API::Vision",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.4"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::LLaMA",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::MermaidInk",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::MistralAI",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::OpenAI",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.3.20"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::OpenRouter",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::PaLM",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.9"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::WolframAlpha",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.2"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::XAI",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.1.3"
+  },
+  {
+   "axis": "pure",
+   "baseline": 0,
+   "dist": "WWW::YouTube",
+   "passed": 0,
+   "reason": "",
+   "status": "no_baseline",
+   "version": "0.0.9"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Collection-Plugin-Development",
+   "passed": 0,
+   "reason": "",
+   "status": "skipped",
+   "version": "0.4.6"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Gnome::Gtk3",
+   "passed": 0,
+   "reason": "",
+   "status": "skipped",
+   "version": "0.49.1"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "HTML::Template",
+   "passed": 0,
+   "reason": "",
+   "status": "skipped",
+   "version": "*"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "IRC::TextColor",
+   "passed": 0,
+   "reason": "",
+   "status": "skipped",
+   "version": "v0.1.1"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Readline",
+   "passed": 0,
+   "reason": "",
+   "status": "skipped",
+   "version": "v0.0.2"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "SQL::NamedPlaceholder",
+   "passed": 0,
+   "reason": "",
+   "status": "skipped",
+   "version": "v0.1.0"
+  },
+  {
+   "axis": "",
+   "baseline": 0,
+   "dist": "Sway::PreviewKeys",
+   "passed": 0,
+   "reason": "",
+   "status": "skipped",
+   "version": "0.2.4"
   }
  ],
- "file_parity": 61.0,
+ "file_parity": 53.4,
  "generated_from": "ecosystem/dists",
- "has_chart": false,
+ "has_chart": true,
  "measured": {
-  "date": "2026-09-10",
-  "host": "linux-x86_64",
-  "mutsu_commit": "a7fe6d9",
+  "date": "2026-09-11",
+  "host": "gha-ubuntu24-4c",
+  "mutsu_commit": "7807eb5",
   "mutsu_version": "0.23.0",
   "raku_version": "2026.07"
  }

--- a/site/e2e.test.mjs
+++ b/site/e2e.test.mjs
@@ -13,7 +13,7 @@
 
 import { chromium } from 'playwright';
 import { spawn, spawnSync } from 'child_process';
-import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { copyFileSync, existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
 
 import { parseCorpus } from './assets/corpus.js';
 import landingEn from './content/landing.en.js';
@@ -103,6 +103,13 @@ if (rendered.status !== 0) {
   console.error('Error: could not render the bench dashboard:', rendered.stderr);
   process.exit(1);
 }
+
+// The ecosystem parity chart is copied out of the ledger at deploy time
+// (pages.yml), and the manifest's `has_chart` is what makes the page ask for it.
+// Stage it the same way here so that wiring is exercised rather than 404ing.
+const ECO_CHART = 'site/history.svg';
+const ECO_CHART_STAGED = !existsSync(ECO_CHART) && existsSync('ecosystem/history.svg');
+if (ECO_CHART_STAGED) copyFileSync('ecosystem/history.svg', ECO_CHART);
 
 // Start HTTP server
 server = spawn('python3', ['-m', 'http.server', String(PORT), '-d', 'site'], {
@@ -263,24 +270,32 @@ try {
 
   assert(await page.textContent('.site-nav a[aria-current="page"]') === 'Ecosystem',
          'the ecosystem page is in the nav and marked current');
-  // The table renders at most a page's worth; the corpus is ~1600 rows and the
-  // filter is what the page is for.
-  const ecoExpected = Math.min(ecoManifest.distributions.length, 400);
+  // Every measured distribution gets a row: the table is not capped, so the
+  // count printed above it and the rows below it cannot disagree. (A 400-row cap
+  // used to hide every green distribution, since the default sort is
+  // worst-first.)
+  const ecoExpected = ecoManifest.distributions.length;
   assert(await page.locator('table.eco tbody tr.eco-row').count() === ecoExpected,
          `every measured distribution has a row (${ecoExpected})`);
   assert(await page.evaluate(() =>
     document.documentElement.scrollWidth <= document.documentElement.clientWidth),
     'the ecosystem page does not scroll sideways');
+  assert(await page.locator('#eco-chart').isVisible() === !!ecoManifest.has_chart,
+         `the parity chart follows the manifest's has_chart (${!!ecoManifest.has_chart})`);
 
   if (ecoManifest.distributions.length) {
     console.log('Test: ecosystem search narrows the table');
     const first = ecoManifest.distributions[0].dist;
+    // Exactly the rows the filter matches -- not "at most the full count", which
+    // a truncating table would also satisfy.
+    const ecoMatching = ecoManifest.distributions.filter(
+      (d) => d.dist.toLowerCase().includes(first.toLowerCase())).length;
     await page.fill('#eco-search', first);
     await page.waitForFunction(
-      (n) => document.querySelectorAll('table.eco tbody tr.eco-row').length <= n,
-      ecoExpected, { timeout: 5000 });
+      (n) => document.querySelectorAll('table.eco tbody tr.eco-row').length === n,
+      ecoMatching, { timeout: 5000 });
     const narrowed = await page.locator('table.eco tbody tr.eco-row').count();
-    assert(narrowed >= 1 && narrowed < ecoExpected + 1,
+    assert(narrowed === ecoMatching && narrowed <= ecoExpected,
            `searching for ${first} narrows the table to ${narrowed} row(s)`);
     assert((await page.textContent('table.eco tbody tr td')).includes(first.split('::')[0]),
            'and the match is the distribution searched for');
@@ -685,6 +700,7 @@ try {
   server.kill();
   rmSync(BENCH_TSV, { force: true });
   rmSync(BENCH_HTML, { force: true });
+  if (ECO_CHART_STAGED) rmSync(ECO_CHART, { force: true });
 }
 
 console.log(`\nResults: ${passed} passed, ${failed} failed`);

--- a/site/ecosystem.html
+++ b/site/ecosystem.html
@@ -252,10 +252,13 @@ function paintRows() {
     return;
   }
 
-  // Render at most a page's worth at a time: the corpus is ~1600 rows and a
-  // filtered view is what the page is for.
+  // Render every match, not a capped slice. The default view is sorted
+  // worst-first, so a cap hid whole status classes (every green distribution
+  // fell past it) while the count above still claimed the full total -- the page
+  // looked broken. One fragment, appended once, keeps a full corpus render cheap
+  // enough to redo on each keystroke.
   const frag = document.createDocumentFragment();
-  for (const d of matches.slice(0, 400)) {
+  for (const d of matches) {
     const tr = document.createElement('tr');
     tr.className = 'eco-row';
 


### PR DESCRIPTION
The ecosystem compatibility page showed only part of the corpus. The data was
never the problem — the deployed `content/ecosystem.json` carries all 1625
records — the table was.

`site/ecosystem.html` rendered `matches.slice(0, 400)`. The cap was added when
the sweep had measured a couple of hundred distributions and the table was not
expected to reach it; the sweep has since measured the whole corpus, so the cap
became the page's dominant behaviour. Rows are sorted worst-first
(`STATUS_ORDER` in `scripts/gen-ecosystem-manifest.py`), which puts the cut 94
rows into `partial`:

| status | records | rows rendered before |
| --- | --- | --- |
| red | 306 | 306 |
| partial | 271 | 94 |
| blocked_load | 360 | 0 |
| blocked_dep | 43 | 0 |
| green | 403 | 0 |
| no_baseline | 235 | 0 |
| skipped | 7 | 0 |

So the page that answers "does my module work on mutsu?" could not display a
single working module in its default view, while the count above the table read
`1625 of 1625`, because it counts matches rather than rendered rows. Search and
the status filter both still reached the hidden rows, which is why this survived:
any query narrow enough to matter came back correct.

## Changes

- **`site/ecosystem.html`**: render every match. A full 1625-row render measures
  ~1.1s to `body[data-ready]` on a cold load and ~90ms to re-render on a
  keystroke in the search box, so it needs no chunking or virtualizing.
- **`site/e2e.test.mjs`**: the row count must equal the manifest's distribution
  count outright instead of `min(count, 400)`, and filtering must yield exactly
  the matching rows rather than "at most the full count" — an assertion a
  truncating table also satisfied.
- **`site/content/ecosystem.json`**: regenerated. The committed snapshot had
  been left at the 251-row shard-C measurement from 2026-09-10 while
  `ecosystem/dists/` grew to 1625, so the e2e suite had been exercising a corpus
  far too small to ever reach the cap. The deployed page never reads this
  snapshot (`pages.yml` regenerates it at deploy time), which is exactly why the
  staleness went unnoticed.
- The regeneration flips the manifest's `has_chart` to true, so the e2e suite
  now stages `ecosystem/history.svg` into `site/` the way `pages.yml` does for
  the deploy, and asserts the chart's visibility follows `has_chart`. That
  wiring had no coverage before. `/site/history.svg` joins the other deploy-time
  artefacts in `.gitignore`.

## Verification

`node site/e2e.test.mjs` — **123 passed, 0 failed**, including
`every measured distribution has a row (1625)` and
`the parity chart follows the manifest's has_chart (true)`. Run with
`SKIP_LESSON_SWEEP=1` and against a `wasm-opt`-less `pkg/` (this container's
proxy blocks the binaryen download); the `wasm-e2e` job runs both in full.

`make test` / `make roast` were not run: the diff is JavaScript, generated JSON,
`.gitignore` and `news/`, with no Rust and no build input either suite reads.
CI runs all five jobs regardless — `site/` is deliberately not on the
documentation allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFCGVqTrjFU3FNAougDC7w