### PR TITLE
perf(capture): stop paying for the capture keys the filter cannot keep

### DIFF
--- a/news/2026-09/closure-capture-walk-stops-paying-for-keys-it-cannot-keep.md
+++ b/news/2026-09/closure-capture-walk-stops-paying-for-keys-it-cannot-keep.md
@@ -1,0 +1,111 @@
+# The closure-capture walk stops paying for the keys it cannot keep
+
+`Interpreter::capture_closure_env` builds a closure's captured env with
+`Env::filtered_flat`, which walks every key visible from the creating scope and
+keeps the ones the closure may name. [#7707](https://github.com/tokuhirom/mutsu/issues/7565)
+and [#7964](https://github.com/tokuhirom/mutsu/issues/7565) taught that filter to
+*reject* two whole families of metadata key a wide import list leaves in the
+importer's scope. They did not stop the walk from *visiting* them, and visiting
+is most of what the walk costs.
+
+Measured on the `use Test` loop from [#7565](https://github.com/tokuhirom/mutsu/issues/7565),
+a closure created inside a sub walks **95 visible keys and keeps 31**. The 64 it
+rejects are almost entirely the module's own bookkeeping:
+
+| family | count | why it is rejected |
+| --- | --- | --- |
+| `__mutsu_callable_id::<pkg>::<name>` | 49 | routine-registration marker; every consumer reads it from the live env at call time |
+| `__mutsu_type::<name>` | 11 | shadow metadata whose subject is not captured |
+| plain user lexicals that are not upvalues | 3 | not free variables of this closure |
+| kept | 31 | the built-in dynamics, `Any`, `?FILE`, the topic, … |
+
+Two changes, both pure to the filter's existing verdicts.
+
+## `filtered_flat` no longer removes from an empty map
+
+`collect` walks the chain outermost tier first and, for every key the filter
+rejects, calls `out.remove(k)` so that a nearer tier's rejection suppresses an
+outer tier's kept entry. On the **outermost** tier that remove is a guaranteed
+miss: `out` is still empty, there is no outer tier whose entry could need
+suppressing, and a map yields each of its own keys once. It still cost a hash and
+a probe per rejected key — on the widest tier of the chain, the one a wide import
+list inflates. All 62 removes this loop performed per closure creation landed on
+that one tier.
+
+`collect` now carries an `outermost` flag and skips the suppressing remove (and
+the tombstone sweep, unreachable for the same reason) while it holds. Pinned by
+`env::tests::filtered_flat_outermost_tier_rejections_do_not_leak`.
+
+## The filter answers the bulk of the walk with one flags word
+
+The per-key predicate asked its cheapest questions last. It now tests the two
+unconditional rejects — `ATTR_TWIGIL_ENV_KEY` and `CALLABLE_ID_META` — as a
+single fused mask over the memoized `Symbol::flags` word, before the
+`__mutsu_callable_type` symbol compare; and it answers a plain user lexical with
+`free`'s membership alone, since the `own_locals` probe cannot change that
+verdict and `free` is empty for most closure literals. A system name short-cuts
+on `own_locals.is_empty()`. Every one of the old expression's verdicts is
+preserved — it is the same boolean, reassociated so that the common key exits
+first.
+
+## Numbers
+
+Warm-run callgrind instruction slopes between 6 000 and 14 000 iterations,
+`MUTSU_JIT=off MUTSU_GC=off`, release, on two shapes of the ticket's loop: the
+original (a leaf closure, which skips the caller-writeback scan) and a variant
+whose closure makes a call (which takes it).
+
+| | base | after | |
+| --- | --- | --- | --- |
+| leaf loop, no `use Test` (the floor) | 76 282 | 75 905 | |
+| leaf loop `+ use Test` | 98 496 | 95 431 | -3.1% |
+| **its tax** | **22 214** | **19 526** | **-12.1%** |
+| calling loop, no `use Test` | 83 117 | 82 668 | |
+| calling loop `+ use Test` | 108 550 | 105 427 | -2.9% |
+| **its tax** | **25 433** | **22 759** | **-10.5%** |
+
+Attributed by ablation on the leaf loop: the outermost-tier remove skip is
+-2 272 of the tax, the predicate reorder a further -416. `Env::filtered_flat` was
+the single largest self cost in the whole program (5.4%) before this and
+`RawTable::remove_entry` (2.1%) has left the profile's delta entirely.
+
+## What the measurement turned up for whoever takes this next
+
+**The captured-env merge at closure entry inserts nothing at all, and costs 2 635
+instructions per iteration to find that out.** `call_compiled_closure_in_unit`
+merges the capture with `entry_or_insert_sym_with` per entry — don't overwrite,
+so the live caller binding wins, which is what dynamics need. On this loop
+`entry_or_insert_sym_with` runs 31 times per call, its `contains_key_sym` runs 31
+times, and `insert_sym` is reached **zero** times: every captured name is already
+visible through the caller's frame chain, because the capture was filtered out of
+that very chain moments earlier. At 72 instructions per `contains_key_sym` that
+is 2.7% of the loop spent proving a no-op.
+
+Making it cheap per key is not the fix; the shape is. The precedence the merge
+implements by hand — caller chain wins, except for an explicit overwrite list
+(`ContainerRef` cells, `self`, a block's topic and `$!`, the authoritative and
+owned capture lists) — is exactly what `overlay -> caller chain -> capture` would
+give for free if the capture were chained *under* the caller as a fallback tier
+instead of merged key by key. That needs `Env` to be able to extend a chain at
+its tail (or a fallback map consulted between the chain and `GLOBAL_BASE`), which
+is a design change worth an ADR rather than a perf slice.
+
+Also measured and **not** worth redoing blind:
+
+- **Hoisting the caller-writeback scan's "captured name, unchanged since
+  capture" `continue` to the top of its loop is a regression**, built and
+  measured at +614 instructions per iteration on the calling loop's floor. The
+  reasoning that suggests it ("the merge leaves captured names in this overlay,
+  so the scan sees ~30 of them") is false precisely because of the finding above:
+  the merge leaves *nothing* in the overlay, so the hoisted test fires for no key
+  and only adds a probe per key to the ~6 that are really there.
+- The remaining tax is still capture plus merge, now over 95 walked keys and 31
+  merged ones. The two items the previous note left stand unchanged: the ~20
+  built-in dynamics every capture carries (they are 19 of the 31, and they are
+  floor, not tax — dropping them needs a way to tell an interpreter's own
+  `init_io_environment` default from a user `my $*OUT = …` redirection, which a
+  key-pure filter cannot see), and the per-tier memo of the walk, which cannot
+  arm while the process-global reflective latch keeps `SetLocal` mirroring every
+  mainline store into the env (`vm_var_assign_set_local.rs`'s `skip_env_write`
+  still consults the global flag, not #7707's per-chunk one). That latch is the
+  ticket's own "worse of the two" and is still unfixed for stores.

--- a/src/env.rs
+++ b/src/env.rs
@@ -995,11 +995,30 @@ impl Env {
     /// The base tier (`GLOBAL_BASE`) is — as in `flattened()` — never
     /// materialized; it stays reachable through the flat env's tail lookup.
     pub(crate) fn filtered_flat(&self, keep: &dyn Fn(Symbol, &Value) -> bool) -> Env {
-        fn collect(env: &Env, out: &mut SymMap, keep: &dyn Fn(Symbol, &Value) -> bool) {
-            if let Some(parent) = &env.parent {
-                collect(parent, out, keep);
-            }
-            if let Some(tomb) = &env.tombstones {
+        /// `outermost` is true for the base of the chain -- the tier processed
+        /// first, while `out` still holds nothing. A rejected or tombstoned key
+        /// there cannot be shadowing an outer tier's kept entry (there is no
+        /// outer tier, and a map yields each of its own keys once), so the
+        /// suppressing `out.remove` is a guaranteed miss: a hash and a probe per
+        /// rejected key, on the widest tier of the chain. A closure created in a
+        /// sub after a bare `use Test` walks 95 visible keys and keeps 31, and
+        /// all 62 of its removes landed on that one tier (#7565).
+        fn collect(
+            env: &Env,
+            out: &mut SymMap,
+            keep: &dyn Fn(Symbol, &Value) -> bool,
+            outermost: bool,
+        ) {
+            let outermost = match &env.parent {
+                Some(parent) => {
+                    collect(parent, out, keep, outermost);
+                    false
+                }
+                None => outermost,
+            };
+            if let Some(tomb) = &env.tombstones
+                && !outermost
+            {
                 for k in tomb {
                     out.remove(k);
                 }
@@ -1007,7 +1026,7 @@ impl Env {
             for (k, v) in env.inner.iter() {
                 if keep(*k, v) {
                     out.insert(*k, v.clone());
-                } else {
+                } else if !outermost {
                     out.remove(k);
                 }
             }
@@ -1031,7 +1050,7 @@ impl Env {
             }
         }
         let mut out = SymMap::with_capacity_and_hasher(cap, Default::default());
-        collect(self, &mut out, keep);
+        collect(self, &mut out, keep, true);
         // `keep` may have rejected `?FILE`, so re-derive rather than inherit.
         let file_sym = out.get(&file_key()).and_then(file_sym_of);
         Self {
@@ -1966,6 +1985,40 @@ mod tests {
         let child2 = Env::scoped_child(tomb);
         assert_eq!(child2.depth, 2);
         assert!(child2.get_sym(s("a")).is_none());
+    }
+
+    #[test]
+    fn filtered_flat_outermost_tier_rejections_do_not_leak() {
+        // The outermost tier is walked into a still-empty `out`, so its rejected
+        // keys take the no-remove fast path (#7565): a rejection there cannot be
+        // suppressing an outer tier's kept entry, because there is no outer
+        // tier. Pin that the result is exactly what a remove-on-every-rejection
+        // walk gives -- a rejected key absent either way, and a nearer tier's
+        // kept entry of a name the outermost tier rejected still present.
+        let mut root = Env::new();
+        root.insert("keep".into(), Value::int(1));
+        root.insert("outer-drop".into(), Value::int(2));
+        root.insert("shadowed".into(), Value::int(3));
+        let mut leaf = Env::scoped_child(root);
+        leaf.insert("shadowed".into(), Value::int(4));
+        leaf.insert("leaf-drop".into(), Value::int(5));
+
+        let merged = leaf
+            .filtered_flat(&|k, _v| k.with_str(|name| name != "outer-drop" && name != "leaf-drop"));
+        assert_eq!(merged.get_sym(s("keep")), Some(&Value::int(1)));
+        assert!(
+            merged.get_sym(s("outer-drop")).is_none(),
+            "a key the outermost tier rejects must not survive"
+        );
+        assert!(
+            merged.get_sym(s("leaf-drop")).is_none(),
+            "a key a nearer tier rejects must not survive"
+        );
+        assert_eq!(
+            merged.get_sym(s("shadowed")),
+            Some(&Value::int(4)),
+            "the nearer tier's entry must still shadow the outermost one"
+        );
     }
 
     #[test]

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1115,32 +1115,47 @@ impl Interpreter {
                 k = subject;
                 flags = subject.flags();
             }
+            // Two unconditional rejects, fused into one mask test because both
+            // are pure string properties of the key and neither needs a set
+            // probe. Most of what this filter walks is answered here:
+            //
+            // * Attribute-twigil keys (`!x`, `@!x`, `%.x`, …) are per-frame
+            //   materializations of `self`'s attributes, not lexicals: the
+            //   closure must read them through its captured `self` at RUN time.
+            //   A creation-time snapshot goes stale the moment the instance
+            //   mutates — a `start` block reading `@!before` inside
+            //   Cro::CompositeConnector.connect saw an empty pre-mutation copy.
+            // * `__mutsu_callable_id::<pkg>::<name>` is a routine-registration
+            //   marker, one per named routine visible in the creating scope —
+            //   after a bare `use Test` that is 49 of the 95 keys this filter
+            //   walks, none of which any closure body can name. Every consumer
+            //   reads it from the LIVE env at call time, where it is still
+            //   visible through the frame chain; the single case that is not (an
+            //   escaping closure whose `use`-inside-`EVAL` scope has been
+            //   popped) is pinned by name in `capture_bare_callees`.
+            const DROP: u16 =
+                crate::symbol::flags::ATTR_TWIGIL_ENV_KEY | crate::symbol::flags::CALLABLE_ID_META;
+            if flags & DROP != 0 {
+                return false;
+            }
             if k == callable_type_sym {
                 return false;
             }
-            // Attribute-twigil keys (`!x`, `@!x`, `%.x`, …) are per-frame
-            // materializations of `self`'s attributes, not lexicals: the
-            // closure must read them through its captured `self` at RUN time.
-            // A creation-time snapshot goes stale the moment the instance
-            // mutates — a `start` block reading `@!before` inside
-            // Cro::CompositeConnector.connect saw an empty pre-mutation copy.
-            if flags & crate::symbol::flags::ATTR_TWIGIL_ENV_KEY != 0 {
-                return false;
+            // A plain user lexical is inherited only as an upvalue, so the
+            // `own_locals` probe cannot change its verdict — and for the
+            // overwhelming majority of closure literals `free` is empty, which
+            // settles it with no probe at all. Split out rather than left to
+            // the fused expression below because this is the *other* half of
+            // what a wide import list puts in the creating scope (every
+            // imported `&name`), and it is reached once per key per closure
+            // creation.
+            if flags & crate::symbol::flags::PLAIN_USER_LEXICAL != 0 {
+                return !free.is_empty() && free.contains(&k);
             }
-            // `__mutsu_callable_id::<pkg>::<name>` is a routine-registration
-            // marker, one per named routine visible in the creating scope —
-            // after a bare `use Test` that is 55 of the 90 entries this filter
-            // used to keep, none of which any closure body can name. Every
-            // consumer reads it from the LIVE env at call time, where it is
-            // still visible through the frame chain; the single case that is
-            // not (an escaping closure whose `use`-inside-`EVAL` scope has been
-            // popped) is pinned by name in `capture_bare_callees`.
-            if flags & crate::symbol::flags::CALLABLE_ID_META != 0 {
-                return false;
-            }
-            free.contains(&k)
-                || (!own_locals.contains(&k)
-                    && flags & crate::symbol::flags::PLAIN_USER_LEXICAL == 0)
+            // A system name is inherited unless this closure declares it
+            // itself; `own_locals` is empty for every closure with no
+            // parameters or `my` of its own.
+            own_locals.is_empty() || !own_locals.contains(&k) || free.contains(&k)
         });
         let tiers = self
             .capture_cache


### PR DESCRIPTION
Next slice of [#7565](https://github.com/tokuhirom/mutsu/issues/7565). #7707 and #7964 taught the closure-capture filter to *reject* two whole families of metadata key that a wide import list leaves in the importer's scope. They did not stop the walk from *visiting* them, and visiting is most of what the walk costs.

On the ticket's loop, a closure created inside a sub walks **95 visible keys and keeps 31**:

| family | count | why it is rejected |
| --- | --- | --- |
| `__mutsu_callable_id::<pkg>::<name>` | 49 | routine-registration marker; every consumer reads it from the live env at call time |
| `__mutsu_type::<name>` | 11 | shadow metadata whose subject is not captured |
| plain user lexicals that are not upvalues | 3 | not free variables of this closure |
| kept | 31 | the built-in dynamics, `Any`, `?FILE`, the topic, … |

## `filtered_flat` no longer removes from an empty map

`collect` walks the chain outermost tier first and, for every rejected key, calls `out.remove(k)` so that a nearer tier's rejection suppresses an outer tier's kept entry. On the **outermost** tier that remove is a guaranteed miss — `out` is still empty, there is no outer tier whose entry could need suppressing, and a map yields each of its own keys once — yet it still cost a hash and a probe per rejected key, on the widest tier of the chain. All 62 removes per closure creation landed on that one tier. `collect` now carries an `outermost` flag and skips the suppressing remove, and the tombstone sweep that is unreachable for the same reason.

## The filter answers the bulk of the walk with one flags word

The per-key predicate asked its cheapest questions last. The two unconditional rejects (`ATTR_TWIGIL_ENV_KEY`, `CALLABLE_ID_META`) are now one fused mask test over the memoized `Symbol::flags` word, ahead of the `__mutsu_callable_type` symbol compare; a plain user lexical is answered by `free`'s membership alone (the `own_locals` probe cannot change that verdict, and `free` is empty for most closure literals); a system name short-cuts on `own_locals.is_empty()`. Same boolean as before, reassociated so the common key exits first.

## Numbers

Warm-run callgrind instruction slopes between 6 000 and 14 000 iterations, `MUTSU_JIT=off MUTSU_GC=off`, release, on two shapes of the ticket's loop: the original (a leaf closure, which skips the caller-writeback scan) and a variant whose closure makes a call (which takes it).

| | base | after | |
| --- | --- | --- | --- |
| leaf loop, no `use Test` (the floor) | 76 282 | 75 905 | |
| leaf loop `+ use Test` | 98 496 | 95 431 | -3.1% |
| **its tax** | **22 214** | **19 526** | **-12.1%** |
| calling loop, no `use Test` | 83 117 | 82 668 | |
| calling loop `+ use Test` | 108 550 | 105 427 | -2.9% |
| **its tax** | **25 433** | **22 759** | **-10.5%** |

Attributed by ablation on the leaf loop: the outermost-tier remove skip is -2 272 of the tax, the predicate reorder a further -416. `Env::filtered_flat` was the single largest self cost in the whole program (5.4%) before this, and `RawTable::remove_entry` (2.1%) has left the delta profile entirely.

## Tests

- `env::tests::filtered_flat_outermost_tier_rejections_do_not_leak` pins that a rejection on the outermost tier neither leaks an entry into the result nor hides a nearer tier's kept entry of the same name.
- `cargo fmt --all`, `make lint`, `make test` (4017 files / 42761 tests, PASS) and `make roast` all run locally. `make roast` is red only on the three files [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) documents as container artefacts: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, runs as uid 0), `roast/S16-filehandles/filetest.t` (`Failed: 25`, uid 0) and `roast/S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17, sandboxed network) — each matching its documented signature exactly.

## Left for the next slice

The news entry records two findings in full. In short:

- **The captured-env merge at closure entry inserts nothing at all, and costs 2 635 instructions per iteration to find that out.** `entry_or_insert_sym_with` runs 31 times per call and `insert_sym` is reached **zero** times: every captured name is already visible through the caller's frame chain, because the capture was filtered out of that very chain moments earlier. The fix is the shape, not the per-key cost — the precedence the merge implements by hand is what `overlay -> caller chain -> capture` would give for free if the capture were chained under the caller as a fallback tier. That is an ADR, not a perf slice.
- **Hoisting the caller-writeback scan's "captured name, unchanged since capture" `continue` to the top of its loop is a regression** (+614 instructions per iteration on the calling loop's floor), built and measured here. It looks like the obvious next step and is false for exactly the reason above: the merge leaves nothing in the overlay, so the hoisted test fires for no key and only adds a probe to the ~6 that are really there.

Leaving #7565 open: the tax is down, not gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG1BkBEZyTqb8yAKKUsUYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG1BkBEZyTqb8yAKKUsUYW)_