### PR TITLE
docs(ecosystem): P5 — cluster the parity ledger into root-caused tickets

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -105,10 +105,12 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
       per-distribution machine-readable records in `ecosystem/`. **P1-P3 have landed: the corpus is
       measured.** Run 34566091231 (2026-09-11, `scope: all`, 27/27 shards green) covers all 1624
       distributions at one commit — **41.2%** dist parity, 53.6% file, 62.4% assertion — and the
-      first `history.tsv` row exists. The next step is **P5**: root-cause the 393 `blocked_load`
-      records (53 of them `raku_also_fails`, i.e. not mutsu's; the rest normalise to 133 distinct
-      load errors whose top ten cover ~1/3) into `todo:ticket` issues, so the KPI feeds the work
-      queue. P4's remaining sliver is a local `make`-level wrapper for the sweep.
+      first `history.tsv` row exists. **P5 has produced its first batch**:
+      `scripts/ecosystem-tickets.py` clusters the ledger by root cause, ranked by distributions
+      affected, and fifteen issues covering ~330 distribution slots were filed from it
+      (docs/ecosystem-parity.md §9). What is left of P5 is the tail — 970 clusters below ten
+      distributions, a sampling job rather than a queue to drain. P4's remaining sliver is a local
+      `make`-level wrapper for the sweep.
       Decisions: [ADR-0085](docs/adr/0085-ecosystem-testsuite-parity-measurement.md);
       operations manual and phases (P1-P5, one PR each):
       [docs/ecosystem-parity.md](docs/ecosystem-parity.md);

--- a/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
+++ b/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
@@ -387,7 +387,12 @@ the history row, which is what keeps the series comparable.
   impact-ordered interpreter bugs the project has, at a moment when roast is
   mined out (PLAN.md §3). They feed the existing queue in the shape
   `scripts/dist-compat-tickets.py` already produces — root cause first, dists
-  affected as the impact count — rather than a new process.
+  affected as the impact count — rather than a new process. **Borne out** by the
+  first P5 batch, with one correction: the grouping had to be done over the
+  ledger's own records rather than over that sampler's TSV rows (hence
+  `scripts/ecosystem-tickets.py`), because the exhaustive ledger carries the
+  `blocked_load` module errors and the per-file `first_failure` that the sampler
+  does not.
 - A rakudo upgrade moves the denominator. That is recorded per record and noted
   in the KPI history, and is the accepted cost of D2.
 - Suites that need the network are invisible to the KPI (they fail on both
@@ -404,10 +409,10 @@ Phases are listed in [docs/ecosystem-parity.md](../ecosystem-parity.md) §7.
 | phase | state |
 |---|---|
 | **P1** — harness, dependency resolver, sandbox, record store, `--only`/`--prefix`/`--rollup` | **done** — `scripts/ecosystem-sweep.py` + `scripts/ecosystem_common.py`; validated on eight distributions, which surfaced real interpreter findings on the first pass |
-| **P2** — first corpus sweep, the first KPI numbers | open; a many-core box (D9), or the `Ecosystem sweep` workflow with `scope: all` (D9 amendment) |
-| **P3** — `ecosystem/history.svg` in the README, `site/ecosystem.html` | open |
-| **P4** — operator runbook | partly done — `.github/workflows/ecosystem-sweep.yml` is the dispatch path (D9 amendment) and docs/ecosystem-parity.md §8 documents both it and the local one |
-| **P5** — root-cause grouping of `regression` records into issues | open |
+| **P2** — first corpus sweep, the first KPI numbers | **done** (2026-09-11) — [run 34566091231](https://github.com/tokuhirom/mutsu/actions/runs/34566091231), all 1624 dists at one commit, 27/27 shards green: 41.2% dist / 53.6% file / 62.4% assertion parity, first `history.tsv` row appended |
+| **P3** — `ecosystem/history.svg` in the README, `site/ecosystem.html` | **done** — the page is generated from the ledger by `scripts/gen-ecosystem-manifest.py`, wired into `pages.yml`, covered by `site/e2e.test.mjs` |
+| **P4** — operator runbook | partly done — `.github/workflows/ecosystem-sweep.yml` is the dispatch path (D9 amendment) and docs/ecosystem-parity.md §8 documents both it and the local one; a local `make`-level wrapper is the only piece missing |
+| **P5** — root-cause grouping of the actionable records into issues | **first batch done** (2026-09-11) — `scripts/ecosystem-tickets.py` clusters the ledger by root cause, ranked by distributions affected; fifteen issues filed, covering ~330 distribution slots. Method, and the "a cluster is a hypothesis" rule it produced, in [docs/ecosystem-parity.md](../ecosystem-parity.md) §9 |
 
 Two decisions were tested by the implementation rather than only argued:
 

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -31,8 +31,8 @@ sides, and publish the difference.
 > **41.2%** dist parity — 53.6% file parity, 62.4% assertion parity. The first
 > `history.tsv` row and the chart exist as of that sweep. A sweep runs either
 > locally (§8) or from GitHub Actions (§8.1), so the numbers do not depend on
-> having a many-core box to hand. What is left is **P5**: turning the red and
-> `blocked_load` records into root-caused tickets.
+> having a many-core box to hand. **P5 has produced its first batch** — fifteen
+> root-caused issues covering ~330 distribution slots, see section 9.
 
 ## 1. What gets measured
 
@@ -393,10 +393,10 @@ dark README; browsers that ignore it get the light palette.
 | ~~**P2**~~ | ~~first full-corpus sweep; `ecosystem/` populated; `summary.*` + the first `history.tsv` row~~ | **done** — run 34566091231 (2026-09-11) measured all 1624 dists at one commit with 27/27 shards green: 41.2% dist / 53.6% file / 62.4% assertion parity, and the first history row is appended. It took three attempts; the two that lost data did so silently, and what they cost is recorded in `news/2026-09/` |
 | ~~**P3**~~ | ~~`ecosystem/history.svg` linked from `README.md`; `site/ecosystem.html` + manifest generator + `pages.yml` wiring~~ | **done** — `site/ecosystem.html` is generated from the ledger by `scripts/gen-ecosystem-manifest.py`, wired into `pages.yml` and the nav, and covered by `site/e2e.test.mjs`; the README's Status section now carries the figure and links the chart, which P2 was the thing producing |
 | **P4** | the operator runbook (§8) — one entry point for a full sweep and for a shard, plus the `--rollup` + `history.tsv` append and the PR it lands as | **partly done** — `.github/workflows/ecosystem-sweep.yml` (§8.1) is that entry point for anyone with dispatch rights: it plans, builds once, measures, rolls up and opens the PR. What is left is the local `make`-level convenience wrapper |
-| **P5** | root-cause grouping of `regression` records into `todo:ticket` issues, in the shape `scripts/dist-compat-tickets.py` already produces; `docs/triage.md` picks them up | the KPI feeds the work queue |
+| **P5** | root-cause grouping of the actionable records into `todo:*` issues | **first batch done** — `scripts/ecosystem-tickets.py` clusters the ledger by root cause, ordered by distributions affected, and fifteen issues were filed from the corpus at `7807eb5` (section 9). Two harness fixes came out of it: a warning can no longer be recorded as a blocker, and a parse failure keeps its location. The remaining tail is a sampling job, not a queue to drain |
 
-P1 and P2 are the campaign; P3-P5 make it repeatable. **P5 is the next phase**,
-and the ledger now says how to start it: of the 393 `blocked_load` records, 53
+P1 and P2 are the campaign; P3-P5 make it repeatable. **P5's method is section
+9**, and the reading that started it still holds: of the 393 `blocked_load` records, 53
 are `raku_also_fails` (rakudo does not load them either, so they are not mutsu's
 to fix and belong outside the numerator), and the remaining 340 normalise to 133
 distinct load errors whose top ten cover a third of them (110 of 340) —
@@ -406,16 +406,13 @@ activation. The 560 `red`/`partial` records have a much longer tail (513 with a
 recorded first failure, 336 distinct), so the cheap grouping is on the load
 axis and the file axis wants sampling rather than exhaustive triage.
 
-**There is deliberately no *scheduled* CI sweep** (ADR-0085 D9): a full sweep is
-~20 CPU-hours, and paying a hosted runner for it weekly, on fewer cores, to
-track a number that moves at the speed of interpreter fixes, buys nothing. The
-headline updates when someone decides to refresh it — a documented state, since
-D7 makes staleness computable — and PLAN.md §1 B1's "working-module regression
-CI" stays a separate, unstarted item rather than being closed by this campaign.
-
-**Operator-*dispatched* CI is supported**, though, and is now the ordinary way to
-refresh the numbers: §8.1. That is the D9 amendment — it removes the
-"you need a 12-core box with `bwrap`" precondition without adding a schedule.
+**The sweep is scheduled nightly, and dispatchable on demand** — §8.1. D9
+originally argued for neither (a full sweep looked like ~20 CPU-hours, too much
+to pay a hosted runner for on a number that moves at the speed of interpreter
+fixes); both amendments to it rest on the measured cost instead, which is 78
+minutes of wall time and ~5.5 hours of job time across 27 shards. PLAN.md §1 B1's
+"working-module regression CI" is still **not** closed by this: a measurement is
+not a gate, and that stays a separate item.
 
 ## 8. Operator runbook
 
@@ -581,7 +578,114 @@ and it was opened with the default `GITHUB_TOKEN`, which GitHub does not let
 trigger workflows; the run summary says so. Push one commit to the branch from a
 clone to start CI.
 
-## 9. Known limits and follow-ups
+## 9. From the ledger to tickets (P5)
+
+`scripts/ecosystem-tickets.py` reads the records back and answers *why*, grouped.
+Every actionable failure site — a `blocked_load` module error, and the
+`first_failure` of every `regression`/`partial` test file — is normalised into a
+root-cause **signature**, and signatures are clustered so that one cluster is one
+interpreter fix.
+
+```sh
+scripts/ecosystem-tickets.py                      # the table, biggest first
+scripts/ecosystem-tickets.py --min-dists 1 --all  # the whole tail
+scripts/ecosystem-tickets.py --family no-such-method
+scripts/ecosystem-tickets.py --issue b98eb9ef     # a ready-to-file issue body
+scripts/ecosystem-tickets.py --json tmp/t.json    # machine-readable
+scripts/ecosystem-tickets.py --self-test
+```
+
+Four decisions are worth knowing before reading its output:
+
+- **Impact is counted in distributions, never in failure sites.** A message
+  repeated across forty modules of one distribution is one bug worth one
+  distribution. The raw per-module counts in the ledger say otherwise, and
+  ranking by them puts `Gnome::Gtk3` at the top of every list.
+- **A cluster key keeps the payload that identifies the fix and drops what is
+  volatile.** `No such method '<m>' on <type>` keys on both; `nqp::<op>` keys on
+  the op. Where the members share one cause by construction — an unknown
+  attribute trait, an invalid typename, a stack overflow — the cluster is the
+  *family*, and the payloads are listed inside it as "what varies".
+- **A message that carries no shared cause is keyed per distribution**, not
+  merged: `not ok 7 -` (an *unnamed* failing assertion) is the same string for
+  every such test in the corpus, and merging those two dozen would produce a
+  mega-ticket no single fix can close.
+- **The output is filed as GitHub issues** ([issue-workflow.md](issue-workflow.md)),
+  not committed as a queue file. A generated queue over ~1600 records would
+  conflict on every sweep, and an issue number keeps resolving after the finding
+  is fixed where a path in a generated file does not. Each body carries
+  `eco-cluster: <id>`, a digest of the signature and therefore stable across
+  sweeps, so "is this cluster already filed?" is a tracker search rather than
+  state in the repository.
+
+### A cluster is a hypothesis. Verify it before filing.
+
+The first batch's clusters were right about *what* fails and wrong about *why*
+often enough that this is a rule, not advice. Half an hour with the `raku` oracle
+turned vague tickets into minimised ones and killed two that would have been
+false:
+
+| the cluster said | what it actually was |
+|---|---|
+| `unknown trait 'is' -> 'json-skip-null'` (61 dists) | not the trait — mutsu handles user attribute traits across module boundaries. `JSON::Class` **re-exports** the trait it imported with `OUR::{'&trait_mod:<is>'} := &trait_mod:<is>`, and that binding is invisible to importers ([#7989](https://github.com/tokuhirom/mutsu/issues/7989)) |
+| `No such method 'AST' for invocant of type 'Str'` (13 dists) | `'say 1'.AST` works today. The L10N tests call `.AST("AF")` — the *localised slang* form, a 1-arity candidate that does not exist ([#8001](https://github.com/tokuhirom/mutsu/issues/8001)) |
+| `Variable $.x used where no 'self' is available` (35 dists) | two unrelated gaps: NativeCall's `HAS` declarator ([#7991](https://github.com/tokuhirom/mutsu/issues/7991)) and `has Int ($.x, $.y)` ([#7992](https://github.com/tokuhirom/mutsu/issues/7992)) |
+| `has overflowed its stack` (17 dists) | not deep recursion — *infinite* recursion: an imported `proto`/`multi` does not shadow an enclosing same-named `my sub`, so lizmat's `P5*` wrappers call themselves ([#7994](https://github.com/tokuhirom/mutsu/issues/7994)) |
+| `Use of Nil in string context` (10 dists) | **nothing.** Both interpreters print that as a warning and carry on; it was the harness recording a warning as the blocker. Not filed — fixed in the harness instead (below) |
+
+So: run the minimal case on both interpreters, and only then write the body. A
+ticket that names the construct is worth ten that quote a message.
+
+### Two harness fixes this phase produced
+
+Both are in `first_error_line()` (`scripts/ecosystem_common.py`), and both change
+what *future* sweeps record — existing records carry the old text until
+re-measured:
+
+- **A warning is no longer a cause.** `Use of Nil in string context`, `Use of
+  uninitialized value`, `Potential difficulties` and friends are printed by
+  rakudo too, and execution continues past them; a line matching them is used
+  only when the run produced nothing else. Ten distributions had a warning
+  recorded as their blocker, which hid ten real causes.
+- **A parse failure keeps its location.** mutsu prints `at <path>:<line>` and a
+  caret line under the reason; both were being dropped. The location is now
+  appended as `... [at dist/lib/A.rakumod:50]`, which is the difference between a
+  triageable record and "the parser was unhappy somewhere in this distribution"
+  — 99 distributions were in the second state. The caret line stays dropped: it
+  carries source text, which would fragment a cluster into one per offending
+  line. Consumers strip the suffix before clustering.
+
+### The first batch (2026-09-11)
+
+Fifteen issues from the corpus measured at `7807eb5`, covering ~330 of the
+~1200 non-green distribution slots:
+[#7988](https://github.com/tokuhirom/mutsu/issues/7988) (99 parse gaps, `todo:deep`),
+[#7989](https://github.com/tokuhirom/mutsu/issues/7989) (61, `OUR::` re-export),
+[#7991](https://github.com/tokuhirom/mutsu/issues/7991) (44, `HAS`),
+[#7993](https://github.com/tokuhirom/mutsu/issues/7993) (21, invalid typename),
+[#7995](https://github.com/tokuhirom/mutsu/issues/7995) (20, timeouts, `todo:perf`),
+[#7996](https://github.com/tokuhirom/mutsu/issues/7996) (20, unknown parent type),
+[#7994](https://github.com/tokuhirom/mutsu/issues/7994) (17, infinite recursion),
+[#8000](https://github.com/tokuhirom/mutsu/issues/8000) (17, `CHECK` swallows its exception),
+[#7999](https://github.com/tokuhirom/mutsu/issues/7999) (16, one parse gap in `Terminal::Widgets`),
+[#7997](https://github.com/tokuhirom/mutsu/issues/7997) (13, `use NativeCall :TEST`),
+[#8001](https://github.com/tokuhirom/mutsu/issues/8001) (13, `Str.AST($lang)`),
+[#8002](https://github.com/tokuhirom/mutsu/issues/8002) (11, duplicate composed attribute),
+[#8003](https://github.com/tokuhirom/mutsu/issues/8003) (9, default constructor),
+[#8004](https://github.com/tokuhirom/mutsu/issues/8004) (9, `%?RESOURCES`),
+[#7992](https://github.com/tokuhirom/mutsu/issues/7992) (2, parenthesised attribute list).
+
+Three of them are **diagnostics** tickets — #8000, #7999 and the message half of
+#7988 — and they are deliberately near the front: 17 distributions report only
+`An exception occurred while evaluating a CHECK`, so nothing can be said about
+what they need until that message carries its inner exception. Fixing a message
+splits a cluster, which is progress even though it moves no KPI.
+
+What is left after this batch is a long tail: 985 clusters in total, of which
+these fifteen are the ones affecting ten or more distributions. The tail is a
+**sampling** job (`--min-dists 1`), not an exhaustive-triage one.
+
+## 10. Known limits and follow-ups
 
 - **`--attempts` multiplies the cost of a red corpus.** The retry runs only on a
   file that did not pass, which is the right side to spend it on, but early in

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -103,6 +103,21 @@ locally-measured one.
 Full runbook, and what the workflow refuses to do:
 [docs/ecosystem-parity.md](../docs/ecosystem-parity.md) §8.
 
+## Asking what to fix first
+
+```sh
+scripts/ecosystem-tickets.py                   # root-cause clusters, most distributions first
+scripts/ecosystem-tickets.py --issue b98eb9ef  # one cluster as a ready-to-file issue body
+```
+
+`scripts/ecosystem-tickets.py` reads these records back and groups them by root
+cause, ranked by how many **distributions** each cause affects (never by failure
+sites — one distribution with forty modules is one bug). Its output is filed as
+GitHub issues rather than committed here; each body carries a stable
+`eco-cluster: <id>` so a later sweep can tell a new cluster from a filed one.
+Method, and the "verify a cluster before filing it" rule, in
+[docs/ecosystem-parity.md](../docs/ecosystem-parity.md) §9.
+
 ## Fixing one
 
 Turning a red record green — check the distribution out, run both sides file by

--- a/news/2026-09/ecosystem-parity-ledger-becomes-a-work-queue.md
+++ b/news/2026-09/ecosystem-parity-ledger-becomes-a-work-queue.md
@@ -1,0 +1,89 @@
+# The ecosystem parity ledger becomes a work queue
+
+P5 of [ADR-0085](../../docs/adr/0085-ecosystem-testsuite-parity-measurement.md) —
+the last phase of the zef-parity campaign ([#7785](https://github.com/tokuhirom/mutsu/issues/7785))
+that still had nothing built. The corpus has been measured since 2026-09-11
+(1625 distributions, 41.1% dist parity), which answered *what* fails. This turns
+those 1625 records into an answer to *why*, and into tickets.
+
+## The tool
+
+`scripts/ecosystem-tickets.py` reads the ledger back, normalises every actionable
+failure site — a `blocked_load` module error, and the `first_failure` of every
+`regression`/`partial` test file — into a root-cause signature, and clusters
+them. 985 clusters over the current corpus; fifteen of them affect ten or more
+distributions.
+
+Four decisions shape its output, and each of them was a way to get the ranking
+wrong:
+
+- **Impact is counted in distributions, never in failure sites.** `Invalid
+  typename 'IndRef'` appears 100 times in the ledger and is one bug affecting six
+  distributions; `Gnome::Gtk3` alone would otherwise top every list with its 55
+  modules.
+- **A cluster key keeps the payload that identifies the fix** (`nqp::<op>`, `No
+  such method '<m>' on <type>`) **and drops what is volatile** (quoted strings,
+  numbers, the temp path a parse failure mentions). Where members share one cause
+  by construction — an unknown attribute trait, an unknown parent type — the
+  cluster is the family and the payloads are listed inside it.
+- **A message with no shared cause is keyed per distribution.** `not ok 7 -` is
+  what the ledger records for an *unnamed* failing assertion, and it is the same
+  string for two dozen unrelated wrong answers; merging them would have produced
+  the single largest cluster in the report and no fix could have closed it.
+- **The output is filed as issues, not committed as a queue file.** A generated
+  queue over 1600 records would conflict on every sweep, and an issue number
+  survives being closed where a path in a generated file does not. Each body
+  carries `eco-cluster: <id>`, a digest of the signature, so the next sweep's
+  "is this already filed?" is a tracker search rather than state in the repo.
+
+## The lesson: a cluster is a hypothesis
+
+Fifteen issues were filed, covering roughly 330 of the ~1200 non-green
+distribution slots. What made them worth reading was not the clustering — it was
+half an hour with the `raku` oracle *after* the clustering, which corrected four
+of the five largest clusters and deleted one outright:
+
+| the cluster said | what it was |
+|---|---|
+| `unknown trait 'is' -> 'json-skip-null'`, 61 dists | not the trait. mutsu handles user attribute traits across module boundaries, in `unit module` and braced-`module` form, with named arguments. `JSON::Class` **re-exports** the trait it imported (`OUR::{'&trait_mod:<is>'} := &trait_mod:<is>`), and that binding is invisible to importers — minimised to three files ([#7989](https://github.com/tokuhirom/mutsu/issues/7989)) |
+| `No such method 'AST' for invocant of type 'Str'`, 13 dists | `'say 1'.AST` works today. The L10N tests call `.AST("AF")` — the localised-slang form, a 1-arity candidate that does not exist ([#8001](https://github.com/tokuhirom/mutsu/issues/8001)) |
+| `Variable $.x used where no 'self' is available`, 35 dists | two unrelated gaps: NativeCall's `HAS` embedded-struct declarator ([#7991](https://github.com/tokuhirom/mutsu/issues/7991)), and `has Int ($.x, $.y)` — plain Raku, no NativeCall ([#7992](https://github.com/tokuhirom/mutsu/issues/7992)) |
+| `has overflowed its stack`, 17 dists | not deep recursion. *Infinite* recursion: an imported `my proto sub f(|) is export {*}` does not shadow an enclosing `my sub f`, so `Net::netent`'s `my sub getnetbyname { use P5getnetbyname; getnetbyname(...) }` calls itself. Seven of lizmat's P5 wrappers are the same idiom ([#7994](https://github.com/tokuhirom/mutsu/issues/7994)) |
+| `Use of Nil in string context`, 10 dists | **nothing at all.** Both interpreters print it as a warning and carry on. It was the harness recording a warning as a blocker |
+
+Three of the fifteen are diagnostics tickets, and deliberately near the front:
+17 distributions report only `An exception occurred while evaluating a CHECK`
+([#8000](https://github.com/tokuhirom/mutsu/issues/8000)), so nothing can be said
+about what they need until that message carries its inner exception. Fixing a
+message splits a cluster — progress that moves no KPI.
+
+The best impact-per-fix in the batch is
+[#7999](https://github.com/tokuhirom/mutsu/issues/7999): one parse gap in
+`Terminal::Widgets::Widget` blocks 16 distributions, 15 of them transitively.
+
+## Two harness fixes that fell out
+
+Both in `first_error_line()` (`scripts/ecosystem_common.py`), and both change what
+*future* sweeps record:
+
+- **A warning is no longer a cause.** `Use of Nil in string context`, `Use of
+  uninitialized value`, `Potential difficulties` and friends are used only when
+  the run produced nothing else. Ten distributions had a warning recorded as
+  their blocker, hiding ten real causes.
+- **A parse failure keeps its location.** mutsu prints `at <path>:<line>` plus a
+  caret line; the extractor was dropping both while keeping the reason. The
+  location is now appended as `... [at dist/lib/A.rakumod:50]`, and clustering
+  strips it. The caret line stays dropped: it carries source text, which would
+  fragment a cluster into one per offending line. 99 distributions are blocked by
+  parse gaps whose records said only that the parser was unhappy somewhere
+  ([#7988](https://github.com/tokuhirom/mutsu/issues/7988)).
+
+`load_records()` moved from `ecosystem-sweep.py` into `ecosystem_common.py` so
+the rollup that publishes the KPI and the tool that reads it cannot disagree
+about what the corpus is.
+
+## What is left
+
+The tail: 970 clusters below ten distributions, which is a sampling job
+(`--min-dists 1`) rather than a queue to drain. P4's local `make`-level wrapper
+for a sweep is the only other piece of the campaign still missing.

--- a/scripts/ecosystem-sweep.py
+++ b/scripts/ecosystem-sweep.py
@@ -322,34 +322,9 @@ def write_record(record):
 
 
 def load_records():
-    """Every record in the ledger, keyed by nothing but its own `dist` field.
-
-    Two files claiming the same distribution is a hard error rather than a
-    silently double-counted denominator. That is not hypothetical: it is exactly
-    what a change to `record_filename()` produces if the rename of the existing
-    records is forgotten, and a rollup would then report a corpus larger than
-    the corpus with one distribution's numbers counted twice.
-    """
-    out = []
-    where = {}
-    for dirpath, _dirs, names in os.walk(DISTS_DIR):
-        for n in sorted(names):
-            if not n.endswith(".json"):
-                continue
-            path = os.path.join(dirpath, n)
-            with open(path, encoding="utf-8") as fh:
-                record = json.load(fh)
-            dist = record.get("dist")
-            if dist in where:
-                raise SystemExit(
-                    f"two records claim the distribution {dist!r}:\n"
-                    f"  {where[dist]}\n  {path}\n"
-                    "One of them is stale -- most likely the filename rule "
-                    "changed and an old-named record was left behind. Delete it."
-                )
-            where[dist] = path
-            out.append(record)
-    return out
+    # The implementation lives in ecosystem_common so that the rollup and
+    # ecosystem-tickets.py cannot disagree about what the corpus is.
+    return eco.load_records(DISTS_DIR)
 
 
 def write_index_snapshot(index, args):

--- a/scripts/ecosystem-tickets.py
+++ b/scripts/ecosystem-tickets.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""ecosystem-tickets.py — turn the parity ledger into an impact-ordered root-cause queue.
+
+`ecosystem/dists/**.json` records *what* fails; this reads them back and answers
+*why*, grouped. Every actionable failure site in the ledger -- a `blocked_load`
+module error, and the `first_failure` of every `regression`/`partial` test file --
+is normalised into a root-cause signature, and signatures are clustered so that
+one cluster is one interpreter fix. Clusters are ordered by the number of
+DISTRIBUTIONS they affect, which is the only impact metric that means anything
+here: a message repeated across 40 modules of one distribution is one bug worth
+one distribution, and the ledger's raw per-module counts say otherwise.
+
+This is phase P5 of ADR-0085. The output is meant to be filed as GitHub issues
+(docs/issue-workflow.md), NOT committed as a queue file: a generated queue over
+~1600 records would conflict on every sweep, and an issue number keeps resolving
+after the finding is fixed where a path in a generated file does not.
+
+    scripts/ecosystem-tickets.py                      # the table, biggest first
+    scripts/ecosystem-tickets.py --min-dists 1 --all  # the whole tail
+    scripts/ecosystem-tickets.py --family no-such-method
+    scripts/ecosystem-tickets.py --issue 3f0a1c2d     # a ready-to-file issue body
+    scripts/ecosystem-tickets.py --json tmp/eco-tickets.json
+    scripts/ecosystem-tickets.py --self-test
+
+A cluster's `id` is a digest of its signature, so it is stable across sweeps: the
+issue body carries `eco-cluster: <id>`, and re-running this after the next sweep
+tells you whether a cluster is new by searching the tracker for that string
+rather than by keeping state in the repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import hashlib
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ecosystem_common as eco  # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DISTS_DIR = os.path.join(REPO, "ecosystem", "dists")
+
+# Sites the ledger records but which are not mutsu's to fix. Both are measured
+# facts about the machine that ran the sweep, not about the interpreter, and both
+# are small enough to enumerate: keeping them in the queue would put a ticket on
+# the board that no interpreter change can close. `--class all` shows them.
+NOISE = (
+    (re.compile(r"failed to lookup address information|Temporary failure in name resolution"),
+     "network"),
+    (re.compile(r"failed to spawn worker thread.*WouldBlock"),
+     "host-resources"),
+)
+
+
+def _q(s: str) -> str:
+    """Collapse quoted payloads and bare numbers -- the volatile part of a message."""
+    s = re.sub(r"(\w)'(\w)", r"\1\2", s)          # don't -> dont, so quotes pair up
+    s = re.sub(r"'[^']*'", "'X'", s)
+    s = re.sub(r'"[^"]*"', '"X"', s)
+    s = re.sub(r"\bline \d+\b", "line N", s)
+    s = re.sub(r"\b\d+\b", "N", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _expectation_dump(s: str) -> str | None:
+    """mutsu's parser failure message is a dump of what it would have accepted.
+
+    It names the *file and line* (and a caret line under it), which is why the
+    harness now records the location -- but it never names the construct it
+    choked on, and the expectation set it prints instead differs with parser
+    state rather than with the cause. So these cluster as ONE family: every
+    member is a distinct unknown parse gap, and none of them can be told apart
+    from its message. They are a sampling job, not one fix.
+    """
+    if "expected statement:" not in s and not s.startswith("Confused."):
+        return None
+    return "parse error described only by the parser's expectation set"
+
+
+# (family, pattern, signature template). First match wins, so order matters.
+# A template of None means "cluster at the family level": the members share one
+# root cause by construction, and one ticket fixes all of them.
+RULES: list[tuple[str, re.Pattern, str | None]] = [
+    # --- one root cause per family ------------------------------------------
+    ("unknown-attribute-trait",
+     re.compile(r"unknown trait '(?P<t>[^']+)' -> '(?P<n>[^']+)' in an attribute declaration"),
+     None),
+    ("invalid-typename",
+     re.compile(r"Invalid typename '(?P<n>[^']+)'"), None),
+    ("inherit-unknown-type",
+     re.compile(r"'(?P<c>[^']+)' cannot inherit from '(?P<p>[^']+)' because it is unknown"), None),
+    ("no-self-available",
+     re.compile(r"Variable (?P<v>[$@%&][.!]\S+) used where no 'self' is available"), None),
+    ("duplicate-composed-attribute",
+     re.compile(r"Trait::Duplicate: attribute '(?P<a>[^']+)' already exists in class"), None),
+    ("augment-missing-class",
+     re.compile(r"You tried to augment class (?P<c>\S+), but it does not exist"), None),
+    ("nil-string-context",
+     re.compile(r"Use of Nil in string context"), None),
+    ("stack-overflow",
+     re.compile(r"has overflowed its stack"), None),
+    ("timeout",
+     re.compile(r"^SWEEP-TIMEOUT$"), None),
+    ("check-phaser",
+     re.compile(r"An exception occurred while evaluating a CHECK"), None),
+    # --- one root cause per named payload -----------------------------------
+    ("no-such-method",
+     re.compile(r"No such method '(?P<m>[^']+)' for invocant of type '(?P<t>[^']+)'"),
+     "No such method '{m}' on {t}"),
+    ("no-such-private-method",
+     re.compile(r"No such private method '(?P<m>[^']+)' for invocant of type '(?P<t>[^']+)'"),
+     "No such private method '{m}' on {t}"),
+    ("nqp-op",
+     re.compile(r"Unsupported nqp:: op: (?P<op>nqp::\w+)"), "Unsupported {op}"),
+    ("unknown-function",
+     re.compile(r"Unknown function: (?P<f>\S+)"), "Unknown function: {f}"),
+    ("missing-module",
+     re.compile(r"Could not find (?P<m>\S+) in:"), "Could not find {m}"),
+    ("import-tag",
+     re.compile(r"Error while importing from '(?P<m>[^']+)': no such tag '(?P<t>[^']+)' declared"),
+     "no such import tag '{t}' in {m}"),
+    ("role-instantiation",
+     re.compile(r"Could not instantiate role '[^']+' because it died with (?P<x>[\w:]+)"),
+     "role instantiation dies with {x}"),
+    ("slang",
+     re.compile(r"slang activation for '[^']+' failed: (?P<why>.*)"), "slang activation: {why}"),
+    ("unknown-role",
+     re.compile(r"Unknown role: (?P<r>\S+)"), "Unknown role: {r}"),
+]
+
+
+def classify(message: str) -> tuple[str, str | None, str]:
+    """(family, signature, variant) for one failure message.
+
+    A signature of `None` means "this message carries no shared root cause": the
+    caller keys the cluster per distribution instead, so that a hundred unrelated
+    bugs cannot pile into one mega-ticket that no single fix closes.
+
+    The `variant` is the identifying payload the rule matched -- which trait,
+    which typename, which parent class. For a family-level cluster that is the
+    whole of what differs between its members, so it must NOT be normalised away
+    the way the signature is.
+    """
+    s = message.strip()
+    # `... [at lib/A.rakumod:50]` -- the location the harness appends so that a
+    # record can be triaged. It is per-record by construction, so clustering on
+    # it would give one cluster per distribution; the sites below keep it.
+    s = re.sub(r"\s*\[at [^\]]+\]$", "", s)
+    # A parse failure names the module it was compiling; the module name is the
+    # dist, not the cause, so strip it before matching.
+    s = re.sub(r"^(Runtime error: )?Failed to parse module '[^']*':\s*", "", s)
+    s = re.sub(r"^Runtime error:\s*", "", s)
+
+    dump = _expectation_dump(s)
+    if dump:
+        return "parse-error-expectation-dump", dump, _q(s)[:100]
+    # `not ok 7 -` with nothing after the dash: an *unnamed* assertion computed
+    # the wrong value. The message is the whole of what the ledger knows, and it
+    # is the same string for every such test in the corpus, so clustering on it
+    # would merge two dozen unrelated wrong answers.
+    if re.fullmatch(r"not ok\s+\d+\s*-?\s*", s):
+        return "wrong-answer-unnamed-assertion", None, s
+    for family, pattern, template in RULES:
+        m = pattern.search(s)
+        if m:
+            variant = " -> ".join(v for v in m.groupdict().values() if v) or _q(s)[:100]
+            if template is None:
+                return family, family, variant
+            return family, template.format(**m.groupdict()), variant
+    return "other", _q(s)[:110], _q(s)[:100]
+
+
+def noise_class(message: str) -> str | None:
+    for pattern, name in NOISE:
+        if pattern.search(message):
+            return name
+    return None
+
+
+def sites(records):
+    """Every actionable failure site in the ledger.
+
+    `raku_also_fails` load entries and `no_baseline` files are excluded here for
+    the same reason they are excluded from the KPI: rakudo does not pass them
+    either, so they are not mutsu's to fix (ADR-0085 D3).
+    """
+    for r in records:
+        for module, verdict in sorted((r.get("load") or {}).items()):
+            if verdict in ("ok", "raku_also_fails"):
+                continue
+            yield r, f"load:{module}", verdict, 0
+        for f in r.get("files") or []:
+            if f.get("cmp") not in ("regression", "partial"):
+                continue
+            message = (f.get("mutsu") or {}).get("first_failure")
+            if not message:
+                continue
+            # rakudo's own `ok` count on this file is exactly what the KPI's
+            # assertion_parity gains if the cluster is fixed.
+            yield r, f"file:{f['path']}", message, (f.get("raku") or {}).get("ok") or 0
+
+
+def cluster(records, *, want_class="actionable"):
+    out: dict[str, dict] = {}
+    for record, where, message, assertions in sites(records):
+        noise = noise_class(message)
+        if want_class == "actionable" and noise:
+            continue
+        if noise:
+            family, signature, variant = "noise-" + noise, noise, noise
+        else:
+            family, signature, variant = classify(message)
+        if signature is None:
+            signature = f"{family} [{record['dist']}]"
+        c = out.setdefault(signature, {
+            "id": hashlib.sha256(signature.encode()).hexdigest()[:8],
+            "family": family,
+            "signature": signature,
+            "dists": set(),
+            "blocked_load_dists": set(),
+            "files": 0,
+            "assertions": 0,
+            "axis_dists": {},
+            "variant_dists": {},
+            "sites": [],
+        })
+        c["dists"].add(record["dist"])
+        c["axis_dists"].setdefault(record.get("axis") or "?", set()).add(record["dist"])
+        if where.startswith("load:"):
+            c["blocked_load_dists"].add(record["dist"])
+        else:
+            c["files"] += 1
+            c["assertions"] += assertions
+        # For a family-level cluster the payload is the thing a reader needs to
+        # see the spread of (which trait, which typename, which parent). Counted
+        # in distributions like everything else here: one distribution with forty
+        # modules is one bug, and a per-site count says otherwise.
+        c["variant_dists"].setdefault(variant, set()).add(record["dist"])
+        if len(c["sites"]) < 6:
+            c["sites"].append({
+                "dist": record["dist"],
+                "version": record.get("version"),
+                "where": where,
+                "message": message[:300],
+            })
+    clusters = []
+    for c in out.values():
+        c["n_dists"] = len(c["dists"])
+        c["dists"] = sorted(c["dists"])
+        c["blocked_load_dists"] = sorted(c["blocked_load_dists"])
+        c["axes"] = {a: len(d) for a, d in sorted(c.pop("axis_dists").items())}
+        c["variants"] = sorted(((v, len(d)) for v, d in c.pop("variant_dists").items()),
+                               key=lambda vd: (-vd[1], vd[0]))[:8]
+        clusters.append(c)
+    clusters.sort(key=lambda c: (-c["n_dists"], -c["assertions"], c["signature"]))
+    return clusters
+
+
+# --- reporting ---------------------------------------------------------------
+
+
+def print_table(clusters, *, min_dists, limit):
+    """`clusters` is every cluster; min_dists/limit only affect what is printed.
+
+    The family rollup is deliberately computed over ALL of them: the long tail is
+    where most of the corpus's distributions are, and a rollup that silently
+    inherited the table's cutoff would hide that.
+    """
+    shown = [c for c in clusters if c["n_dists"] >= min_dists][:limit]
+    print(f"{'id':8}  {'dists':>5} {'files':>5} {'asserts':>7}  {'family':28} signature")
+    for c in shown:
+        print(f"{c['id']:8}  {c['n_dists']:5} {c['files']:5} {c['assertions']:7}  "
+              f"{c['family']:28} {c['signature'][:64]}")
+    shown_ids = {id(c) for c in shown}
+    rest = [c for c in clusters if id(c) not in shown_ids]
+    print(f"\n{len(shown)} of {len(clusters)} clusters shown; the other {len(rest)} cover "
+          f"{len({d for c in rest for d in c['dists']})} distributions and "
+          f"{sum(c['assertions'] for c in rest)} rakudo assertions")
+    fam = collections.defaultdict(set)
+    per_dist = collections.Counter()
+    for c in clusters:
+        fam[c["family"]].update(c["dists"])
+        if c["signature"].endswith("]") and c["signature"].startswith(c["family"] + " ["):
+            per_dist[c["family"]] += 1
+    print("\nby family (distributions, deduped across signatures):")
+    for f, d in sorted(fam.items(), key=lambda kv: -len(kv[1])):
+        note = (f"  -- {per_dist[f]} per-distribution clusters, no shared root cause"
+                if per_dist[f] else "")
+        print(f"  {len(d):4}  {f}{note}")
+
+
+BLOB = "https://github.com/tokuhirom/mutsu/blob/main"
+
+
+def issue_body(c, *, summary=None):
+    """A self-contained `todo:*` issue body for one cluster."""
+    head = [
+        "Measured by the ecosystem parity ledger "
+        "([#7785](https://github.com/tokuhirom/mutsu/issues/7785) P5, "
+        f"[ADR-0085]({BLOB}/docs/adr/0085-ecosystem-testsuite-parity-measurement.md)). "
+        "One root cause, grouped across the corpus by `scripts/ecosystem-tickets.py`.",
+        "",
+        f"`eco-cluster: {c['id']}`  ·  family `{c['family']}`",
+        "",
+        "## Impact",
+        "",
+        "| | |",
+        "|---|---|",
+        f"| distributions affected | **{c['n_dists']}** |",
+        f"| of which cannot even `use` their own modules (`blocked_load`) | {len(c['blocked_load_dists'])} |",
+        f"| failing test files | {c['files']} |",
+        f"| rakudo assertions in those files (what `assertion_parity` gains) | {c['assertions']} |",
+        f"| axis | {', '.join(f'{k} {v}' for k, v in sorted(c['axes'].items()))} |",
+        "",
+        "## The failure",
+        "",
+        f"Signature: `{c['signature']}`",
+        "",
+    ]
+    if len(c["variants"]) > 1:
+        head += ["What varies between them (count = distributions):", ""]
+        head += [f"- `{v}` ×{n}" for v, n in c["variants"]]
+        head += [""]
+    head += ["## Sites", "",
+             "Each of these is a file rakudo passes cleanly, or a module rakudo loads, "
+             "in the same sandbox with the same `-I` list.", ""]
+    for s in c["sites"]:
+        head.append(f"- **{s['dist']}** {s['version'] or ''} — `{s['where']}`  \n  `{s['message']}`")
+    listed, rest = c["dists"][:30], max(0, c["n_dists"] - 30)
+    head += ["", f"<details><summary>Affected distributions ({c['n_dists']})</summary>", "",
+             ", ".join(f"`{d}`" for d in listed)
+             + (f", and {rest} more -- `scripts/ecosystem-tickets.py --issue {c['id']}` "
+                "lists them from the ledger" if rest else ""),
+             "", "</details>", "",
+             "## Reproducing", "",
+             "```sh",
+             f"scripts/ecosystem-sweep.py --only {c['sites'][0]['dist']}   # re-measures one record",
+             f"scripts/ecosystem-tickets.py --issue {c['id']}    # this report, from the ledger",
+             "```",
+             "",
+             "The per-distribution workflow (check the tarball out, run both sides file by "
+             f"file, minimise) is the [`ecosystem-dist-fix`]({BLOB}/.agents/skills/"
+             "ecosystem-dist-fix/SKILL.md) skill. **Add a `t/` regression test for the "
+             "minimised case**, not for the distribution.",
+             ""]
+    if summary:
+        head += ["## Notes", "", summary, ""]
+    return "\n".join(head)
+
+
+# --- self-test ---------------------------------------------------------------
+
+def self_test() -> int:
+    cases = [
+        ("Can't use unknown trait 'is' -> 'json-skip-null' in an attribute declaration.",
+         "unknown-attribute-trait", "unknown-attribute-trait"),
+        ("Can't use unknown trait 'is' -> 'xml-element' in an attribute declaration.",
+         "unknown-attribute-trait", "unknown-attribute-trait"),
+        ("No such method 'AST' for invocant of type 'Str'",
+         "no-such-method", "No such method 'AST' on Str"),
+        ("Runtime error: Failed to parse module 'Red': Unexpected block in infix position "
+         "(missing statement control word before the expression?)",
+         "other", "Unexpected block in infix position (missing statement control word before "
+         "the expression?)"),
+        ("expected statement: expected expected statement: expected expression statement or ')'",
+         "parse-error-expectation-dump", None),
+        ("Confused. expected statement: expected use statement or import statement or ...",
+         "parse-error-expectation-dump", None),
+        ("Unsupported nqp:: op: nqp::p6bindattrinvres", "nqp-op",
+         "Unsupported nqp::p6bindattrinvres"),
+        # The harness's location suffix must not reach the signature, or every
+        # record becomes its own cluster.
+        ("Unsupported nqp:: op: nqp::hash [at dist/lib/A.rakumod:12]", "nqp-op",
+         "Unsupported nqp::hash"),
+        ("Invalid typename 'IndRef' in parameter declaration.", "invalid-typename", None),
+        ("thread '<unnamed>' (12) has overflowed its stack", "stack-overflow", None),
+        ("SWEEP-TIMEOUT", "timeout", None),
+    ]
+    # An unnamed failing assertion must NOT get a shared signature -- see
+    # classify(). This is the one case where `None` is the required answer.
+    if classify("not ok 7 -")[:2] != ("wrong-answer-unnamed-assertion", None):
+        print(f"FAIL unnamed assertion clustered: {classify('not ok 7 -')}")
+        return 1
+    # A family-level cluster's payload must survive: it is the only thing that
+    # distinguishes its members, and normalising it away made every trait in the
+    # corpus read as the same one.
+    variants = {classify(f"Can't use unknown trait 'is' -> '{t}' in an attribute "
+                         "declaration.")[2] for t in ("json-skip-null", "xml-element")}
+    if len(variants) != 2:
+        print(f"FAIL family payload collapsed: {variants}")
+        return 1
+    fails = 0
+    for message, want_family, want_sig in cases:
+        family, sig, _variant = classify(message)
+        if family != want_family or (want_sig is not None and sig != want_sig):
+            fails += 1
+            print(f"FAIL {message[:60]!r}\n  got  ({family}, {sig})\n  want ({want_family}, {want_sig})")
+    # A parse failure must not cluster by the module it was compiling: two
+    # distributions hitting one parser gap have to land in the same cluster.
+    a = classify("Failed to parse module 'A::B': Cannot interpolate attribute in a regex")[:2]
+    b = classify("Failed to parse module 'C::D': Cannot interpolate attribute in a regex")[:2]
+    if a != b:
+        fails += 1
+        print(f"FAIL module name leaked into the signature: {a} != {b}")
+    # Noise must be recognised, and must not be silently reclassified as a bug.
+    if noise_class("Failed to resolve 'x': failed to lookup address information") != "network":
+        fails += 1
+        print("FAIL network noise not classified")
+    if noise_class("No such method 'AST' for invocant of type 'Str'") is not None:
+        fails += 1
+        print("FAIL a real failure was classified as noise")
+    # The id is a pure function of the signature (stable across sweeps).
+    ids = {c: hashlib.sha256(c.encode()).hexdigest()[:8] for c in ("a", "b")}
+    if len(set(ids.values())) != 2:
+        fails += 1
+    print(f"ecosystem-tickets self-test: {len(cases) + 4} checks, {fails} failed")
+    return 1 if fails else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--limit", type=int, default=30, help="rows in the table (default 30)")
+    ap.add_argument("--all", action="store_true", help="every cluster, no row limit")
+    ap.add_argument("--min-dists", type=int, default=2,
+                    help="drop clusters affecting fewer distributions (default 2)")
+    ap.add_argument("--family", help="only this family")
+    ap.add_argument("--class", dest="cls", choices=("actionable", "all"), default="actionable",
+                    help="`all` also shows sites the sweep's own host caused")
+    ap.add_argument("--issue", metavar="ID", help="print a ready-to-file issue body for a cluster")
+    ap.add_argument("--note", help="with --issue: a Notes paragraph (what you already know)")
+    ap.add_argument("--json", metavar="OUT", help="write every cluster as JSON")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    # `| head` on a 985-row table would otherwise end in a BrokenPipeError trace.
+    try:
+        import signal
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    except (ImportError, AttributeError, ValueError):
+        pass
+
+    if args.self_test:
+        raise SystemExit(self_test())
+
+    records = eco.load_records(DISTS_DIR)
+    clusters = cluster(records, want_class=args.cls)
+    if args.family:
+        clusters = [c for c in clusters if c["family"] == args.family]
+
+    if args.issue:
+        for c in clusters:
+            if c["id"] == args.issue:
+                print(issue_body(c, summary=args.note))
+                return
+        raise SystemExit(f"no cluster with id {args.issue} "
+                         "(ids come from a run with the same --class/--min-dists)")
+
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as fh:
+            json.dump({"clusters": clusters, "records": len(records)}, fh, indent=2)
+        print(f"wrote {len(clusters)} clusters -> {args.json}")
+
+    print_table(clusters, min_dists=args.min_dists,
+                limit=len(clusters) if args.all else args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ecosystem_common.py
+++ b/scripts/ecosystem_common.py
@@ -360,6 +360,27 @@ _HARNESS_NOISE = re.compile(
     r"test failures|you planned|you failed|looks like you|^#|^1\.\.|dubious|"
     r"^ok\b|^not ok\b", re.I)
 
+# `at <path>:<line>` and the caret line under it: where a parse failure happened.
+# Both interpreters print them under the reason, and the reason alone cannot be
+# triaged -- 99 distributions in the first corpus sweep recorded a parse failure
+# with no indication of which line of which module it was.
+_LOCATION = re.compile(r"^at (?P<path>\S+):(?P<line>\d+)\s*$")
+_CARET = re.compile(r"^(------>|\s*\^\s*$)")
+
+# A backtrace frame (`in block <unit> at t/01.t line 4`) says where the failure
+# surfaced but not what it was, so it must never be the recorded cause -- which
+# it becomes for any message whose reason line matches none of the keywords.
+_BACKTRACE = re.compile(r"^in (block|sub|method|routine|any|code)\b.*\bline \d+")
+
+# Lines both interpreters print and then CARRY ON past. They are not why a file
+# died, but they are printed before the thing that killed it, so taking the first
+# candidate line makes them the recorded cause: ten distributions in the first
+# corpus sweep recorded `Use of Nil in string context` -- a warning rakudo prints
+# too -- as their blocker, which hid ten real causes.
+_WARNING = re.compile(
+    r"^Use of (Nil|uninitialized value)|^Potential difficulties|^Useless use of|"
+    r"^Saw \d+ occurrence|will never be called|^Duplicate free|^WARNING:", re.I)
+
 
 def parse_tap(out: str):
     """(planned, ok, real_not_ok, todo_not_ok, skipped) from raw TAP output.
@@ -401,6 +422,16 @@ def tap_verdict(out: str, rc):
     return "pass"
 
 
+def _short_location(path: str, line: str) -> str:
+    """`at /tmp/sweep-x9/lib/A/B.rakumod:50` -> `lib/A/B.rakumod:50`.
+
+    The absolute part is a temp directory that differs between two runs of the
+    same measurement, so keeping it would make an unchanged record churn in git;
+    the tail is what identifies the construct.
+    """
+    return "/".join(path.split("/")[-3:]) + ":" + line
+
+
 def first_error_line(out: str) -> str:
     """The first meaningful error line, skipping the generic TAP-harness noise
     ('Runtime error: Test failures', '# You planned N ...') that reports only
@@ -411,22 +442,56 @@ def first_error_line(out: str) -> str:
     path. The reason is the line after it, which is what a reader needs to tell
     one parse failure from another -- without this, every parse blocker in the
     ledger reads as the same undifferentiated `===SORRY!===`.
+
+    Two things the reason line alone could not do, both measured on the first
+    corpus sweep:
+
+    * **A warning is not a cause.** `Use of Nil in string context` and friends
+      are printed by rakudo too and execution continues past them, so a line
+      matching `_WARNING` is only used when the run produced nothing else.
+    * **A parse failure needs its location.** `at <path>:<line>` is appended as
+      `... [at lib/A.rakumod:50]`, which is the difference between a triageable
+      record and "the parser was unhappy somewhere in this distribution".
+      Consumers that cluster by root cause strip the suffix.
     """
-    candidates = []
+    candidates: list[str] = []
+    location_after: dict[int, str] = {}
     for line in out.splitlines():
         s = line.strip()
         if not s or _HARNESS_NOISE.search(s) or s.startswith("===SORRY!==="):
             continue
+        m = _LOCATION.match(s)
+        if m:
+            # Belongs to the candidate above it, not a candidate of its own.
+            if candidates:
+                location_after.setdefault(len(candidates) - 1,
+                                          _short_location(m["path"], m["line"]))
+            continue
+        if _CARET.match(s) or _BACKTRACE.match(s):
+            continue
         candidates.append(s)
-    for s in candidates:
-        low = s.lower()
-        if ("sorry" in low or "panicked" in low or "unhandled" in low
-                or s.startswith("X::") or ("::" in s and "exception" in low)
-                or "no such" in low or "unknown method" in low
-                or "unknown function" in low or "cannot" in low
-                or low.startswith("runtime error")):
-            return s[:200]
-    return candidates[0][:200] if candidates else ""
+
+    def pick(indices):
+        for i in indices:
+            s = candidates[i]
+            low = s.lower()
+            if ("sorry" in low or "panicked" in low or "unhandled" in low
+                    or s.startswith("X::") or ("::" in s and "exception" in low)
+                    or "no such" in low or "unknown method" in low
+                    or "unknown function" in low or "cannot" in low
+                    or low.startswith("runtime error")):
+                return i
+        return indices[0] if indices else None
+
+    real = [i for i, s in enumerate(candidates) if not _WARNING.match(s)]
+    i = pick(real)
+    if i is None:                       # nothing but warnings: report one anyway
+        i = pick(list(range(len(candidates))))
+    if i is None:
+        return ""
+    s = candidates[i][:200]
+    where = location_after.get(i)
+    return f"{s} [at {where}]" if where else s
 
 
 def first_failing_assertion(out: str) -> str:
@@ -498,6 +563,39 @@ def record_filename(dist: str) -> str:
     return f"{stem}~{digest}.json"
 
 
+def load_records(dists_dir: str) -> list[dict]:
+    """Every record in the ledger, keyed by nothing but its own `dist` field.
+
+    Two files claiming the same distribution is a hard error rather than a
+    silently double-counted denominator. That is not hypothetical: it is exactly
+    what a change to `record_filename()` produces if the rename of the existing
+    records is forgotten, and a rollup would then report a corpus larger than the
+    corpus with one distribution's numbers counted twice.
+
+    Shared by `--rollup` and by `ecosystem-tickets.py`, so a reader of the ledger
+    cannot get a different corpus than the rollup that published the KPI.
+    """
+    out = []
+    where = {}
+    for dirpath, _dirs, names in os.walk(dists_dir):
+        for n in sorted(names):
+            if not n.endswith(".json"):
+                continue
+            path = os.path.join(dirpath, n)
+            with open(path, encoding="utf-8") as fh:
+                record = json.load(fh)
+            dist = record.get("dist")
+            if dist in where:
+                raise SystemExit(
+                    f"two records claim the distribution {dist!r}:\n"
+                    f"  {where[dist]}\n  {path}\n"
+                    "One of them is stale -- most likely the filename rule "
+                    "changed and an old-named record was left behind. Delete it.")
+            where[dist] = path
+            out.append(record)
+    return out
+
+
 # --- self-test ---------------------------------------------------------------
 
 def _self_test() -> int:
@@ -510,16 +608,28 @@ def _self_test() -> int:
     """
     cases = [
         # A ===SORRY!=== header spends its width on a temp path; the reason is
-        # the line after it.
+        # the line after it, and the location under it is what makes the reason
+        # triageable. The caret line is dropped: it carries source text, which
+        # would fragment a root-cause cluster by the offending line.
         ("===SORRY!=== Error while compiling /tmp/x/lib/A.rakumod\n"
          "expected statement: expected ')'\n"
-         "at lib/A.rakumod:50",
-         "expected statement: expected ')'"),
+         "at /tmp/sweep-x9/dist/lib/A.rakumod:50\n"
+         "------>    my $x = (1,2;\n"
+         "                   ^",
+         "expected statement: expected ')' [at dist/lib/A.rakumod:50]"),
         # Generic TAP-harness death lines report that a run died, not why.
         ("1..3\nok 1 - a\nRuntime error: Test failures\n"
          "No such method 'frobnicate' for invocant of type 'Str'",
          "No such method 'frobnicate' for invocant of type 'Str'"),
         ("Unknown role: CustomUnmarshaller", "Unknown role: CustomUnmarshaller"),
+        # A warning both interpreters print, followed by the real cause: the
+        # warning must not be recorded as the blocker.
+        ("Use of Nil in string context\n"
+         "  in block <unit> at t/01.t line 4\n"
+         "Runtime error: X::Syntax::Malformed: Malformed my",
+         "Runtime error: X::Syntax::Malformed: Malformed my"),
+        # ... but if a warning is all there is, it is better than nothing.
+        ("Use of Nil in string context", "Use of Nil in string context"),
     ]
     failures = 0
     for out, want in cases:


### PR DESCRIPTION
P5 of [ADR-0085](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0085-ecosystem-testsuite-parity-measurement.md) — the last phase of the zef-parity campaign ([#7785](https://github.com/tokuhirom/mutsu/issues/7785)) with nothing built. The corpus has been measured since 2026-09-11 (1625 distributions, 41.1% dist parity), which answered *what* fails; this turns those records into an answer to *why*, and into tickets.

Documentation and tooling only — no interpreter change, so CI classifies it docs-only and skips the build jobs (`scripts/*.py` and `docs/`/`news/`/`ecosystem/` are on the `ci-docs-only.sh` allowlist; `--check-inputs` and `--self-test` both pass).

## `scripts/ecosystem-tickets.py`

Reads `ecosystem/dists/**.json` back, normalises every actionable failure site — a `blocked_load` module error, and the `first_failure` of every `regression`/`partial` test file — into a root-cause signature, and clusters them. 985 clusters over the current corpus; fifteen affect ten or more distributions.

```sh
scripts/ecosystem-tickets.py                      # the table, biggest first
scripts/ecosystem-tickets.py --min-dists 1 --all  # the whole tail
scripts/ecosystem-tickets.py --issue b98eb9ef     # a ready-to-file issue body
scripts/ecosystem-tickets.py --self-test
```

Four decisions, each of which was a way to get the ranking wrong:

- **Impact is counted in distributions, never in failure sites.** `Invalid typename 'IndRef'` appears 100 times in the ledger and is one bug affecting six distributions; ranking by sites puts `Gnome::Gtk3`'s 55 modules on top of every list.
- **A cluster key keeps the payload that identifies the fix** (`nqp::<op>`, method name + invocant type) **and drops what is volatile** (quoted strings, numbers, the temp path a parse failure mentions). Where members share one cause by construction, the cluster is the *family* and the payloads are listed inside it as "what varies" — in distributions too.
- **A message with no shared cause is keyed per distribution.** `not ok 7 -` is what the ledger records for an *unnamed* failing assertion, identical for two dozen unrelated wrong answers; merging them would have produced the largest cluster in the report and no fix could have closed it.
- **The output is filed as issues, not committed as a queue file.** A generated queue over 1600 records would conflict on every sweep, and an issue number survives being closed where a path in a generated file does not. Each body carries a stable `eco-cluster: <id>`, so "already filed?" is a tracker search rather than state in the repo.

## The first batch — 15 issues, ~330 distribution slots

[#7988](https://github.com/tokuhirom/mutsu/issues/7988) (99 parse gaps) · [#7989](https://github.com/tokuhirom/mutsu/issues/7989) (61) · [#7991](https://github.com/tokuhirom/mutsu/issues/7991) (44) · [#7993](https://github.com/tokuhirom/mutsu/issues/7993) (21) · [#7995](https://github.com/tokuhirom/mutsu/issues/7995) (20, `todo:perf`) · [#7996](https://github.com/tokuhirom/mutsu/issues/7996) (20) · [#7994](https://github.com/tokuhirom/mutsu/issues/7994) (17) · [#8000](https://github.com/tokuhirom/mutsu/issues/8000) (17) · [#7999](https://github.com/tokuhirom/mutsu/issues/7999) (16) · [#7997](https://github.com/tokuhirom/mutsu/issues/7997) (13) · [#8001](https://github.com/tokuhirom/mutsu/issues/8001) (13) · [#8002](https://github.com/tokuhirom/mutsu/issues/8002) (11) · [#8003](https://github.com/tokuhirom/mutsu/issues/8003) (9) · [#8004](https://github.com/tokuhirom/mutsu/issues/8004) (9) · [#7992](https://github.com/tokuhirom/mutsu/issues/7992) (2)

## A cluster is a hypothesis — verify it before filing

What made those bodies worth reading was not the clustering; it was half an hour with the `raku` oracle afterwards, which corrected four of the five largest clusters and deleted one:

| the cluster said | what it was |
|---|---|
| `unknown trait 'is' -> 'json-skip-null'`, 61 dists | **not the trait.** mutsu handles user attribute traits across module boundaries, in `unit module` and braced-`module` form, with named arguments. `JSON::Class` **re-exports** what it imported (`OUR::{'&trait_mod:<is>'} := &trait_mod:<is>`) and that binding is invisible to importers — minimised to three files (#7989) |
| `No such method 'AST' for invocant of type 'Str'`, 13 | `'say 1'.AST` works today; the L10N tests call `.AST("AF")`, the localised-slang form (#8001) |
| `Variable $.x used where no 'self' is available`, 35 | two unrelated gaps: NativeCall's `HAS` declarator (#7991) and `has Int ($.x, $.y)`, plain Raku (#7992) |
| `has overflowed its stack`, 17 | not deep recursion — *infinite* recursion: an imported `my proto sub f(|) is export {*}` does not shadow an enclosing `my sub f`, so `Net::netent`'s wrapper calls itself (#7994) |
| `Use of Nil in string context`, 10 | **nothing.** Both interpreters print it as a warning and carry on — the harness was recording a warning as a blocker |

## Two harness fixes that fell out

Both in `first_error_line()`, both changing what *future* sweeps record (existing records keep the old text until re-measured):

- **A warning is no longer a cause** — used only when the run produced nothing else. Backtrace frames (`in block <unit> at t/01.t line 4`) are skipped for the same reason: they say where, not what.
- **A parse failure keeps its location.** mutsu prints `at <path>:<line>` plus a caret line and both were dropped, which is why 99 distributions record only that the parser was unhappy somewhere. Appended as `... [at dist/lib/A.rakumod:50]`; consumers strip it before clustering. The caret line stays dropped — its source text would fragment a cluster into one per offending line.

`load_records()` moves from `ecosystem-sweep.py` into `ecosystem_common.py` so the rollup that publishes the KPI and the tool that reads it cannot disagree about what the corpus is. `--rollup` over the current ledger produces a byte-identical `summary.json`/`summary.md`.

## Also

Corrects a stale claim in `docs/ecosystem-parity.md` §7 that there is deliberately no scheduled CI sweep — the workflow has carried a nightly `schedule:` since ADR-0085 D9's second amendment, which §8.1 of the same file documents.

## Verification

- `scripts/ecosystem_common.py --self-test`, `scripts/ecosystem-tickets.py --self-test` (15 checks), `scripts/ci-docs-only.sh --self-test` / `--check-inputs` — all pass.
- `ecosystem-sweep.py --rollup` after the refactor leaves the ledger unchanged (`git status` clean).
- `ecosystem-sweep.py --only L10N::AF` re-measured one record end to end on this box (bwrap + rakudo 2026.07) to confirm the cluster was not stale; the record was reverted afterwards so the ledger stays CI-measured.
- Every claim in the issue bodies was run on both interpreters; the negative results are recorded in the bodies so the next person does not repeat them.

Refs #7785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Y5PciZAhEyPDLv7JMx7AK

---
_Generated by [Claude Code](https://claude.ai/code/session_013Y5PciZAhEyPDLv7JMx7AK)_