### PR TITLE
fix(parser): parse typed parenthesized has declarations

### DIFF
--- a/news/2026-09/has-typed-attribute-list.md
+++ b/news/2026-09/has-typed-attribute-list.md
@@ -1,0 +1,9 @@
+# Typed parenthesised `has` declarations now parse
+
+mutsu now accepts Raku's `has Type ($.first, $.second)` form and applies the
+common type constraint to every declared attribute. This also covers the
+`int32` list form used by NativeCall CStruct declarations.
+
+The declarations are lowered through the existing grouped-attribute path, so
+plain classes and CStruct field layouts now agree with Rakudo instead of
+evaluating the attribute twigils as an expression without a `self`.

--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -14,9 +14,14 @@ use crate::value::Value;
 
 use super::super::sub::parse_type_constraint_expr;
 
-/// Parse parenthesized list form of `has`: `has ($a, $.b, $!c)`
+/// Parse parenthesized list form of `has`: `has ($a, $.b, $!c)` or
+/// `has Int ($a, $.b, $!c)`.
 /// Desugars into a SyntheticBlock containing multiple HasDecl statements.
-fn has_decl_list(input: &str) -> PResult<'_, Stmt> {
+fn has_decl_list(
+    input: &str,
+    type_constraint: Option<String>,
+    type_smiley: Option<String>,
+) -> PResult<'_, Stmt> {
     let (mut rest, _) = parse_char(input, '(')?;
     let mut stmts = Vec::new();
     loop {
@@ -52,8 +57,8 @@ fn has_decl_list(input: &str) -> PResult<'_, Stmt> {
             handles: Vec::new(),
             is_rw: false,
             is_readonly: false,
-            type_constraint: None,
-            type_smiley: None,
+            type_constraint: type_constraint.clone(),
+            type_smiley: type_smiley.clone(),
             is_required: None,
             sigil: sigil as char,
             where_constraint: None,
@@ -205,10 +210,11 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
         return Err(err);
     }
 
-    // Handle parenthesized list form: has ($a, $.b, $!c)
+    // Handle parenthesized list form: has ($a, $.b, $!c), including a common
+    // type constraint such as `has Int ($a, $.b)`.
     // This desugars into a Block containing multiple HasDecl statements.
     if rest.starts_with('(') {
-        return has_decl_list(rest);
+        return has_decl_list(rest, None, None);
     }
 
     // Optional type constraint.
@@ -219,7 +225,11 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
             if r2.starts_with("method") || r2.starts_with("submethod") {
                 return has_type_method_decl(r2, &tc);
             }
-            if r2.starts_with('$') || r2.starts_with('@') || r2.starts_with('%') {
+            if r2.starts_with('(')
+                || r2.starts_with('$')
+                || r2.starts_with('@')
+                || r2.starts_with('%')
+            {
                 // Extract smiley suffix and strip it for the type_constraint name
                 let (base, smiley) = if let Some(b) = tc.strip_suffix(":D") {
                     (b.to_string(), Some("D".to_string()))
@@ -230,6 +240,9 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
                 } else {
                     (tc.to_string(), None)
                 };
+                if r2.starts_with('(') {
+                    return has_decl_list(r2, Some(base), smiley);
+                }
                 (r2, Some(base), smiley)
             } else {
                 (saved, None, None)

--- a/t/oo/attribute/has-multi-attribute.t
+++ b/t/oo/attribute/has-multi-attribute.t
@@ -1,0 +1,30 @@
+use Test;
+use NativeCall;
+
+plan 7;
+
+# A type constraint before a parenthesised attribute list applies to every
+# declaration in the list, rather than leaving the list to the expression
+# parser (which evaluates `$.x` without a `self`).
+class Point {
+    has Int ($.x, $.y);
+}
+
+my $point = Point.new(x => 1, y => 2);
+is $point.x, 1, 'the first typed attribute is declared';
+is $point.y, 2, 'the second typed attribute is declared';
+is Point.^attributes.elems, 2, 'the typed list creates two attributes';
+
+# NativeCall uses the same declaration form for scalar CStruct fields. This
+# pins the parser path without assuming that a CStruct is allocatable beyond
+# the existing scalar-field support.
+class NativePoint is repr('CStruct') {
+    has int32 ($.x, $.y, $.z);
+}
+
+my $native = NativePoint.new(x => 3, y => 4, z => 5);
+is $native.x, 3, 'the first native field is declared';
+is $native.y, 4, 'the second native field is declared';
+is $native.z, 5, 'the third native field is declared';
+is nativesizeof(NativePoint), 12, 'all native fields contribute to the CStruct layout';
+


### PR DESCRIPTION
Closes #7992

## Summary

- Parse typed parenthesised `has` declarations such as `has Int ($.x, $.y)`.
- Apply the common type constraint and smiley to every generated attribute declaration.
- Add plain-class and NativeCall CStruct regressions plus a news entry.

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`
