### PR TITLE
fix(parser): four more rows off the parse-failure index — tight `-->`, `.$name` on the topic, a pseudo-type positional, and a class of consumed-span panics

### DIFF
--- a/news/2026-09/parse-failure-index-literal-arrow-topic-dyncall-consumed-span.md
+++ b/news/2026-09/parse-failure-index-literal-arrow-topic-dyncall-consumed-span.md
@@ -1,0 +1,122 @@
+# Four more rows off the parse-failure index: a tight `-->`, `.$name` on the topic, a pseudo-type positional, and a whole class of consumed-span panics
+
+[#7954](https://github.com/tokuhirom/mutsu/issues/7954) is the located index of the
+largest single `blocked_load` bucket in the first full-corpus ecosystem sweep — 56
+distributions whose own modules do not parse, each reported only as "the parse
+failed". Two of its rows landed earlier (`news/2026-09/regex-declarator-traits-and-stacked-loose-unary.md`).
+This pass takes four more, three of them reduced from rows the index could only
+mark as "containers" — the reported line named an enclosing `class`/`sub` because
+the parser could not recover far enough to point at the real construct.
+
+The method throughout: fetch the distribution's tarball from the URL in its
+`ecosystem/dists/` record, `--dump-ast` each module the META6 `provides` names (a
+parse error needs no dependency closure), then binary-search the failing file down
+to the smallest line range that still fails, and reduce that to a one-liner checked
+against `raku`.
+
+## A `-->` written tight against a literal parameter
+
+`Math::Matrix` selects among its `norm` candidates on a string literal, and writes
+the return type with no space in front of it:
+
+```raku
+multi method norm(Math::Matrix:D: 'column-sum'--> Numeric) { ... }
+```
+
+A literal-value parameter is recognized by running the full expression parser over
+the parameter text and asking whether what came back is a literal. Nothing stops
+that parser's postfix layer from lexing the `--` of `-->` onto the literal it has
+just read, so this arrived as `('column-sum'--) > Numeric` — not a literal, so the
+literal-parameter branch declined, and the parameter list then failed outright. A
+sigiled parameter (`$x-->`) was never affected: the parameter parser reads its name
+itself and never reaches the postfix layer.
+
+`parse_literal_param_value` now makes two passes. The broad pass is the old one, and
+still recognizes every literal spelling mutsu supports. The narrow pass is the
+literal-parameter grammar itself — an optional sign and one primary term, exactly
+what `literal_value_from_expr` accepts — which structurally cannot reach an infix or
+postfix operator, so the `-->` survives for the signature parser to read. Keeping the
+broad pass first means nothing that parsed before parses differently now.
+
+## `.$name` — an indirect method name on the topic
+
+`python::itertools` writes `@iterable.map({.$function})`. The explicit-invocant form
+(`$x.$function`) had a parser branch, and so did the code-sigil topic form (`.&name`),
+but the `$`/`@`/`%` topic form had none, so `.$function` fell through to the
+method-name parse and died. `topic_method_call` now mirrors the postfix path,
+building the same `DynamicMethodCall` with the topic as invocant — a Code object is
+invoked with it, a non-Callable is a runtime error, and `.&name` keeps its own
+meaning.
+
+## A pseudo-type as an anonymous positional
+
+`CRDT` exports operators over its own type:
+
+```raku
+multi prefix:<-->(::?CLASS)  is export { X::G-Counter::Decrease.new.throw }
+```
+
+Only a `:` marker declares an invocant, so a parameter whose whole text is
+`::?CLASS` or `::?ROLE` is an anonymous positional exactly as `sub f(Int)` is. The
+parser instead treated *every* non-variable continuation of the pseudo-type as an
+invocant, which made this a hard `X::Syntax::Signature::InvocantNotAllowed` — a
+`sub` may not take an invocant — and, more quietly, turned `method m(::?CLASS)` into
+a zero-argument method whose caller got "No such method". The branch now splits: a
+following `:` (with or without intervening whitespace) is the invocant marker it
+always was, and anything else is an anonymous typed positional, built by a new
+`type_only_param` helper factored out of the identical bareword-type path so both
+spellings pick up `is` traits and a `where` clause the same way.
+
+## A whole class of consumed-span panics
+
+`Collection`'s `RefreshPlugins.rakumod` did not report a parse error at all — it
+**panicked**, on a byte index that fell inside a `｣`. The cause is a parser
+invariant that a heredoc breaks. When a heredoc's introducing line carries code
+*after* the marker:
+
+```raku
+MapFail.new(:note(qq:to/WARN/)).throw unless %released{$format}{$n-plug};
+    Major part error? No released plugin ｢{ $n-plug }_v{ $n-v }｣ for ｢$plug｣
+    WARN
+```
+
+the heredoc reader splices the rest of that line onto the text following the
+terminator and resumes on that freshly built buffer. `rest` is then not a tail slice
+of the string the caller passed, so the `&input[..input.len() - rest.len()]`
+subtraction several parsers used to recover their consumed span named an arbitrary
+offset — with ASCII text it silently read the wrong span, and with multi-byte text
+it landed inside a character and aborted the process.
+
+`consumed_span` already existed for precisely this, recovering the span by pointer
+provenance and returning `None` when there is none; its doc comment even names the
+heredoc case. Nine sites that predated it were still doing the subtraction, and two
+of them were reachable: the statement-expression sink-warning wrappers (the
+`Collection` panic) and the six fat-arrow autoquote decisions (`qq:to/E/ => 1`
+panicked the same way). All nine now go through the helper; three further sites keep
+the subtraction, because their `rest` provably comes from a scanner that cannot leave
+the buffer (a digit scan, a name parse, a version-literal scan). The `None` fallbacks are
+chosen per site: the sink-source wrappers have nothing to record without a span and
+skip; the fat-arrow decisions only ever inspect the *start* of the span, so falling
+back to the whole input answers them identically; the `for`-body `&?BLOCK` scan falls
+back to the superset, which can only over-detect and so enables the block-magic
+binding rather than dropping it.
+
+## Result
+
+`Collection`, `Math::Matrix` and `python::itertools` now parse every module in their
+`provides` clean, and `CRDT`'s `G-Counter.rakumod` does too. Pins:
+`t/routines/signature/literal-param-return-arrow.t`,
+`t/routines/signature/signature-pseudo-type-anon-param.t`,
+`t/oo/method/topic-dynamic-method-call.t`,
+`t/lang/quoting/heredoc-trailing-code-consumed-span.t` — all four green under rakudo
+itself, so they pin rakudo's behaviour rather than mutsu's.
+
+`CRDT.rakumod` still does not parse, on one further construct the index had not
+isolated: a type capture carrying a nominal invocant type, `method merge(::T CRDT:D: $ --> T)`.
+That is not a parser-only gap — mutsu keeps a parameter's type constraint as a single
+string, and the capture is encoded *in* that string, so there is no room for both
+`::T` and `CRDT:D`; the plain `method m(::T: $x --> T)` form already mis-binds at
+runtime. Filed as #7984 rather than forced through here, along with #7985 for a
+narrower gap the pseudo-type fix exposed (`::?CLASS`/`::?ROLE` as a parameter type
+inside a `role` never resolves to the consuming class). #7954 stays open: it is an
+index, and the remaining rows span roughly twenty distinct constructs.

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -25,6 +25,7 @@ use crate::token_kind::TokenKind;
 use crate::value::Value;
 
 use super::helpers::ws;
+pub(in crate::parser) use postfix::consumed_span;
 pub(in crate::parser) use postfix::dot_assign_to_name;
 pub(in crate::parser) use postfix::is_angle_key_char;
 pub(in crate::parser) use postfix::postfix_expr_continue;
@@ -83,7 +84,15 @@ pub(super) fn expression(input: &str) -> PResult<'_, Expr> {
             let (r, value) = parse_fat_arrow_value(r)?;
             // Auto-quote bareword on LHS of => only for plain barewords.
             // Parenthesized forms like `(Mu) => 4` must preserve the original value key.
-            let consumed = &input[..input.len() - rest.len()];
+            //
+            // `consumed_span` rather than an `input.len() - rest.len()` subtraction:
+            // a heredoc left-hand side with trailing code on its marker line
+            // (`qq:to/E/ => 1`) resumes the parse on a freshly built buffer, so
+            // `rest` is not a tail slice of `input` and the subtraction lands at an
+            // arbitrary offset — a mid-character one panics (#7954). Every use below
+            // only inspects the START of the span, so falling back to the whole
+            // `input` answers each of them identically.
+            let consumed = consumed_span(input, rest).unwrap_or(input);
             // A qualified name (`Bool::True`, `Foo::Bar`) is NOT autoquoted — it is
             // evaluated to its value, so `Bool::True => "a"` has the Bool *value*
             // as its (positional) key, matching raku.
@@ -155,7 +164,7 @@ pub(in crate::parser) fn expression_no_assign(input: &str) -> PResult<'_, Expr> 
         let r = &r[2..];
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
-        let consumed = &input[..input.len() - rest.len()];
+        let consumed = consumed_span(input, rest).unwrap_or(input);
         // A leading-`::` pseudo-package form (`::V`) is a symbol lookup evaluated to
         // its value, not autoquoted (see the note in `expression`).
         let leading_colons = consumed.trim_start().starts_with("::");
@@ -218,7 +227,7 @@ pub(in crate::parser) fn expression_no_word_logical(input: &str) -> PResult<'_, 
         let r = &r[2..];
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
-        let consumed = &input[..input.len() - rest.len()];
+        let consumed = consumed_span(input, rest).unwrap_or(input);
         let leading_colons = consumed.trim_start().starts_with("::");
         let is_bareword =
             !leading_colons && matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
@@ -268,7 +277,7 @@ pub(in crate::parser) fn expression_no_sequence(input: &str) -> PResult<'_, Expr
         let r = &r[2..];
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
-        let consumed = &input[..input.len() - rest.len()];
+        let consumed = consumed_span(input, rest).unwrap_or(input);
         // A leading-`::` pseudo-package form (`::V`) is a symbol lookup evaluated to
         // its value, not autoquoted (see the note in `expression`).
         let leading_colons = consumed.trim_start().starts_with("::");
@@ -373,7 +382,7 @@ pub(in crate::parser) fn listop_arg_expr(input: &str) -> PResult<'_, Expr> {
         let r = &r[2..];
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
-        let consumed = &input[..input.len() - rest.len()];
+        let consumed = consumed_span(input, rest).unwrap_or(input);
         // A leading-`::` pseudo-package form (`::V`) is a symbol lookup evaluated to
         // its value, not autoquoted (see the note in `expression`).
         let leading_colons = consumed.trim_start().starts_with("::");
@@ -441,7 +450,7 @@ pub(in crate::parser) fn call_arg_expr(input: &str) -> PResult<'_, Expr> {
         let r = &r[2..];
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
-        let consumed = &input[..input.len() - rest.len()];
+        let consumed = consumed_span(input, rest).unwrap_or(input);
         // A leading-`::` pseudo-package form (`::V`) is a symbol lookup evaluated to
         // its value, not autoquoted (see the note in `expression`).
         let leading_colons = consumed.trim_start().starts_with("::");

--- a/src/parser/expr/precedence_meta_ops/meta_bracket.rs
+++ b/src/parser/expr/precedence_meta_ops/meta_bracket.rs
@@ -12,12 +12,16 @@ use crate::token_kind::TokenKind;
 ///
 /// Returns `true` when the infix loop should break.
 pub(crate) fn block_newline_terminates(input: &str, rest: &str, after_ws: &str) -> bool {
-    let consumed = input.len() - rest.len();
-    if consumed == 0 {
+    // `consumed_span` rather than an `input.len() - rest.len()` subtraction: a
+    // heredoc left-hand side with trailing code on its marker line resumes the
+    // parse on a freshly built buffer, so `rest` is not a tail slice of `input`
+    // and the subtraction names an unrelated byte (#7954). No consumed span means
+    // no `}` to find, and no statement for this rule to end.
+    let Some(consumed) = crate::parser::expr::postfix::consumed_span(input, rest) else {
         return false;
-    }
+    };
     // Check if the character just before `rest` is `}`
-    if input.as_bytes()[consumed - 1] != b'}' {
+    if !consumed.ends_with('}') {
         return false;
     }
     // Check if the whitespace gap between rest and after_ws contains a newline

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -1414,6 +1414,44 @@ pub(in crate::parser::primary) fn topic_method_call(input: &str) -> PResult<'_, 
     } else {
         (r, None)
     };
+    // Indirect method name held in a variable, on the topic: `.$name`, `.@names`,
+    // `.%h<k>`. This mirrors the explicit-invocant postfix path (`$x.$name`), which
+    // builds a `DynamicMethodCall` whose `name_expr` is the variable — a Code object
+    // there is invoked with the invocant, a Str names the method. The topic form had
+    // no such branch, so `{.$function}` (python::itertools, #7954) died in the
+    // method-name parse below. `.&name` keeps its own `CallOn`/`CodeVar` path above.
+    if r.starts_with(['$', '@', '%']) {
+        let (r, name_expr) = crate::parser::primary::primary(r)?;
+        let r = consume_unspace(r);
+        let topic = || Box::new(Expr::Var("_".to_string()));
+        if r.starts_with('(') {
+            let (r, _) = parse_char(r, '(')?;
+            let (r, _) = ws(r)?;
+            let (r, args) = parse_call_arg_list(r)?;
+            let (r, _) = ws(r)?;
+            let (r, _) = parse_char(r, ')')?;
+            return Ok((
+                r,
+                Expr::DynamicMethodCall {
+                    target: topic(),
+                    name_expr: Box::new(name_expr),
+                    args,
+                    modifier,
+                    quoted: false,
+                },
+            ));
+        }
+        return Ok((
+            r,
+            Expr::DynamicMethodCall {
+                target: topic(),
+                name_expr: Box::new(name_expr),
+                args: Vec::new(),
+                modifier,
+                quoted: false,
+            },
+        ));
+    }
     // Parse the method name with the proper Raku hyphen rule: a `-` is part of
     // the identifier only when followed by another identifier char, so `.value--`
     // is `.value` followed by postfix `--`, not a method named `value--`.

--- a/src/parser/stmt/control/for_loops.rs
+++ b/src/parser/stmt/control/for_loops.rs
@@ -305,7 +305,15 @@ fn for_stmt_with_mode(input: &str, mode: crate::ast::ForMode) -> PResult<'_, Stm
     } else {
         block(rest)?
     };
-    let consumed_block = &block_input[..block_input.len() - rest.len()];
+    // `consumed_span` rather than an `input.len() - rest.len()` subtraction: a
+    // heredoc inside the body whose marker line carries trailing code resumes the
+    // parse on a freshly built buffer, so `rest` is not a tail slice of
+    // `block_input` and the subtraction lands at an arbitrary offset — a
+    // mid-character one panics (#7954). Falling back to the whole remaining source
+    // can only over-detect `&?BLOCK`, which enables the block-magic binding rather
+    // than dropping it.
+    let consumed_block =
+        crate::parser::expr::consumed_span(block_input, rest).unwrap_or(block_input);
     let uses_block_magic = consumed_block.contains("&?BLOCK");
     // When no explicit params, collect placeholder variables from the body
     let (param, params) = if param.is_none() && params.is_empty() {

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -184,15 +184,23 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
     // the original text so a sink-context "Useless use" warning preserves it.
     // Confined to this statement position so the wrapper never leaks into
     // signatures / type checks / ranges (see `number::wrap_divergent_literal`).
-    let expr = if matches!(expr, Expr::Literal(_)) {
-        let consumed = &input[..input.len() - rest.len()];
-        crate::parser::primary::wrap_divergent_literal(expr, consumed)
-    } else {
+    //
+    // `consumed_span` rather than an `input.len() - rest.len()` subtraction: a
+    // heredoc whose marker line carries trailing code (`Foo.new(:n(qq:to/E/)).throw
+    // unless $ok`) resumes the parse on a freshly built buffer, so `rest` is not a
+    // tail slice of `input` and the subtraction lands at an arbitrary offset — a
+    // mid-character one panics (Collection, #7954). No contiguous source span then
+    // exists to record, and neither wrapper has anything to preserve without one.
+    let consumed = crate::parser::expr::consumed_span(input, rest);
+    let expr = match (matches!(expr, Expr::Literal(_)), consumed) {
+        (_, None) => expr,
+        (true, Some(consumed)) => crate::parser::primary::wrap_divergent_literal(expr, consumed),
         // A bare colonpair statement (`:foo(42)`) parses to the same
         // `Binary { FatArrow }` as a fatarrow; record its source so a
         // sink-context warning echoes the colonpair form, not `foo => 42`.
-        let consumed = &input[..input.len() - rest.len()];
-        crate::parser::primary::wrap_colonpair_sink_source(expr, consumed)
+        (false, Some(consumed)) => {
+            crate::parser::primary::wrap_colonpair_sink_source(expr, consumed)
+        }
     };
 
     if let Expr::BareWord(name) = &expr

--- a/src/parser/stmt/sub_param/helpers.rs
+++ b/src/parser/stmt/sub_param/helpers.rs
@@ -127,6 +127,83 @@ pub(crate) fn parse_subsig_tail(input: &str) -> PResult<'_, SubsigTail> {
     ))
 }
 
+/// An anonymous parameter that is nothing but a type — `multi infix:<->(e1, e2)`,
+/// `sub f(Int)`, `multi prefix:<-->(::?CLASS)` — together with the `is` traits and
+/// `where` clause it may still carry. `input` starts right after the type.
+pub(crate) fn type_only_param(
+    input: &str,
+    type_constraint: String,
+    named: bool,
+    slurpy: bool,
+) -> PResult<'_, ParamDef> {
+    use crate::parser::helpers::{ws, ws1};
+    let mut p = make_param("__type_only__".to_string());
+    p.type_constraint = Some(type_constraint);
+    p.named = named;
+    p.slurpy = slurpy;
+    let mut param_traits = Vec::new();
+    let (mut r, _) = ws(input)?;
+    while let Some(r2) = crate::parser::stmt::keyword("is", r) {
+        let (r2, _) = ws1(r2)?;
+        let (r2, trait_name) = crate::parser::stmt::ident(r2)?;
+        let (r2, _) =
+            crate::parser::stmt::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
+        param_traits.push(trait_name);
+        let (r2, _) = ws(r2)?;
+        r = r2;
+    }
+    p.traits = param_traits;
+    if let Some(r2) = crate::parser::stmt::keyword("where", r) {
+        let (r2, _) = ws1(r2)?;
+        let (r2, constraint) = super::where_constraint::parse_where_constraint_expr(r2)?;
+        p.where_constraint = Some(Box::new(constraint));
+        r = r2;
+    }
+    Ok((r, p))
+}
+
+/// A literal-value parameter (`multi sub foo(0)`, `foo(-١)`, `foo(Inf)`, `foo("x")`).
+///
+/// Two passes, because the two grammars disagree about `-->`. The broad pass runs the
+/// full expression parser, which is what recognizes every literal spelling mutsu
+/// supports; but nothing stops its postfix layer from lexing the `--` of a signature's
+/// `-->` onto the literal it just read, so `norm(M:D: 'column-sum'--> Numeric)`
+/// (Math::Matrix, #7954) came back as `('column-sum'--) > Numeric` — not a literal, and
+/// the whole parameter list then failed. The narrow pass is the literal-parameter
+/// grammar itself: an optional sign and one primary term, matching exactly what
+/// [`literal_value_from_expr`](crate::parser::stmt::sub::literal_value_from_expr)
+/// accepts. It structurally cannot reach an infix or postfix operator, so the `-->`
+/// survives for the caller to read.
+pub(crate) fn parse_literal_param_value(input: &str) -> Option<(&str, Value)> {
+    fn finish<'a>(lit_rest: &'a str, expr: &Expr) -> Option<(&'a str, Value)> {
+        let v = crate::parser::stmt::sub::literal_value_from_expr(expr)?;
+        let (after_lit, _) = crate::parser::helpers::ws(lit_rest).ok()?;
+        let at_param_end = after_lit.starts_with([')', ',', ';', ']', '{'])
+            || after_lit.starts_with("-->")
+            || after_lit.is_empty();
+        at_param_end.then_some((after_lit, v))
+    }
+    if let Ok((lit_rest, lit_expr)) = crate::parser::expr::expression(input)
+        && let Some(found) = finish(lit_rest, &lit_expr)
+    {
+        return Some(found);
+    }
+    let (signed, sign) = match input.as_bytes().first() {
+        Some(b'-') => (&input[1..], Some(crate::token_kind::TokenKind::Minus)),
+        Some(b'+') => (&input[1..], Some(crate::token_kind::TokenKind::Plus)),
+        _ => (input, None),
+    };
+    let (lit_rest, term) = crate::parser::primary::primary(signed).ok()?;
+    let expr = match sign {
+        Some(op) => Expr::Unary {
+            op,
+            expr: Box::new(term),
+        },
+        None => term,
+    };
+    finish(lit_rest, &expr)
+}
+
 /// Returns (rest, required, optional_marker).
 /// `!` → required=true, optional_marker=false
 /// `?` → required=false, optional_marker=true

--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -265,7 +265,9 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         {
             type_constraint = Some(tc);
             rest = r;
-        } else {
+        } else if r.starts_with(':') {
+            // A whitespace-separated invocant marker (`::?CLASS : $x`); the form
+            // with the `:` attached to the type was consumed above.
             let mut p = super::helpers::make_param("self".to_string());
             p.type_constraint = Some(tc);
             p.is_invocant = true;
@@ -273,6 +275,15 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             p.traits
                 .push(crate::ast::IMPLICIT_INVOCANT_TRAIT.to_string());
             return Ok((r, p));
+        } else {
+            // Neither a variable nor an invocant marker follows: this is an
+            // ANONYMOUS POSITIONAL parameter typed by the pseudo-type, exactly as
+            // `sub f(Int)` is. Only the `:` marker declares an invocant, so
+            // `multi prefix:<-->(::?CLASS) is export { ... }` (CRDT, #7954) is a
+            // one-argument sub — reading it as an invocant made it an
+            // X::Syntax::Signature::InvocantNotAllowed in a `sub`, and turned
+            // `method m(::?CLASS)` into a zero-argument method.
+            return super::helpers::type_only_param(r, tc, named, slurpy);
         }
     }
 
@@ -532,33 +543,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             }
             // Bare identifier as type-only parameter (e.g., enum values in multi dispatch)
             // multi infix:<->(e1, e2) { ... }
-            let mut p = super::helpers::make_param("__type_only__".to_string());
-            p.type_constraint = Some(tc);
-            p.named = named;
-            p.slurpy = slurpy;
-            // Optional traits (`is rw`, `is copy`, …) and a `where` clause on the
-            // anonymous parameter.
-            let mut param_traits = Vec::new();
-            let (mut r3, _) = ws(r2)?;
-            while let Some(r) = super::super::keyword("is", r3) {
-                let (r, _) = ws1(r)?;
-                let (r, trait_name) = super::super::ident(r)?;
-                let (r, _) =
-                    super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
-                param_traits.push(trait_name);
-                let (r, _) = ws(r)?;
-                r3 = r;
-            }
-            p.traits = param_traits;
-            let (r3, where_constraint) = if let Some(r) = super::super::keyword("where", r3) {
-                let (r, _) = ws1(r)?;
-                let (r, constraint) = super::where_constraint::parse_where_constraint_expr(r)?;
-                (r, Some(Box::new(constraint)))
-            } else {
-                (r3, None)
-            };
-            p.where_constraint = where_constraint;
-            return Ok((r3, p));
+            return super::helpers::type_only_param(r2, tc, named, slurpy);
         } else {
             // Check for multiple prefix type constraints (e.g. `Int Str $x`)
             if let Some((r3, _second_tc)) = super::type_constraint::parse_type_constraint_expr(r2) {
@@ -625,16 +610,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
     }
 
     // Handle literal value parameters: multi sub foo(0), foo(-١), foo(Inf), foo("x")
-    if let Ok((lit_rest, lit_expr)) = expression(rest)
-        && let Some(v) = super::super::sub::literal_value_from_expr(&lit_expr)
-        && let Ok((after_lit, _)) = ws(lit_rest)
-        && (after_lit.starts_with(')')
-            || after_lit.starts_with(',')
-            || after_lit.starts_with(';')
-            || after_lit.starts_with(']')
-            || after_lit.starts_with('{')
-            || after_lit.starts_with("-->"))
-    {
+    if let Some((after_lit, v)) = super::helpers::parse_literal_param_value(rest) {
         let mut p = super::helpers::make_param("__literal__".to_string());
         // If no explicit type constraint, infer from the literal value type
         p.type_constraint = type_constraint.or_else(|| {

--- a/t/lang/quoting/heredoc-trailing-code-consumed-span.t
+++ b/t/lang/quoting/heredoc-trailing-code-consumed-span.t
@@ -1,0 +1,65 @@
+use v6;
+use Test;
+
+# Regression (#7954, the `expected statement ...` parse-failure index): a heredoc
+# whose introducing line carries code AFTER the marker resumes the parse on a
+# freshly BUILT buffer — the rest of that line spliced onto the text after the
+# terminator. `rest` is then not a tail slice of the string the caller passed, so
+# the `&input[..input.len() - rest.len()]` subtractions several parsers used to
+# recover their consumed span landed at an arbitrary offset. With multi-byte text
+# in the body that offset fell inside a character and the parser PANICKED
+# (Collection's `RefreshPlugins.rakumod`, via a `MapFail.new(:note(qq:to/WARN/))
+# .throw unless ...`); with ASCII it silently read the wrong span. The sites now
+# recover the span by pointer provenance (`consumed_span`) instead.
+
+plan 8;
+
+# A statement-modifier tail after the marker, with a multi-byte body — the exact
+# shape that panicked.
+class MapFail is Exception {
+    has $.note;
+    method message { $.note }
+}
+my $plug = 'p';
+my $ok = False;
+my $thrown = '';
+try {
+    MapFail.new(:note(qq:to/WARN/)).throw unless $ok;
+        Major part error? No released plugin ｢{ $plug }_v1｣ corresponding to ｢$plug｣ in ｢mode｣
+        WARN
+    CATCH { default { $thrown = .message } }
+}
+ok $thrown.contains('｢p_v1｣'), 'a heredoc under a statement modifier keeps its multi-byte body';
+ok $thrown.contains('corresponding to ｢p｣ in ｢mode｣'), 'and the whole body survives';
+
+# The same shape with the modifier NOT firing: nothing is thrown.
+my $fired = True;
+my $second = 'untouched';
+MapFail.new(:note(qq:to/SKIP/)).throw unless $fired;
+    ｢never｣ thrown ｢at all｣ because the modifier is false
+    SKIP
+is $second, 'untouched', 'the statement modifier still suppresses the throw';
+
+# A heredoc as the left-hand side of `=>`: the fat-arrow paths recovered the same
+# span to decide whether to autoquote a bareword key.
+my %h = qq:to/E/ => 'v';
+    ｢キー｣ の値、これは十分に長い行なので境界がずれると文字の中に落ちる
+    E
+is %h.values, ('v',), 'a heredoc `=>` key keeps its value';
+ok %h.keys[0].contains('｢キー｣'), 'and the key keeps its multi-byte body';
+
+# A heredoc inside a `for` body whose marker line carries a postfix chain: the
+# loop's `&?BLOCK` scan recovered the same span.
+my @out;
+for 1, 2 {
+    @out.push: qq:to/B/.trim;
+        行 $_ ｢だけ｣
+        B
+}
+is @out, ['行 1 ｢だけ｣', '行 2 ｢だけ｣'], 'a heredoc in a for body interpolates the topic per iteration';
+
+# Bareword-key autoquoting, the thing those fat-arrow spans actually decide, is
+# unchanged for an ordinary key.
+my %plain = key => 1;
+is %plain<key>, 1, 'a bareword `=>` key is still autoquoted';
+is (Bool::True => 2).key, True, 'and a qualified name on the left is still evaluated';

--- a/t/oo/method/topic-dynamic-method-call.t
+++ b/t/oo/method/topic-dynamic-method-call.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# Regression (#7954, the `expected statement ...` parse-failure index): an
+# indirect method name held in a variable, called on the TOPIC — `.$name`. The
+# explicit-invocant form (`$x.$name`) and the code-sigil topic form (`.&name`)
+# each had their own parser branch, but the `$`/`@`/`%` topic form had none, so
+# `@iterable.map({.$function})` (python::itertools) was a hard parse error.
+
+plan 10;
+
+# The construct the index reduced to.
+my $double = { $_ * 2 };
+is [1, 2].map({ .$double }), (2, 4), '.$code calls the code object on the topic';
+
+# The same shapes the explicit-invocant form supports.
+$_ = 3;
+is (.$double), 6, '.$code works against a bare topic';
+is 3.$double, 6, 'and the explicit-invocant form still does';
+
+my $add = sub ($x, $y) { $x + $y };
+is (.$add(4)), 7, '.$code(args) passes the topic as the first argument';
+
+# A method captured as a Callable is invoked with the topic as its invocant.
+my $upper = Str.^lookup('uc');
+$_ = 'aBc';
+is (.$upper), 'ABC', '.$code invokes a captured method on the topic';
+is 'aBc'.$upper, 'ABC', 'and the explicit-invocant form agrees';
+
+# `for` supplies the topic per iteration.
+my @seen;
+for 1, 2, 3 { @seen.push: .$double }
+is @seen, [2, 4, 6], '.$code re-reads the topic on each iteration';
+
+# A non-Callable is a runtime error, not a method name — `.$name` is an indirect
+# INVOCATION, never a lookup by string.
+my $not-code = 'uc';
+dies-ok { $_ = 'aBc'; .$not-code }, '.$str does not name a method to call';
+
+# `.&name` keeps its own meaning — a sub called with the topic as first argument.
+sub triple($n) { $n * 3 }
+is [1, 2].map({ .&triple }), (3, 6), '.&name still calls a named sub on the topic';
+
+# A `.` immediately before a `$` inside a string is still literal text, not a
+# method call — the interpolation parser owns that, and must keep owning it.
+my $x = '5';
+is "$x.$x", '5.5', 'a `.$var` inside a string interpolates two variables';

--- a/t/routines/signature/literal-param-return-arrow.t
+++ b/t/routines/signature/literal-param-return-arrow.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# Regression (#7954, the `expected statement ...` parse-failure index): a
+# signature's `-->` written with no space after a LITERAL parameter. The literal
+# parameter is recognized by running the full expression parser, whose postfix
+# layer happily lexed the `--` of `-->` onto the literal it had just read, so
+# `multi method norm(M:D: 'column-sum'--> Numeric)` (Math::Matrix) came back as
+# `('column-sum'--) > Numeric` — not a literal at all, and the whole parameter
+# list then failed to parse. A sigiled parameter was unaffected, because the
+# parameter parser reads its name itself and never reaches the postfix layer.
+
+plan 13;
+
+# The construct the index reduced to: the Math::Matrix multi, whose literal
+# parameter is what selects between the candidates.
+class Mat {
+    multi method norm(Mat:D: 'column-sum'--> Numeric){ 1 }
+    multi method norm(Mat:D: 'row-sum'--> Numeric){ 2 }
+    multi method norm(Mat:D: --> Numeric){ 3 }
+}
+is Mat.new.norm('column-sum'), 1, 'a string literal parameter dispatches with `-->` right behind it';
+is Mat.new.norm('row-sum'), 2, 'and the second literal candidate is reachable too';
+is Mat.new.norm, 3, 'and the literal-free candidate still matches';
+
+# Every literal spelling, with and without the space before the arrow.
+sub str-tight("lit"--> Int) { 1 }
+sub str-loose("lit" --> Int) { 2 }
+is str-tight("lit"), 1, 'a double-quoted literal parameter takes a tight `-->`';
+is str-loose("lit"), 2, 'and a spaced one still works';
+
+sub int-tight(3--> Int) { 4 }
+is int-tight(3), 4, 'an integer literal parameter takes a tight `-->`';
+
+sub neg-tight(-3--> Int) { 5 }
+is neg-tight(-3), 5, 'a negated integer literal parameter takes a tight `-->`';
+
+sub num-tight(1.5--> Str) { "r" }
+is num-tight(1.5), "r", 'a rational literal parameter takes a tight `-->`';
+
+# The literal is still a literal: it constrains the argument.
+dies-ok { str-tight("other") }, 'the literal parameter still rejects a different string';
+dies-ok { int-tight(4) }, 'and still rejects a different integer';
+
+# The declared return type survives the tighter spelling.
+sub bad-return("lit"--> Int) { "not an Int" }
+dies-ok { bad-return("lit") }, 'the `-->` return type is enforced, not swallowed';
+
+# A sigiled parameter — the shape that already worked — must keep working.
+sub sigiled($x--> Int) { 6 }
+is sigiled(9), 6, 'a sigiled parameter takes a tight `-->`';
+
+# Postfix `--` on a term is untouched: only a signature owns `-->`.
+my $n = 5;
+my $before = $n--;
+ok $before == 5 && $n == 4, 'postfix `--` still decrements outside a signature';

--- a/t/routines/signature/signature-pseudo-type-anon-param.t
+++ b/t/routines/signature/signature-pseudo-type-anon-param.t
@@ -1,0 +1,67 @@
+use v6;
+use Test;
+
+# Regression (#7954, the `expected statement ...` parse-failure index): a
+# parameter whose whole text is the pseudo-type `::?CLASS` / `::?ROLE`, with no
+# variable and no `:` marker after it. Only the `:` marker declares an invocant,
+# so such a parameter is an ANONYMOUS POSITIONAL exactly as `sub f(Int)` is. The
+# parser read every non-variable continuation as an invocant instead, which made
+# `multi prefix:<-->(::?CLASS) is export { ... }` (CRDT) a hard
+# X::Syntax::Signature::InvocantNotAllowed — a `sub` may not take an invocant —
+# and quietly turned `method m(::?CLASS)` into a zero-argument method.
+
+plan 14;
+
+class Plain {
+    sub takes-one(::?CLASS) { 'sub' }
+    multi sub multi-takes-one(::?CLASS) { 'multi sub' }
+    method via-sub { takes-one(self) }
+    method via-multi-sub { multi-takes-one(self) }
+
+    method one-arg(::?CLASS) { 'method' }
+    multi method dispatched(::?CLASS) { 'object' }
+    multi method dispatched(Int) { 'int' }
+    method smiley(::?CLASS:D) { 'definite' }
+}
+
+# A `sub` nested in the class: an anonymous positional, not a rejected invocant.
+is Plain.new.via-sub, 'sub', '`sub f(::?CLASS)` takes one positional argument';
+is Plain.new.via-multi-sub, 'multi sub', 'and so does the `multi sub` form';
+
+# A method: the parameter is a positional, so it is in ADDITION to the invocant.
+is Plain.new.one-arg(Plain.new), 'method', '`method m(::?CLASS)` takes one positional argument';
+is Plain.new.one-arg(Plain), 'method', 'and it accepts the type object too';
+
+# It is a real type constraint, not a name-only placeholder.
+dies-ok { Plain.new.one-arg(3) }, 'the pseudo-type still rejects an argument of another type';
+
+# Multi dispatch sees it as a real candidate parameter.
+is Plain.new.dispatched(Plain.new), 'object', 'the pseudo-type candidate matches an instance';
+is Plain.new.dispatched(3), 'int', 'and the sibling candidate still matches an Int';
+
+# A type smiley on the anonymous positional.
+is Plain.new.smiley(Plain.new), 'definite', '`::?CLASS:D` works as an anonymous positional';
+dies-ok { Plain.new.smiley(Plain) }, 'and its `:D` rejects the type object';
+
+# The `:` invocant marker keeps its meaning in every spelling.
+class Marked {
+    method attached(::?CLASS: $x) { $x }
+    method smiley-attached(::?CLASS:D: $x) { $x }
+    method spaced(::?CLASS:D : $x) { $x }
+}
+is Marked.new.attached(7), 7, '`::?CLASS: $x` still declares the invocant';
+is Marked.new.smiley-attached(7), 7, 'and `::?CLASS:D: $x` does too';
+is Marked.new.spaced(7), 7, 'and a whitespace-separated marker does too';
+
+role Marker {
+    method bare(::?ROLE:) { 'role invocant' }
+}
+class DoesMarker does Marker { }
+is DoesMarker.new.bare, 'role invocant', '`::?ROLE:` still declares the invocant';
+
+# A named parameter written after the pseudo-type is still a named parameter,
+# not an invocant (the `:` of `:from(:$for)` is the named marker).
+class Named {
+    method create(::?CLASS:D :from(:$for)) { $for.WHAT.^name }
+}
+is Named.new.create(:for(Named.new)), 'Named', 'a named parameter after the pseudo-type is still named';


### PR DESCRIPTION
Four independent parser bugs, each reduced from a row of the #7954 `blocked_load` parse-failure index down to a one-liner checked against rakudo. Three came from rows the index could only mark as "containers" — the reported line named an enclosing `class`/`sub` because the parser could not recover far enough to point at the real construct.

Method: fetch each distribution's tarball from the URL in its `ecosystem/dists/` record, `--dump-ast` every module its META6 `provides` names (a parse error needs no dependency closure), binary-search the failing file to the smallest still-failing line range, reduce to a one-liner, compare with `raku`.

## 1. A `-->` written tight against a literal parameter

`Math::Matrix` dispatches its `norm` candidates on a string literal, with no space before the return arrow:

```raku
multi method norm(Math::Matrix:D: 'column-sum'--> Numeric) { ... }
```

A literal-value parameter is recognized by running the **full expression parser** over the parameter text and asking whether a literal came back. Nothing stops that parser's postfix layer from lexing the `--` of `-->` onto the literal it just read, so this arrived as `('column-sum'--) > Numeric` — not a literal, the branch declined, and the whole parameter list failed. A sigiled parameter (`$x-->`) was never affected: the parameter parser reads its own name and never reaches the postfix layer.

`parse_literal_param_value` now makes two passes. The broad pass is the old one and still recognizes every literal spelling mutsu supports; the narrow fallback is the literal-parameter grammar itself — an optional sign plus one primary term, exactly what `literal_value_from_expr` accepts — which structurally cannot reach an infix or postfix operator, so the `-->` survives for the signature parser. Broad-first means nothing that parsed before parses differently.

## 2. `.$name` — an indirect method name on the topic

`python::itertools` writes `@iterable.map({.$function})`. `$x.$name` had a parser branch and so did `.&name`, but the `$`/`@`/`%` topic form had none, so `.$function` fell through to the method-name parse and died. `topic_method_call` now mirrors the postfix path, building the same `DynamicMethodCall` with the topic as invocant.

## 3. A pseudo-type as an anonymous positional

```raku
multi prefix:<-->(::?CLASS)  is export { X::G-Counter::Decrease.new.throw }   # CRDT
```

Only a `:` marker declares an invocant, so a parameter whose whole text is `::?CLASS`/`::?ROLE` is an anonymous positional exactly as `sub f(Int)` is. The parser treated *every* non-variable continuation as an invocant, which made this a hard `X::Syntax::Signature::InvocantNotAllowed` — a `sub` may not take an invocant — and, more quietly, turned `method m(::?CLASS)` into a zero-argument method whose caller got "No such method". The branch now splits: a following `:` (with or without intervening whitespace) is the invocant marker it always was; anything else is an anonymous typed positional, built by a new `type_only_param` helper factored out of the identical bareword-type path so both spellings pick up `is` traits and a `where` clause the same way.

## 4. A class of consumed-span panics

`Collection`'s `RefreshPlugins.rakumod` did not report a parse error — it **panicked**, on a byte index inside a `｣`. When a heredoc's introducing line carries code *after* the marker:

```raku
MapFail.new(:note(qq:to/WARN/)).throw unless %released{$format}{$n-plug};
    Major part error? No released plugin ｢{ $n-plug }_v{ $n-v }｣ for ｢$plug｣
    WARN
```

the heredoc reader splices the rest of that line onto the text after the terminator and resumes on that freshly built buffer. `rest` is then not a tail slice of the string the caller passed, so the `&input[..input.len() - rest.len()]` subtraction used to recover a consumed span names an arbitrary offset — with ASCII it silently read the wrong span; with multi-byte text it landed mid-character and aborted the process. `qq:to/E/ => 1` panicked the same way in the fat-arrow autoquote paths.

`consumed_span` already existed for exactly this, recovering the span by pointer provenance and returning `None` when there is none — its doc comment even names the heredoc case. Nine sites predating it still did the subtraction; all nine now use the helper, with per-site `None` fallbacks: the sink-source wrappers have nothing to record and skip, the fat-arrow decisions only inspect the *start* of the span so the whole input answers them identically, and the `for`-body `&?BLOCK` scan takes the superset (which can only over-detect, enabling the block-magic binding rather than dropping it). Three further sites keep the subtraction because their `rest` provably comes from a same-buffer scanner (a digit scan, a name parse, a version-literal scan).

## Result

`Collection`, `Math::Matrix` and `python::itertools` now parse every module in their `provides` clean, and `CRDT`'s `G-Counter.rakumod` does too.

`CRDT.rakumod` still does not, on one construct the index had not isolated: `method merge(::T CRDT:D: $ --> T)`, a type capture carrying a nominal invocant type. That is not a parser-only gap — `ParamDef` keeps a parameter's type as a single string with the capture encoded *inside* it, leaving no room for both `::T` and `CRDT:D`, and the plain `method m(::T: $x --> T)` form already mis-binds at runtime. Filed as #7984 rather than forced through here, with #7985 for a narrower gap this PR's pseudo-type fix exposed (`::?CLASS`/`::?ROLE` as a parameter type inside a `role` never resolves to the consuming class).

**#7954 stays open** — it is an index, and the remaining rows span roughly twenty distinct constructs.

## Tests

Four pins, all green under rakudo itself, so they pin rakudo's behaviour rather than mutsu's:

- `t/routines/signature/literal-param-return-arrow.t`
- `t/routines/signature/signature-pseudo-type-anon-param.t`
- `t/oo/method/topic-dynamic-method-call.t`
- `t/lang/quoting/heredoc-trailing-code-consumed-span.t`

Write-up: `news/2026-09/parse-failure-index-literal-arrow-topic-dyncall-consumed-span.md`.

## Verification

- `cargo fmt --all`, `make check-t-layout` — clean.
- `make lint` — all four configurations green (default clippy, `jit` off, wasm32, rustdoc).
- `make test` — `All tests successful. Files=4021, Tests=42806`.
- `make roast` — `Files=1435, Tests=219511`; the only failures are the three container-only ones documented in `docs/agent-environments.md` (`roast/6.c/S32-io/file-tests.t` `Failed: 4` tests 6-8/10 and `roast/S16-filehandles/filetest.t` `Failed: 25` from running as `uid 0`; `roast/S32-io/IO-Socket-Async.t` exit 124 from the sandboxed network), with the failure shapes that table records.

Refs #7954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Boh5K2Ev9yPg2EPJmek4AF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Boh5K2Ev9yPg2EPJmek4AF)_