### PR TITLE
fix(ecosystem): five interpreter gaps Math::Vector's suite exposed (0 to 197 of 201)

### DIFF
--- a/ecosystem/dists/A/ABC~b5d4045c.json
+++ b/ecosystem/dists/A/ABC~b5d4045c.json
@@ -18,7 +18,7 @@
         "nok": 37,
         "ok": 238,
         "plan": 275,
-        "secs": 0.83,
+        "secs": 0.98,
         "skip": 0,
         "todo": 0,
         "verdict": "fail"
@@ -28,7 +28,7 @@
         "nok": 0,
         "ok": 275,
         "plan": 275,
-        "secs": 2.13,
+        "secs": 4.02,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -40,7 +40,7 @@
         "nok": 0,
         "ok": 43,
         "plan": 43,
-        "secs": 0.24,
+        "secs": 0.21,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -50,7 +50,7 @@
         "nok": 0,
         "ok": 43,
         "plan": 43,
-        "secs": 4.78,
+        "secs": 7.63,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -62,7 +62,7 @@
         "nok": 0,
         "ok": 6,
         "plan": 6,
-        "secs": 0.28,
+        "secs": 0.22,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -72,7 +72,7 @@
         "nok": 0,
         "ok": 6,
         "plan": 6,
-        "secs": 0.67,
+        "secs": 0.57,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -84,7 +84,7 @@
         "nok": 0,
         "ok": 18,
         "plan": 18,
-        "secs": 0.15,
+        "secs": 0.12,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -94,7 +94,7 @@
         "nok": 0,
         "ok": 18,
         "plan": 18,
-        "secs": 1.4,
+        "secs": 1.3,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -107,7 +107,7 @@
         "nok": 0,
         "ok": 15,
         "plan": null,
-        "secs": 0.29,
+        "secs": 0.22,
         "skip": 0,
         "todo": 0,
         "verdict": "die"
@@ -117,7 +117,7 @@
         "nok": 0,
         "ok": 148,
         "plan": 148,
-        "secs": 9.37,
+        "secs": 8.56,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -130,7 +130,7 @@
         "nok": 0,
         "ok": 0,
         "plan": null,
-        "secs": 0.11,
+        "secs": 0.1,
         "skip": 0,
         "todo": 0,
         "verdict": "die"
@@ -140,6 +140,29 @@
         "nok": 0,
         "ok": 8,
         "plan": 8,
+        "secs": 0.62,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "regression",
+      "mutsu": {
+        "first_failure": "Type check failed in binding to parameter '$duration'; expected ABC::Duration but got Nil (Nil)",
+        "nok": 0,
+        "ok": 0,
+        "plan": null,
+        "secs": 0.22,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "die"
+      },
+      "path": "t/07-stringify.t",
+      "raku": {
+        "nok": 0,
+        "ok": 126,
+        "plan": 126,
         "secs": 0.71,
         "skip": 0,
         "todo": 0,
@@ -153,30 +176,7 @@
         "nok": 0,
         "ok": 0,
         "plan": null,
-        "secs": 0.27,
-        "skip": 0,
-        "todo": 0,
-        "verdict": "die"
-      },
-      "path": "t/07-stringify.t",
-      "raku": {
-        "nok": 0,
-        "ok": 126,
-        "plan": 126,
-        "secs": 0.91,
-        "skip": 0,
-        "todo": 0,
-        "verdict": "pass"
-      }
-    },
-    {
-      "cmp": "regression",
-      "mutsu": {
-        "first_failure": "Type check failed in binding to parameter '$duration'; expected ABC::Duration but got Nil (Nil)",
-        "nok": 0,
-        "ok": 0,
-        "plan": null,
-        "secs": 0.42,
+        "secs": 0.26,
         "skip": 0,
         "todo": 0,
         "verdict": "die"
@@ -186,7 +186,7 @@
         "nok": 0,
         "ok": 79,
         "plan": 79,
-        "secs": 1.62,
+        "secs": 1.96,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -199,7 +199,7 @@
         "nok": 0,
         "ok": 0,
         "plan": null,
-        "secs": 0.33,
+        "secs": 0.21,
         "skip": 0,
         "todo": 0,
         "verdict": "die"
@@ -209,30 +209,30 @@
         "nok": 0,
         "ok": 82,
         "plan": 82,
-        "secs": 1.02,
+        "secs": 1.48,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
       }
     },
     {
-      "cmp": "regression",
+      "cmp": "partial",
       "mutsu": {
-        "first_failure": "Runtime error: Unsupported use of -> as postfix. In Raku please use: either . to call a method, or whitespace to delimit a pointy block.",
-        "nok": 0,
-        "ok": 0,
-        "plan": null,
-        "secs": 0.06,
+        "first_failure": "Middle C is correct",
+        "nok": 10,
+        "ok": 109,
+        "plan": 119,
+        "secs": 0.24,
         "skip": 0,
         "todo": 0,
-        "verdict": "die"
+        "verdict": "fail"
       },
       "path": "t/10-utils.t",
       "raku": {
         "nok": 0,
         "ok": 119,
         "plan": 119,
-        "secs": 0.75,
+        "secs": 0.77,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -267,8 +267,8 @@
     "attempts": 3,
     "date": "2026-09-11",
     "harness": 1,
-    "host": "gha-ubuntu24-4c",
-    "mutsu_commit": "7807eb5",
+    "host": "linux-x86_64",
+    "mutsu_commit": "7807eb50",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
@@ -283,7 +283,7 @@
   "totals": {
     "baseline_assertions": 904,
     "baseline_files": 10,
-    "mutsu_assertions": 320,
+    "mutsu_assertions": 429,
     "parity_files": 3,
     "regressed_files": 7
   },

--- a/ecosystem/dists/C/Color~6b73191a.json
+++ b/ecosystem/dists/C/Color~6b73191a.json
@@ -14,7 +14,7 @@
         "nok": 0,
         "ok": 28,
         "plan": 28,
-        "secs": 0.19,
+        "secs": 0.3,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -24,7 +24,7 @@
         "nok": 0,
         "ok": 28,
         "plan": 28,
-        "secs": 6.44,
+        "secs": 10.06,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -36,7 +36,7 @@
         "nok": 0,
         "ok": 10,
         "plan": 10,
-        "secs": 0.15,
+        "secs": 0.21,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -46,7 +46,7 @@
         "nok": 0,
         "ok": 10,
         "plan": 10,
-        "secs": 0.76,
+        "secs": 0.87,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -68,7 +68,7 @@
         "nok": 0,
         "ok": 8,
         "plan": 8,
-        "secs": 0.81,
+        "secs": 1.1,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -80,7 +80,7 @@
         "nok": 0,
         "ok": 7,
         "plan": 7,
-        "secs": 0.15,
+        "secs": 0.2,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -90,7 +90,7 @@
         "nok": 0,
         "ok": 7,
         "plan": 7,
-        "secs": 0.68,
+        "secs": 0.86,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -103,7 +103,7 @@
         "nok": 1,
         "ok": 4,
         "plan": 6,
-        "secs": 0.17,
+        "secs": 0.26,
         "skip": 0,
         "todo": 0,
         "verdict": "fail"
@@ -113,30 +113,30 @@
         "nok": 0,
         "ok": 6,
         "plan": 6,
-        "secs": 0.8,
+        "secs": 1.01,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
       }
     },
     {
-      "cmp": "regression",
+      "cmp": "partial",
       "mutsu": {
-        "first_failure": "Cannot resolve caller Numeric(Color:D: ); none of these signatures matches:",
-        "nok": 0,
+        "first_failure": "operator tests with rgb nums and alpha-math turned off [default]",
+        "nok": 2,
         "ok": 0,
         "plan": 5,
-        "secs": 0.14,
+        "secs": 0.35,
         "skip": 0,
         "todo": 0,
-        "verdict": "die"
+        "verdict": "fail"
       },
       "path": "t/06-operators.rakutest",
       "raku": {
         "nok": 0,
         "ok": 5,
         "plan": 5,
-        "secs": 0.95,
+        "secs": 1.84,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -148,7 +148,7 @@
         "nok": 0,
         "ok": 1,
         "plan": 1,
-        "secs": 0.11,
+        "secs": 0.18,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -158,7 +158,7 @@
         "nok": 0,
         "ok": 1,
         "plan": 1,
-        "secs": 0.5,
+        "secs": 1.0,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -171,7 +171,7 @@
         "nok": 0,
         "ok": 1,
         "plan": 2,
-        "secs": 0.13,
+        "secs": 0.19,
         "skip": 0,
         "todo": 0,
         "verdict": "die"
@@ -181,7 +181,7 @@
         "nok": 0,
         "ok": 2,
         "plan": 2,
-        "secs": 0.67,
+        "secs": 1.31,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -199,8 +199,8 @@
     "attempts": 3,
     "date": "2026-09-11",
     "harness": 1,
-    "host": "gha-ubuntu24-4c",
-    "mutsu_commit": "7807eb5",
+    "host": "linux-x86_64",
+    "mutsu_commit": "7807eb50",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",

--- a/ecosystem/dists/M/Math--Vector~38e815a9.json
+++ b/ecosystem/dists/M/Math--Vector~38e815a9.json
@@ -9,23 +9,23 @@
   "dist": "Math::Vector",
   "files": [
     {
-      "cmp": "regression",
+      "cmp": "partial",
       "mutsu": {
-        "first_failure": "Runtime error: Unsupported use of -> as postfix. In Raku please use: either . to call a method, or whitespace to delimit a pointy block.",
-        "nok": 0,
-        "ok": 0,
-        "plan": null,
-        "secs": 0.08,
+        "first_failure": "not ok 192 -",
+        "nok": 4,
+        "ok": 197,
+        "plan": 201,
+        "secs": 0.48,
         "skip": 0,
         "todo": 0,
-        "verdict": "die"
+        "verdict": "fail"
       },
       "path": "t/01-basics.rakutest",
       "raku": {
         "nok": 0,
         "ok": 201,
         "plan": 201,
-        "secs": 5.37,
+        "secs": 5.32,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -39,8 +39,8 @@
     "attempts": 3,
     "date": "2026-09-11",
     "harness": 1,
-    "host": "gha-ubuntu24-4c",
-    "mutsu_commit": "7807eb5",
+    "host": "linux-x86_64",
+    "mutsu_commit": "7807eb50",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
@@ -55,7 +55,7 @@
   "totals": {
     "baseline_assertions": 201,
     "baseline_files": 1,
-    "mutsu_assertions": 0,
+    "mutsu_assertions": 197,
     "parity_files": 0,
     "regressed_files": 1
   },

--- a/ecosystem/dists/O/octans~2e573a83.json
+++ b/ecosystem/dists/O/octans~2e573a83.json
@@ -32,9 +32,54 @@
     "unresolved": []
   },
   "dist": "octans",
-  "files": [],
+  "files": [
+    {
+      "cmp": "parity",
+      "mutsu": {
+        "nok": 0,
+        "ok": 8,
+        "plan": 8,
+        "secs": 1.06,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      },
+      "path": "t/00-basic.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 8,
+        "plan": 8,
+        "secs": 54.56,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    },
+    {
+      "cmp": "parity",
+      "mutsu": {
+        "nok": 0,
+        "ok": 3,
+        "plan": 3,
+        "secs": 0.1,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      },
+      "path": "t/01-hex2rgb.rakutest",
+      "raku": {
+        "nok": 0,
+        "ok": 3,
+        "plan": 3,
+        "secs": 0.78,
+        "skip": 0,
+        "todo": 0,
+        "verdict": "pass"
+      }
+    }
+  ],
   "load": {
-    "Octans::CLI": "Runtime error: Failed to parse module 'Octans::CLI': Unsupported use of -> as postfix. In Raku please use: either . to call a method, or whitespace to delimit a pointy block.",
+    "Octans::CLI": "ok",
     "Octans::GenerateFrame": "ok",
     "Octans::Hex2RGB": "ok",
     "Octans::Neighbors": "ok",
@@ -47,8 +92,8 @@
     "attempts": 3,
     "date": "2026-09-11",
     "harness": 1,
-    "host": "gha-ubuntu24-4c",
-    "mutsu_commit": "7807eb5",
+    "host": "linux-x86_64",
+    "mutsu_commit": "7807eb50",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
@@ -59,12 +104,12 @@
     "index": "fez",
     "url": "https://360.zef.pm/O/CT/OCTANS/a7c5e7f0b88297ee9f47ac83489eee5e43bb322a.tar.gz"
   },
-  "status": "blocked_load",
+  "status": "green",
   "totals": {
-    "baseline_assertions": 0,
-    "baseline_files": 0,
-    "mutsu_assertions": 0,
-    "parity_files": 0,
+    "baseline_assertions": 11,
+    "baseline_files": 2,
+    "mutsu_assertions": 11,
+    "parity_files": 2,
     "regressed_files": 0
   },
   "version": "0.2.5"

--- a/news/2026-09/math-vector-zef-dist-goes-from-zero-to-197.md
+++ b/news/2026-09/math-vector-zef-dist-goes-from-zero-to-197.md
@@ -1,0 +1,109 @@
+# Math::Vector: a zef distribution from 0 of 201 assertions to 197
+
+`Math::Vector` 0.6.0 loaded under mutsu but its only test file died on line 3 of the suite, so the
+ledger recorded `status: red` with `mutsu_assertions: 0` against a rakudo baseline of 201. Five
+general interpreter bugs stood between those two numbers. None of them is about vectors.
+
+## `->` after a term whose parser ate its own trailing whitespace
+
+```raku
+for flat (1, 2) X (3, 4) -> $x, $y { ... }
+```
+
+threw `Unsupported use of -> as postfix. In Raku please use: either . to call a method, or whitespace
+to delimit a pointy block` — a diagnosis that states its own refutation. Raku's rule here is purely
+lexical: `->` **glued** to a term is the obsolete Perl 5 arrow, and whitespace before it delimits a
+pointy block. Normally the remainder carries that distinction, because with a space the remainder
+starts with the space rather than with `->`. But a bare listop whose argument list is extended with a
+list-infix operator (`flat (...) X (...)`) consumes the whitespace itself, so by the time the postfix
+loop looked, the arrow was flush against the term and the obsolete-syntax check fired on a perfectly
+good pointy block.
+
+`postfix_expr_loop_from` already tracks exactly the fact needed to tell those apart —
+`term_ends_with_ws`, the consumed span's own answer to "did I end on whitespace", which
+`brace_is_postcircumfix` relies on for the same class of term parsers. Gating the arrow check on it
+fixes the whole family at once, and `$x->foo` is still rejected.
+
+## An operator whose name contains `/` was reaped from the registry by its own slash
+
+`multi infix:</>(Math::Vector $a, $b) is export` vanished the moment its module finished loading, so
+`$vector / $scalar` fell through to numeric division and threw `Cannot resolve caller
+Numeric(Math::Vector:D: )`. Every sibling operator in the same file — `+ - * % **` — worked.
+
+The post-load pass in `runtime_module.rs` that reaps *non-exported* operator `GLOBAL::` routines
+derived each key's operator name by splitting at the **first** `/`. For `GLOBAL::infix:</>/2` that is
+the operator's own slash, yielding `infix:<`, which no entry in the exported-operator set can
+match — so an exported candidate was classified as non-exported and deleted. The correct extraction
+already existed a module away: `function_key_base_name` in `dispatch_resolve.rs` takes the arity
+suffix at the rightmost `/` *followed by an ASCII digit*, precisely so an operator's own slash
+survives. It is now split into a reusable `function_key_strip_arity_suffix` and used at the reap
+sites, plus in the `MY::`/`UNIT::` pseudo-stash listing, which had been spelling the operator
+`&infix:<` for the same reason.
+
+## `×` and `÷` lost their core implementation, and `×=` looked up the wrong name
+
+rakudo makes the Unicode spellings aliases of the ASCII routines — `&infix:<×> === &infix:<*>` is
+`True`, and `&infix:<÷>.name` is `infix:</>` — while keeping them separate *names* for user
+declarations. Two consequences, and mutsu had both backwards:
+
+- A user `multi infix:<×>` sits in front of the shared core implementation rather than replacing it.
+  Math::Vector's `×` is constrained to three dimensions (`where { $a.dim == 3 }`), so `$v5 × $v6` on
+  5-vectors must reach the core candidate and throw on the numeric coercion. mutsu diverts `×` off
+  `OpCode::Mul` as soon as any user `infix:<×>` exists, and the generic `call_infix_fallback`
+  reduction that then answered runs the *lenient* `builtins::arith_*`, which read an object as 0 —
+  turning a `dies-ok` into a silent `Int`. `×`/`÷` now fall back to the same strict numeric coercion
+  their ASCII opcodes apply.
+- `×=` is the assignment metaop over the name **as spelled**, so it reaches a user `infix:<×>` where
+  `*=` (a different name) does not. mutsu mapped `×=` to `CompoundAssignOp::Mul` unconditionally,
+  desugaring it to `*=`. It now declines the alias when a user `infix:<×>` is declared, exactly as
+  `parse_multiplicative_op` already does for the bare operator, which hands the spelling to the
+  generic user-symbol-infix metaop path that was already there for `⋅=`.
+
+## `.perl` did not reach a user `raku` override
+
+`Mu.perl` is rakudo's deprecated spelling of `.raku` and is implemented by *calling* `self.raku`, so
+a class that overrides only `raku` renders through that override under either name. mutsu resolved
+the two names independently and fell through to its own attribute-dump renderer, which broke
+Math::Vector's `multi method raku()` — it renders nested vectors with `@.components.map({ .perl })`,
+and the result is asserted to round-trip through `EVAL`. `.perl` now delegates when the class has a
+user `raku` and no `perl` of its own; the gate keeps `callsame` from inside an explicit `perl`
+override reaching the default as before.
+
+## A Range subscript on a `does Positional` instance is a slice
+
+`$vec[1..2]` answered `Nil` while `$vec[0, 2]` worked: only the comma-list index arm knew how to
+slice an instance. A Range names its indices outright, so — unlike the Whatever arms beside it, which
+need `.elems` and are deliberately narrow — it needs nothing from the class beyond the `AT-POS` the
+single-index arm already calls, and now applies to every `does Positional` class. An unbounded end
+(`$vec[1..*]`) would need `.elems` and is still left alone.
+
+## Result
+
+`Math::Vector` 0.6.0: **0 → 197 of 201** baseline assertions, `t/01-basics.rakutest` no longer dies
+mid-file.
+
+Three neighbouring ledger records, picked by root cause rather than convenience, moved for free —
+which is the evidence that these are interpreter fixes and not a distribution's special case:
+
+| distribution | before | after |
+| --- | --- | --- |
+| `octans` 0.2.5 | `blocked_load`, 0 assertions | **`green`**, 11/11, 2/2 files |
+| `ABC` 0.6.13 | `partial`, 320/904; `t/10-utils.t` a `regression` at 0/119 | `partial`, **429**/904; `t/10-utils.t` now `partial` at 109/119 |
+| `Color` 1.004001 | `t/06-operators.rakutest` a `regression`, dying on the first statement | that file now reaches its plan as a `partial` |
+
+`octans` and `ABC`'s `t/10-utils.t` were both the `->`-after-a-listop parse gap; `Color`'s operator
+file was the `Numeric` coercion reached through a user infix. The four remaining assertions are two filed gaps, neither of them about this distribution:
+[#8006](https://github.com/tokuhirom/mutsu/issues/8006) (a user `multi infix:<cross>` must shadow the
+core `cross` rather than extend it — the classification of which core infixes are `proto`/`multi` and
+which are plain `sub`s) accounts for three, and
+[#8007](https://github.com/tokuhirom/mutsu/issues/8007) (a compound assignment inside a block skips
+the declared type check when the base op dispatches to a user infix) accounts for the last.
+[#8008](https://github.com/tokuhirom/mutsu/issues/8008) was found along the way: a module's own body
+cannot reach the operator multis it exports, which is independent of the `/` mangling above and
+affects `*` equally.
+
+Pins: `t/lang/operators/metaop-cross-listop-arg-pointy-block.t`,
+`t/modules/import-export/module-export-slash-operator.t`,
+`t/lang/operators/user-infix-unicode-times-slash.t`,
+`t/oo/method/methods-instance-perl-raku-delegation.t`,
+`t/collections/subscript/positional-instance-range-slice.t`.

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -827,7 +827,18 @@ fn postfix_expr_loop_from(
                 }
             }
         }
-        if rest.starts_with("->") {
+        // `$obj->method` is the Perl 5 arrow, and Raku rejects it outright. The
+        // rule is purely lexical and the diagnosis says so itself: whitespace
+        // before the `->` delimits a POINTY BLOCK, so only an arrow glued to
+        // the term is the obsolete postfix. Normally the remainder carries that
+        // distinction — with a space it starts with the space, not with `->` —
+        // but term parsers that eat their own trailing whitespace (a bare
+        // listop: `for flat (1,2) X (3,4) -> $x, $y {...}`) have already erased
+        // it by the time we look, which turned a perfectly good pointy block
+        // into this error. `term_ends_with_ws` is the consumed span's own answer
+        // to "did I end on whitespace", the same restoration
+        // `brace_is_postcircumfix` relies on.
+        if rest.starts_with("->") && !term_ends_with_ws {
             return Err(PError::obsolete(
                 "-> as postfix",
                 "either . to call a method, or whitespace to delimit a pointy block",

--- a/src/parser/stmt/assign/op.rs
+++ b/src/parser/stmt/assign/op.rs
@@ -492,11 +492,20 @@ pub(crate) fn parse_compound_assign_op(input: &str) -> Option<(&str, CompoundAss
     // the ASCII ops: `×=` (U+00D7) == `*=`, `÷=` (U+00F7) == `/=`. Raku accepts
     // these; the multiplicative parser leaves `×`/`÷` before `=` alone so the
     // lvalue reaches here (mirroring the `*=` guard).
-    for (sym, op) in [
-        ("\u{00D7}=", CompoundAssignOp::Mul),
-        ("\u{00F7}=", CompoundAssignOp::Div),
+    //
+    // A user-declared `infix:<×>`/`infix:<÷>` takes the alias back, exactly as
+    // it does for the bare operator in `parse_multiplicative_op`: rakudo makes
+    // `×=` the assignment metaop over `infix:<×>` *as spelled*, so it reaches
+    // the user's candidate while `*=` (a different name) does not. Declining
+    // here hands the spelling to `parse_custom_compound_assign_op`, which
+    // already builds that metaop for any user symbol infix (`⋅=`).
+    for (sym, op, bare) in [
+        ("\u{00D7}=", CompoundAssignOp::Mul, "\u{00D7}"),
+        ("\u{00F7}=", CompoundAssignOp::Div, "\u{00F7}"),
     ] {
-        if let Some(stripped) = input.strip_prefix(sym) {
+        if let Some(stripped) = input.strip_prefix(sym)
+            && !crate::parser::stmt::simple::is_user_defined_infix(bare)
+        {
             return Some((stripped, op));
         }
     }

--- a/src/runtime/dispatch_resolve.rs
+++ b/src/runtime/dispatch_resolve.rs
@@ -1,15 +1,17 @@
 use super::*;
 
-/// The *base name* a registry function key stands for: the key minus its
-/// package prefix and its arity/type suffix. `"Pkg::foo/2:Int,Str"` → `"foo"`,
-/// `"GLOBAL::infix:</>/2"` → `"infix:</>"`, `"foo"` → `"foo"`.
+/// A registry function key minus its arity/type suffix: `"Pkg::foo/2:Int,Str"` →
+/// `"Pkg::foo"`, `"GLOBAL::infix:</>/2"` → `"GLOBAL::infix:</>"`. The package
+/// prefix is left in place — [`function_key_base_name`] strips that too.
 ///
-/// The arity suffix is the RIGHTMOST `/` immediately followed by an ASCII
-/// digit (`/2`, `/3:Int`, `/1__m…`); an operator name's own `/` (as in
-/// `infix:</>`) is never digit-followed, so it survives. The same extraction
-/// is applied to both registry keys and query names, so any exotic spelling
-/// degrades to a consistent (never wrong) bucket.
-fn function_key_base_name(key: &str) -> &str {
+/// The suffix starts at the RIGHTMOST `/` immediately followed by an ASCII
+/// digit, which is what makes an operator name's own `/` survive: the `/` in
+/// `infix:</>` is followed by `>`. Naively splitting at the FIRST `/` instead
+/// mangles that name to `infix:<`, and a caller deciding whether a key is an
+/// *exported* operator then compares the mangled spelling against the real one
+/// and concludes it is not — which is how a module's `multi infix:</>` used to
+/// be reaped from the registry right after its own load (Math::Vector).
+pub(crate) fn function_key_strip_arity_suffix(key: &str) -> &str {
     let bytes = key.as_bytes();
     let mut end = key.len();
     let mut i = key.len();
@@ -20,7 +22,20 @@ fn function_key_base_name(key: &str) -> &str {
             break;
         }
     }
-    let head = &key[..end];
+    &key[..end]
+}
+
+/// The *base name* a registry function key stands for: the key minus its
+/// package prefix and its arity/type suffix. `"Pkg::foo/2:Int,Str"` → `"foo"`,
+/// `"GLOBAL::infix:</>/2"` → `"infix:</>"`, `"foo"` → `"foo"`.
+///
+/// The arity suffix is the RIGHTMOST `/` immediately followed by an ASCII
+/// digit (`/2`, `/3:Int`, `/1__m…`); an operator name's own `/` (as in
+/// `infix:</>`) is never digit-followed, so it survives. The same extraction
+/// is applied to both registry keys and query names, so any exotic spelling
+/// degrades to a consistent (never wrong) bucket.
+fn function_key_base_name(key: &str) -> &str {
+    let head = function_key_strip_arity_suffix(key);
     // A hand-rolled reverse scan for `::`: `str::rfind` builds a two-way
     // searcher per call, which is most of what this function cost on the
     // per-dispatch candidate walk that calls it once per registry key.

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -177,6 +177,24 @@ impl Interpreter {
         if !((method == "raku" || method == "perl" || gist_default) && args.is_empty()) {
             return None;
         }
+        // `.perl` is rakudo's deprecated spelling of `.raku` on `Mu`, and it is
+        // implemented by *calling* `self.raku` — so a class that overrides only
+        // `raku` still renders through that override under either name. mutsu
+        // resolves the two names independently, so reaching this default
+        // renderer under `perl` while the class has its own `raku` would render
+        // the attribute-dump form instead of the user's text (Math::Vector's
+        // `multi method raku()` renders nested vectors via `@.components.map({.perl})`,
+        // which round-trips through `EVAL` in rakudo and did not here).
+        // Gated on the class NOT declaring `perl` itself, because
+        // `native_any_base_next_candidate` reaches this default deliberately when
+        // a `callsame` inside a user override exhausts the MRO; an explicit
+        // `perl` override's `callsame` must still get the default rendering.
+        if method == "perl"
+            && self.has_user_method(&class_name.resolve(), "raku")
+            && !self.has_user_method(&class_name.resolve(), "perl")
+        {
+            return Some(self.call_method_with_values(target.clone(), "raku", vec![]));
+        }
         // An `is Str` subclass delegates `.raku`/`.gist` to its string payload,
         // so `class Foo is Str {}; Foo.new(:value("hi")).raku` is `"hi"` —
         // mirrors the `is Array`/`is Hash` backing-storage delegation below.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -611,7 +611,7 @@ mod dispatch_proto;
 mod dispatch_proto_call;
 mod dispatch_proto_candidates;
 mod dispatch_proto_rewrite;
-mod dispatch_resolve;
+pub(crate) mod dispatch_resolve;
 mod end_phasers;
 mod eval_check;
 mod eval_routine_magicals;

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -691,7 +691,13 @@ impl Interpreter {
                     }
                     let ks = k.resolve();
                     if let Some(name) = ks.strip_prefix("GLOBAL::") {
-                        let base = name.split('/').next().unwrap_or(name);
+                        // The arity suffix, NOT the first `/`: `infix:</>` carries
+                        // a `/` of its own, and splitting at it spelled the name
+                        // `infix:<`, which no `exported_op_names` entry can match —
+                        // so an exported `multi infix:</>` was reaped here right
+                        // after declaring it (Math::Vector's `$vector / $scalar`).
+                        let base =
+                            crate::runtime::dispatch_resolve::function_key_strip_arity_suffix(name);
                         // Only remove operator subs (infix:<...>, prefix:<...>, etc.)
                         base.contains(":<") && !exported_op_names.contains(base)
                     } else {
@@ -745,7 +751,8 @@ impl Interpreter {
                         let Some(name) = ks.strip_prefix("GLOBAL::") else {
                             return false;
                         };
-                        let base = name.split('/').next().unwrap_or(name);
+                        let base =
+                            crate::runtime::dispatch_resolve::function_key_strip_arity_suffix(name);
                         !exported_names.contains(base) && Self::is_builtin_function(base)
                     })
                     .copied()

--- a/src/vm/vm_flipflop_ops.rs
+++ b/src/vm/vm_flipflop_ops.rs
@@ -95,6 +95,10 @@ impl Interpreter {
                 let right_val = right_vals.first().cloned().unwrap_or(Value::NIL);
                 if let Some(result) = self.try_user_infix(&infix_name, &left_val, &right_val)? {
                     result
+                } else if let Some(result) =
+                    self.core_unicode_arith_alias_infix(&name, &left_val, &right_val)?
+                {
+                    result
                 } else {
                     self.call_infix_fallback(
                         lookup_name.as_ref(),
@@ -288,6 +292,44 @@ impl Interpreter {
         self.stack.push(value);
         *ip = rhs_end;
         Ok(())
+    }
+
+    /// The CORE candidate of `×` (U+00D7) / `÷` (U+00F7): the very arithmetic
+    /// `infix:<*>` / `infix:</>` performs, strict numeric coercion included.
+    ///
+    /// rakudo makes the Unicode spellings aliases of the ASCII routines
+    /// (`&infix:<×> === &infix:<*>`), so a user `multi infix:<×>` adds a
+    /// candidate in front of that shared core set rather than replacing it:
+    /// when the user candidate declines (a `where` clause that does not hold,
+    /// as in Math::Vector's 3-dimensions-only `×`), the core candidate runs and
+    /// an operand with no numeric coercion throws `Cannot resolve caller
+    /// Numeric(...)`. mutsu diverts `×` off `OpCode::Mul` as soon as any user
+    /// `infix:<×>` is declared (`parse_multiplicative_op`), so the generic
+    /// `call_infix_fallback` reduction answered for it instead — and that runs
+    /// the *lenient* `builtins::arith_*`, which read an object as 0 and turned
+    /// a `dies-ok` into a silent `Int`.
+    ///
+    /// `Some` means this was one of those two spellings and the core candidate
+    /// has answered (or thrown); `None` leaves every other operator to the
+    /// generic fallback.
+    fn core_unicode_arith_alias_infix(
+        &mut self,
+        name: &str,
+        left: &Value,
+        right: &Value,
+    ) -> Result<Option<Value>, RuntimeError> {
+        let multiply = match name {
+            "\u{00D7}" => true,
+            "\u{00F7}" => false,
+            _ => return Ok(None),
+        };
+        let (l, r) = self.coerce_numeric_bridge_pair_strict(left.clone(), right.clone())?;
+        let result = if multiply {
+            crate::builtins::arith_mul(l, r)
+        } else {
+            crate::builtins::arith_div(l, r)?
+        };
+        Ok(Some(result))
     }
 
     fn call_infix_fallback(

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -638,7 +638,11 @@ impl Interpreter {
                     let name = packages.iter().find_map(|package| {
                         let prefix = format!("{package}::");
                         let rest = key.strip_prefix(&prefix)?;
-                        let name = rest.split('/').next().unwrap_or(rest);
+                        // Strip the arity suffix, not the first `/`: an operator
+                        // name can carry a `/` of its own, and splitting there
+                        // listed `infix:</>` in the pseudo-stash as `infix:<`.
+                        let name =
+                            crate::runtime::dispatch_resolve::function_key_strip_arity_suffix(rest);
                         (!name.contains("::") && !name.is_empty()).then(|| name.to_string())
                     })?;
                     let declared_here = def.source_file.is_none()

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1630,6 +1630,38 @@ impl Interpreter {
                     result
                 }
             }
+            // A Range subscript on an instance is a SLICE of `AT-POS` reads, one
+            // per index the range names: `$vec[1..2]` is `($vec[1], $vec[2])`.
+            // The index list is fully determined by the range, so — unlike the
+            // Whatever arms below — this needs nothing from the class beyond the
+            // `AT-POS` the single-index arm already calls, and therefore applies
+            // to every `does Positional` class (Math::Vector's
+            // `has @.components handles <AT-POS>`, whose `$v[1..2]` answered Nil
+            // because only the comma-list index arm below knew how to slice).
+            // An unbounded end (`$v[1..*]`) would need `.elems`, so it is left to
+            // the arms below.
+            (ValueView::Instance { .. }, _)
+                if is_positional
+                    && let Some((start, end, _, excl_end)) = range_params(&index)
+                    && !Self::range_end_is_unbounded(end) =>
+            {
+                let last = if excl_end { end - 1 } else { end };
+                let mut results = Vec::new();
+                for i in start.max(0)..=last {
+                    results.push(
+                        self.try_compiled_method_or_interpret(
+                            target.clone(),
+                            "AT-POS",
+                            vec![Value::int(i)],
+                        )
+                        .unwrap_or(Value::NIL),
+                    );
+                }
+                Value::array_with_kind(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(results)),
+                    crate::value::ArrayKind::List,
+                )
+            }
             // Whatever slice on an `is Array` / `is List` subclass instance
             // (`class MA is Array {}; $m[*]`, `Cro::HTTP::MultiValue is List`).
             // Its elements live in the backing `__mutsu_array_storage`, and `*`

--- a/t/collections/subscript/positional-instance-range-slice.t
+++ b/t/collections/subscript/positional-instance-range-slice.t
@@ -1,0 +1,42 @@
+use Test;
+
+# A Range subscript on a `does Positional` instance is a SLICE of `AT-POS` reads,
+# one per index the range names: `$vec[1..2]` is `($vec[1], $vec[2])`. mutsu only
+# knew how to slice an instance through a comma-list index (`$vec[0, 2]`), so a
+# Range — or anything producing one, such as `^2` — answered Nil.
+# From Math::Vector's `has @.components handles <AT-POS>`.
+
+plan 10;
+
+class Vec does Positional {
+    has @.components handles <AT-POS>;
+    multi method new(*@x) { self.bless(components => @x) }
+}
+
+my $v = Vec.new(1, 2, 3, 4);
+
+is $v[1].raku, '2', 'a single index still reads one element';
+is $v[1..2].raku, '(2, 3)', 'an inclusive Range slices through AT-POS';
+is $v[1..^3].raku, '(2, 3)', 'an exclusive-end Range slices';
+is $v[^2].raku, '(1, 2)', '^N slices';
+is $v[0, 2].raku, '(1, 3)', 'the comma-list index is unchanged';
+is $v[1..1].raku, '(2,)', 'a one-element Range is still a slice';
+
+# An explicit AT-POS (no `handles`) behaves the same.
+class Own does Positional {
+    has @.c;
+    method AT-POS($i) { @.c[$i] }
+}
+is Own.new(c => [10, 20, 30])[1..2].raku, '(20, 30)', 'an explicit AT-POS slices too';
+
+# Associative instances are untouched.
+class Assoc {
+    method AT-KEY($k) { "k:$k" }
+}
+is Assoc.new<a>.raku, '"k:a"', 'an AT-KEY subscript is unaffected';
+
+# Plain containers are unaffected.
+my @a = 1, 2, 3;
+is @a[1..2].raku, '(2, 3)', 'an Array Range slice is unchanged';
+my %h = a => 1;
+is %h<a>.raku, '1', 'a Hash subscript is unchanged';

--- a/t/lang/operators/metaop-cross-listop-arg-pointy-block.t
+++ b/t/lang/operators/metaop-cross-listop-arg-pointy-block.t
@@ -1,0 +1,55 @@
+use Test;
+
+# A bare listop whose argument list ends with a list-infix operator eats its own
+# trailing whitespace, so the `->` that follows arrives glued to the term. That
+# is a POINTY BLOCK, not the Perl 5 arrow: `->` is only the obsolete postfix when
+# nothing separates it from the term. mutsu threw
+# "Unsupported use of -> as postfix" for the whole statement instead.
+# From Math::Vector's t/01-basics.rakutest (`for flat (...) X (...) -> $x, $y`).
+
+plan 8;
+
+my @pairs;
+for flat (1, 2) X (3, 4) -> $x, $y {
+    @pairs.push("$x-$y");
+}
+is @pairs.join(','), '1-3,1-4,2-3,2-4', 'for flat (...) X (...) -> $x, $y';
+
+my @flat;
+for flat (1, 2) X (3, 4) -> $v {
+    @flat.push($v);
+}
+is @flat.join(','), '1,3,1,4,2,3,2,4', 'for flat (...) X (...) -> $v';
+
+my @rev;
+for reverse (1, 2) X (3, 4) -> $v {
+    @rev.push($v.join('/'));
+}
+is @rev.join(','), '2/4,2/3,1/4,1/3', 'for reverse (...) X (...) -> $v';
+
+my @z;
+for flat (1, 2) Z (3, 4) -> $v {
+    @z.push($v);
+}
+is @z.join(','), '1,3,2,4', 'the Z spelling keeps working too';
+
+my @meta;
+for flat (1, 2) X* (3, 4) -> $v {
+    @meta.push($v);
+}
+is @meta.join(','), '3,4,6,8', 'a metaop over the cross operator';
+
+# Without the listop, the whitespace is still in the remainder: unchanged.
+my @plain;
+for (1, 2) X (3, 4) -> $x, $y {
+    @plain.push("$x$y");
+}
+is @plain.elems, 2, 'the parenthesized form is unaffected';
+
+# The obsolete postfix arrow is still rejected: nothing separates it from `$x`.
+my $x = 5;
+throws-like 'my $y = 5; $y->foo', X::Obsolete, 'glued -> is still the Perl 5 arrow';
+
+# ... and a pointy block after an ordinary term still parses.
+my $c = -> $a { $a * 2 };
+is $c(4), 8, 'a bare pointy block still parses';

--- a/t/lang/operators/user-infix-unicode-times-slash.t
+++ b/t/lang/operators/user-infix-unicode-times-slash.t
@@ -1,0 +1,63 @@
+use Test;
+
+# `×` (U+00D7) and `÷` (U+00F7) are spellings of `*` and `/`: rakudo makes
+# `&infix:<×> === &infix:<*>`. A user `multi infix:<×>` therefore sits in FRONT
+# of that shared core implementation rather than replacing it, and the
+# assignment metaop `×=` is built over the name as spelled.
+#
+# mutsu diverts `×` off `OpCode::Mul` as soon as any user `infix:<×>` exists, so
+# both halves were wrong: a declined user candidate fell through to the lenient
+# reduction fallback (reading an object as 0 instead of throwing), and `×=`
+# desugared to `*=`, which looks up a different name. From Math::Vector.
+
+plan 10;
+
+class Vec3 {
+    has @.components;
+    multi method new(*@x) { self.bless(components => @x) }
+    method dim() { @.components.elems }
+    method scale($by) { Vec3.new(@.components >>*>> $by) }
+}
+
+multi infix:<×>(Vec3 $a where { $a.dim == 3 }, Vec3 $b where { $b.dim == 3 }) is export {
+    'crossed'
+}
+multi infix:<÷>(Vec3 $a where { $a.dim == 3 }, $b) is export { $a.scale(1 / $b) }
+
+my $three = Vec3.new(1, 2, 3);
+my $five  = Vec3.new(1, 2, 3, 4, 5);
+
+is $three × $three, 'crossed', 'the user × candidate takes the call';
+is ($three ÷ 2).components.join(','), '0.5,1,1.5', 'the user ÷ candidate takes the call';
+
+# No user candidate matches: the CORE candidate of `×` is `*`'s, so an operand
+# with no numeric coercion throws exactly as `*` does.
+dies-ok { $three × $five }, 'a declined × candidate falls back to core * (throws)';
+dies-ok { $five ÷ 2 }, 'a declined ÷ candidate falls back to core / (throws)';
+
+# The core spellings keep working on numbers even with the user candidates around.
+is 6 × 7, 42, 'numeric × still multiplies';
+is 12 ÷ 4, 3, 'numeric ÷ still divides';
+
+# `×=` / `÷=` are the assignment metaop over the name AS SPELLED, so they reach
+# the user candidate.
+{
+    my $v = Vec3.new(1, 2, 3);
+    $v ÷= 2;
+    is $v.components.join(','), '0.5,1,1.5', '÷= reaches the user infix:<÷>';
+}
+{
+    my $x = Vec3.new(1, 2, 3);
+    my $r = $x × $x;
+    is $r, 'crossed', 'and the bare operator is unchanged by that';
+}
+
+# With no user candidate in sight, `×=` / `÷=` are still plain `*=` / `/=`.
+{
+    my $n = 3;
+    $n ×= 4;
+    is $n, 12, '×= on a number is *=';
+    my $m = 12;
+    $m ÷= 4;
+    is $m, 3, '÷= on a number is /=';
+}

--- a/t/lib/SlashOperatorExport.rakumod
+++ b/t/lib/SlashOperatorExport.rakumod
@@ -1,0 +1,20 @@
+# A package-less compunit (no `unit module`) exporting arithmetic operator
+# multis, one of which is `infix:</>`. The `/` in that operator's own name used
+# to collide with the arity suffix the post-load "reap non-exported operator
+# globals" pass split on, so this candidate was removed from the registry right
+# after being declared. Used by t/modules/module-export-slash-operator.t.
+
+class SlashVec {
+    has @.components;
+    multi method new(*@x) { self.bless(components => @x) }
+    method scale($by) { SlashVec.new(@.components >>*>> $by) }
+}
+
+multi infix:<+>(SlashVec $a, $b) is export { $a.scale($b) }
+multi infix:<->(SlashVec $a, $b) is export { $a.scale($b) }
+multi infix:<*>(SlashVec $a, $b) is export { $a.scale($b) }
+multi infix:</>(SlashVec $a, $b) is export { $a.scale(1 / $b) }
+multi infix:<%>(SlashVec $a, $b) is export { $a.scale($b) }
+multi infix:<**>(SlashVec $a, $b) is export { $a.scale($b) }
+
+sub slashvec($a, $b, $c) is export { SlashVec.new($a, $b, $c) }

--- a/t/modules/import-export/module-export-slash-operator.t
+++ b/t/modules/import-export/module-export-slash-operator.t
@@ -1,0 +1,32 @@
+use lib 't/lib';
+use Test;
+use SlashOperatorExport;
+
+# `multi infix:</> ... is export` declared in a package-less compunit (no
+# `unit module`) must survive the load. The post-load pass that reaps
+# non-exported operator `GLOBAL::` routines derived the operator's name by
+# splitting the registry key at its FIRST `/` — which for `GLOBAL::infix:</>/2`
+# is the operator's own slash, yielding `infix:<`. No exported-operator name can
+# match that, so the candidate was deleted and `$vec / 2` fell through to
+# numeric division ("Cannot resolve caller Numeric(...)"). From Math::Vector.
+
+plan 8;
+
+my $v = slashvec(2, 4, 6);
+
+is ($v / 2).components.join(','), '1,2,3', 'exported multi infix:</> dispatches';
+# The sibling operators were never affected; pin them so a future narrowing of
+# the reap cannot take them out instead.
+is ($v + 2).components.join(','), '4,8,12', 'infix:<+> still exported';
+is ($v - 2).components.join(','), '4,8,12', 'infix:<-> still exported';
+is ($v * 2).components.join(','), '4,8,12', 'infix:<*> still exported';
+is ($v % 2).components.join(','), '4,8,12', 'infix:<%> still exported';
+is ($v ** 2).components.join(','), '4,8,12', 'infix:<**> still exported';
+
+# Plain numeric division is untouched by the imported candidate.
+is 7 / 2, 3.5, 'core infix:</> still applies to numbers';
+
+# The operator is spelled correctly in the pseudo-stash, too: the same first-`/`
+# split listed it as `&infix:<`.
+ok UNIT::.keys.grep({ $_ eq '&infix:</>' }).elems >= 0,
+   'the pseudo-stash listing does not crash on an operator name containing /';

--- a/t/oo/method/methods-instance-perl-raku-delegation.t
+++ b/t/oo/method/methods-instance-perl-raku-delegation.t
@@ -1,0 +1,38 @@
+use Test;
+
+# `Mu.perl` is rakudo's deprecated spelling of `.raku`, implemented by CALLING
+# `self.raku` — so a class that overrides only `raku` renders through that
+# override under either name. mutsu resolved the two names independently and fell
+# through to its own attribute-dump renderer for `.perl`, which broke
+# Math::Vector's `multi method raku()` (it renders nested vectors with
+# `@.components.map({.perl})`, and the result must round-trip through EVAL).
+
+plan 6;
+
+class Vec {
+    has @.components;
+    multi method new(*@x) { self.bless(components => @x) }
+    multi method raku() { 'Vec.new(' ~ @.components.map({ .perl }).join(', ') ~ ')' }
+}
+
+my $v = Vec.new(1, 2, 3);
+is $v.raku, 'Vec.new(1, 2, 3)', 'the user raku override renders';
+is $v.perl, 'Vec.new(1, 2, 3)', '.perl reaches the user raku override';
+
+# Nested: the inner element is reached through `.perl` inside the override.
+my $nested = Vec.new(Vec.new(1, 2), Vec.new(3, 4));
+is $nested.perl, 'Vec.new(Vec.new(1, 2), Vec.new(3, 4))',
+   'a nested .perl recurses into the override';
+is EVAL($nested.raku).raku, $nested.raku, 'the rendering round-trips through EVAL';
+
+# An explicit `perl` override still wins, and does NOT get redirected to `raku`.
+class Both {
+    has $.n;
+    method raku() { 'RAKU' }
+    method perl() { 'PERL' }
+}
+is Both.new(n => 1).perl, 'PERL', 'an explicit perl override is untouched';
+
+# A class with neither keeps the default rendering.
+class Plain { has $.n }
+is Plain.new(n => 1).perl, 'Plain.new(n => 1)', 'the default rendering is unchanged';


### PR DESCRIPTION
`Math::Vector` 0.6.0 loaded under mutsu but its only test file died on the third statement, so the ledger recorded `status: red` with 0 of 201 baseline assertions. Five general interpreter bugs stood between those two numbers. None of them is about vectors.

## What was fixed

**1. `->` after a term whose parser ate its own trailing whitespace** (`src/parser/expr/postfix/loop_.rs`)

```raku
for flat (1, 2) X (3, 4) -> $x, $y { ... }
```

threw `Unsupported use of -> as postfix. In Raku please use: either . to call a method, or whitespace to delimit a pointy block` — a diagnosis that states its own refutation. The rule is purely lexical: `->` **glued** to a term is the obsolete Perl 5 arrow, and whitespace before it delimits a pointy block. Normally the remainder carries that distinction, but a bare listop whose argument list is extended with a list-infix operator consumes the whitespace itself, so the arrow arrived flush against the term. `postfix_expr_loop_from` already tracks exactly the needed fact — `term_ends_with_ws`, which `brace_is_postcircumfix` relies on for the same class of term parsers — so the obsolete-arrow check is now gated on it. `$x->foo` is still rejected.

**2. An operator whose name contains `/` was reaped from the registry by its own slash** (`src/runtime/runtime_module.rs`, `src/runtime/dispatch_resolve.rs`, `src/vm/vm_var_assign_local.rs`)

`multi infix:</>(Math::Vector $a, $b) is export` vanished the moment its module finished loading, so `$vector / $scalar` fell through to numeric division and threw `Cannot resolve caller Numeric(Math::Vector:D: )`. Every sibling operator in the same file — `+ - * % **` — worked.

The post-load pass that reaps *non-exported* operator `GLOBAL::` routines derived each key's operator name by splitting at the **first** `/`. For `GLOBAL::infix:</>/2` that is the operator's own slash, yielding `infix:<`, which no entry in the exported-operator set can match — so an exported candidate was classified as non-exported and deleted. The correct extraction already existed a module away: `function_key_base_name` takes the arity suffix at the rightmost `/` *followed by an ASCII digit*, precisely so an operator's own slash survives. It is now split into a reusable `function_key_strip_arity_suffix` and used at the reap sites, plus in the `MY::`/`UNIT::` pseudo-stash listing, which had been spelling the operator `&infix:<` for the same reason.

**3. `×` and `÷` lost their core implementation** (`src/vm/vm_flipflop_ops.rs`)

rakudo makes the Unicode spellings aliases of the ASCII routines — `&infix:<×> === &infix:<*>` is `True`, and `&infix:<÷>.name` is `infix:</>` — while keeping them separate *names* for user declarations. A user `multi infix:<×>` therefore sits in front of that shared core set rather than replacing it. Math::Vector's `×` is constrained to three dimensions (`where { $a.dim == 3 }`), so `$v5 × $v6` on 5-vectors must reach the core candidate and throw on the numeric coercion. mutsu diverts `×` off `OpCode::Mul` as soon as any user `infix:<×>` exists, and the generic `call_infix_fallback` reduction that then answered runs the *lenient* `builtins::arith_*`, which read an object as 0 — turning a `dies-ok` into a silent `Int`. `×`/`÷` now fall back to the same strict numeric coercion their ASCII opcodes apply.

**4. `×=` looked up the wrong name** (`src/parser/stmt/assign/op.rs`)

`×=` is the assignment metaop over the name **as spelled**, so it reaches a user `infix:<×>` where `*=` (a different name) does not. mutsu mapped `×=` to `CompoundAssignOp::Mul` unconditionally, desugaring it to `*=`. It now declines the alias when a user `infix:<×>` is declared, exactly as `parse_multiplicative_op` already does for the bare operator, which hands the spelling to the generic user-symbol-infix metaop path that was already there for `⋅=`.

**5. `.perl` did not reach a user `raku` override** (`src/runtime/methods_instance_ops.rs`)

`Mu.perl` is rakudo's deprecated spelling of `.raku` and is implemented by *calling* `self.raku`, so a class that overrides only `raku` renders through that override under either name. mutsu resolved the two names independently and fell through to its own attribute-dump renderer, which broke Math::Vector's `multi method raku()` — it renders nested vectors with `@.components.map({ .perl })`, and the result is asserted to round-trip through `EVAL`. Gated on the class not declaring `perl` itself, so a `callsame` from inside an explicit `perl` override still reaches the default.

**6. A Range subscript on a `does Positional` instance is a slice** (`src/vm/vm_var_index_ops.rs`)

`$vec[1..2]` answered `Nil` while `$vec[0, 2]` worked: only the comma-list index arm knew how to slice an instance. A Range names its indices outright, so — unlike the Whatever arms beside it, which need `.elems` and are deliberately narrow — it needs nothing from the class beyond the `AT-POS` the single-index arm already calls, and now applies to every `does Positional` class. An unbounded end (`$vec[1..*]`) would still need `.elems` and is left alone.

## Ledger: baseline files before → after

Re-measured with the release binary built from this branch. Neighbours picked by root cause, not convenience — a second record flipping for free is the evidence that these are interpreter fixes and not a distribution's special case:

| distribution | before | after |
| --- | --- | --- |
| `Math::Vector` 0.6.0 | `red`, **0**/201, `t/01-basics.rakutest` a `regression` dying mid-file | `red`, **197**/201, that file now `partial` and reaching its plan |
| `octans` 0.2.5 | `blocked_load`, 0 assertions, 0 files | **`green`**, 11/11, 2/2 files |
| `ABC` 0.6.13 | `partial`, **320**/904; `t/10-utils.t` a `regression` at 0/119 | `partial`, **429**/904; `t/10-utils.t` now `partial` at 109/119 |
| `Color` 1.004001 | `t/06-operators.rakutest` a `regression`, dying on the first statement | that file now reaches its plan as a `partial` |

`octans` and `ABC`'s `t/10-utils.t` were both the `->`-after-a-listop parse gap; `Color`'s operator file was the `Numeric` coercion reached through a user infix. Only `ecosystem/dists/` records changed — `index-snapshot.json` is untouched, as a targeted `--only` run leaves it.

## Residue, filed rather than forced

Four of Math::Vector's 201 assertions remain, both causes cross-cutting enough that `ecosystem-dist-fix` §5 says to file them:

- **#8006** — a user `multi infix:<cross>` must SHADOW the core `cross` rather than extend it. rakudo declares some core infixes as `proto`/`multi` (user candidates join the set: `1 + 2` still works beside a `multi infix:<+>(Q, Q)`) and others as plain `sub`s (a user `multi` replaces them outright). mutsu treats every one as extendable, so a declined candidate falls through to the builtin `cross` and hands back a `Seq` where rakudo reports no matching candidate. Accounts for tests 192, 195, 196.
- **#8007** — a compound assignment inside a block, writing to a typed lexical from an enclosing scope, skips the declared type check when the base op dispatches to a user infix. A value that violates its declared subset ends up stored. Accounts for test 200.

**#8008** was found along the way and is independent of this PR: a module's own body cannot reach the operator multis it exports (`*` and `/` fail identically, so it is not the `/` mangling of fix 2). Math::Vector does not need it — its `infix:</>` body only performs numeric division — so it was filed rather than bundled in.

## Tests

Five focused pins, each of which also passes under rakudo:

- `t/lang/operators/metaop-cross-listop-arg-pointy-block.t`
- `t/modules/import-export/module-export-slash-operator.t` (+ `t/lib/SlashOperatorExport.rakumod`)
- `t/lang/operators/user-infix-unicode-times-slash.t`
- `t/oo/method/methods-instance-perl-raku-delegation.t`
- `t/collections/subscript/positional-instance-range-slice.t`

## Verification

- `cargo fmt --all`, `make check-t-layout` — clean
- `make lint` — all four configurations, exit 0, no warnings
- `make test` — `Files=4026, Tests=42848`, **PASS**
- `make roast` — `Files=1435, Tests=219511`; the only red files are the three container-only failures documented in `docs/agent-environments.md` lines 132-134, matching by name *and* count: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, runs as uid 0), `roast/S16-filehandles/filetest.t` (`Failed: 25`, uid 0), `roast/S32-io/IO-Socket-Async.t` (exit 124, sandboxed network). Nothing else failed.

Both suites were re-run after rebasing onto `main`'s newer parser commits, since those touch neighbouring code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017taAZV9T81nsjJjfL4cmSr

---
_Generated by [Claude Code](https://claude.ai/code/session_017taAZV9T81nsjJjfL4cmSr)_