### PR TITLE
fix(site): the generated data files revalidate instead of going stale

### DIFF
--- a/news/2026-09/site-data-files-revalidate-instead-of-going-stale.md
+++ b/news/2026-09/site-data-files-revalidate-instead-of-going-stale.md
@@ -1,0 +1,61 @@
+# The site's generated data files revalidate instead of going stale
+
+The site has six fetches of a generated file under `site/content/`: the
+batteries and ecosystem manifests, the compatibility stats (twice), the
+landing-page highlights and the tutorial lessons. All six were plain `fetch()`
+calls with no cache hint, and nothing on the site does URL versioning or
+registers a service worker.
+
+What GitHub Pages actually serves (measured on the deployed site):
+
+```
+cache-control: max-age=600
+etag: "6aa4869a-4da3c"
+```
+
+Every path gets the same fixed header — Pages has no way to set headers per
+path — so within ten minutes of a deploy a returning reader is served the
+previous data with no request made at all, while the HTML around it may already
+be the new one. `x-cache: HIT, age: 55` on a second request confirms the Fastly
+edge holds the same window, though Pages purges it on publish, so in practice
+the residency that matters is the browser's.
+
+All six now go through `site/assets/data.js`:
+
+```js
+export function fetchData(path) {
+  return fetch(path, { cache: 'no-cache' });
+}
+```
+
+`no-cache` is not `no-store`: the browser still stores the response and still
+reuses it, it just revalidates with the ETag first, so an unchanged 300 KB
+manifest costs a 304 rather than a download. One conditional request buys "the
+data on screen is never staler than the page around it" — which is the pairing
+that matters here, because the manifests are regenerated on every sweep while
+the page reading them changes rarely.
+
+Module imports of `content/*.js` (landing copy, examples, the manual text) are
+deliberately left alone: those are source rather than measurements, they change
+with the page that imports them, and the shell's own cache window is the right
+granularity for them.
+
+## Why not version the URLs
+
+`content/x.json?v=<commit>` cannot do this job, and this is the reason worth
+recording. The version token would have to live in the HTML, and the HTML
+carries the same 600-second cache — so a stale shell would simply ask for its
+stale data by name. Only the shell's own revalidation can refresh the shell,
+which is why the fix is about how the data files are fetched and not about
+cache-busting the site.
+
+## Pinned
+
+`site/e2e.test.mjs` collects every request to `content/*.{json,txt}` across the
+whole run and asserts, at the end, that all five files were fetched and each
+carried a revalidating directive. Chromium puts the `no-cache` mode on the wire
+as `Cache-Control: max-age=0`, on a cold load as well as a warm one, and a bare
+`fetch` sends no directive at all — both measured, including a negative check
+confirming a bare `fetch` fails the assertion. So a new page that reaches for a
+generated file with a plain `fetch` fails the suite rather than silently
+inheriting the ten-minute window.

--- a/site/README.md
+++ b/site/README.md
@@ -35,6 +35,8 @@ assets/
   site.css          all styling
   i18n.js           language selection, UI strings, shared nav + footer
   corpus.js         parser for the .txt snippet corpora (shared with Node)
+  data.js           fetch for the generated content/ files: always revalidate,
+                    never accept a stale cached copy (the file says why)
   highlight.js      the small Raku syntax highlighter
   editor.js         textarea + highlight overlay widget
   runner.js         WASM lifecycle: isolated runs and long-lived REPL sessions

--- a/site/assets/data.js
+++ b/site/assets/data.js
@@ -1,0 +1,30 @@
+// Fetching one of the generated data files under content/.
+//
+// Every such file is regenerated at deploy time by .github/workflows/pages.yml
+// (the batteries and ecosystem manifests, the compatibility stats) or vendored
+// from the repository's own corpora (highlights, lessons), and the page that
+// reads one changes far less often than the file does. GitHub Pages serves
+// everything with a fixed `Cache-Control: max-age=600` and does not let us set
+// headers per path, so within ten minutes of a deploy a returning reader can be
+// served yesterday's numbers underneath today's page, with no request made at
+// all.
+//
+// `cache: 'no-cache'` is the fix, and it is not `no-store`: the browser still
+// stores the response and still reuses it, it just revalidates with the ETag
+// first, so an unchanged 300 KB manifest costs a 304 instead of a download.
+// One conditional request buys "the data on screen is never staler than the
+// page around it".
+//
+// Versioning the URL instead (`content/x.json?v=<commit>`) cannot do this job:
+// the token would have to live in the HTML, which carries the same 600-second
+// cache, so a stale shell would simply ask for its stale data by name. The
+// shell's own revalidation is the only thing that can refresh the shell, which
+// is why this is about the data files and not about cache-busting the site.
+//
+// Module imports of content/*.js (landing copy, examples, the manual text) are
+// deliberately not routed through here: those are source, not measurements, and
+// they change with the page that imports them, so the shell's cache window is
+// the right granularity for them.
+export function fetchData(path) {
+  return fetch(path, { cache: 'no-cache' });
+}

--- a/site/batteries.html
+++ b/site/batteries.html
@@ -27,6 +27,7 @@
 <script type="module">
 import { renderChrome, t, currentLang } from './assets/i18n.js';
 import { renderMarkdown } from './assets/mini-md.js';
+import { fetchData } from './assets/data.js';
 
 renderChrome('batteries');
 
@@ -181,7 +182,7 @@ function paintList() {
 
 async function loadLibraries() {
   try {
-    const res = await fetch('content/batteries.json');
+    const res = await fetchData('content/batteries.json');
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
     LIBRARIES = Array.isArray(data.libraries) ? data.libraries : [];

--- a/site/e2e.test.mjs
+++ b/site/e2e.test.mjs
@@ -124,6 +124,18 @@ try {
   const errors = [];
   page.on('pageerror', err => errors.push(err.message));
 
+  // Every generated data file under content/ must be fetched through
+  // assets/data.js, which revalidates rather than accept a copy cached under
+  // GitHub Pages' fixed max-age=600 — those files are regenerated at deploy
+  // time while the page reading them is not. Collected across the whole run and
+  // asserted at the end, once every page has been visited. Module imports of
+  // content/*.js are source, not measurements, and are exempt by design.
+  const dataReqs = new Map();
+  page.on('request', (req) => {
+    const m = /\/content\/([^?]*\.(?:json|txt))$/.exec(req.url());
+    if (m) dataReqs.set(m[1], req);
+  });
+
   /* =============================================================== *
    * Landing page
    * =============================================================== */
@@ -687,6 +699,22 @@ try {
   await page.click('#reset-btn');
   const afterReset = await replEval(page, 'say $x.defined');
   assert(afterReset === 'False', `reset clears declarations (got: ${JSON.stringify(afterReset)})`);
+
+  // --- Test: the generated data files are never read from a stale cache ---
+  // Chromium puts the `cache: 'no-cache'` mode on the wire as
+  // `Cache-Control: max-age=0` (cold load included, measured), and a plain
+  // fetch sends no cache directive at all — so this fails the moment a page
+  // reaches for a generated file with a bare `fetch`.
+  console.log('Test: generated data files are revalidated, not read from a cache');
+  for (const name of ['ecosystem.json', 'batteries.json', 'stats.json',
+                      'highlights.txt', 'lessons.txt']) {
+    const req = dataReqs.get(name);
+    assert(req !== undefined, `some page fetched content/${name}`);
+    const cc = req ? (await req.allHeaders())['cache-control'] ?? '' : '';
+    assert(/(^|,\s*)(no-cache|max-age=0)(\s*,|$)/.test(cc),
+           `content/${name} is fetched with a revalidating cache mode` +
+           ` (Cache-Control: ${JSON.stringify(cc)})`);
+  }
 
   // --- Test: No page errors (unreachable traps) ---
   console.log('Test: No WASM crashes');

--- a/site/ecosystem.html
+++ b/site/ecosystem.html
@@ -83,6 +83,7 @@
 
 <script type="module">
 import { renderChrome, currentLang } from './assets/i18n.js';
+import { fetchData } from './assets/data.js';
 
 renderChrome('ecosystem');
 
@@ -298,7 +299,7 @@ paintRows();
 const EMPTY = { distributions: [], counts: { green: 0, graded: 0 },
                 dist_parity: 0, file_parity: 0, measured: {}, has_chart: false };
 
-fetch('content/ecosystem.json')
+fetchData('content/ecosystem.json')
   .then(r => (r.ok ? r.json() : null))
   .then(data => { DATA = data ?? EMPTY; })
   .catch(() => { DATA = EMPTY; })

--- a/site/index.html
+++ b/site/index.html
@@ -65,6 +65,7 @@
 <script type="module">
 import { renderChrome, currentLang, langHref } from './assets/i18n.js';
 import { parseCorpus } from './assets/corpus.js';
+import { fetchData } from './assets/data.js';
 import { createSnippet } from './assets/snippet.js';
 
 import landingEn from './content/landing.en.js';
@@ -286,7 +287,7 @@ function paintAll() {
 
 async function loadStats() {
   try {
-    const res = await fetch('content/stats.json');
+    const res = await fetchData('content/stats.json');
     if (!res.ok) return;                       // not deployed: keep the fallback
     const s = await res.json();
     if (s.roastPass > 0 && s.roastTotal > 0) STATS = s;
@@ -296,7 +297,7 @@ async function loadStats() {
 async function main() {
   renderChrome('home');
   await loadStats();
-  buildCards(parseCorpus(await (await fetch('content/highlights.txt')).text()));
+  buildCards(parseCorpus(await (await fetchData('content/highlights.txt')).text()));
   window.addEventListener('langchange', paintAll);
   paintAll();
   document.body.dataset.ready = '1';

--- a/site/manual.html
+++ b/site/manual.html
@@ -29,6 +29,7 @@
 
 <script type="module">
 import { renderChrome, currentLang } from './assets/i18n.js';
+import { fetchData } from './assets/data.js';
 
 import manualEn from './content/manual.en.js';
 import manualJa from './content/manual.ja.js';
@@ -138,7 +139,7 @@ window.addEventListener('langchange', () => {
 
 async function loadStats() {
   try {
-    const res = await fetch('content/stats.json');
+    const res = await fetchData('content/stats.json');
     if (!res.ok) return;                       // not deployed: keep the fallback
     const s = await res.json();
     if (s.roastPass > 0 && s.roastTotal > 0) {

--- a/site/tutorial.html
+++ b/site/tutorial.html
@@ -51,6 +51,7 @@
 <script type="module">
 import { renderChrome, currentLang, t } from './assets/i18n.js';
 import { parseCorpus, groupCorpus } from './assets/corpus.js';
+import { fetchData } from './assets/data.js';
 import { createSnippet } from './assets/snippet.js';
 
 import tutorialEn from './content/tutorial.en.js';
@@ -61,7 +62,7 @@ const PROGRESS_KEY = 'mutsu-tutorial-done';
 
 renderChrome('tutorial');
 
-const lessons = parseCorpus(await (await fetch('content/lessons.txt')).text());
+const lessons = parseCorpus(await (await fetchData('content/lessons.txt')).text());
 const chapters = groupCorpus(lessons);
 
 /* ---- progress ---------------------------------------------------- */


### PR DESCRIPTION
Follow-up to #7981: the ecosystem page's data can be served from a stale cache
for up to ten minutes after a sweep, and so can every other generated file the
site reads.

The site has six fetches of a generated file under `site/content/` — the
batteries and ecosystem manifests, the compatibility stats (twice), the
landing-page highlights, the tutorial lessons. All six were plain `fetch()`
calls with no cache hint, and nothing on the site versions a URL or registers a
service worker.

What Pages actually serves, measured on the deployed site:

```
cache-control: max-age=600
etag: "6aa4869a-4da3c"
```

Every path gets the same fixed header and Pages offers no way to set headers per
path, so within ten minutes of a deploy a returning reader is served the
previous data **with no request made at all**, underneath an HTML shell that may
already be the new one. A second request shows `x-cache: HIT, age: 55`, so the
Fastly edge holds the same window — though Pages purges it on publish, which is
why the residency that matters in practice is the browser's.

## The fix

All six now go through the new `site/assets/data.js`:

```js
export function fetchData(path) {
  return fetch(path, { cache: 'no-cache' });
}
```

`no-cache` is not `no-store`: the browser still stores the response and still
reuses it, it just revalidates with the ETag first, so an unchanged 300 KB
manifest costs a 304 rather than a download. One conditional request buys "the
data on screen is never staler than the page around it" — the pairing that
matters here, because the manifests are regenerated on every sweep while the
page reading them changes rarely.

Module imports of `content/*.js` (landing copy, examples, the manual text) are
deliberately left alone: source rather than measurements, changing with the page
that imports them, so the shell's own cache window is the right granularity.

## Why not version the URLs

`content/x.json?v=<commit>` cannot do this job, and this is the part worth
recording. The token would have to live in the HTML, and the HTML carries the
same 600-second cache — so a stale shell would simply ask for its stale data by
name. Only the shell's own revalidation can refresh the shell, which is why this
is about how the data files are fetched and not about cache-busting the site.

## Verification

`node site/e2e.test.mjs` — **133 passed, 0 failed** (10 new assertions).

The suite now collects every request to `content/*.{json,txt}` across the whole
run and asserts at the end that all five files were fetched and each carried a
revalidating directive. Measured, not assumed: Chromium puts the `no-cache` mode
on the wire as `Cache-Control: max-age=0` on cold and warm loads alike, and a
bare `fetch` sends no directive at all. A negative check confirmed the pin
bites —

```
probe=bare     cache-control=""           -> assertion FAILS
probe=nocache  cache-control="max-age=0"  -> assertion PASSES
```

— so a new page that reaches for a generated file with a plain `fetch` fails the
suite rather than silently inheriting the ten-minute window.

Run with `SKIP_LESSON_SWEEP=1` and against a `wasm-opt`-less `pkg/` (this
container's proxy blocks the binaryen download); the `wasm-e2e` job runs both in
full.

`make test` / `make roast` were not run: the diff is JavaScript, Markdown and
`news/`, with no Rust and no build input either suite reads. CI runs all five
jobs regardless — `site/` is deliberately not on the documentation allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFCGVqTrjFU3FNAougDC7w

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFCGVqTrjFU3FNAougDC7w)_