### PR TITLE
fix(parser): `${...}` in a string is a composer, not a Perl 5 deref

### DIFF
--- a/ecosystem/dists/V/vCard--Parser~967faae5.json
+++ b/ecosystem/dists/V/vCard--Parser~967faae5.json
@@ -16,7 +16,7 @@
         "nok": 0,
         "ok": 1,
         "plan": 1,
-        "secs": 0.19,
+        "secs": 0.1,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -26,7 +26,7 @@
         "nok": 0,
         "ok": 1,
         "plan": 1,
-        "secs": 3.23,
+        "secs": 2.95,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -38,7 +38,7 @@
         "nok": 0,
         "ok": 23,
         "plan": 23,
-        "secs": 0.18,
+        "secs": 0.12,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -48,30 +48,29 @@
         "nok": 0,
         "ok": 23,
         "plan": 23,
-        "secs": 0.81,
+        "secs": 0.52,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
       }
     },
     {
-      "cmp": "regression",
+      "cmp": "parity",
       "mutsu": {
-        "first_failure": "Unsupported use of ${:group(\"MyGroup\")}. In Raku please use: $(:group(\"MyGroup\")) for hard ref or $::(:group(\"MyGroup\")) for symbolic ref.",
         "nok": 0,
-        "ok": 7,
+        "ok": 9,
         "plan": 9,
-        "secs": 0.15,
+        "secs": 0.18,
         "skip": 0,
         "todo": 0,
-        "verdict": "die"
+        "verdict": "pass"
       },
       "path": "t/03-actions.rakutest",
       "raku": {
         "nok": 0,
         "ok": 9,
         "plan": 9,
-        "secs": 2.65,
+        "secs": 2.39,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -83,7 +82,7 @@
         "nok": 0,
         "ok": 1,
         "plan": 1,
-        "secs": 0.15,
+        "secs": 0.1,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -93,7 +92,7 @@
         "nok": 0,
         "ok": 1,
         "plan": 1,
-        "secs": 0.59,
+        "secs": 0.45,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -108,9 +107,9 @@
   "measured": {
     "attempts": 3,
     "date": "2026-09-11",
-    "harness": 1,
-    "host": "gha-ubuntu24-4c",
-    "mutsu_commit": "7807eb5",
+    "harness": 2,
+    "host": "linux-x86_64",
+    "mutsu_commit": "eb8a2af5",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
@@ -121,13 +120,13 @@
     "index": "fez",
     "url": "https://360.zef.pm/V/CA/VCARD_PARSER/44ecbda53fdaab15f4e3ad4bc0ad1769363cdd39.tar.gz"
   },
-  "status": "partial",
+  "status": "green",
   "totals": {
     "baseline_assertions": 34,
     "baseline_files": 4,
-    "mutsu_assertions": 32,
-    "parity_files": 3,
-    "regressed_files": 1
+    "mutsu_assertions": 34,
+    "parity_files": 4,
+    "regressed_files": 0
   },
   "version": "0.0.2"
 }

--- a/news/2026-09/brace-contextualizer-in-string-interpolation.md
+++ b/news/2026-09/brace-contextualizer-in-string-interpolation.md
@@ -1,0 +1,54 @@
+# `"${:a}"` is a hash composer, not a Perl 5 dereference
+
+`${...}` is two different constructs wearing the same spelling. One is Perl 5's
+scalar dereference, which Raku diagnoses with `X::Obsolete`; the other is Raku's
+own contextualizer — rakudo's grammar has
+
+```
+token contextualizer {
+    [ <sigil> '(' ~ ')'    <coercee=sequence>
+    | <sigil> <?[ \[ \{ ]> <coercee=circumfix>
+    ]
+}
+```
+
+so `${a => 1}` is the `{...}` circumfix (a hash composer) in item context, and
+`@{:a, :b}` is the same circumfix in list context. Rakudo keeps the P5 diagnosis
+from swallowing them with an explicit guard on `special_variable:sym<${ }>`:
+
+```
+<!{ $<text> ~~ / '=>' || ':'<:alpha> || '|%' / }>
+<!{ $<text> ~~ / ^ \s* $ / }>
+```
+
+where `$<text>` is the source between the brace and the *first* `}`.
+
+mutsu applied a rough version of that guard outside strings — `${a => 1}` worked
+because the parse produced an `Expr::Hash` — but the string-interpolation path in
+`parser/primary/string/interp_var.rs` had none of it: any `${` in a double-quoted
+string was rewritten into a thrown `X::Obsolete`. So
+
+```raku
+say "${:group("MyGroup")}";   # rakudo: group<TAB>MyGroup
+```
+
+died mid-file with *Unsupported use of ${:group("MyGroup")}*. That is line 31 of
+vCard::Parser 0.0.2's `t/03-actions.rakutest`, which is why that file stopped at
+7 of its 9 planned tests.
+
+The guard is now rakudo's, spelled once as `var::perl5::is_brace_contextualizer`
+and consulted from all three sites that had to choose between the two readings:
+the bare `${...}` (`container/sigil_context.rs`), the bare `@{...}`
+(`var/sigil_vars.rs`), and string interpolation. The bare `@{...}` gained the
+list contextualizer it never had — `@{:a, :b}` used to parse as a subscript and
+quietly evaluate to `(Any, Any)`.
+
+Interpolation is deliberately asymmetric between the sigils, because rakudo is:
+`"${:a}"` interpolates the itemized hash, while in `"@{:a}"` the `@` is not an
+interpolation trigger at all — it stays a literal `@` and the `{...}` is an
+ordinary block interpolation. Both spellings are pinned, along with the P5
+forms (`${$scalar}`, `@{@array}`, `"${1}"`) that must still be `X::Obsolete`, in
+`t/lang/quoting/interp-brace-contextualizer.t`.
+
+vCard::Parser goes from `partial` (3 of 4 baseline files, 32 of 34 assertions) to
+`green`: 4 of 4 files, 34 of 34 assertions, matching rakudo exactly.

--- a/src/parser/primary/container/sigil_context.rs
+++ b/src/parser/primary/container/sigil_context.rs
@@ -138,10 +138,16 @@ pub(crate) fn itemized_brace_expr(input: &str) -> PResult<'_, Expr> {
         return Err(PError::expected("itemized brace expression"));
     }
     let block_start = rest;
+    // rakudo's `special_variable:sym<${ }>` guard decides this before the block
+    // is parsed: a `{...}` holding a pair, a `=>` or a `|%` slip is the Raku
+    // contextualizer, not the Perl 5 deref (see `is_brace_contextualizer`).
+    let is_contextualizer = crate::parser::primary::var::is_brace_contextualizer(
+        crate::parser::primary::var::brace_deref_text(block_start),
+    );
     let (rest, inner) = crate::parser::primary::misc::block_or_hash_expr(rest)?;
     // When the inner expression is a Hash literal, ${ } creates an itemized hash
     // (wrapped in a Scalar container), not a Capture.
-    if matches!(inner, Expr::Hash(_)) {
+    if is_contextualizer || matches!(inner, Expr::Hash(_)) {
         Ok((
             rest,
             Expr::MethodCall {

--- a/src/parser/primary/string/interp_var.rs
+++ b/src/parser/primary/string/interp_var.rs
@@ -352,8 +352,20 @@ pub(crate) fn try_interpolate_var<'a>(
                 }
             }
         }
-        // ${...} is Perl 5 scalar dereference syntax — throw X::Obsolete
+        // `${...}` is either Raku's item contextualizer over the `{...}`
+        // circumfix (`"${:a}"` interpolates the one-pair hash) or the Perl 5
+        // scalar dereference, which is X::Obsolete. rakudo's guard decides —
+        // see `is_brace_contextualizer`.
         if next == '{' {
+            if let Ok((remainder, expr)) =
+                crate::parser::primary::container::itemized_brace_expr(rest)
+            {
+                if !current.is_empty() {
+                    parts.push(Expr::Literal(literal_str(std::mem::take(current))));
+                }
+                parts.push(expr);
+                return Some(remainder);
+            }
             if !current.is_empty() {
                 parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }
@@ -459,8 +471,17 @@ pub(crate) fn try_interpolate_var<'a>(
         {
             return Some(result);
         }
-        // @{...} is Perl 5 array dereference syntax — throw X::Obsolete
-        if next == '{' {
+        // `@{...}` is the Perl 5 array dereference — X::Obsolete — unless
+        // rakudo's guard exempts the braces (see `is_brace_contextualizer`).
+        // When it does, the `@` is *not* an interpolation trigger at all:
+        // rakudo leaves it as a literal `@` and interpolates `{...}` as an
+        // ordinary block, so `"@{:a}"` is `@` followed by the hash. Falling
+        // through here reproduces that.
+        if next == '{'
+            && !crate::parser::primary::var::is_brace_contextualizer(
+                crate::parser::primary::var::brace_deref_text(&rest[1..]),
+            )
+        {
             if !current.is_empty() {
                 parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -23,6 +23,7 @@ pub(crate) use adverb::{parse_adverb_value_pub, parse_anon_adverb_value};
 pub(in crate::parser) use ident::parse_qualified_ident_prefix_with_hyphens;
 pub(crate) use ident::{is_pseudo_package, parse_ident_with_hyphens};
 pub(crate) use perl5::detect_perl5_scalar_var;
+pub(crate) use perl5::{brace_deref_text, is_brace_contextualizer};
 pub(in crate::parser) use scalar::mint_anon_state_name;
 pub(in crate::parser) use scalar::parse_symbolic_deref_segments;
 

--- a/src/parser/primary/var/perl5.rs
+++ b/src/parser/primary/var/perl5.rs
@@ -4,6 +4,49 @@
 /// and emit structured `X::Syntax::Perl5Var` error messages.
 use crate::parser::helpers::{is_raku_identifier_continue, is_raku_identifier_start};
 
+/// Does `$sigil{...}` spell a Raku contextualizer rather than a Perl 5 deref?
+///
+/// `${...}` is ambiguous: it is the Perl 5 scalar dereference (diagnosed with
+/// `X::Obsolete`), but it is also Raku's contextualizer applied to the `{...}`
+/// circumfix — `${a => 1}` is an itemized hash, and rakudo's
+/// `special_variable:sym<${ }>` is guarded so the diagnosis never swallows it:
+///
+/// ```text
+/// <!{ $<text> ~~ / '=>' || ':'<:alpha> || '|%' / }>
+/// <!{ $<text> ~~ / ^ \s* $ / }>
+/// ```
+///
+/// `text` is the source between the brace and the *first* `}`, exactly as
+/// rakudo's non-greedy `$<text>=[.*?] '}'` captures it. When any of those
+/// patterns hits, the braces hold a hash composer (or a block) and the
+/// construct is Raku, not a P5ism.
+pub(crate) fn is_brace_contextualizer(text: &str) -> bool {
+    if text.trim().is_empty() {
+        return true;
+    }
+    if text.contains("=>") || text.contains("|%") {
+        return true;
+    }
+    let mut chars = text.chars();
+    while let Some(c) = chars.next() {
+        if c == ':' && chars.clone().next().is_some_and(char::is_alphabetic) {
+            return true;
+        }
+    }
+    false
+}
+
+/// The `text` [`is_brace_contextualizer`] wants, given a source slice that
+/// starts at the opening `{`: everything up to the first `}` (or, when the
+/// brace is unterminated, the rest of the input).
+pub(crate) fn brace_deref_text(at_brace: &str) -> &str {
+    let inner = at_brace.strip_prefix('{').unwrap_or(at_brace);
+    match inner.find('}') {
+        Some(end) => &inner[..end],
+        None => inner,
+    }
+}
+
 /// Detect Perl 5 special variables that are unsupported in Raku.
 /// Returns `Some(error_message)` if the input starts with a Perl 5 variable pattern,
 /// or `None` if it is a valid Raku variable.

--- a/src/parser/primary/var/sigil_vars.rs
+++ b/src/parser/primary/var/sigil_vars.rs
@@ -117,6 +117,34 @@ fn parse_leading_colon_qualified(input: &str) -> Option<(&str, String, Option<Ex
     Some((r, full_name, dynamic))
 }
 
+/// Parse `@{...}` as Raku's list contextualizer, given the source at the `{`.
+///
+/// The mirror of [`crate::parser::primary::container::itemized_brace_expr`] for
+/// the `@` sigil: rakudo's `contextualizer` token is
+/// `<sigil> <?[ \[ \{ ]> <coercee=circumfix>`, so `@{:a, :b}` is the `{...}`
+/// circumfix in list context, not a dereference. Fails (so the caller can fall
+/// back to diagnosing the Perl 5 deref) whenever
+/// [`super::is_brace_contextualizer`] says the braces do not hold a composer.
+fn brace_list_contextualizer(input: &str) -> PResult<'_, Expr> {
+    if !input.starts_with('{') {
+        return Err(PError::expected("brace list contextualizer"));
+    }
+    if !super::is_brace_contextualizer(super::brace_deref_text(input)) {
+        return Err(PError::expected("brace list contextualizer"));
+    }
+    let (rest, inner) = crate::parser::primary::misc::block_or_hash_expr(input)?;
+    Ok((
+        rest,
+        Expr::MethodCall {
+            target: Box::new(inner),
+            name: crate::symbol::Symbol::intern("list"),
+            args: vec![],
+            modifier: None,
+            quoted: false,
+        },
+    ))
+}
+
 /// Parse an @array variable reference.
 pub(crate) fn array_var(input: &str) -> PResult<'_, Expr> {
     let (input, _) = parse_char(input, '@')?;
@@ -246,20 +274,25 @@ pub(crate) fn array_var(input: &str) -> PResult<'_, Expr> {
             ));
         }
     }
-    // @{expr} is Perl 5 array dereference syntax — throw X::Obsolete
-    if twigil.is_empty()
-        && rest.starts_with('{')
-        && let Ok((r2, inner)) = crate::parser::primary::misc::block_or_hash_expr(rest)
-        && !matches!(inner, crate::ast::Expr::Hash(_))
-    {
-        let block_src = &rest[..rest.len() - r2.len()];
-        let deref_inner = block_src
-            .strip_prefix('{')
-            .and_then(|s| s.strip_suffix('}'))
-            .unwrap_or("expr");
-        return Err(PError::from_typed(
-            crate::value::RuntimeError::obsolete_p5_deref('@', deref_inner),
-        ));
+    // `@{...}` is either Raku's list contextualizer over the `{...}` circumfix
+    // (`@{:a, :b}` is the two-pair list) or the Perl 5 array dereference. The
+    // guard that tells them apart is rakudo's own — see `is_brace_contextualizer`.
+    if twigil.is_empty() && rest.starts_with('{') {
+        if let Ok(parsed) = brace_list_contextualizer(rest) {
+            return Ok(parsed);
+        }
+        if let Ok((r2, inner)) = crate::parser::primary::misc::block_or_hash_expr(rest)
+            && !matches!(inner, crate::ast::Expr::Hash(_))
+        {
+            let block_src = &rest[..rest.len() - r2.len()];
+            let deref_inner = block_src
+                .strip_prefix('{')
+                .and_then(|s| s.strip_suffix('}'))
+                .unwrap_or("expr");
+            return Err(PError::from_typed(
+                crate::value::RuntimeError::obsolete_p5_deref('@', deref_inner),
+            ));
+        }
     }
     // Handle @<name> — list coercion of a named capture variable from $/
     // (e.g., after a regex match, @<fie> gives the positional elements of $<fie>)

--- a/t/lang/quoting/interp-brace-contextualizer.t
+++ b/t/lang/quoting/interp-brace-contextualizer.t
@@ -1,0 +1,55 @@
+use Test;
+
+# `${...}` is ambiguous: the Perl 5 scalar dereference (X::Obsolete) and Raku's
+# item contextualizer applied to the `{...}` circumfix. Rakudo's
+# `special_variable:sym<${ }>` is guarded so the diagnosis never swallows the
+# Raku form -- the braces are a composer when their text (up to the first `}`)
+# holds `=>`, `:` + alpha, or `|%`, or is blank.
+#
+# mutsu applied that guard outside strings only, so `"${:group("MyGroup")}"`
+# died with the P5 diagnosis mid-file. Found in vCard::Parser 0.0.2's
+# t/03-actions.rakutest, which is exactly this line.
+
+plan 14;
+
+# --- the contextualizer, interpolated ---------------------------------------
+
+is "${:group("MyGroup")}", "group\tMyGroup",
+    'a colonpair composer interpolates as the itemized hash';
+is "${a => 1}", "a\t1", 'a fat-arrow composer interpolates too';
+is "${}", '', 'empty braces are the empty hash, not a deref';
+is "pre ${:x(5)} post", "pre x\t5 post", 'it composes with surrounding text';
+
+# --- and outside a string, where it already worked ---------------------------
+
+is ${:group("MyGroup")}.raku, '${:group("MyGroup")}',
+    'the bare form is still the itemized hash';
+is ${a => 1, b => 2}.raku, '${:a(1), :b(2)}', 'several pairs';
+
+# `@{...}` is the same circumfix in list context.
+is @{:a, :b}.elems, 2, '@{...} is the list contextualizer, not a subscript';
+is-deeply @{:a, :b}.sort(*.key).list, (:a, :b), '... yielding the pairs themselves';
+
+# Interpolation does not trigger on `@{`: rakudo leaves the `@` literal and
+# interpolates `{...}` as an ordinary block.
+is "@{:a}", '@a	True', 'an interpolated @{...} keeps a literal @';
+
+# --- the Perl 5 deref is still diagnosed ------------------------------------
+
+my $scalar = 1;
+my @array = 1, 2;
+
+sub thrown($src) {
+    my $e;
+    { EVAL $src; CATCH { default { $e = $_ } } }
+    $e;
+}
+
+is thrown(Q[${$scalar}]).^name, 'X::Obsolete', 'bare ${$scalar} is still obsolete';
+is thrown(Q["${$scalar}"]).^name, 'X::Obsolete', '... and so is the interpolated form';
+is thrown(Q[@{@array}]).^name, 'X::Obsolete', 'bare @{@array} is still obsolete';
+is thrown(Q["@{@array}"]).^name, 'X::Obsolete', '... and its interpolated form';
+is thrown(Q["${1}"]).^name, 'X::Obsolete',
+    'a digit in the braces is a P5ism, not a composer';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Distribution

**vCard::Parser 0.0.2** (`pure`, dep closure: JSON::Tiny) — `partial` → **`green`**.

| | before | after |
|---|---|---|
| baseline files passing | 3 / 4 | **4 / 4** |
| baseline assertions | 32 / 34 | **34 / 34** |

`t/03-actions.rakutest` died at its line 31, having run 7 of 9 planned tests:

```
Unsupported use of ${:group("MyGroup")}. In Raku please use: $(:group("MyGroup")) for hard ref or $::(:group("MyGroup")) for symbolic ref.
```

No issue filed — nothing is left red.

## Root cause

`${...}` is two constructs sharing a spelling. One is Perl 5's scalar dereference, which Raku
diagnoses with `X::Obsolete`. The other is Raku's own contextualizer applied to the `{...}`
circumfix — rakudo's grammar has

```
token contextualizer {
    [ <sigil> '(' ~ ')'    <coercee=sequence>
    | <sigil> <?[ \[ \{ ]> <coercee=circumfix>
    ]
}
```

so `${a => 1}` is a hash composer in item context and `@{:a, :b}` is the same circumfix in list
context. Rakudo keeps the P5 diagnosis from swallowing them with an explicit guard on
`special_variable:sym<${ }>`:

```
<!{ $<text> ~~ / '=>' || ':'<:alpha> || '|%' / }>
<!{ $<text> ~~ / ^ \s* $ / }>
```

where `$<text>` is the source between the brace and the **first** `}`.

mutsu applied a rough version of that guard outside strings — bare `${a => 1}` worked because the
parse produced an `Expr::Hash` — but the string-interpolation path in
`parser/primary/string/interp_var.rs` had none of it and rewrote *every* `${` in a double-quoted
string into a thrown `X::Obsolete`.

## The fix

The guard is now rakudo's, spelled once as `var::perl5::is_brace_contextualizer` and consulted from
all three sites that must choose between the two readings: bare `${...}`
(`container/sigil_context.rs`), bare `@{...}` (`var/sigil_vars.rs`), and string interpolation.

Bare `@{...}` gains the list contextualizer it never had — `@{:a, :b}` used to parse as a subscript
and quietly evaluate to `(Any, Any)`.

Interpolation stays **asymmetric** between the sigils, because rakudo is: `"${:a}"` interpolates the
itemized hash, while in `"@{:a}"` the `@` is not an interpolation trigger at all — it stays a
literal `@` and the `{...}` is an ordinary block interpolation. Both were checked against
`raku 2026.07`.

## Test

`t/lang/quoting/interp-brace-contextualizer.t` (14 assertions, passes under rakudo and mutsu alike).
It pins the composer forms, the `$`/`@` interpolation asymmetry, and the P5 forms that must stay
`X::Obsolete` (`${$scalar}`, `@{@array}`, `"${1}"`, `${%h}`-style).

## Verification

- `cargo fmt --all`, `make lint` (all four configurations) — clean
- `make test` — `All tests successful`, `Result: PASS`
- `make roast` — red only in the three known environment-only files named in
  `docs/agent-environments.md` (`6.c/S32-io/file-tests.t` `Failed: 4`,
  `S16-filehandles/filetest.t` `Failed: 25`, `S32-io/IO-Socket-Async.t` exit 124), with the
  documented shapes
- `MUTSU_BIN=target/release/mutsu scripts/ecosystem-sweep.py --only 'vCard::Parser'` →
  `green 4/4 files`; `index-snapshot.json` left unchanged

No other ledger record names this construct, so there were no neighbours to re-measure.

News: `news/2026-09/brace-contextualizer-in-string-interpolation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D4Uqn6toDKkFgWDStxXZj

---
_Generated by [Claude Code](https://claude.ai/code/session_011D4Uqn6toDKkFgWDStxXZj)_