### PR TITLE
docs(ecosystem): close the parity campaign, point the work per distribution

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -100,26 +100,23 @@ work; see the CLAUDE.md "mzef package manager and distribution" section. The **R
 
 ### B4. Module-compatibility frontier (the base of batteries)
 
-- [ ] **★Ecosystem parity KPI** — run every zef distribution's own test suite on **both** rakudo and
-      mutsu and publish the difference as the project's headline compatibility number, with
-      per-distribution machine-readable records in `ecosystem/`. **P1-P3 have landed: the corpus is
-      measured.** Run 34566091231 (2026-09-11, `scope: all`, 27/27 shards green) covers all 1624
-      distributions at one commit — **41.2%** dist parity, 53.6% file, 62.4% assertion — and the
-      first `history.tsv` row exists. **P5 has produced its first batch**:
-      `scripts/ecosystem-tickets.py` clusters the ledger by root cause, ranked by distributions
-      affected, and fifteen issues covering ~330 distribution slots were filed from it
-      (docs/ecosystem-parity.md §9). What is left of P5 is the tail — 970 clusters below ten
-      distributions, a sampling job rather than a queue to drain. P4 is closed: the workflow is the
-      entry point, and the `make`-level wrapper it also listed was dropped (it would fail
-      `ci-docs-only.sh --check-inputs`; docs/ecosystem-parity.md §8).
-      Decisions: [ADR-0085](docs/adr/0085-ecosystem-testsuite-parity-measurement.md);
-      operations manual and phases (P1-P5, one PR each):
-      [docs/ecosystem-parity.md](docs/ecosystem-parity.md);
-      tracking issue [#7785](https://github.com/tokuhirom/mutsu/issues/7785).
-      The sweep runs **nightly at 03:20 JST** (`schedule:` in `ecosystem-sweep.yml`, ADR-0085 D9's
-      second amendment) and can also be dispatched for one shard or one distribution. It is a
-      measurement, not a gate, so it still does **not** close B1's "working-module regression CI" —
-      that stays a separate item.
+- [ ] **★Ecosystem parity: per-distribution work** — the KPI itself is **built and running**; what
+      remains is turning red records green, one distribution (or one root cause) at a time. The
+      corpus is measured nightly at 03:20 JST and published: **41.1%** dist parity, 53.4% file,
+      63.1% assertion, with per-distribution records in `ecosystem/` and the chart in
+      `ecosystem/history.svg`. Pick work one of two ways — by **root cause** from the clustered
+      issues (`scripts/ecosystem-tickets.py`, see docs/ecosystem-parity.md §9; the ten largest
+      clusters are filed as `todo:*` issues), or by **distribution** with
+      [`ecosystem-dist-fix`](.agents/skills/ecosystem-dist-fix/SKILL.md) (named) /
+      [`ecosystem-dist-roulette`](.agents/skills/ecosystem-dist-roulette/SKILL.md) (a uniform random
+      draw, locked on [#7884](https://github.com/tokuhirom/mutsu/issues/7884) so parallel agents do
+      not collide). Prefer a root cause when one covers several distributions; a uniform draw is what
+      keeps the published figure honest.
+      Method: [docs/ecosystem-parity.md](docs/ecosystem-parity.md);
+      decisions: [ADR-0085](docs/adr/0085-ecosystem-testsuite-parity-measurement.md). The campaign
+      that built all of this was [#7785](https://github.com/tokuhirom/mutsu/issues/7785), closed
+      2026-09-12. The sweep is a measurement, not a gate, so it does **not** close B1's
+      "working-module regression CI" — that stays a separate item.
 - [ ] **★Real-dist compatibility sweep** — run real fez dists under mutsu and fix the general bugs
       they surface. Ledger: [docs/dist-compat-sweep.md](docs/dist-compat-sweep.md). **The `--run-tests`
       axis is the sharper frontier**: running each loading dist's own suite with raku as the baseline.

--- a/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
+++ b/docs/adr/0085-ecosystem-testsuite-parity-measurement.md
@@ -1,6 +1,6 @@
 # ADR-0085 — The ecosystem KPI is per-distribution test-suite parity against rakudo
 
-- Status: Accepted (design confirmed 2026-09-10; P1-P3 implemented — see "Implementation status"; D9 amended 2026-09-10 to allow an operator-dispatched CI sweep, and again 2026-09-11 to schedule it nightly on measured cost)
+- Status: Accepted and **fully implemented** (design confirmed 2026-09-10; P1-P5 landed by 2026-09-12 — see "Implementation status"; D9 amended 2026-09-10 to allow an operator-dispatched CI sweep, and again 2026-09-11 to schedule it nightly on measured cost)
 - Date: 2026-09-10
 - Issue: [#7785](https://github.com/tokuhirom/mutsu/issues/7785)
 - Operations manual (the "how"): [docs/ecosystem-parity.md](../ecosystem-parity.md)
@@ -404,7 +404,10 @@ the history row, which is what keeps the series comparable.
 
 ## Implementation status
 
-Phases are listed in [docs/ecosystem-parity.md](../ecosystem-parity.md) §7.
+Phases are listed in [docs/ecosystem-parity.md](../ecosystem-parity.md) §7. **All
+five are done**, and #7785 was closed on 2026-09-12: what this ADR describes is
+now infrastructure that runs, and the work it feeds is per distribution and per
+root cause, tracked one issue per cause rather than as one ecosystem issue.
 
 | phase | state |
 |---|---|

--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -8,7 +8,10 @@ sides, and publish the difference.
   — the decisions (rakudo as the denominator, flat dependency closures,
   one file per distribution, the sandbox and environment contract). Read it
   before changing the method; this file is the *how*.
-- **Tracking issue**: [#7785](https://github.com/tokuhirom/mutsu/issues/7785).
+- **The campaign that built this**: [#7785](https://github.com/tokuhirom/mutsu/issues/7785),
+  closed 2026-09-12 with all five phases landed. There is no open tracking issue any more,
+  deliberately: the remaining work is **per distribution and per root cause**, and it is
+  tracked as one issue per cause (§9) rather than as one issue for the ecosystem.
 - **Acting on a record**: this file measures; taking one distribution from red
   to green is
   [`.agents/skills/ecosystem-dist-fix/SKILL.md`](../.agents/skills/ecosystem-dist-fix/SKILL.md),
@@ -24,15 +27,21 @@ sides, and publish the difference.
   release gate on the ~40 *bundled* dists. This campaign is neither: it is an
   exhaustive, re-runnable ledger over the whole ecosystem.
 
-> **Status: P1, P2 and P3 landed.** The corpus has been measured: [run
-> 34566091231](https://github.com/tokuhirom/mutsu/actions/runs/34566091231)
-> (2026-09-11, `scope=all`, 27/27 shards green) covers all **1624**
-> distributions at mutsu `1557d41` against rakudo 2026.07, and the headline is
-> **41.2%** dist parity — 53.6% file parity, 62.4% assertion parity. The first
-> `history.tsv` row and the chart exist as of that sweep. A sweep runs either
-> locally (§8) or from GitHub Actions (§8.1), so the numbers do not depend on
-> having a many-core box to hand. **P5 has produced its first batch** — fifteen
-> root-caused issues covering ~330 distribution slots, see section 9.
+> **Status: built, measured, published, and running nightly.** All five phases
+> landed between 2026-09-10 and 2026-09-12. The corpus is measured at one commit
+> per sweep ([run 34566091231](https://github.com/tokuhirom/mutsu/actions/runs/34566091231)
+> was the first, 27/27 shards green over all 1624 distributions); the headline is
+> **41.1%** dist parity — 53.4% file, 63.1% assertion — and `history.tsv` plus the
+> chart carry it over time. A sweep runs nightly, on dispatch, or locally (§8).
+> P5's first batch filed fifteen root-caused issues covering ~330 distribution
+> slots (§9).
+>
+> **What to do with this now: pick work, not phases.** Either take a root cause
+> from the clustered issues (§9), or take a distribution with the
+> [`ecosystem-dist-fix`](../.agents/skills/ecosystem-dist-fix/SKILL.md) /
+> [`ecosystem-dist-roulette`](../.agents/skills/ecosystem-dist-roulette/SKILL.md)
+> skills. Prefer a root cause when one covers several distributions; prefer the
+> uniform random draw over cherry-picking a cheap record, which games the figure.
 
 ## 1. What gets measured
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -6,7 +6,10 @@ with rakudo as the denominator.
 
 - **Method and metric definitions**: [docs/ecosystem-parity.md](../docs/ecosystem-parity.md)
 - **Why it is shaped this way**: [ADR-0085](../docs/adr/0085-ecosystem-testsuite-parity-measurement.md)
-- **Tracking issue**: [#7785](https://github.com/tokuhirom/mutsu/issues/7785)
+- **How the work is picked now**: by root cause (below) or by distribution (the two skills at
+  the end of this file). The campaign that built the ledger was
+  [#7785](https://github.com/tokuhirom/mutsu/issues/7785), closed 2026-09-12 — read it for the
+  method and the numbers it started from
 
 ## What is here
 

--- a/news/2026-09/ecosystem-parity-campaign-closed.md
+++ b/news/2026-09/ecosystem-parity-campaign-closed.md
@@ -1,0 +1,52 @@
+# The ecosystem parity campaign is closed; the work moves per distribution
+
+[#7785](https://github.com/tokuhirom/mutsu/issues/7785) — "check the test pass
+rate of the zef module", filed 2026-09-09 — is closed. All five phases of
+[ADR-0085](../../docs/adr/0085-ecosystem-testsuite-parity-measurement.md) landed
+in three days, and what the issue asked for exists:
+
+- every zef distribution's own test suite runs under **both** rakudo and mutsu,
+  with rakudo as the denominator (a file rakudo does not pass cleanly is never
+  charged to mutsu);
+- the result is machine-readable **in the repository** — one JSON record per
+  distribution under `ecosystem/dists/`, carrying the rakudo version, the mutsu
+  commit, the dependency closure and the host that measured it;
+- re-measurement is per distribution (`--only Dist::Name`), per shard
+  (`--prefix A`), per status (`--status blocked_load`), or whole-corpus, locally
+  or from GitHub Actions, and the corpus is re-measured **nightly**;
+- users can see it: `site/ecosystem.html`, generated from the ledger;
+- and the headline number is published with its history and chart — **41.1%**
+  dist parity, 53.4% file, 63.1% assertion.
+
+## Why close it rather than leave it open
+
+A tracking issue is worth keeping while there is a thing to build. There no
+longer is: the campaign's own deliverables are done, and #7785 had started to
+accumulate the *other* kind of work — "make this distribution pass", "fix this
+root cause" — which is exactly what it should not carry. One issue cannot track
+1200 non-green distributions, and an open umbrella issue makes it look as though
+something is waiting on a phase rather than on ordinary interpreter work.
+
+So from now on the queue is picked one of two ways, both of which already exist:
+
+- **by root cause** — `scripts/ecosystem-tickets.py` clusters the ledger and
+  ranks clusters by how many distributions each affects; the fifteen largest are
+  filed as `todo:*` issues (#7988, #7989, #7991-#7997, #7999-#8004), and a new
+  sweep's new clusters are found by searching the tracker for their
+  `eco-cluster: <id>`;
+- **by distribution** — the
+  [`ecosystem-dist-fix`](../../.agents/skills/ecosystem-dist-fix/SKILL.md) skill
+  for a named one, or
+  [`ecosystem-dist-roulette`](../../.agents/skills/ecosystem-dist-roulette/SKILL.md)
+  for a uniform random draw with a lock on
+  [#7884](https://github.com/tokuhirom/mutsu/issues/7884) so parallel agents do
+  not collide.
+
+Prefer a root cause when one covers several distributions — the largest single
+cluster is 99 distributions, and one parse fix in `Terminal::Widgets::Widget`
+unblocks 16. Prefer the uniform draw over picking a cheap-looking record: the
+published figure is only honest if the sample is not chosen to flatter it.
+
+PLAN.md's B4 bullet was rewritten to say that (it had been tracking phases), and
+`docs/ecosystem-parity.md` now opens with "pick work, not phases" instead of a
+phase status line.


### PR DESCRIPTION
User decision: [#7785](https://github.com/tokuhirom/mutsu/issues/7785) is closed, and the ecosystem work continues **per distribution / per root cause** from here. Documentation only.

## Why the campaign is done

Everything the issue asked for exists, across all five [ADR-0085](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0085-ecosystem-testsuite-parity-measurement.md) phases:

| the ask | where it is |
|---|---|
| run each module's suite on both interpreters | `scripts/ecosystem-sweep.py`, rakudo as the denominator |
| the difference is the KPI | **41.1%** dist parity · 53.4% file · 63.1% assertion, with `ecosystem/history.tsv` + `history.svg` |
| record the rakudo version and mutsu commit | in every record's `measured` block, with the host and dependency closure |
| machine-readable, in the repository | `ecosystem/dists/<S>/<Dist--Name>~<digest>.json`, one file per distribution |
| re-measure per module | `--only Dist::Name`, `--prefix A`, `--status blocked_load`, `--all`; nightly, on dispatch, or locally |
| available to users | `site/ecosystem.html`, generated from the ledger |

## Why close it rather than leave it open

An umbrella issue is worth keeping while something is being built. This one had started to accumulate the *other* kind of work — "make this distribution pass", "fix this root cause" — which one issue cannot track for 1200 non-green distributions, and which makes the ecosystem look as though it is waiting on a phase rather than on ordinary interpreter work.

## What the documents say instead

They stop describing phases and start describing how to pick work:

- **`docs/ecosystem-parity.md`** opens with *"pick work, not phases"* and names the two routes — a root cause from the clustered issues (§9), or a distribution via [`ecosystem-dist-fix`](https://github.com/tokuhirom/mutsu/blob/main/.agents/skills/ecosystem-dist-fix/SKILL.md) / [`ecosystem-dist-roulette`](https://github.com/tokuhirom/mutsu/blob/main/.agents/skills/ecosystem-dist-roulette/SKILL.md) — with the rule that a root cause wins when it covers several distributions (the largest cluster is 99; one parse fix in `Terminal::Widgets::Widget` unblocks 16) and that the uniform random draw beats cherry-picking a cheap record, which games the published figure. Its "Tracking issue" bullet now says the campaign is closed and that there is deliberately no open umbrella issue.
- **`PLAN.md`**'s B4 bullet was tracking P1-P5; it now states the standing per-module work and where the queue comes from.
- **`docs/adr/0085-…md`** — status line reads "Accepted and **fully implemented**", and the implementation-status section says the same.
- **`ecosystem/README.md`** — the tracking-issue bullet becomes a "how the work is picked now" bullet.
- **`news/2026-09/ecosystem-parity-campaign-closed.md`** records the close and the reasoning.

`scripts/ci-docs-only.sh --check-inputs` passes; the diff is docs/news/PLAN/ledger-README only, so CI skips the build jobs.

Refs #7785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Y5PciZAhEyPDLv7JMx7AK

---
_Generated by [Claude Code](https://claude.ai/code/session_013Y5PciZAhEyPDLv7JMx7AK)_