### PR TITLE
perf(runtime): scratch interpreters stop rebuilding the process environment

### DIFF
--- a/news/2026-09/scratch-interpreters-stop-rebuilding-the-process-environment.md
+++ b/news/2026-09/scratch-interpreters-stop-rebuilding-the-process-environment.md
@@ -1,0 +1,86 @@
+# Scratch interpreters stop rebuilding the process environment
+
+A grammar-with-actions parse builds one lightweight *scratch* interpreter per
+subrule-with-arguments call, per embedded code block and per token-method
+dispatch — 3,109 of them on a 60-row `benchmarks/bench-yaml-parse.raku`
+document. Round 10 of [#7576](https://github.com/tokuhirom/mutsu/issues/7576)
+already stopped each of those from rebuilding the ~450-`ClassDef` built-in
+registry. A callgrind profile of the post-round-11 binary showed
+`Interpreter::new` still owning **916 M of the run's 6.09 Bn instructions
+(15.1%)**, and the two things it was spending them on were both *process
+constants* being recomputed 3,109 times.
+
+## The bundled-battery scan ran once per scratch interpreter
+
+`Interpreter::new` called `resolve_bundled_lib_paths()` unconditionally. That
+is a `current_exe()` probe, a `read_dir` of the bundle base, and then a `join`
+plus an `is_dir` stat for every distribution in it — about 40 entries. Per
+parse that came to 3,109 directory scans: 124,360 `DirEntry::path`s, 133,687
+`is_dir` stats, 149,232 `Path::join`s and 124,360 `Path::display().to_string()`
+conversions, for **6.7% of the whole program's instructions**. Like round 11's
+proto-variant scan, it never appeared under its own name in a self-cost profile
+— the cost sat in `malloc`, `memcpy`, `Utf8Chunks::next` and
+`CStr::from_bytes_with_nul`, and only caller attribution
+(`callgrind_annotate --tree=calling`) put it back where it belonged.
+
+The answer depends only on `MUTSU_BUNDLE_DIR` and the running executable's
+location, neither of which can change under a running interpreter, so
+`Interpreter::bundled_lib_paths_shared()` now memoizes it process-wide and
+hands out a shared `Arc`. The memo is keyed on the `MUTSU_BUNDLE_DIR` value it
+was taken under, so a process that changes the variable still re-scans; a
+bundle directory whose *contents* change mid-process is not picked up, which is
+what `-I` / `MUTSULIB` / `use lib` are for.
+
+## …and so did the whole IO environment
+
+`Interpreter::new` also called `init_io_environment()` unconditionally: four
+`create_handle` calls for `$*OUT`/`$*ERR`/`$*IN`/`$*ARGFILES`, a
+`make_io_spec_instance`, a `current_dir()` syscall, four `IO::Path` instances
+for `$*CWD`/`$*TMPDIR`/`$*HOME`/`$*EXECUTABLE`, and eighteen env inserts —
+**293 M instructions, 4.8% of the run**.
+
+Every one of the ten scratch construction sites spells
+`Interpreter { env: <the caller's env>, .. }`, so all of that seeded env is
+dropped unread before the scratch executes anything. The seeding is now behind
+the same `is_building_scratch()` guard the built-in registry already used.
+
+That leaves the handle table. A handle op resolves the id carried by an
+`IO::Handle` value in whichever table the *running* interpreter owns, and the
+env a scratch is handed is the caller's — so its handle ids are the caller's
+too. They agreed only because every fresh table was seeded with the same four
+handles in the same order, putting them on ids 1-4 on both sides; nothing made
+an id past those four agree. (No case was found where a scratch actually
+performed a handle op that missed — code blocks reach their handles through the
+caller's own VM frame — so this was a coincidence holding rather than a bug
+biting.) Scratch interpreters are now built through
+`new_regex_scratch_sharing_io()`, which shares the caller's
+`Arc<RwLock<IoHandleTable>>` outright, so the ids mean the same thing on both
+sides however many handles are open. Sharing is sound within a thread, which is
+the only place a scratch is ever built; the lock discipline is unchanged.
+`t/io/code-block-io-handle-table.t` pins the behaviour, driving handles whose
+ids are deliberately past the four standard streams.
+
+## Effect
+
+On a 60-row variant of `benchmarks/bench-yaml-parse.raku`, measured with
+`valgrind --tool=callgrind`
+(deterministic and load-independent, per the method note rounds 10 and 11 added
+to the ticket):
+
+| | instructions | `Interpreter::new` inclusive |
+| --- | ---: | ---: |
+| before | 6,089,938,867 | 916,259,748 (15.05%) |
+| after | 5,170,738,311 | 174,830,509 (3.38%) |
+| | **-15.1%** | **-81%** |
+
+`read_dir` calls over the whole parse go from 3,109 to 1. What is left in
+`Interpreter::new` is the `Interpreter` struct's own construction — 369,981
+allocations for its default-initialized fields — which is a different problem
+from recomputing a process constant.
+
+The next site on this ticket is now `parse_regex_uncached`: 597 M instructions
+(11.6% of the reduced total) for 1,438 top-level parses, where a `rust-gdb`
+hit-count sweep over the whole parse counts **10,958 parses of only 255 distinct
+patterns**. The recursive sub-pattern entry point (`parse_regex_with_mode`, used
+at ~15 sites inside the parser for groups, alternations, separators and scoped
+patterns) has no cache at all, unlike `parse_regex`.

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -122,7 +122,7 @@ impl Interpreter {
         let mut interp = Interpreter {
             env,
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Self::new_regex_scratch()
+            ..self.new_regex_scratch_sharing_io()
         };
         self.copy_decl_registry_into(&mut interp);
         let val = match interp.eval_block_value(&stmts) {
@@ -621,7 +621,7 @@ impl Interpreter {
         let mut scratch = Interpreter {
             env: self.env.clone(),
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Self::new_regex_scratch()
+            ..self.new_regex_scratch_sharing_io()
         };
         self.copy_full_registry_into(&mut scratch);
         for (k, child) in named.iter() {
@@ -745,7 +745,7 @@ impl Interpreter {
         let mut scratch = Interpreter {
             env: self.env.clone(),
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Self::new_regex_scratch()
+            ..self.new_regex_scratch_sharing_io()
         };
         self.copy_full_registry_into(&mut scratch);
         // Seed the scratch's `$*` vars from the overlay (latest delimiters etc.).

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -16,7 +16,7 @@ impl Interpreter {
         let mut interp = Interpreter {
             env,
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Self::new_regex_scratch()
+            ..self.new_regex_scratch_sharing_io()
         };
         self.copy_decl_registry_into(&mut interp);
         let val = match interp.eval_block_value(&stmts) {

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -1005,7 +1005,7 @@ impl Interpreter {
         let mut interp = Interpreter {
             env: self.env.clone(),
             current_package: Arc::new(RwLock::new(pkg.to_string())),
-            ..Self::new_regex_scratch()
+            ..self.new_regex_scratch_sharing_io()
         };
         // Full registry: the grammar's methods live in `Registry::classes`, which
         // the lean `copy_decl_registry_into` omits.

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -724,7 +724,7 @@ impl Interpreter {
                     let mut interp = Interpreter {
                         env: self.env.clone(),
                         current_package: Arc::new(RwLock::new(self.current_package())),
-                        ..Self::new_regex_scratch()
+                        ..self.new_regex_scratch_sharing_io()
                     };
                     self.copy_decl_registry_into(&mut interp);
                     for (k, v) in current_caps.regex_vars.iter().chain(&new_caps.regex_vars) {

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -521,7 +521,7 @@ impl Interpreter {
             current_package: Arc::new(RwLock::new(pkg.to_string())),
             var_dynamic_flags: self.var_dynamic_flags.clone(),
             state_vars: self.state_vars.clone(),
-            ..Self::new_regex_scratch()
+            ..self.new_regex_scratch_sharing_io()
         };
         self.copy_decl_registry_into(&mut interp);
         interp.regex_match_len_at_start(pattern, text)

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -738,7 +738,7 @@ impl Interpreter {
         let mut interp = Interpreter {
             env: self.make_regex_eval_env(caps),
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Self::new_regex_scratch()
+            ..self.new_regex_scratch_sharing_io()
         };
         self.copy_decl_registry_into(&mut interp);
         match interp.eval_block_value(&stmts) {

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -200,7 +200,7 @@ impl Interpreter {
         let mut interp = Interpreter {
             env: self.env.clone(),
             current_package: Arc::new(RwLock::new(pkg.to_string())),
-            ..Self::new_regex_scratch()
+            ..self.new_regex_scratch_sharing_io()
         };
         self.copy_full_registry_into(&mut interp);
         if self.test_module_loaded() {

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -360,7 +360,7 @@ impl Interpreter {
             let mut interp = Interpreter {
                 env: self.env.clone(),
                 current_package: Arc::new(RwLock::new(def.package.resolve())),
-                ..Self::new_regex_scratch()
+                ..self.new_regex_scratch_sharing_io()
             };
             self.copy_decl_registry_into(&mut interp);
             let saved_env = interp.env.clone();

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -273,6 +273,50 @@ impl Interpreter {
         paths
     }
 
+    /// The process-wide memo behind [`Interpreter::bundled_lib_paths_shared`],
+    /// keyed by the `MUTSU_BUNDLE_DIR` value the last scan was made under so a
+    /// process that changes it still re-scans.
+    #[allow(clippy::type_complexity)]
+    fn bundled_lib_paths_memo()
+    -> &'static std::sync::RwLock<Option<(Option<String>, Arc<Vec<String>>)>> {
+        static MEMO: std::sync::RwLock<Option<(Option<String>, Arc<Vec<String>>)>> =
+            std::sync::RwLock::new(None);
+        &MEMO
+    }
+
+    /// [`Self::resolve_bundled_lib_paths`], scanned at most once per process
+    /// (per `MUTSU_BUNDLE_DIR` value) and handed out as a shared `Arc`.
+    ///
+    /// The scan is a `read_dir` of the bundle base plus a `join` + `is_dir`
+    /// stat for every distribution in it — ~40 entries, ~130 KB of
+    /// instructions. `Interpreter::new` ran it unconditionally, and a
+    /// grammar-with-actions parse builds one scratch interpreter per
+    /// subrule-with-arguments call and per embedded code block: 3,109 of them
+    /// on a 60-row `benchmarks/bench-yaml-parse.raku` document, i.e. 3,109 full
+    /// directory scans (124,360 `DirEntry::path`s, 133,687 `is_dir` stats) of a
+    /// directory whose contents cannot change under us, for 6.7% of the whole
+    /// program's instructions (#7576 round 12).
+    ///
+    /// The answer depends only on `MUTSU_BUNDLE_DIR` and the running
+    /// executable's location, so it is memoized on the former (the latter
+    /// cannot change within a process). A bundle directory whose *contents*
+    /// change mid-process is not picked up — adding a module search path at
+    /// runtime is what `-I` / `MUTSULIB` / `use lib` are for.
+    pub(crate) fn bundled_lib_paths_shared() -> Arc<Vec<String>> {
+        let bundle_dir = std::env::var("MUTSU_BUNDLE_DIR").ok();
+        if let Ok(memo) = Self::bundled_lib_paths_memo().read()
+            && let Some((key, paths)) = memo.as_ref()
+            && *key == bundle_dir
+        {
+            return Arc::clone(paths);
+        }
+        let paths = Arc::new(Self::resolve_bundled_lib_paths());
+        if let Ok(mut memo) = Self::bundled_lib_paths_memo().write() {
+            *memo = Some((bundle_dir, Arc::clone(&paths)));
+        }
+        paths
+    }
+
     pub(crate) fn resolve_bundled_lib_paths() -> Vec<String> {
         use std::path::PathBuf;
         let base: Option<PathBuf> = if let Ok(dir) = std::env::var("MUTSU_BUNDLE_DIR") {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -51,6 +51,36 @@ impl Interpreter {
         interp
     }
 
+    /// [`Self::new_regex_scratch`], sharing the caller's open IO handle table.
+    ///
+    /// Use this at every scratch construction site. The `env` a scratch is
+    /// handed is the caller's, so every IO handle value it can see carries the
+    /// *caller's* handle id, and a handle op resolves that id in whichever
+    /// table the running interpreter owns ([`Self::with_handle_mut`]). A
+    /// scratch built by `new_regex_scratch` alone owns its own table, so the
+    /// ids only agreed because [`Self::new`] seeded every fresh table with the
+    /// same four handles (`$*OUT`/`$*ERR`/`$*IN`/`$*ARGFILES`) in the same
+    /// order, putting them on ids 1-4 on both sides; nothing made an id past
+    /// those four agree. No case is known where a scratch actually performed a
+    /// handle op that missed — code blocks reach their handles through the
+    /// caller's own VM frame — but the agreement was a coincidence, not an
+    /// invariant, and skipping the seeding (the `is_building_scratch` guard on
+    /// `init_io_environment` in [`Self::new`]) removes even that. Sharing the
+    /// `Arc` replaces the coincidence with the real table.
+    ///
+    /// Sharing is sound within a thread — the only place a scratch interpreter
+    /// is ever built, synchronously inside the caller's own regex evaluation:
+    /// `io_handles` is an `Arc<RwLock<_>>` precisely so the VM and the
+    /// Interpreter can reach one table as peers (see the `io_handles` module
+    /// docs). The lock discipline is unchanged: no guard is held across a
+    /// re-entrant handle operation. Pinned by
+    /// `t/io/code-block-io-handle-table.t`.
+    pub(crate) fn new_regex_scratch_sharing_io(&self) -> Self {
+        let mut interp = Self::new_regex_scratch();
+        interp.io_handles = Arc::clone(&self.io_handles);
+        interp
+    }
+
     /// Take any pending regex security error from the thread-local store.
     pub(crate) fn take_pending_regex_error() -> Option<RuntimeError> {
         // Delegate to the regex_parse module's thread-local error store
@@ -2951,7 +2981,7 @@ impl Interpreter {
             current_unit: crate::runtime::main_unit(),
             closures_created: 0,
             lib_paths: Default::default(),
-            bundled_lib_paths: std::sync::Arc::new(Self::resolve_bundled_lib_paths()),
+            bundled_lib_paths: Self::bundled_lib_paths_shared(),
             io_handles: Arc::new(RwLock::new(io_handles::IoHandleTable {
                 map: HashMap::new(),
                 next_id: 1,
@@ -3298,7 +3328,18 @@ impl Interpreter {
             lazy_pull_entry_call_depth: None,
             rw_map_topic_capture: None,
         };
-        interpreter.init_io_environment();
+        // A scratch interpreter (regex/grammar sub-interpreter) has its `env`
+        // replaced wholesale by the caller's, so every `$*OUT`/`$*CWD`/
+        // `$*TMPDIR`/`$*HOME`/`$*EXECUTABLE`/`$*SPEC` entry seeded here is
+        // dropped unread, and the four IO handles created for them are left
+        // unreferenced — the caller's env carries the CALLER's handle ids, and
+        // `new_regex_scratch_sharing_io` is what makes those resolve. On a
+        // 60-row `benchmarks/bench-yaml-parse.raku` document that was 3,109
+        // rebuilds of the process IO environment, 4.8% of the whole program's
+        // instructions (#7576 round 12).
+        if !Self::is_building_scratch() {
+            interpreter.init_io_environment();
+        }
         interpreter.env.insert("Any".to_string(), Value::NIL);
         // A scratch interpreter (regex/grammar sub-interpreter) inherits the
         // caller's env and has its registry replaced by `copy_decl_registry_into`,

--- a/t/io/code-block-io-handle-table.t
+++ b/t/io/code-block-io-handle-table.t
@@ -1,0 +1,81 @@
+use Test;
+
+plan 6;
+
+# A regex/grammar code block may be evaluated by a *scratch* interpreter built
+# from inside the regex engine. The env such a scratch is handed is the
+# caller's, so every IO handle value it can see -- `$*OUT`, `$*ERR`, and
+# anything the program opened -- carries the CALLER's handle id, and a handle
+# op resolves that id in whichever table the running interpreter owns
+# (`Interpreter::with_handle_mut`).
+#
+# A scratch used to build its own table and seed it with four fresh
+# STDOUT/STDERR/STDIN/ARGFILES handles, which landed on ids 1..4 -- the same
+# ids the caller's four had. Ids therefore agreed by coincidence of allocation
+# order rather than because the lookup was right, and nothing pinned what
+# happened past those four. Scratch interpreters now skip that seeding and
+# share the caller's table outright, so an id means the same thing on both
+# sides however many handles are open.
+#
+# Every case below drives a handle whose id is past the four standard streams:
+# each `open` takes the next id, so the handle under test is one only the
+# caller's own table can resolve.
+
+my $dir = $*TMPDIR.child("mutsu-regex-io-handle-{$*PID}");
+$dir.mkdir;
+LEAVE { try { .unlink for $dir.dir; $dir.rmdir } }
+
+sub fresh($name) {
+    my $path = $dir.child($name);
+    # Burn a few handle ids first so the one under test is never one of the
+    # four a fresh interpreter would have seeded for itself.
+    my @burn = (^4).map({ open($dir.child("{$name}-burn-$_"), :w) });
+    my $fh = open($path, :w);
+    $_.close for @burn;
+    ($path, $fh);
+}
+
+# 1. A code block inside a plain regex.
+{
+    my ($path, $fh) = fresh("regex");
+    my $matched = "abc" ~~ / a { $fh.print("from-regex") } bc /;
+    $fh.close;
+    ok ?$matched, "regex with a code block still matches";
+    is $path.slurp, "from-regex", "a code block writes through the caller's handle";
+}
+
+# 2. A code block inside a grammar token, reached through .parse.
+{
+    my ($path, $fh) = fresh("grammar");
+    my $out = $fh;
+    grammar G {
+        token TOP { <word> }
+        token word { <[a..z]>+ { $out.print("from-token") } }
+    }
+    my $m = G.parse("hello");
+    $fh.close;
+    ok $m.defined, "grammar with a code block still parses";
+    is $path.slurp, "from-token", "a token's code block writes through the caller's handle";
+}
+
+# 3. The same handle stays usable in the caller afterwards: sharing the table
+#    must not consume or invalidate the entry the code block used.
+{
+    my ($path, $fh) = fresh("after");
+    "xy" ~~ / x { $fh.print("inside:") } y /;
+    $fh.print("outside");
+    $fh.close;
+    is $path.slurp, "inside:outside", "the handle keeps working after the match";
+}
+
+# 4. A handle OPENED inside a code block belongs to the same table, so the
+#    caller can go on using it rather than finding a dangling id.
+{
+    my $path = $dir.child("opened-inside");
+    my $opened;
+    "pq" ~~ / p { $opened = open($path, :w) } q /;
+    $opened.print("opened-inside-a-code-block");
+    $opened.close;
+    is $path.slurp, "opened-inside-a-code-block",
+        "a handle opened inside a code block is usable in the caller";
+}


### PR DESCRIPTION
Round 12 of #7576.

A grammar-with-actions parse builds one lightweight *scratch* interpreter per subrule-with-arguments call, per embedded code block and per token-method dispatch — 3,109 of them on a 60-row variant of `benchmarks/bench-yaml-parse.raku`. Round 10 stopped each of those from rebuilding the ~450-`ClassDef` built-in registry. A callgrind profile of the post-round-11 binary showed `Interpreter::new` **still** owning 916 M of the run's 6.09 Bn instructions (**15.1%**), and the two things it was spending them on were both *process constants* recomputed 3,109 times.

## (a) The bundled-battery scan ran once per scratch interpreter — 6.7%

`Interpreter::new` called `resolve_bundled_lib_paths()` unconditionally: a `current_exe()` probe, a `read_dir` of the bundle base, then a `join` plus an `is_dir` stat for every distribution in it (~40 entries). Over one parse: **3,109 directory scans** — 124,360 `DirEntry::path`s, 133,687 `is_dir` stats, 149,232 `Path::join`s, 124,360 `Path::display().to_string()` conversions.

Like round 11's proto-variant scan, it never appeared under its own name in a self-cost profile — the cost sat in `malloc` / `memcpy` / `Utf8Chunks::next` / `CStr::from_bytes_with_nul`, and only caller attribution (`callgrind_annotate --tree=calling`) put it back where it belonged.

The answer depends only on `MUTSU_BUNDLE_DIR` and the running executable's location, neither of which can change under a running interpreter, so `Interpreter::bundled_lib_paths_shared()` memoizes it process-wide and hands out a shared `Arc`. The memo is keyed on the `MUTSU_BUNDLE_DIR` value it was taken under, so a process that changes the variable still re-scans.

## (b) …and so did the whole IO environment — 4.8%

`init_io_environment()` ran on every construction too: four `create_handle` calls, a `make_io_spec_instance`, a `current_dir()` syscall, four `IO::Path` instances and eighteen env inserts. Every one of the ten scratch construction sites spells `Interpreter { env: <the caller's env>, .. }`, so all of that seeded env is dropped unread before the scratch executes anything. It is now behind the same `is_building_scratch()` guard the built-in registry already used.

That leaves the handle table. A handle op resolves an `IO::Handle` value's id in whichever table the *running* interpreter owns, and a scratch is handed the caller's env — so the caller's ids. They agreed only because every fresh table was seeded with the same four handles in the same order, putting them on ids 1-4 on both sides; nothing made an id past those four agree. **No case was found where a scratch actually performed a handle op that missed** (code blocks reach their handles through the caller's own VM frame), so this was a coincidence holding rather than a bug biting — but the seeding is gone now, so scratches are built through `new_regex_scratch_sharing_io()`, which shares the caller's `Arc<RwLock<IoHandleTable>>` outright. Sharing is sound within a thread, the only place a scratch is ever built; the lock discipline is unchanged.

## Effect

60-row document, `valgrind --tool=callgrind` (deterministic and load-independent, per the method note rounds 10/11 added to the ticket):

| | instructions | `Interpreter::new` inclusive |
| --- | ---: | ---: |
| before | 6,089,938,867 | 916,259,748 (15.05%) |
| after | 5,170,738,311 | 174,830,509 (3.38%) |
| | **-15.1%** | **-81%** |

`read_dir` calls over the whole parse: 3,109 → 1.

## Testing

- `t/io/code-block-io-handle-table.t` (new, 6 tests): drives handles whose ids are deliberately past the four standard streams from inside a regex code block and a grammar token, and checks a handle opened *inside* a code block stays usable in the caller. Placement per `make check-t-layout`.
- `cargo fmt --all`, `make lint` — green.
- `make test` — green (4024 files, 42828 tests).
- `make roast` — the only failures are the three documented container-only ones (`roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` fail because this container runs as `uid 0`; `roast/S32-io/IO-Socket-Async.t` times out under the network sandbox). See `docs/agent-environments.md`.

## What's next on the ticket

`parse_regex_uncached` is now the biggest identified site: 597 M instructions (11.6% of the reduced total) for 1,438 top-level parses. A `rust-gdb` hit-count sweep over the whole parse counts **10,958 parses of only 255 distinct patterns** — the recursive sub-pattern entry point (`parse_regex_with_mode`, used at ~15 sites inside the parser for groups, alternations, separators and scoped patterns) has no cache at all, unlike `parse_regex`. Left for the next round; the ticket stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_