### PR TITLE
roast: whitelist caps.t and regex.t, whose fixes landed without them

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -74,12 +74,13 @@ Concretely:
 
 ## Current assumptions
 
-- The whitelist stands at **1433 / 1465** (2026-09-11, `wc -l roast-whitelist.txt` against
-  `find roast -name '*.t' -not -path 'roast/packages/*'`) = **32** files not whitelisted. The count
-  moved from 1435/1463 because the 2026-09-11 roast re-vendor (`b2cbe8a4` → `85a87909`) added
-  subtests to six whitelisted files and one new file; two of those seven were recovered the same
-  day by implementing what they asked for — see "Files dewhitelisted by the 2026-09-11 roast
-  re-vendor" below.
+- The whitelist stands at **1437 / 1465** (2026-09-12, `wc -l roast-whitelist.txt` against
+  `find roast -name '*.t' -not -path 'roast/packages/*'`) = **28** files not whitelisted — the
+  highest it has ever been, and two files better than before the 2026-09-11 roast re-vendor.
+  That re-vendor (`b2cbe8a4` → `85a87909`) added subtests to six whitelisted files and one new
+  file, temporarily costing five whitelist entries; **all seven were recovered within a day** by
+  implementing what each one asked for (#7902, #7903, #7904, #7905, #7906, #7907), so the section
+  that used to track them here is gone. See `news/2026-09/` for the write-ups.
 - **The S\* files (per-synopsis feature tests) are exhausted.** All of the former large campaigns
   (true lazy arrays / desugaring of dispatch and operator sugar / S17 concurrency & async /
   first-class-container container identity / cross-thread lexical writeback) are complete, and
@@ -90,7 +91,7 @@ Concretely:
   ([ADR-0009](../docs/adr/0009-regex-code-assertion-execution-model.md)). The former
   ①(stack overflow)/②(unparseable)/③(hang)/④(error-message) clusters are all cleared
   (history: [news/2026-07.md](../news/2026-07.md)).
-- **No cluster remains.** The 32 non-whitelisted files are nearly all non-goal / no-oracle /
+- **No cluster remains.** The 28 non-whitelisted files are nearly all non-goal / no-oracle /
   awaiting-infrastructure (see the tables below); the few ★achievable ones each need their own
   unrelated feature. **roast is no longer the productive axis** — prefer PLAN.md §1 (Batteries),
   §5 (perf) or §6, and pick up a roast file only when such work happens to unblock it.
@@ -139,41 +140,6 @@ noted.
 | Non-goal | `S12-traits/basic.t` | 0 at parse | SORRY (removed) | Removed `trait_auxiliary` syntax. raku also rejects it |
 | Non-goal | `S12-traits/parameterized.t` | aborts at 6/8 | SORRY (removed) | Same as above (the `trait_auxiliary:<is>` category has been removed from the language) |
 | Unpassable | `S32-temporal/time.t` | 8/10, notok 2 | SORRY | The test contains 2 deliberate `flunk("FIXME ...")` failures, plus raku also has `gmtime`/`localtime`/`times` undefined |
-
-## Files dewhitelisted by the 2026-09-11 roast re-vendor
-
-The re-vendor moved roast from `b2cbe8a4` (2026-06-12) to `85a87909` (2026-09-07). Seventeen
-upstream commits touched 20 test files; 19 of those were whitelisted. Thirteen still pass
-unchanged, and the four rows below are the ones that do not.
-
-**Two of the six files this section originally listed are already gone from it.** The C99
-hexfloat-literal gap ([#7902](https://github.com/tokuhirom/mutsu/issues/7902)) and the `%a`/`%A`
-`sprintf` directives ([#7903](https://github.com/tokuhirom/mutsu/issues/7903)) were both
-implemented on `main` within hours of being filed, so `S02-literals/numeric.t` went straight back
-onto the whitelist (89 subtests) and the brand-new `S32-str/sprintf-a.t` joined it (586 subtests) —
-a net gain over the pre-re-vendor whitelist. Their details are in `news/`.
-
-**Read the raku column before assuming the rest are mutsu defects.** Each remaining subtest is a
-*spec test written against an unfixed rakudo bug* (rakudo#4105, #5588, #2962, #4512), so the local
-oracle — Rakudo v2026.07 — fails them too, and by a wider margin than mutsu does in every one of
-these four files. These are therefore **No oracle (spec ahead of the local rakudo)**, not
-regressions: mutsu did not get worse, the target moved. Verify against a newer rakudo before
-treating any single subtest here as settled.
-
-Measured 2026-09-11 on `target/release/mutsu` (`MUTSU_FUDGE=1 prove`); raku measured by running
-the unfudged files under `raku -I roast/packages/Test-Helpers`.
-
-| Classification | File | mutsu | raku (v2026.07) | Blocker (one line) |
-|---|---|---|---|---|
-| No oracle | `S05-capture/caps.t` ([#7904](https://github.com/tokuhirom/mutsu/issues/7904)) | **55/56**, notok 47 | 43/56 | Test 47 `^ [(\d) \s]+ <?{ $0.sum == 28 }>` — a code assertion must see only the captures left *after* backtracking into a quantified group (rakudo#4105). mutsu already passes the other 12 new backtracking-capture subtests that rakudo v2026.07 fails |
-| No oracle | `S05-metasyntax/charset.t` ([#7905](https://github.com/tokuhirom/mutsu/issues/7905)) | **89/90**, notok 54 | 57/90 | Test 54 `'bb' ~~ /<![a] - [b]> ./` — a negated lookahead of a *class subtraction* must match a subtracted character (rakudo#4512). mutsu returns Nil; so does raku v2026.07. The other 34 new mixed-class/subtraction lookahead subtests pass in mutsu and 32 of them fail in rakudo |
-| No oracle | `S05-metasyntax/regex.t` ([#7906](https://github.com/tokuhirom/mutsu/issues/7906)) | **66/68**, notok 59/67 | 58/68 | Block-quantifier limits under backtracking (rakudo#5588). 59: `("abcdn" ~~ /(. ** {2..3})+ n/)` must keep the `{2..3}` minimum across a restart (mutsu matches `bcdn`, raku `abcdn` with the wrong capture split — both wrong, differently). 67: `("a,a" ~~ /^ (a **? {2} % ",") $/)` — a frugal block quantifier with a separator must count its first repetition once; Nil in both |
-| No oracle | `S05-modifier/ignorecase.t` ([#7907](https://github.com/tokuhirom/mutsu/issues/7907)) | **110/115**, notok 29/31/35/39/40 | 103/115 | Character-class fold semantics (rakudo#2962): a class entry that case-folds to *two* characters (`ß`, the `ﬀ` ligature) must still match itself but must not match part of its fold, and an entry written as base character + combining escape (`<[ a \x[308] ]>`) must match the composed grapheme and not the bare base. mutsu already passes the hex/named-escape and titlecase subtests that rakudo v2026.07 fails |
-
-`S32-io/IO-Socket-Async.t` also changed upstream (the EADDRINUSE probe now holds a real port
-instead of guessing one) and stays whitelisted: it still times out in the remote agent container at
-"planned 40 ran 17", which is the container's network sandbox, not this change — see
-[docs/agent-environments.md](../docs/agent-environments.md).
 
 ### Investigation notes (carried over from the retired S*.md files)
 

--- a/news/2026-09/roast-revendor-fully-recovered.md
+++ b/news/2026-09/roast-revendor-fully-recovered.md
@@ -1,0 +1,65 @@
+# The 2026-09-11 roast re-vendor is fully paid off — whitelist at an all-time 1437
+
+The [roast re-vendor](roast-revendor-2026-09.md) to upstream `85a87909` cost five whitelist entries
+on the day it landed, because upstream had added subtests for five still-open rakudo bugs plus a
+brand-new 586-subtest file. Each gap was filed as its own issue with a repro and a measured rakudo
+comparison. **All seven files are now whitelisted**, every issue closed by a merged fix:
+
+| Issue | Fix | File | Recovered |
+| --- | --- | --- | --- |
+| #7902 | `8fdafe81` C99 hexadecimal float literals | `S02-literals/numeric.t` | 89 subtests |
+| #7903 | `4f970ce7` `sprintf` `%a` / `%A` | `S32-str/sprintf-a.t` (new) | 586 subtests |
+| #7904 | #7935 numify Match captures in `sum` | `S05-capture/caps.t` | 56 subtests |
+| #7905 | #7938 preserve subtraction in a negated class lookahead | `S05-metasyntax/charset.t` | 90 subtests |
+| #7906 | #7945 preserve block-quantifier bounds on backtracking | `S05-metasyntax/regex.t` | 68 subtests |
+| #7907 | #7962 preserve expanded ignorecase class entries | `S05-modifier/ignorecase.t` | 115 subtests |
+
+The whitelist is **1437 / 1465** — 28 files not whitelisted, the fewest it has ever been, and two
+files *better* than the 1435 it stood at before the re-vendor. The net gain is the new
+`sprintf-a.t` (586 subtests) and `numeric.t`'s recovery.
+
+## The two that were left behind
+
+`caps.t` and `regex.t` were the reason this entry exists. Their fixes (#7935 and #7945) merged on
+2026-09-11, and both files pass completely on `main` — but neither was put back into
+`roast-whitelist.txt`, so for a day CI was not guarding 124 subtests that had already been made to
+work. `TODO_roast/BLOCKERS.md` had drifted the same way: it still carried all four regex rows and a
+stale `1433 / 1465` count against an actual 1435.
+
+Re-measured on `dcc038dc` (release build, `MUTSU_FUDGE=1 prove`), all four files pass:
+
+```
+PASS  roast/S05-capture/caps.t             (was NOT whitelisted)
+PASS  roast/S05-metasyntax/regex.t         (was NOT whitelisted)
+PASS  roast/S05-metasyntax/charset.t       (whitelisted)
+PASS  roast/S05-modifier/ignorecase.t      (whitelisted)
+```
+
+so both were added and the now-empty "Files dewhitelisted by the 2026-09-11 roast re-vendor"
+section was deleted from `BLOCKERS.md` with the counts refreshed.
+
+**The lesson is the gap itself, not the two files.** Closing the issue and merging the fix is not
+the end of a dewhitelisted roast file: the whitelist entry is a separate artifact, and nothing in
+CI notices that a file which passes is absent from it — the suite only runs what the whitelist
+names, so a recovered file simply stays silently unguarded. When a fix closes a roast blocker,
+re-running the file and restoring its whitelist line is part of that fix, and `docs/vendoring.md`'s
+post-re-vendor checklist is where that expectation lives.
+
+## Where mutsu now stands against the oracle
+
+All six of these files were spec tests written against rakudo bugs that are *still open upstream*,
+so Rakudo v2026.07 fails every one of them. Having implemented all six, mutsu now scores strictly
+higher than the local rakudo on each:
+
+| File | mutsu | raku v2026.07 |
+| --- | --- | --- |
+| `S05-capture/caps.t` | 56/56 | 43/56 |
+| `S05-metasyntax/charset.t` | 90/90 | 57/90 |
+| `S05-metasyntax/regex.t` | 68/68 | 58/68 |
+| `S05-modifier/ignorecase.t` | 115/115 | 103/115 |
+| `S02-literals/numeric.t` | 89/89 | SORRY |
+| `S32-str/sprintf-a.t` | 586/586 | 0/586 |
+
+That is the case for keeping the vendored roast current, in one table: the update did not cost four
+files, it named six concrete, well-scoped features worth implementing and they were all done inside
+a day.

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -400,6 +400,7 @@ roast/S04-statements/while.t
 roast/S04-statements/with.t
 roast/S05-capture/alias.t
 roast/S05-capture/array-alias.t
+roast/S05-capture/caps.t
 roast/S05-capture/dot.t
 roast/S05-capture/match-object.t
 roast/S05-capture/named.t
@@ -448,6 +449,7 @@ roast/S05-metasyntax/longest-alternative.t
 roast/S05-metasyntax/lookaround.t
 roast/S05-metasyntax/null.t
 roast/S05-metasyntax/proto-token-ltm.t
+roast/S05-metasyntax/regex.t
 roast/S05-metasyntax/repeat.t
 roast/S05-metasyntax/sequential-alternation.t
 roast/S05-metasyntax/single-quotes.t


### PR DESCRIPTION
The 2026-09-11 roast re-vendor (#7900) temporarily dewhitelisted five files and left one new file unwhitelisted. All six gaps were filed as issues and **all six are now closed by merged fixes** — but two of the files were never put back into `roast-whitelist.txt`.

| Issue | Fix | File | On the whitelist? |
|---|---|---|---|
| #7902 | `8fdafe81` C99 hexfloat literals | `S02-literals/numeric.t` | yes |
| #7903 | `4f970ce7` `sprintf` `%a`/`%A` | `S32-str/sprintf-a.t` | yes |
| #7904 | #7935 numify Match captures in `sum` | `S05-capture/caps.t` | **no** |
| #7905 | #7938 preserve subtraction in a negated class lookahead | `S05-metasyntax/charset.t` | yes |
| #7906 | #7945 preserve block-quantifier bounds on backtracking | `S05-metasyntax/regex.t` | **no** |
| #7907 | #7962 preserve expanded ignorecase class entries | `S05-modifier/ignorecase.t` | yes |

For a day CI was therefore not guarding 124 subtests that had already been made to work. The suite runs only what the whitelist names, so a recovered file stays silently unguarded and nothing flags it — closing the issue and merging the fix is not the end of a dewhitelisted roast file.

Re-measured on `dcc038dc` (release build, `MUTSU_FUDGE=1 prove`):

```
PASS  roast/S05-capture/caps.t             (was NOT whitelisted)
PASS  roast/S05-metasyntax/regex.t         (was NOT whitelisted)
PASS  roast/S05-metasyntax/charset.t       (whitelisted)
PASS  roast/S05-modifier/ignorecase.t      (whitelisted)
```

## What this changes

- **`roast-whitelist.txt`**: adds `caps.t` and `regex.t` → **1437 / 1465**, i.e. 28 files not whitelisted. That is the fewest it has ever been, and two files *better* than the 1435 it stood at before the re-vendor.
- **`TODO_roast/BLOCKERS.md`**: it had drifted the same way — still carrying all four regex rows and a `1433 / 1465` count against an actual 1435. The "Files dewhitelisted by the 2026-09-11 roast re-vendor" section now has no live entries and is deleted; the Current assumptions counts are refreshed.
- **`news/2026-09/roast-revendor-fully-recovered.md`**: the write-up, including the "restoring the whitelist line is part of the fix" lesson.

## Against the oracle

All six files are spec tests written against rakudo bugs that are **still open upstream**, so Rakudo v2026.07 fails every one. Having implemented all six, mutsu now scores strictly higher on each:

| File | mutsu | raku v2026.07 |
|---|---|---|
| `S05-capture/caps.t` | 56/56 | 43/56 |
| `S05-metasyntax/charset.t` | 90/90 | 57/90 |
| `S05-metasyntax/regex.t` | 68/68 | 58/68 |
| `S05-modifier/ignorecase.t` | 115/115 | 103/115 |
| `S02-literals/numeric.t` | 89/89 | SORRY |
| `S32-str/sprintf-a.t` | 586/586 | 0/586 |

## Verification

- `make test` **PASS**.
- `make roast` — `Files=1437`, and the only failures are the documented container-only ones: `6.c/S32-io/file-tests.t` tests 6-8/10 and `S16-filehandles/filetest.t` tests 57-64/69-72/77-80/101..125, both from running as `uid 0` (`docs/agent-environments.md`).
- No Rust source changed, so clippy/rustdoc output matches `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pmx4WKX5S4aRuLvTyHSMEC


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pmx4WKX5S4aRuLvTyHSMEC)_