### PR TITLE
fix: resolve role pseudo-types in method parameters

### DIFF
--- a/news/2026-09/role-pseudo-type-parameters.md
+++ b/news/2026-09/role-pseudo-type-parameters.md
@@ -1,0 +1,8 @@
+# Role pseudo-types resolve in method parameters
+
+`::?CLASS` and `::?ROLE` used as method parameter types inside a role now
+resolve when the role is composed into a class. Both named parameters and
+anonymous type-only parameters accept the appropriate consuming value and
+reject unrelated values, matching Rakudo.
+
+Fixes [#7985](https://github.com/tokuhirom/mutsu/issues/7985).

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -396,6 +396,68 @@ pub(super) fn substitute_type_params_in_method(
     }
 }
 
+/// Resolve role pseudo-types after a role method is copied into a concrete
+/// class. `::?CLASS` names the class receiving the role, while `::?ROLE` names
+/// the role that originally declared the method. Keep the transformation on
+/// the copied `MethodDef`: the role's own definition must retain the pseudo
+/// types until a consuming class (or a role pun) provides their meaning.
+pub(super) fn resolve_role_pseudo_types_in_method(
+    method: &mut MethodDef,
+    class_name: &str,
+    role_name: &str,
+) {
+    fn resolve_type_name(type_name: &str, class_name: &str, role_name: &str) -> String {
+        type_name
+            .replace("::?CLASS", class_name)
+            .replace("::?ROLE", role_name)
+    }
+
+    fn resolve_param_def(pd: &ParamDef, class_name: &str, role_name: &str) -> ParamDef {
+        let mut resolved = pd.clone();
+        if let Some(type_constraint) = &resolved.type_constraint {
+            resolved.type_constraint =
+                Some(resolve_type_name(type_constraint, class_name, role_name));
+        }
+        if let Some(sub_signature) = &resolved.sub_signature {
+            resolved.sub_signature = Some(
+                sub_signature
+                    .iter()
+                    .map(|p| resolve_param_def(p, class_name, role_name))
+                    .collect(),
+            );
+        }
+        if let Some(outer_sub_signature) = &resolved.outer_sub_signature {
+            resolved.outer_sub_signature = Some(
+                outer_sub_signature
+                    .iter()
+                    .map(|p| resolve_param_def(p, class_name, role_name))
+                    .collect(),
+            );
+        }
+        if let Some((signature_params, signature_return)) = &resolved.code_signature {
+            let resolved_params = signature_params
+                .iter()
+                .map(|p| resolve_param_def(p, class_name, role_name))
+                .collect();
+            let resolved_return = signature_return
+                .as_ref()
+                .map(|r| resolve_type_name(r, class_name, role_name));
+            resolved.code_signature = Some((resolved_params, resolved_return));
+        }
+        resolved
+    }
+
+    method.param_defs = method
+        .param_defs
+        .iter()
+        .map(|pd| resolve_param_def(pd, class_name, role_name))
+        .collect();
+    method.return_type = method
+        .return_type
+        .as_ref()
+        .map(|rt| resolve_type_name(rt, class_name, role_name));
+}
+
 /// Context threaded through the `$!attr` declaration validators so that an
 /// undeclared private attribute can be reported as a fully-populated
 /// `X::Attribute::Undeclared` (with `package-name`/`package-kind`).

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1,4 +1,6 @@
-use super::registration_class::{AttrValidationCtx, ResolvedHandle, make_delegation_method};
+use super::registration_class::{
+    AttrValidationCtx, ResolvedHandle, make_delegation_method, resolve_role_pseudo_types_in_method,
+};
 use super::registration_class_body_method_forms::method_sub_form_params;
 use super::*;
 use crate::ast::HandleSpec;
@@ -734,6 +736,16 @@ impl Interpreter {
                 if !has_local {
                     let method_sym = Symbol::intern(&mname);
                     for mut d in mdefs {
+                        if d.original_role.is_none() {
+                            d.original_role = d.role_origin.clone();
+                        }
+                        let source_role = d
+                            .original_role
+                            .as_deref()
+                            .or(d.role_origin.as_deref())
+                            .unwrap_or(base_role)
+                            .to_string();
+                        resolve_role_pseudo_types_in_method(&mut d, name, &source_role);
                         if d.role_origin.is_none() {
                             d.role_origin = Some(base_role.to_string());
                         }
@@ -1106,6 +1118,13 @@ impl Interpreter {
                     if md.original_role.is_none() {
                         md.original_role = md.role_origin.clone();
                     }
+                    let source_role = md
+                        .original_role
+                        .as_deref()
+                        .or(md.role_origin.as_deref())
+                        .unwrap_or(owner)
+                        .to_string();
+                    resolve_role_pseudo_types_in_method(&mut md, role_name, &source_role);
                     md.role_origin = Some(owner.to_string());
                     md
                 })

--- a/src/runtime/registration_class_compose.rs
+++ b/src/runtime/registration_class_compose.rs
@@ -4,8 +4,8 @@
 //! `registration_class_decl.rs` — no behavior change.
 
 use super::registration_class::{
-    ResolvedRoleCandidate, parse_role_type_args, should_treat_role_arg_as_type_expr,
-    substitute_type_params_in_method, type_value_name,
+    ResolvedRoleCandidate, parse_role_type_args, resolve_role_pseudo_types_in_method,
+    should_treat_role_arg_as_type_expr, substitute_type_params_in_method, type_value_name,
 };
 use super::registration_class_decl::BUILTIN_PARENT_TYPES;
 use super::*;
@@ -359,6 +359,13 @@ impl Interpreter {
                         if method.original_role.is_none() {
                             method.original_role = method.role_origin.clone();
                         }
+                        let source_role = method
+                            .original_role
+                            .as_deref()
+                            .or(method.role_origin.as_deref())
+                            .unwrap_or(base_role_name)
+                            .to_string();
+                        resolve_role_pseudo_types_in_method(&mut method, cx.name, &source_role);
                         method.role_origin = Some(base_role_name.to_string());
                         method.role_param_bindings = candidate_role_bindings.clone();
                         method
@@ -372,6 +379,13 @@ impl Interpreter {
                         if method.original_role.is_none() {
                             method.original_role = method.role_origin.clone();
                         }
+                        let source_role = method
+                            .original_role
+                            .as_deref()
+                            .or(method.role_origin.as_deref())
+                            .unwrap_or(base_role_name)
+                            .to_string();
+                        resolve_role_pseudo_types_in_method(&mut method, cx.name, &source_role);
                         method.role_origin = Some(base_role_name.to_string());
                         method.role_param_bindings = candidate_role_bindings.clone();
                         method

--- a/src/runtime/registration_class_compose_body.rs
+++ b/src/runtime/registration_class_compose_body.rs
@@ -4,7 +4,8 @@
 //! extraction from `registration_class_decl.rs` — no behavior change.
 
 use super::registration_class::{
-    parse_role_type_args, substitute_type_params_in_method, type_value_name,
+    parse_role_type_args, resolve_role_pseudo_types_in_method, substitute_type_params_in_method,
+    type_value_name,
 };
 use super::registration_class_compose::RoleCompositionCx;
 use super::*;
@@ -410,6 +411,17 @@ impl Interpreter {
                                     if method.original_role.is_none() {
                                         method.original_role = method.role_origin.clone();
                                     }
+                                    let source_role = method
+                                        .original_role
+                                        .as_deref()
+                                        .or(method.role_origin.as_deref())
+                                        .unwrap_or(parent_base)
+                                        .to_string();
+                                    resolve_role_pseudo_types_in_method(
+                                        &mut method,
+                                        cx.name,
+                                        &source_role,
+                                    );
                                     method.role_origin = Some(parent_base.to_string());
                                     method
                                 })
@@ -423,6 +435,17 @@ impl Interpreter {
                                     if method.original_role.is_none() {
                                         method.original_role = method.role_origin.clone();
                                     }
+                                    let source_role = method
+                                        .original_role
+                                        .as_deref()
+                                        .or(method.role_origin.as_deref())
+                                        .unwrap_or(parent_base)
+                                        .to_string();
+                                    resolve_role_pseudo_types_in_method(
+                                        &mut method,
+                                        cx.name,
+                                        &source_role,
+                                    );
                                     method.role_origin = Some(parent_base.to_string());
                                     method
                                 })

--- a/t/oo/role/role-pseudo-type-param.t
+++ b/t/oo/role/role-pseudo-type-param.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# `::?CLASS` and `::?ROLE` are resolved when a role method is copied into its
+# consuming class. They must work for both named and anonymous parameters.
+
+plan 8;
+
+role PseudoTypes {
+    method named-role(::?ROLE $value) { 'role' }
+    method named-class(::?CLASS $value) { 'class' }
+    method anonymous-role(::?ROLE) { 'anonymous role' }
+    method anonymous-class(::?CLASS) { 'anonymous class' }
+}
+
+class Consumer does PseudoTypes { }
+class Foreign { }
+
+my $consumer = Consumer.new;
+my $foreign = Foreign.new;
+
+is $consumer.named-role($consumer), 'role',
+    'a named ::?ROLE parameter accepts the consuming class';
+is $consumer.named-class($consumer), 'class',
+    'a named ::?CLASS parameter accepts the consuming class';
+is $consumer.anonymous-role($consumer), 'anonymous role',
+    'an anonymous ::?ROLE parameter accepts the consuming class';
+is $consumer.anonymous-class($consumer), 'anonymous class',
+    'an anonymous ::?CLASS parameter accepts the consuming class';
+
+dies-ok { $consumer.named-role($foreign) },
+    'a named ::?ROLE parameter rejects a foreign class';
+dies-ok { $consumer.named-class($foreign) },
+    'a named ::?CLASS parameter rejects a foreign class';
+dies-ok { $consumer.anonymous-role($foreign) },
+    'an anonymous ::?ROLE parameter rejects a foreign class';
+dies-ok { $consumer.anonymous-class($foreign) },
+    'an anonymous ::?CLASS parameter rejects a foreign class';


### PR DESCRIPTION
## Summary

- resolve `::?CLASS` and `::?ROLE` in role method parameter constraints when methods are composed into a class
- preserve the originating role for transitive role composition, role puns, and augmented classes
- parse pseudo-types without an invocant colon as anonymous type-only parameters
- add regression coverage and a news entry for #7985

## Validation

- `make lint`
- `make test`
- `make roast`

Fixes #7985
