### PR TITLE
perf(regex): subrule resolution stops rebuilding the token-key scan per reference

### DIFF
--- a/news/2026-09/subrule-resolution-stops-rebuilding-the-token-key-scan.md
+++ b/news/2026-09/subrule-resolution-stops-rebuilding-the-token-key-scan.md
@@ -1,0 +1,87 @@
+# Subrule resolution stops rebuilding the token-key scan on every reference
+
+Round 11 of the YAML-throughput investigation ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
+Round 10 ended with "no single dominant site any more — allocator traffic ~20%,
+`memcpy` 6.7%, `LocalKey::with` 5.7%, SipHash 8.1%". A fresh
+`valgrind --tool=callgrind` profile of a 120-row YAML document said otherwise:
+one call site owned **15% of the whole program**, and it was hiding inside
+those flat allocator/TLS/hash totals rather than under its own name.
+
+Measured on a 60-row document (`benchmarks/bench-yaml-parse.raku`'s shape with
+`$ROWS = 60`, two sections), instructions retired go **8.13 Bn -> 5.89 Bn, a
+27.5% cut**. Instruction counts are deterministic and load-independent, so they
+— not wall clock on a shared container — are what the four changes below are
+attributed against; the local wall clock moved with them (1.13s -> 0.95s at 60
+rows, 2.49s -> 2.02s at 120), but per `CLAUDE.md` the number that belongs in a
+document is the `bench-data` CI series, which this entry predates.
+
+## (a) Five copies of the proto-variant scan allocated a `String` per registry key
+
+Resolving any `<subrule>` collects the rule's `:sym<…>` proto candidates by
+walking **every** key of `Registry::token_defs` and prefix-testing it. All five
+hand-rolled copies of that walk spelled the test as
+`.map(|key| key.resolve())` — and `Symbol::resolve` is `as_str().to_owned()`,
+so each one built an owned `String` for every key just to run `strip_prefix`
+against it and drop it again.
+
+On the profiled document that was 50,634 scans x ~92 keys = **4.6M
+allocations**, 4.6M `Symbol::as_str` thread-local round trips and 4.4M
+`memcmp`s: 1.11 Bn instructions, 15.2% of the run, and 43% of every allocation
+the program made. It never appeared in a self-cost profile under its own name
+because the cost sat in `malloc`/`free`/`LocalKey::with`/`memcmp`.
+
+The five copies are now one helper, `Interpreter::proto_variant_keys_sorted`,
+which filters on the interned `&'static str` that `Symbol::as_str` already
+hands out and returns the matching keys **as symbols** — so no call site
+re-interns a key it just read out of the map either. `-11.6%`.
+
+## (b) …and then re-derived the same few lists thousands of times
+
+With the allocations gone the scan was still O(all registered token keys) per
+`<subrule>` reference, for a handful of distinct prefixes: 8.5% of the run.
+It is now memoized per prefix behind the `TOKEN_DEFS_GEN` generation, the same
+invalidation discipline `PARSED_TOKEN_CANDIDATES` and `REGEX_PARSE_CACHE`
+already use. The regex `:my`-declarator path restores a whole `token_defs`
+snapshot when the match ends and did **not** bump that generation on the way
+out (only the declaration bumped it on the way in), so the restore now goes
+through `Interpreter::restore_token_defs`, which does — closing a staleness
+window that the pre-existing generation-keyed memos shared. `-8.5%`.
+
+## (c) The regex engine's hot maps paid SipHash
+
+`RegexCaptures`'s `named`/`regex_vars`/`capture_alias_map`/`hash_captures`, the
+three left-recursion bookkeeping tables (`LR_MEMO`/`LR_ACTIVE`/`LR_SEED_READ`,
+probed up to seven times per subrule activation) and the call-graph
+streamability memos were all `std::collections::HashMap`, i.e. SipHash. Their
+keys are interned `Symbol`s (a `u32`) and grammar rule names — not adversarial
+input — and the maps are rebuilt several times per matched capture:
+`sip::Hasher::write` plus `BuildHasher::hash_one` came to 7.9% of the run.
+Switching them to `rustc_hash::FxHashMap` (already a dependency, already used
+for the symbol table and the compiled-function maps) takes that to 1.7%.
+`-7.1%`.
+
+## (d) `<subrule>` atom text was re-parsed on every match attempt
+
+`parse_named_regex_lookup_spec` splits an atom's text (`<name=.rule(args)>`)
+into its silent/alias/token-lookup/argument parts. It is a pure function of
+that string, and it ran once per *match attempt* — 232k calls, 813k
+`trim_matches`, 232k allocations, ~2.6% of the run with its callees, for a
+handful of distinct strings. It is memoized now, returning a shared
+`Arc<NamedRegexLookupSpec>`. In the same vein `PARSED_TOKEN_CANDIDATES` is
+keyed by `(Symbol, Symbol)` instead of `(String, String)`, so probing it no
+longer allocates two owned strings per probe. `-3.6%` between them.
+
+## Where this leaves the ticket
+
+mutsu parses the 120-row document in ~2.0s against rakudo v2026.07's ~0.27s on
+the same container: still ~7.5x, down from ~9.2x. The remaining profile is
+genuinely flat — `malloc`/`free`/`_int_malloc` ~21%, `memcpy` 6.2%,
+`LocalKey::with` 4.6% spread across a dozen callers, and no mutsu function
+above 1.6%. The next round is the per-capture `Match`/`RegexCaptures`
+construction traffic itself (the ticket's long-standing item 4), not another
+call-site fix.
+
+`t/grammar/grammar-qualified-proto-candidate-scan.t` pins the semantics the
+rewritten scan has to keep — derived-adds-to-base, MRO dedup, the
+declaration-order LTM tie-break and the `<Pkg::rule>` qualified form — with all
+eight expectations verified against rakudo v2026.07.

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -516,7 +516,7 @@ impl Interpreter {
             start as i64,
             end as i64,
             &[],
-            &std::collections::HashMap::new(),
+            &Default::default(),
             crate::runtime::MatchTarget::new(text),
         )
     }

--- a/src/runtime/methods_format.rs
+++ b/src/runtime/methods_format.rs
@@ -172,7 +172,7 @@ impl Interpreter {
                         0,
                         len,
                         &[],
-                        &HashMap::new(),
+                        &Default::default(),
                         crate::runtime::MatchTarget::new(&fmt),
                     )));
                 }

--- a/src/runtime/regex/regex_call_graph.rs
+++ b/src/runtime/regex/regex_call_graph.rs
@@ -34,7 +34,11 @@
 //! `regex_match_lazy_subrule.rs`), exactly as the first half of Slice 2 does.
 
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet, VecDeque};
+// `STREAMABLE` is probed before every `<subrule>` call is even resolved, so
+// these memo tables are Fx-hashed rather than SipHash-hashed — a grammar rule
+// name is not adversarial input (<https://github.com/tokuhirom/mutsu/issues/7576>).
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::collections::VecDeque;
 
 use super::super::*;
 use crate::runtime::regex_types::{RegexAtom, RegexPattern};
@@ -135,7 +139,7 @@ thread_local! {
     static DIRECT_CALLS: RefCell<(
         u64,
         HashMap<RuleNode, Result<std::sync::Arc<Vec<RuleNode>>, StreamDecline>>,
-    )> = RefCell::new((0, HashMap::new()));
+    )> = RefCell::new((0, HashMap::default()));
 
     /// `pkg -> subrule atom text -> may this call be streamed?`. This is the
     /// hot lookup: it is consulted before the call is resolved (and before its
@@ -149,7 +153,7 @@ thread_local! {
     /// ([`crate::vm::vm_stats::record_subrule_stream`]) without recomputing.
     #[allow(clippy::type_complexity)]
     static STREAMABLE: RefCell<(u64, HashMap<String, HashMap<String, Option<StreamDecline>>>)> =
-        RefCell::new((0, HashMap::new()));
+        RefCell::new((0, HashMap::default()));
 }
 
 fn token_defs_gen() -> u64 {
@@ -164,7 +168,7 @@ impl Interpreter {
     /// different work to clear.
     fn reenter_decline(&mut self, name: &str, pkg: &str) -> Option<StreamDecline> {
         let start: RuleNode = (pkg.to_string(), name.to_string());
-        let mut seen: HashSet<RuleNode> = HashSet::from([start.clone()]);
+        let mut seen: HashSet<RuleNode> = HashSet::from_iter([start.clone()]);
         let mut queue: VecDeque<RuleNode> = VecDeque::from([start]);
         while let Some((cur_pkg, cur_name)) = queue.pop_front() {
             let calls = match self.direct_rule_calls(&cur_name, &cur_pkg) {
@@ -487,7 +491,7 @@ fn collect_atom_calls(atom: &RegexAtom, pkg: &str, out: &mut Vec<RuleNode>) -> b
             {
                 return false;
             }
-            out.push((pkg.to_string(), spec.lookup_name));
+            out.push((pkg.to_string(), spec.lookup_name.clone()));
             true
         }
         // `<{ ... }>` matches whatever regex the code returns; `<~~>` re-enters

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -351,7 +351,7 @@ impl Interpreter {
     /// accumulator and stored `CapNode`s (their child axes are the same types).
     fn reduce_child_axes(
         &mut self,
-        named: &mut HashMap<Symbol, NamedSlot>,
+        named: &mut crate::runtime::NamedCaptureMap,
         positional: &mut [PosSlot],
         target: Option<&MatchTarget>,
     ) {
@@ -427,7 +427,7 @@ impl Interpreter {
     fn install_fresh_rule_dynvars(
         &mut self,
         rule_name: Option<&str>,
-        recorded: &HashMap<String, Value>,
+        recorded: &crate::runtime::RegexVarMap,
     ) -> Vec<String> {
         if self.grammar_rule_dynvar_decls.is_empty() {
             return Vec::new();

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -1,6 +1,6 @@
 use super::super::*;
+use rustc_hash::FxHashMap as HashMap;
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
 use unicode_normalization::UnicodeNormalization;
 use unicode_normalization::char::is_combining_mark;
 use unicode_segmentation::UnicodeSegmentation;
@@ -235,7 +235,7 @@ impl Drop for InlineVarsSeed {
 /// [`INLINE_REGEX_VARS_SEED`]).
 pub(crate) fn take_inline_regex_vars_seed() -> HashMap<String, Value> {
     if !INLINE_REGEX_VARS_ACTIVE.with(Cell::get) {
-        return HashMap::new();
+        return HashMap::default();
     }
     INLINE_REGEX_VARS_SEED
         .with(|s| s.borrow().clone())
@@ -418,7 +418,7 @@ pub(crate) fn dynvar_overlay_reset_scan() {
     REGEX_DYNVAR_OVERLAY.with(|slot| {
         let mut b = slot.borrow_mut();
         if b.is_some() {
-            *b = Some(HashMap::new());
+            *b = Some(HashMap::default());
         }
     });
     REGEX_GRAMMAR_DYNVAR_SEEN.with(|c| c.set(false));
@@ -451,7 +451,7 @@ pub(crate) struct RegexDynvarOverlayGuard {
 impl RegexDynvarOverlayGuard {
     pub(crate) fn activate() -> Self {
         let prev_overlay =
-            REGEX_DYNVAR_OVERLAY.with(|slot| slot.borrow_mut().replace(HashMap::new()));
+            REGEX_DYNVAR_OVERLAY.with(|slot| slot.borrow_mut().replace(HashMap::default()));
         let prev_seen = REGEX_GRAMMAR_DYNVAR_SEEN.with(|c| c.replace(false));
         RegexDynvarOverlayGuard {
             prev_overlay,
@@ -1159,9 +1159,9 @@ pub(super) fn pos_slot_texts(slots: &[PosSlot], chars: &[char]) -> Vec<String> {
 /// [`pos_slot_texts`] for the named axis: the per-name text lists. Silent-action
 /// marker keys never had text entries pre-P4 and are skipped.
 pub(super) fn named_slot_texts(
-    named: &HashMap<crate::symbol::Symbol, NamedSlot>,
+    named: &crate::runtime::NamedCaptureMap,
     chars: &[char],
-) -> HashMap<String, Vec<String>> {
+) -> std::collections::HashMap<String, Vec<String>> {
     named
         .iter()
         .filter(|(k, _)| !k.starts_with(SILENT_ACTION_MARKER_PREFIX))

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -1,5 +1,10 @@
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+// The left-recursion bookkeeping tables below are probed several times per
+// `<subrule>` call at every position, so they are Fx-hashed rather than
+// SipHash-hashed — a grammar rule name is not adversarial input, and the
+// hashing showed up as a measurable share of a YAML-parse profile
+// (<https://github.com/tokuhirom/mutsu/issues/7576>).
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::super::*;
 use super::regex_helpers::{
@@ -17,19 +22,19 @@ thread_local! {
     /// regex_match_ends_from_caps_in_pkg). Empty vec means "no match yet" (initial seed).
     #[allow(clippy::type_complexity)]
     static LR_MEMO: RefCell<HashMap<(String, usize), Vec<(usize, RegexCaptures)>>>
-        = RefCell::new(HashMap::new());
+        = RefCell::new(HashMap::default());
 
     /// Set of (rule_name, remaining_chars_count) pairs currently being evaluated.
     /// When a recursive call sees its key here, it returns the current seed.
     static LR_ACTIVE: RefCell<HashMap<(String, usize), ()>>
-        = RefCell::new(HashMap::new());
+        = RefCell::new(HashMap::default());
 
     /// Keys whose seed was actually CONSULTED (read by a recursive re-entry)
     /// while they were active — i.e. the keys that are genuinely
     /// left-recursive at this position. Only those need the seed-growing
     /// loop's second iteration; see the `seed_was_consulted` check below.
     static LR_SEED_READ: RefCell<HashSet<(String, usize)>>
-        = RefCell::new(HashSet::new());
+        = RefCell::new(HashSet::default());
 }
 
 /// ADR-0022 §4.4(a): one `|` branch's rank key (prefix_len, litlen) paired

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -670,7 +670,7 @@ impl Interpreter {
                 if spec.token_lookup || !spec.arg_exprs.is_empty() {
                     return None;
                 }
-                let literal = spec.lookup_name;
+                let literal = spec.lookup_name.clone();
                 let name_chars: Vec<char> = literal.chars().collect();
                 if pos + name_chars.len() > chars.len() {
                     false

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -38,7 +38,7 @@ impl Interpreter {
         let vars = if inline {
             super::regex_helpers::InlineVarsSeed::arm(&current_caps.regex_vars)
         } else {
-            super::regex_helpers::InlineVarsSeed::arm(&HashMap::new())
+            super::regex_helpers::InlineVarsSeed::arm(&Default::default())
         };
         (vars, Self::arm_outer_caps_seed(atom, current_caps))
     }
@@ -351,7 +351,7 @@ impl Interpreter {
                 negated,
                 is_behind,
             } => {
-                let mut inner_vars: HashMap<String, Value> = HashMap::new();
+                let mut inner_vars = crate::runtime::RegexVarMap::default();
                 let matched = if *is_behind {
                     let mut found = false;
                     for start in 0..=pos {
@@ -1038,14 +1038,14 @@ impl Interpreter {
                 if spec.token_lookup {
                     return None;
                 }
-                let literal = spec.lookup_name;
+                let literal = spec.lookup_name.clone();
                 let name_chars: Vec<char> = literal.chars().collect();
                 if pos + name_chars.len() > chars.len() {
                     return None;
                 }
                 if chars[pos..pos + name_chars.len()] == name_chars[..] {
                     let mut new_caps = RegexCaptures::default();
-                    let capture_name = spec.capture_name.unwrap_or(literal);
+                    let capture_name = spec.capture_name.clone().unwrap_or(literal);
                     new_caps
                         .named
                         .entry(Symbol::intern(&capture_name))

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -454,7 +454,7 @@ impl Interpreter {
         if let RegexAtom::Named(atom_name) = &token.atom {
             let spec = Self::parse_named_regex_lookup_spec(atom_name);
             if spec.silent && !spec.lookup_name.is_empty() {
-                std::sync::Arc::make_mut(&mut sub).action_name = Some(spec.lookup_name);
+                std::sync::Arc::make_mut(&mut sub).action_name = Some(spec.lookup_name.clone());
             }
         }
         // A sigil-prefixed alias (`$<alias> = <rule>`) shares the subrule's
@@ -479,7 +479,7 @@ impl Interpreter {
                 && std::sync::Arc::ptr_eq(original, &sub)
             {
                 let node = std::sync::Arc::make_mut(original);
-                node.action_name = Some(spec.lookup_name);
+                node.action_name = Some(spec.lookup_name.clone());
                 sub = std::sync::Arc::clone(original);
             }
         }

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -498,14 +498,14 @@ impl Interpreter {
             if !handled_state_postfix && !handled_direct_assign {
                 let eval_src = stmt_src.clone();
                 let Some(stmts) = self.parse_regex_code_cached(&eval_src) else {
-                    self.registry_mut().token_defs = saved_token_defs;
+                    self.restore_token_defs(saved_token_defs.clone());
                     self.writeback_persist_always(&persist_always);
                     self.restore_env_entries(restore_always);
                     self.restore_env_entries(restore_on_fail);
                     return None;
                 };
                 if self.eval_block_value(&stmts).is_err() {
-                    self.registry_mut().token_defs = saved_token_defs;
+                    self.restore_token_defs(saved_token_defs.clone());
                     self.writeback_persist_always(&persist_always);
                     self.restore_env_entries(restore_always);
                     self.restore_env_entries(restore_on_fail);
@@ -545,7 +545,7 @@ impl Interpreter {
 
         let mut result = self.regex_match_with_captures_core(&remaining_pattern, text);
         let matched = result.is_some();
-        self.registry_mut().token_defs = saved_token_defs;
+        self.restore_token_defs(saved_token_defs);
         // A declarative `:my`/`:let` lexical is hoisted out of the pattern and
         // evaluated into `env` above, so an inline `{ … }` block reads it straight
         // from there. A `make`-bearing block does not run inline — it is replayed

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -3,6 +3,14 @@ use super::regex_helpers::{NamedRegexLookupSpec, PENDING_REGEX_GOAL_FAILURE};
 use crate::symbol::Symbol;
 use crate::value::ValueView;
 
+thread_local! {
+    /// Atom text -> its parsed [`NamedRegexLookupSpec`]. See
+    /// [`Interpreter::parse_named_regex_lookup_spec`].
+    static NAMED_LOOKUP_SPEC_CACHE: std::cell::RefCell<
+        rustc_hash::FxHashMap<String, std::sync::Arc<NamedRegexLookupSpec>>,
+    > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
+}
+
 impl Interpreter {
     pub(in crate::runtime) fn clear_pending_goal_failure() {
         PENDING_REGEX_GOAL_FAILURE.with(|slot| {
@@ -292,21 +300,9 @@ impl Interpreter {
                 }
             }
         }
-        let variant_prefix = format!("{scope}::{name}");
-        let mut sym_keys: Vec<String> = self
-            .registry()
-            .token_defs
-            .keys()
-            .map(|key| key.resolve())
-            .filter(|key| {
-                key.strip_prefix(&variant_prefix)
-                    .is_some_and(crate::runtime::resolution::is_proto_variant_suffix)
-            })
-            .collect();
-        self.sort_sym_keys_by_decl_order(&mut sym_keys);
-        for key in &sym_keys {
-            let sym_val = Self::extract_variant_ident(key);
-            if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
+        for &key in self.proto_variant_keys_sorted(&exact_key).iter() {
+            let sym_val = Self::extract_variant_ident(key.as_str());
+            if let Some(defs) = self.registry().token_defs.get(&key) {
                 for def in defs {
                     if let Some(p) = Self::token_pattern_from_def(def) {
                         out.push((p, def.package.resolve(), sym_val.clone()));
@@ -533,7 +529,34 @@ impl Interpreter {
         (trimmed.to_string(), Vec::new())
     }
 
-    pub(super) fn parse_named_regex_lookup_spec(name: &str) -> NamedRegexLookupSpec {
+    /// The parsed shape of a `<…>` subrule atom's text, memoized.
+    ///
+    /// [`Self::parse_named_regex_lookup_spec_uncached`] is a pure function of
+    /// the atom text, but it is called once per *match attempt* of the atom —
+    /// so on a grammar parse it re-splits, re-trims and re-allocates the same
+    /// `lookup_name`/`capture_name`/`arg_exprs` thousands of times for a
+    /// handful of distinct strings. A callgrind profile of a YAML parse put it
+    /// (with its callees) at ~2.6% of the whole program, 232k allocations
+    /// ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
+    ///
+    /// The answer depends on nothing but the string, so — unlike
+    /// [`crate::runtime::regex_parse::REGEX_PARSE_CACHE`] — this memo needs no
+    /// generation key: a rule (re)definition cannot change how its *reference*
+    /// spells itself.
+    pub(super) fn parse_named_regex_lookup_spec(
+        name: &str,
+    ) -> std::sync::Arc<NamedRegexLookupSpec> {
+        if let Some(hit) = NAMED_LOOKUP_SPEC_CACHE.with(|c| c.borrow().get(name).cloned()) {
+            return hit;
+        }
+        let spec = std::sync::Arc::new(Self::parse_named_regex_lookup_spec_uncached(name));
+        NAMED_LOOKUP_SPEC_CACHE.with(|c| {
+            c.borrow_mut().insert(name.to_owned(), spec.clone());
+        });
+        spec
+    }
+
+    fn parse_named_regex_lookup_spec_uncached(name: &str) -> NamedRegexLookupSpec {
         let mut raw = name.trim();
         let mut silent = false;
         if let Some(stripped) = raw.strip_prefix('.') {

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -229,7 +229,7 @@ impl Interpreter {
             pos as i64,
             pos as i64,
             &[],
-            &HashMap::new(),
+            &Default::default(),
             MatchTarget::from_chars(chars),
         );
         let mut call_args = vec![cursor];

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -18,8 +18,12 @@ thread_local! {
     /// JSON-grammar parse profile). Entries record the `TOKEN_DEFS_GEN` they
     /// were built under; a stale generation rebuilds (same invalidation
     /// discipline as `REGEX_PARSE_CACHE` and the charclass cache).
+    /// Keyed by interned symbols rather than `(String, String)`: this map is
+    /// probed once per `<subrule>` reference, and building an owned two-`String`
+    /// key just to look it up cost two allocations per probe — visible in a
+    /// YAML-parse profile ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
     static PARSED_TOKEN_CANDIDATES: std::cell::RefCell<
-        rustc_hash::FxHashMap<(String, String), CachedCandidates>,
+        rustc_hash::FxHashMap<(Symbol, Symbol), CachedCandidates>,
     > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
 
     /// Memoized WITH-ARGS subrule resolution: (pkg, name, rendered-args) →
@@ -98,9 +102,10 @@ impl Interpreter {
     ) -> Option<std::sync::Arc<Vec<ParsedTokenCandidate>>> {
         let tok_gen =
             crate::runtime::regex_parse::TOKEN_DEFS_GEN.load(std::sync::atomic::Ordering::Relaxed);
+        let cache_key = (Symbol::intern(pkg), Symbol::intern(name));
         if let Some(hit) = PARSED_TOKEN_CANDIDATES.with(|c| {
             c.borrow()
-                .get(&(pkg.to_string(), name.to_string()))
+                .get(&cache_key)
                 .filter(|(cached_gen, _)| *cached_gen == tok_gen)
                 .map(|(_, v)| std::sync::Arc::clone(v))
         }) {
@@ -117,10 +122,8 @@ impl Interpreter {
         }
         let arc = std::sync::Arc::new(parsed_list);
         PARSED_TOKEN_CANDIDATES.with(|c| {
-            c.borrow_mut().insert(
-                (pkg.to_string(), name.to_string()),
-                (tok_gen, std::sync::Arc::clone(&arc)),
-            );
+            c.borrow_mut()
+                .insert(cache_key, (tok_gen, std::sync::Arc::clone(&arc)));
         });
         Some(arc)
     }
@@ -263,19 +266,8 @@ impl Interpreter {
         if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(name)) {
             out.extend(defs.clone());
         }
-        let mut sym_keys: Vec<String> = self
-            .registry()
-            .token_defs
-            .keys()
-            .map(|key| key.resolve())
-            .filter(|key| {
-                key.strip_prefix(name)
-                    .is_some_and(crate::runtime::resolution::is_proto_variant_suffix)
-            })
-            .collect();
-        self.sort_sym_keys_by_decl_order(&mut sym_keys);
-        for key in &sym_keys {
-            if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
+        for &key in self.proto_variant_keys_sorted(name).iter() {
+            if let Some(defs) = self.registry().token_defs.get(&key) {
                 out.extend(defs.clone());
             }
         }

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -11,8 +11,24 @@
 
 use crate::symbol::Symbol;
 use crate::value::Value;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 use std::sync::Arc;
+
+/// The named-capture map shape shared by [`RegexCaptures`], [`CapChildren`]
+/// and every helper that walks one.
+///
+/// Fx-hashed, not SipHash-hashed, on purpose: the key is an interned
+/// [`Symbol`] (a `u32`), these maps are probed and rebuilt several times per
+/// matched capture, and a regex capture name is never adversarial input in the
+/// sense SipHash's DoS resistance exists for. A callgrind profile of a YAML
+/// parse put `sip::Hasher::write` + `BuildHasher::hash_one` at ~8% of the whole
+/// program, with the regex-capture maps among the dominant callers
+/// ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
+pub(crate) type NamedCaptureMap = HashMap<Symbol, NamedSlot>;
+
+/// The `:my $var = …` regex-variable map shape, Fx-hashed for the same
+/// reason as [`NamedCaptureMap`].
+pub(crate) type RegexVarMap = HashMap<String, Value>;
 
 #[derive(Clone)]
 pub(crate) struct RegexPattern {
@@ -120,7 +136,7 @@ impl NamedSlot {
 /// regex) deliberately gets `None` instead of a link, so its own backreferences
 /// stay scoped to itself.
 pub(crate) struct OuterBackrefCaps {
-    pub(crate) named: HashMap<Symbol, NamedSlot>,
+    pub(crate) named: NamedCaptureMap,
     pub(crate) positional: Vec<PosSlot>,
     pub(crate) parent: Option<Arc<OuterBackrefCaps>>,
 }
@@ -201,7 +217,7 @@ pub(crate) struct CapChildren {
     /// from `.hash`.
     /// Capture names stay interned throughout matching and backtracking; only
     /// Match `.hash` materialization resolves them back to user-facing strings.
-    pub(crate) named: HashMap<Symbol, NamedSlot>,
+    pub(crate) named: NamedCaptureMap,
     pub(crate) capture_alias_map: HashMap<String, String>,
     /// Positional captures as span-bearing slots (ADR-0016 P4). Unlike the
     /// pre-P4 parallel vectors, the span survives onto the stored node — the
@@ -289,7 +305,7 @@ impl RegexCaptures {
 pub(crate) struct RegexCaptures {
     /// Named captures as span-bearing slots (ADR-0016 P4). Keyed by capture
     /// name; silent-action captures use interned `SILENT_ACTION_MARKER_PREFIX` keys.
-    pub(crate) named: HashMap<Symbol, NamedSlot>,
+    pub(crate) named: NamedCaptureMap,
     /// Positional captures as span-bearing slots (ADR-0016 P4): span, nested
     /// subcaptures, quantified iteration lists, and the Nil marker in one axis.
     pub(crate) positional: Vec<PosSlot>,

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -67,6 +67,11 @@ pub(crate) struct MethodEntry {
     pub(crate) proto: Option<FunctionDef>,
 }
 
+/// The grammar token/rule table's shape: name -> its registered overloads.
+/// Named so the snapshot/restore paths (`Interpreter::restore_token_defs`) can
+/// spell it without re-writing the type.
+pub(crate) type TokenDefsMap = HashMap<Symbol, Vec<std::sync::Arc<FunctionDef>>>;
+
 /// Program declaration registry. See module docs.
 ///
 /// Fields are migrated here group-by-group (PLAN.md PR-A). Fields are
@@ -426,7 +431,7 @@ pub(crate) struct Registry {
     /// held behind `Arc` so the whole-map snapshot/restore clones (and the
     /// per-resolution candidate merges) are O(n) refcount bumps rather than
     /// deep clones of the token bodies.
-    pub(crate) token_defs: HashMap<Symbol, Vec<std::sync::Arc<FunctionDef>>>,
+    pub(crate) token_defs: TokenDefsMap,
     /// `proto sub` declaration markers (existence set). Private: every
     /// mutation must go through the `proto_subs_*` accessors below so the
     /// `proto_gen` invalidation counter for `Interpreter::has_proto_cached`

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -16,6 +16,23 @@ use crate::symbol::Symbol;
 /// registered by the same top-to-bottom pass over its unit.
 static NEXT_DECL_ORDER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
+thread_local! {
+    /// Memo for [`Interpreter::proto_variant_keys_sorted`]: prefix -> the
+    /// `TOKEN_DEFS_GEN` the answer was computed under, and the answer.
+    ///
+    /// The scan it memoizes is O(all registered token keys) and runs once per
+    /// `<subrule>` resolution, for a handful of distinct prefixes — 8.5% of a
+    /// YAML-parse profile went into re-deriving the same few lists
+    /// ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)). Entries carry
+    /// the generation they were built under, the same invalidation discipline
+    /// as `PARSED_TOKEN_CANDIDATES` and `REGEX_PARSE_CACHE` — anything that
+    /// (re)defines, restores or wholesale-replaces `token_defs` bumps it.
+    #[allow(clippy::type_complexity)]
+    static PROTO_VARIANT_KEYS: std::cell::RefCell<
+        rustc_hash::FxHashMap<String, (u64, std::sync::Arc<Vec<Symbol>>)>,
+    > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
+}
+
 /// Take the next declaration-order stamp. Called from every `FunctionDef`
 /// construction site in the registration paths.
 pub(crate) fn next_decl_order() -> u64 {
@@ -202,31 +219,80 @@ impl Interpreter {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
-    /// Collect token defs for a given scope (exact + :sym<> variants).
-    /// Candidate identity of a token def: the def's own name when it is a
-    /// proto candidate of `token_name` (`statement:sym<expr>`), else the bare
-    /// `token_name`.
-    /// Declaration order of a token key's candidates (the earliest-declared
-    /// one), for sorting proto sym-variant candidates by Rakudo's LTM
-    /// declaration-order tie-break. Unknown keys sort last (`u64::MAX`), then
-    /// alphabetically as a stable fallback.
-    pub(crate) fn token_key_decl_order(&self, key: &str) -> u64 {
+    /// Put `token_defs` back to a snapshot taken before a `:my token …` inside
+    /// a regex could add to it, invalidating every generation-keyed memo built
+    /// while the extra definition was visible (`PROTO_VARIANT_KEYS`,
+    /// `PARSED_TOKEN_CANDIDATES`, `REGEX_PARSE_CACHE`, the call-graph tables).
+    /// The declaration itself bumped the generation on the way in; the removal
+    /// has to bump it on the way out for the same reason.
+    pub(crate) fn restore_token_defs(&mut self, saved: crate::runtime::registry::TokenDefsMap) {
+        self.registry_mut().token_defs = saved;
+        crate::runtime::regex_parse::TOKEN_DEFS_GEN
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// The lowest declaration order among the candidates registered under one
+    /// `token_defs` key — Rakudo's LTM tie-break. Takes the key as a `Symbol`
+    /// because that is how `token_defs` is keyed, so a scan never re-interns a
+    /// key it just read out of the map.
+    pub(crate) fn token_key_decl_order_sym(&self, key: Symbol) -> u64 {
         self.registry()
             .token_defs
-            .get(&Symbol::intern(key))
+            .get(&key)
             .and_then(|defs| defs.iter().map(|d| d.decl_order).min())
             .unwrap_or(u64::MAX)
     }
 
-    /// Sort resolved `:sym<>` variant keys by declaration order (Rakudo's LTM
-    /// tie-break), falling back to alphabetical order for keys that share a
-    /// declaration order or are unregistered — keeping the result deterministic.
-    pub(crate) fn sort_sym_keys_by_decl_order(&self, sym_keys: &mut [String]) {
-        sym_keys.sort_by(|a, b| {
-            self.token_key_decl_order(a)
-                .cmp(&self.token_key_decl_order(b))
-                .then_with(|| a.cmp(b))
+    /// Every `token_defs` key that spells a `:sym<…>` proto variant of
+    /// `prefix`, sorted by declaration order (Rakudo's LTM tie-break) and
+    /// falling back to alphabetical order for keys that share a declaration
+    /// order or are unregistered, so the result stays deterministic.
+    ///
+    /// This walks the whole `token_defs` key set, and it is walked once per
+    /// `<subrule>` resolution, so it must not allocate per key: a callgrind
+    /// profile of a YAML parse had the five hand-rolled copies of this scan
+    /// materializing a `String` for every key (`Symbol::resolve`) just to test
+    /// a prefix and throw it away — 4.6M allocations, ~15% of the whole
+    /// program ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
+    /// `Symbol::as_str` hands out the interned `&'static str` instead, and the
+    /// key symbols come back as symbols so no call site re-interns them.
+    pub(crate) fn proto_variant_keys_sorted(&self, prefix: &str) -> std::sync::Arc<Vec<Symbol>> {
+        let generation =
+            crate::runtime::regex_parse::TOKEN_DEFS_GEN.load(std::sync::atomic::Ordering::Relaxed);
+        if let Some(hit) = PROTO_VARIANT_KEYS.with(|c| {
+            c.borrow()
+                .get(prefix)
+                .filter(|(entry_gen, _)| *entry_gen == generation)
+                .map(|(_, keys)| keys.clone())
+        }) {
+            return hit;
+        }
+        let keys = std::sync::Arc::new(self.proto_variant_keys_sorted_uncached(prefix));
+        PROTO_VARIANT_KEYS.with(|c| {
+            c.borrow_mut()
+                .insert(prefix.to_owned(), (generation, keys.clone()));
         });
+        keys
+    }
+
+    fn proto_variant_keys_sorted_uncached(&self, prefix: &str) -> Vec<Symbol> {
+        let mut keys: Vec<Symbol> = self
+            .registry()
+            .token_defs
+            .keys()
+            .copied()
+            .filter(|key| {
+                key.as_str()
+                    .strip_prefix(prefix)
+                    .is_some_and(is_proto_variant_suffix)
+            })
+            .collect();
+        keys.sort_by(|a, b| {
+            self.token_key_decl_order_sym(*a)
+                .cmp(&self.token_key_decl_order_sym(*b))
+                .then_with(|| a.as_str().cmp(b.as_str()))
+        });
+        keys
     }
 
     pub(crate) fn token_def_identity(def_name: &str, token_name: &str) -> String {
@@ -262,24 +328,12 @@ impl Interpreter {
             seen.insert(name.to_string());
         }
         let scope_prefix_len = scope.len() + 2;
-        let variant_prefix = format!("{scope}::{name}");
-        let mut sym_keys: Vec<String> = self
-            .registry()
-            .token_defs
-            .keys()
-            .map(|key| key.resolve())
-            .filter(|key| {
-                key.strip_prefix(&variant_prefix)
-                    .is_some_and(is_proto_variant_suffix)
-            })
-            .collect();
-        self.sort_sym_keys_by_decl_order(&mut sym_keys);
-        for key in &sym_keys {
-            let identity = &key[scope_prefix_len..];
+        for &key in self.proto_variant_keys_sorted(&exact_key).iter() {
+            let identity = &key.as_str()[scope_prefix_len..];
             if seen.contains(identity) {
                 continue;
             }
-            if let Some(sym_defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
+            if let Some(sym_defs) = self.registry().token_defs.get(&key) {
                 defs.extend(sym_defs.clone());
                 seen.insert(identity.to_string());
             }
@@ -296,20 +350,8 @@ impl Interpreter {
         if let Some(exact) = self.registry().token_defs.get(&Symbol::intern(&exact_key)) {
             defs.extend(exact.clone());
         }
-        let variant_prefix = format!("{scope}::{name}");
-        let mut sym_keys: Vec<String> = self
-            .registry()
-            .token_defs
-            .keys()
-            .map(|key| key.resolve())
-            .filter(|key| {
-                key.strip_prefix(&variant_prefix)
-                    .is_some_and(is_proto_variant_suffix)
-            })
-            .collect();
-        self.sort_sym_keys_by_decl_order(&mut sym_keys);
-        for key in &sym_keys {
-            if let Some(sym_defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
+        for &key in self.proto_variant_keys_sorted(&exact_key).iter() {
+            if let Some(sym_defs) = self.registry().token_defs.get(&key) {
                 defs.extend(sym_defs.clone());
             }
         }
@@ -370,16 +412,8 @@ impl Interpreter {
             if let Some(exact) = self.registry().token_defs.get(&Symbol::intern(name)) {
                 defs.extend(exact.clone());
             }
-            let mut sym_keys: Vec<String> = self
-                .registry()
-                .token_defs
-                .keys()
-                .map(|key| key.resolve())
-                .filter(|key| key.strip_prefix(name).is_some_and(is_proto_variant_suffix))
-                .collect();
-            self.sort_sym_keys_by_decl_order(&mut sym_keys);
-            for key in &sym_keys {
-                if let Some(sym_defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
+            for &key in self.proto_variant_keys_sorted(name).iter() {
+                if let Some(sym_defs) = self.registry().token_defs.get(&key) {
                     defs.extend(sym_defs.clone());
                 }
             }

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -873,7 +873,7 @@ impl Value {
         named: &HashMap<String, Vec<String>>,
         target: crate::runtime::MatchTarget,
     ) -> Self {
-        let m = Self::make_match_object_full(from, to, &[], &HashMap::new(), target.clone());
+        let m = Self::make_match_object_full(from, to, &[], &Default::default(), target.clone());
         if positional_texts.is_empty() && named.is_empty() {
             return m;
         }

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -19,16 +19,16 @@ impl Value {
         from: i64,
         to: i64,
         positional: &[crate::runtime::PosSlot],
-        named: &HashMap<crate::symbol::Symbol, crate::runtime::NamedSlot>,
+        named: &crate::runtime::NamedCaptureMap,
         target: crate::runtime::MatchTarget,
     ) -> Self {
         let has_children = !named.is_empty() || !positional.is_empty();
         let children = has_children.then(|| {
             Box::new(crate::runtime::CapChildren {
                 named: named.clone(),
-                capture_alias_map: HashMap::new(),
+                capture_alias_map: Default::default(),
                 positional: positional.to_vec(),
-                regex_vars: HashMap::new(),
+                regex_vars: Default::default(),
             })
         });
         let cap = crate::runtime::CapNode {
@@ -49,7 +49,7 @@ impl Value {
         from: i64,
         to: i64,
         positional: &[crate::runtime::PosSlot],
-        named: &HashMap<crate::symbol::Symbol, crate::runtime::NamedSlot>,
+        named: &crate::runtime::NamedCaptureMap,
         target: crate::runtime::MatchTarget,
     ) -> Self {
         let visible_len = positional

--- a/t/grammar/grammar-qualified-proto-candidate-scan.t
+++ b/t/grammar/grammar-qualified-proto-candidate-scan.t
@@ -1,0 +1,61 @@
+use v6;
+use Test;
+
+# Resolving a `<subrule>` walks every registered token key to collect the
+# rule's `:sym<>` proto candidates, merging an ancestor grammar's candidates
+# through the MRO and deduplicating by candidate identity. That scan was
+# rewritten to work off the interned key symbols instead of materializing a
+# String per key (#7576); these cases pin the semantics it has to keep —
+# derived-adds-to-base, MRO dedup, the declaration-order LTM tie-break, and
+# the `<Pkg::rule>` qualified form that resolves through its own copy of the
+# scan. All expectations verified against rakudo v2026.07.
+
+plan 8;
+
+{
+    grammar Base {
+        proto token item {*}
+        token item:sym<num> { \d+ }
+        token item:sym<word> { \w+ }
+    }
+    grammar Deriv is Base {
+        token item:sym<bang> { '!' }
+    }
+
+    ok Deriv.parse('!', :rule<item>).defined,
+        'a derived grammar candidate matches';
+    ok Deriv.parse('12', :rule<item>).defined,
+        'an inherited proto candidate still matches in the derived grammar';
+    nok Base.parse('!', :rule<item>).defined,
+        'the base grammar is not extended by its descendant';
+
+    grammar Qual {
+        rule TOP { <Base::item> }
+    }
+    ok Qual.parse('99').defined, 'a <Pkg::rule> reference resolves';
+    is Qual.parse('99')<Base::item>.Str, '99',
+        'the qualified reference captures under its written name';
+    nok Qual.parse('!').defined,
+        'the qualified reference sees only the named package candidates';
+}
+
+{
+    # An equal-length tie between an inherited candidate and a derived one is
+    # broken by declaration order, and the derived grammar still reaches its
+    # own candidate when the base one cannot match.
+    grammar B2 {
+        proto token pp {*}
+        token pp:sym<ab> { <sym> }
+    }
+    grammar D2 is B2 {
+        token pp:sym<ax> { 'a' \w }
+    }
+    class A2 {
+        method pp:sym<ab>($/) { make 'BASE' }
+        method pp:sym<ax>($/) { make 'DERIVED' }
+    }
+    is D2.parse('ab', :rule<pp>, :actions(A2)).ast, 'DERIVED',
+        'the later-declared derived candidate wins the equal-length tie';
+    is D2.parse('az', :rule<pp>, :actions(A2)).ast, 'DERIVED',
+        'the derived candidate matches where the inherited one cannot';
+}


### PR DESCRIPTION
Round 11 of #7576.

Round 10 closed with "no single dominant site any more — allocator traffic ~20%, `memcpy` 6.7%, `LocalKey::with` 5.7%, SipHash 8.1%". A fresh `valgrind --tool=callgrind` profile of a 120-row YAML document said otherwise: **one call site owned 15% of the whole program**, hidden *inside* those flat allocator/TLS/hash totals rather than under its own name.

Instructions retired on a 60-row document (`benchmarks/bench-yaml-parse.raku`'s shape with `$ROWS = 60`): **8.13 Bn → 5.89 Bn, −27.5%**. Instruction counts are deterministic and load-independent, so they — not wall clock on a shared container — are what each change is attributed against. (Local wall clock moved with them: 1.13s → 0.95s at 60 rows, 2.49s → 2.02s at 120; per `CLAUDE.md` the number for a document is the `bench-data` CI series, which this predates.)

## (a) Five copies of the proto-variant scan allocated a `String` per registry key — −11.6%

Resolving any `<subrule>` collects the rule's `:sym<…>` proto candidates by walking **every** key of `Registry::token_defs` and prefix-testing it. All five hand-rolled copies of that walk spelled the test as `.map(|key| key.resolve())` — and `Symbol::resolve` is `as_str().to_owned()` — so each built an owned `String` for every key just to run `strip_prefix` against it and drop it again.

On the profiled document: 50,634 scans × ~92 keys = **4.6M allocations**, 4.6M `Symbol::as_str` thread-local round trips, 4.4M `memcmp`s — 1.11 Bn instructions, 15.2% of the run, **43% of every allocation the program made**. It never showed in a self-cost profile under its own name because the cost sat in `malloc`/`free`/`LocalKey::with`/`memcmp`.

The five copies are now one helper, `Interpreter::proto_variant_keys_sorted`, filtering on the interned `&'static str` and returning the matching keys **as symbols**, so no call site re-interns a key it just read out of the map.

## (b) …and then re-derived the same few lists thousands of times — −8.5%

The scan is O(all registered token keys) per `<subrule>` reference, for a handful of distinct prefixes. It is memoized per prefix behind `TOKEN_DEFS_GEN`, the same invalidation discipline `PARSED_TOKEN_CANDIDATES` and `REGEX_PARSE_CACHE` already use.

The regex `:my`-declarator path restored a whole `token_defs` snapshot when the match ended and did **not** bump that generation on the way out (only the declaration bumped it on the way in). It now goes through `Interpreter::restore_token_defs`, which does — closing a staleness window the pre-existing generation-keyed memos shared.

## (c) The regex engine's hot maps paid SipHash — −7.1%

`RegexCaptures`'s `named`/`regex_vars`/`capture_alias_map`/`hash_captures`, the three left-recursion bookkeeping tables (`LR_MEMO`/`LR_ACTIVE`/`LR_SEED_READ`, probed up to seven times per subrule activation) and the call-graph streamability memos were all `std::collections::HashMap`. Their keys are interned `Symbol`s (a `u32`) and grammar rule names — not adversarial input — and the maps are rebuilt several times per matched capture: `sip::Hasher::write` + `BuildHasher::hash_one` were 7.9% of the run, 1.7% after switching them to `rustc_hash::FxHashMap` (already a dependency, already used for the symbol table and the compiled-function maps).

Note this cannot introduce order nondeterminism anywhere these maps are iterated: `RandomState` already randomised the order per process run, so Fx only makes an already-unspecified order stable.

## (d) `<subrule>` atom text was re-parsed on every match attempt — −3.6%

`parse_named_regex_lookup_spec` is a pure function of the atom's text and ran once per *match attempt* — 232k calls, 813k `trim_matches`, 232k allocations, ~2.6% with callees, for a handful of distinct strings. Memoized now, returning a shared `Arc<NamedRegexLookupSpec>`. In the same vein `PARSED_TOKEN_CANDIDATES` is keyed by `(Symbol, Symbol)` instead of `(String, String)`, so probing it no longer allocates two owned strings per probe.

## Where this leaves the ticket

mutsu parses the 120-row document in ~2.0s against rakudo v2026.07's ~0.27s on the same container: **~7.5x, down from ~9.2x**. The remaining profile is genuinely flat — `malloc`/`free`/`_int_malloc` ~21%, `memcpy` 6.2%, `LocalKey::with` 4.6% across a dozen callers, no mutsu function above 1.6%. The next round is the per-capture `Match`/`RegexCaptures` construction traffic itself (the ticket's long-standing item 4), not another call-site fix. The ticket stays open.

## Testing

- `t/grammar/grammar-qualified-proto-candidate-scan.t` (new) pins the semantics the rewritten scan has to keep — derived-adds-to-base, MRO dedup, the declaration-order LTM tie-break, and the `<Pkg::rule>` qualified form that resolves through its own copy of the scan. All eight expectations verified against rakudo v2026.07.
- `make test`: PASS (4018 files, 42769 tests).
- `make lint`: PASS (all four configurations).
- `make roast`: 1435 files, 219511 tests; the only failures are the three container-only ones documented in `docs/agent-environments.md` (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` run as `uid 0`, `S32-io/IO-Socket-Async.t` sandboxed network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_