### PR TITLE
fix(ecosystem): a sweep timeout is a claim about the budget, not the file

### DIFF
--- a/.github/workflows/ecosystem-sweep.yml
+++ b/.github/workflows/ecosystem-sweep.yml
@@ -150,6 +150,7 @@ jobs:
           set -euo pipefail
           python3 scripts/ecosystem-ci.py --self-test
           python3 scripts/ecosystem_common.py --self-test
+          python3 scripts/ecosystem-sweep.py --self-test
 
       - name: Plan the matrix
         id: plan

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -120,6 +120,20 @@ than leaving it to the operator:
    varies across attempts is marked `flaky: true` and excluded from the KPI on
    both sides. Only failures are retried, so the cost is proportional to the
    problem.
+8. **A timeout is a claim about the budget until a longer run disproves it.**
+   Re-running a timed-out file on the *same* budget is the one retry that can
+   never learn anything: a hang hangs again, and a file whose own runtime sits
+   at the budget is phase-locked into timing out again, because whatever sets
+   its runtime also sets when the previous attempt ended. So the first timeout
+   buys one retry at twice the budget and is not counted towards `flaky`; a
+   file that times out at the larger budget is believed and the retries stop,
+   which costs a genuine hang no more wall clock than the same-budget retries
+   it replaces. `DateTime::React`'s `t/01-basic.t` is the case that forced this
+   (`news/2026-09/`): it sleeps through two minute rollovers, so it runs for
+   `121 - second-of-minute` seconds and therefore always *ends* at
+   second-of-minute 1 — putting every following run at the one phase where it
+   needs ~120.1s, just over the 120s default. It passes 8/8 on both
+   interpreters; the sweep was discarding it as `flaky`.
 
 ## 3. Dependencies — a flat `-I` closure, resolved offline
 
@@ -214,7 +228,7 @@ never hand-edited — a conflict in them is resolved by regenerating, not mergin
     "date": "2026-09-10",
     "mutsu_commit": "66a1e4e", "mutsu_version": "0.23.0",
     "raku_version": "2026.07", "raku_backend": "moar 2026.07",
-    "host": "linux-x86_64", "sandbox": "bwrap", "harness": 1
+    "host": "linux-x86_64", "sandbox": "bwrap", "harness": 2
   },
   "deps": { "mode": "flat-closure", "digest": "sha256:…",
             "resolved": ["Foo::Bar"], "unresolved": [], "bundled_would_supply": [] },
@@ -279,7 +293,8 @@ scripts/ecosystem-sweep.py --all --jobs 8
 scripts/ecosystem-sweep.py --rollup
 ```
 
-Other flags: `--timeout` (default 120s/file, both sides), `--max-files` (per
+Other flags: `--timeout` (default 120s/file, both sides — a file that exhausts
+it gets one retry at twice the budget, see §2.8), `--max-files` (per
 dist, to bound a pathological suite), `--include-xt`, `--sandbox {bwrap,none}`,
 `--no-index-snapshot` (see below),
 `--mutsu-only` (see *Baseline caching* below), `--refresh-baseline`, `--dry-run` (resolve and print the
@@ -573,7 +588,9 @@ form `gha-ubuntu24-4c`, so they are never silently mixed with locally-measured
 ones. A hosted runner has ~4 cores, so `--timeout 120` bites earlier in
 wall-clock terms than on a 12-core box — symmetrically for both interpreters, so
 such a file lands in `no_baseline` rather than being charged to mutsu, but it
-does make the measurable baseline slightly smaller than a local sweep's.
+does make the measurable baseline slightly smaller than a local sweep's. The
+escalated retry of §2.8 recovers the files that only just exhaust the budget,
+which is most of what that gap was.
 
 If the pull request opens with no CI running on it, the repository's GitHub App
 credentials (`TAGPR_APP_CLIENT_ID` / `TAGPR_APP_PRIVATE_KEY`) are not configured
@@ -603,4 +620,7 @@ clone to start CI.
   red. Attractive, out of scope here.
 - **Timing/concurrency suites** (S17-flavoured) are the expected home of
   `flaky: true`; if the retry rule proves insufficient, quarantine them the way
-  `flaky-tests.txt` quarantines local tests rather than weakening the KPI.
+  `flaky-tests.txt` quarantines local tests rather than weakening the KPI. Rule
+  out §2.8 first: a suite that is merely *slow* used to arrive here wearing the
+  same label, and a `flaky: true` whose only non-passing verdict was a timeout
+  is that case, not a timing bug.

--- a/ecosystem/dists/D/DateTime--React~70324d56.json
+++ b/ecosystem/dists/D/DateTime--React~70324d56.json
@@ -17,7 +17,7 @@
         "nok": 0,
         "ok": 1,
         "plan": 1,
-        "secs": 0.3,
+        "secs": 0.18,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -27,20 +27,19 @@
         "nok": 0,
         "ok": 1,
         "plan": 1,
-        "secs": 21.48,
+        "secs": 14.81,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
       }
     },
     {
-      "cmp": "no_baseline",
-      "flaky": true,
+      "cmp": "parity",
       "mutsu": {
         "nok": 0,
         "ok": 8,
         "plan": 8,
-        "secs": 119.39,
+        "secs": 120.18,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -50,7 +49,7 @@
         "nok": 0,
         "ok": 8,
         "plan": 8,
-        "secs": 67.02,
+        "secs": 94.12,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -64,9 +63,9 @@
   "measured": {
     "attempts": 3,
     "date": "2026-09-11",
-    "harness": 1,
-    "host": "gha-ubuntu24-4c",
-    "mutsu_commit": "7807eb5",
+    "harness": 2,
+    "host": "linux-x86_64",
+    "mutsu_commit": "7fcc0140",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
@@ -79,10 +78,10 @@
   },
   "status": "green",
   "totals": {
-    "baseline_assertions": 1,
-    "baseline_files": 1,
-    "mutsu_assertions": 1,
-    "parity_files": 1,
+    "baseline_assertions": 9,
+    "baseline_files": 2,
+    "mutsu_assertions": 9,
+    "parity_files": 2,
     "regressed_files": 0
   },
   "version": "0.2.0"

--- a/news/2026-09/ecosystem-sweep-timeout-is-a-claim-about-the-budget.md
+++ b/news/2026-09/ecosystem-sweep-timeout-is-a-claim-about-the-budget.md
@@ -1,0 +1,81 @@
+# The ecosystem sweep was throwing away a distribution that passes
+
+`DateTime::React` measured `green 1/1`, and the one file it counted was
+`t/00-sanity.t` — three lines around a bare `ok True`. Its real suite,
+`t/01-basic.t`, was stamped `flaky: true` and demoted to `no_baseline`, so the
+distribution's only interesting measurement never reached the KPI.
+
+It is not flaky. It passes 8/8 under mutsu, exactly as it does under rakudo, and
+the two interpreters agree on every part of the module's API — the `term:<…>`
+exports resolve bare and with parens, the `state`-cached `Supply` is the same
+object on a second call, the compatibility `&minute-shifts` is a `Sub`, and
+`Shift::Minute` composes `DateTimeEventish` and reports `type => 'minute'` with a
+60-second `next-at - time`. Nothing in mutsu was broken here. The measurement was.
+
+## The file always ends at the same second
+
+`t/01-basic.t` waits for two minute rollovers:
+
+```raku
+my $now = DateTime.now;
+my $s   = 60 + ceiling 60 - $now.second;
+...
+sleep $s + 1;
+```
+
+So its runtime is `121 - second-of-minute` — which means it *always finishes at
+second-of-minute 1*, whatever second it started at. Measured on this box:
+
+```
+raku start second-of-minute=41.84   end=01.55   duration=79.72
+raku start second-of-minute=01.56   end=01.69   duration=120.12
+```
+
+The sweep runs rakudo and then mutsu on the same file back to back, and retries a
+non-passing file up to three times. Every one of those runs therefore *starts* at
+second-of-minute ≈1 — the single phase at which the file needs ~120.1s, just over
+the sweep's 120s default budget. The first attempt timed out, and so did the
+retries, because a same-budget retry re-rolls a die that is not random: whatever
+decides the file's runtime also decides when the previous attempt ended. The
+120s budget was the whole failure, and it was invisible in the record, which said
+only `flaky`.
+
+## A timeout is a claim about the budget
+
+`measure()` in `scripts/ecosystem-sweep.py` now treats the first timeout as
+provisional. It buys one retry at twice the budget, and does not itself count
+towards `flaky`: until a longer run has disproved it, a timeout says something
+about the budget, not about the file. If the longer run passes, the file was
+never non-deterministic, only slow. If it times out too, that verdict is believed
+and the retries stop — so a genuine hang costs no more wall clock than the two
+same-budget retries this replaces, and a green corpus costs exactly what it did
+before.
+
+The rule is pinned by `scripts/ecosystem-sweep.py --self-test`, wired into the
+sweep workflow's existing self-test step alongside `ecosystem-ci` and
+`ecosystem_common`: a slow file passes and is not flaky, a hang is still a
+timeout and stops after one escalation, a `die` still retries at the same budget,
+a later verdict replaces a budget-limited timeout, and `--attempts 1` escalates
+nothing. `measured.harness` goes to `2`, so records say which method produced
+them.
+
+After the change, re-measured with `--only`:
+
+```
+[1/1] DateTime::React                          green        2/2 files
+```
+
+`t/01-basic.t` is `parity`, 8 assertions on each side, mutsu at 120.18s — the run
+that used to be discarded. Baseline files for this distribution go 1 → 2 and
+baseline assertions 1 → 9.
+
+## What else this recovers
+
+Across the 4907 file-entries currently in `ecosystem/`, 32 are timeouts and every
+single one sits at 120.1s — nothing in the corpus times out because it hung *well*
+past the budget; they all die within a tenth of a second of it. Some of those are
+real hangs that will keep timing out at 240s and be recorded as such, which is the
+point: the escalated retry is what tells the two populations apart, and the ledger
+could not distinguish them before. `DateTime::React` was simply the clearest case,
+because it is the only entry in the corpus that passed at 119.4s on one attempt
+and timed out on another.

--- a/scripts/ecosystem-sweep.py
+++ b/scripts/ecosystem-sweep.py
@@ -39,7 +39,10 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(REPO, "ecosystem")
 DISTS_DIR = os.path.join(DATA_DIR, "dists")
 SCHEMA = 1
-HARNESS = 1
+HARNESS = 2
+
+# How much more time the one retry after a timeout gets. See measure().
+TIMEOUT_RETRY_FACTOR = 2
 
 # `use Test` must reach the vendored upstream Test.rakumod on both sides, or the
 # two are counting `ok` lines emitted by different harnesses. The module exports
@@ -96,18 +99,49 @@ def measure(cmd, cwd, timeout, sandbox, sbx_home, writable, attempts):
     A suite that flakes must not move the KPI, and retrying everything would
     triple the cost of a green corpus -- so the retry is spent only where the
     answer was not already 'pass'. Returns (side, flaky).
+
+    A timeout is the one verdict a same-budget retry can never learn anything
+    from. A genuine hang hangs again; and a file whose own runtime sits at the
+    budget is phase-locked into timing out again, because the thing that
+    decides its runtime also decides when the previous attempt ended.
+    DateTime::React's `t/01-basic.t` is the worked example: it sleeps until two
+    minute rollovers have fired, so it runs for `121 - second-of-minute`
+    seconds and therefore *always* ends at second-of-minute 1 -- which makes
+    every following run of it start at the one phase where it needs ~120.1s,
+    just over the default budget. Measured end-to-end, the file passes 8/8
+    under both interpreters; the sweep was throwing that away three times in a
+    row and stamping the survivor `flaky`.
+
+    So the first timeout buys a single retry at TIMEOUT_RETRY_FACTOR times the
+    budget, and does not itself count towards `flaky`: until a longer run has
+    disproved it, a timeout is a statement about the budget, not about the
+    file. If the longer run passes, the file was never non-deterministic, only
+    slower than the default. If it times out too, that is believed and the loop
+    stops -- so a real hang costs no more wall clock than the two same-budget
+    retries this replaces.
     """
     best = None
     verdicts = set()
+    budget = timeout
     for _ in range(attempts):
         start = dt.datetime.now()
-        rc, out = run(cmd, cwd, timeout, sandbox, sbx_home, writable)
+        rc, out = run(cmd, cwd, budget, sandbox, sbx_home, writable)
         side = side_result(rc, out, (dt.datetime.now() - start).total_seconds())
-        verdicts.add(side["verdict"])
-        if best is None or side["verdict"] == "pass":
+        timed_out = side["verdict"] == "timeout"
+        budget_limited = timed_out and budget == timeout and attempts > 1
+        if not budget_limited:
+            verdicts.add(side["verdict"])
+        # A budget-limited timeout is the weakest verdict there is, so any
+        # later attempt -- a pass, or a `die` that says what actually broke --
+        # replaces it.
+        if best is None or side["verdict"] == "pass" or best["verdict"] == "timeout":
             best = side
         if side["verdict"] == "pass":
             break
+        if timed_out:
+            if not budget_limited:
+                break
+            budget = timeout * TIMEOUT_RETRY_FACTOR
     return best, len(verdicts) > 1
 
 
@@ -703,5 +737,86 @@ def bundled_modules() -> set[str]:
     return names
 
 
+# --- self-test ---------------------------------------------------------------
+
+def _self_test() -> int:
+    """`python3 scripts/ecosystem-sweep.py --self-test`
+
+    Covers measure()'s retry budget, the one piece of this harness whose bugs
+    are invisible in the records it writes: a file wrongly called `timeout` just
+    disappears from the KPI, which looks exactly like a distribution that has
+    no baseline.
+    """
+    global run
+    real_run = run
+    failures = []
+
+    def check(name, cond):
+        print(f"{'ok' if cond else 'NOT OK'} - {name}")
+        if not cond:
+            failures.append(name)
+
+    def scripted(*plan):
+        """Stub `run` from a list of (budget_needed, output) pairs: the attempt
+        times out unless the budget it was given covers budget_needed."""
+        calls = []
+
+        def fake(cmd, cwd, timeout, sandbox, sbx_home, writable=()):
+            needed, out = plan[min(len(calls), len(plan) - 1)]
+            calls.append(timeout)
+            if needed > timeout:
+                return None, "SWEEP-TIMEOUT"
+            return 0, out
+        return fake, calls
+
+    passing = "ok 1 - fine\n1..1\n"
+    dying = "Died horribly\n"
+
+    # A file that needs a little more than the budget -- DateTime::React's
+    # t/01-basic.t -- must end up `pass`, and must NOT be called flaky: it is
+    # slow, not non-deterministic.
+    run, calls = scripted((130, passing))
+    side, flaky = measure(["x"], ".", 120, None, None, (), 3)
+    check("slow file passes on the escalated retry", side["verdict"] == "pass")
+    check("slow file is not flaky", flaky is False)
+    check("escalated retry doubled the budget", calls == [120, 240])
+
+    # A genuine hang is still a timeout, and costs one escalated retry rather
+    # than two same-budget ones.
+    run, calls = scripted((10**9, passing))
+    side, flaky = measure(["x"], ".", 120, None, None, (), 3)
+    check("a hang is still a timeout", side["verdict"] == "timeout")
+    check("a hang stops after the escalated retry", calls == [120, 240])
+
+    # A pass first time costs exactly one run, and retries are still spent on
+    # genuinely flaky non-timeout verdicts.
+    run, calls = scripted((0, passing))
+    side, flaky = measure(["x"], ".", 120, None, None, (), 3)
+    check("a passing file runs once", calls == [120] and side["verdict"] == "pass")
+
+    run, calls = scripted((0, dying), (0, passing))
+    side, flaky = measure(["x"], ".", 120, None, None, (), 3)
+    check("a die still retries at the same budget", calls == [120, 120])
+    check("die-then-pass is flaky", flaky is True and side["verdict"] == "pass")
+
+    # A timeout followed by a real failure reports the failure: the timeout was
+    # only ever a statement about the budget.
+    run, calls = scripted((130, dying))
+    side, flaky = measure(["x"], ".", 120, None, None, (), 3)
+    check("a later verdict replaces a budget-limited timeout", side["verdict"] == "die")
+
+    # With no retry budget at all, nothing is escalated.
+    run, calls = scripted((130, passing))
+    side, flaky = measure(["x"], ".", 120, None, None, (), 1)
+    check("attempts=1 does not escalate", calls == [120] and side["verdict"] == "timeout")
+
+    run = real_run
+    print(f"ecosystem-sweep self-test: "
+          f"{'all cases pass' if not failures else f'{len(failures)} FAILED'}")
+    return 1 if failures else 0
+
+
 if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        raise SystemExit(_self_test())
     raise SystemExit(main())


### PR DESCRIPTION
## Distribution

`DateTime::React` 0.2.0 (`axis: pure`), deps `Timezones::ZoneInfo`, `User::Timezone`.

Baseline files **1 → 2**, baseline assertions **1 → 9**. Status stays `green`, but it now means something.

## What was wrong

The record read `green 1/1`, and the one counted file was `t/00-sanity.t` — three lines around a bare `ok True`. The distribution's real suite, `t/01-basic.t`, was stamped `flaky: true` and demoted to `no_baseline`, so the only interesting measurement never reached the KPI.

It is not flaky, and nothing in mutsu was broken. `t/01-basic.t` passes 8/8 under mutsu exactly as it does under rakudo, and the two interpreters agree on every part of the module's API: the `term:<…>` exports resolve bare and with parens, the `state`-cached `Supply` is the same object on a second call, the compatibility `&minute-shifts` is a `Sub`, and `Shift::Minute` composes `DateTimeEventish` and reports `type => 'minute'` with a 60-second `next-at - time`. What failed was the measurement.

## Root cause: the file always ends at the same second

`t/01-basic.t` waits for two minute rollovers — `my $s = 60 + ceiling 60 - $now.second; … sleep $s + 1;` — so it runs for `121 - second-of-minute` seconds, and therefore **always finishes at second-of-minute 1**, whatever second it started at. Measured here:

```
raku start second-of-minute=41.84   end=01.55   duration=79.72
raku start second-of-minute=01.56   end=01.69   duration=120.12
```

The sweep runs rakudo and then mutsu on the same file back to back, and retries a non-passing file up to three times. Every one of those runs therefore *starts* at second-of-minute ≈1 — the single phase at which the file needs ~120.1s, just over the 120s default budget. Each same-budget retry re-rolled a die that is not random: whatever sets the file's runtime also sets when the previous attempt ended. The budget was the whole failure, and the record said only `flaky`.

## The fix

`measure()` now treats the first timeout as provisional. It buys one retry at twice the budget and does not itself count towards `flaky`: until a longer run has disproved it, a timeout says something about the budget, not about the file.

- Longer run passes → the file was never non-deterministic, only slow. It is counted.
- Longer run times out too → believed, and the retries stop. A genuine hang costs no more wall clock than the two same-budget retries this replaces.
- A green corpus costs exactly what it did before; `die`/`fail` retries are untouched.

`measured.harness` goes to `2` so records say which method produced them.

## Verification

`scripts/ecosystem-sweep.py --self-test` is new and wired into the sweep workflow's existing self-test step, next to `ecosystem-ci` and `ecosystem_common`. It pins: a slow file passes and is not flaky; the escalated retry doubles the budget; a hang is still a timeout and stops after one escalation; a passing file runs once; a `die` still retries at the same budget and die-then-pass is still flaky; a later verdict replaces a budget-limited timeout; `--attempts 1` escalates nothing.

Re-measured with the release binary:

```
$ MUTSU_BIN=target/release/mutsu scripts/ecosystem-sweep.py --only 'DateTime::React'
index-snapshot.json: left unchanged (targeted --only run)
[1/1] DateTime::React                          green        2/2 files
```

`t/01-basic.t` is now `parity` — 8 assertions a side, mutsu 120.18s, the run that used to be discarded. `ecosystem/index-snapshot.json` is untouched, and the only `ecosystem/` line in the diff is the one `dists/` record.

## Scope

Docs-only by `scripts/ci-docs-only.sh --classify` (`scripts/*.py`, `.github/**` except `ci.yml`, `docs/`, `news/`, `ecosystem/`), so the five build jobs skip on purpose — nothing under `src/` changed, and there is nothing for the suites to catch.

Of the 4907 file-entries currently in `ecosystem/`, 32 are timeouts and every one sits at 120.1s: nothing in the corpus times out *well* past the budget. Some of those are real hangs that will keep timing out at 240s and be recorded as such — that is the point, since the ledger could not tell the two populations apart before.

No issues filed: this distribution exposed no interpreter gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsGvSWoDhphqavVF4Y3dJm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsGvSWoDhphqavVF4Y3dJm)_