### PR TITLE
fix: preserve typed constraints in captured compound assignments

### DIFF
--- a/news/2026-09/typed-compound-capture-writeback.md
+++ b/news/2026-09/typed-compound-capture-writeback.md
@@ -1,0 +1,6 @@
+# Typed captured scalars keep their constraint during user-infix compound assignment
+
+Compound assignment to a typed scalar captured by a nested block now carries
+the declared constraint onto the shared cell used for writeback. A user-defined
+base infix can no longer store a result that violates the scalar's declared
+type.

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -151,6 +151,31 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Carry a declared scalar `of` constraint onto a cell created while
+    /// promoting that scalar for a closure or named-sub capture. Once a scalar
+    /// is boxed, the cell is the authoritative write target and name metadata
+    /// is not enough to protect writes from a different frame.
+    pub(crate) fn register_container_cell_constraint_for_name(
+        &mut self,
+        value: &Value,
+        name: &str,
+    ) {
+        let ValueView::ContainerRef(cell) = value.view() else {
+            return;
+        };
+        let constraint = self
+            .var_type_constraint(name)
+            .or_else(|| self.var_type_constraint(name.trim_start_matches('$')));
+        if let Some(constraint) = constraint {
+            let display = if name.starts_with(['$', '@', '%', '&']) {
+                name.to_string()
+            } else {
+                format!("${name}")
+            };
+            crate::value::register_container_constraint_named(&cell, &constraint, &display);
+        }
+    }
+
     /// Materialize a deferred vivification token's terminal slot into a fresh
     /// shared `ContainerCell` holding `val`, and install it at the slot.
     ///

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1591,6 +1591,7 @@ impl Interpreter {
                 continue;
             }
             let container = cur.clone().into_container_ref();
+            self.register_container_cell_constraint_for_name(&container, &s);
             self.locals[idx] = container.clone();
             self.env_mut().insert(s.clone(), container.clone());
             // Track C: if a thread is already running (shared_vars active) and a

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -520,6 +520,7 @@ impl Interpreter {
             return;
         }
         let container = cur.into_container_ref();
+        self.register_container_cell_constraint_for_name(&container, name);
         self.locals[idx] = container.clone();
         let nm = code.locals[idx].clone();
         self.env_mut().insert(nm.clone(), container.clone());

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -122,6 +122,11 @@ impl Interpreter {
             let mut guard = arc.lock().unwrap();
             let old = seed_meta_assign_identity(guard.clone(), identity)?;
             let new_val = self.apply_compound_base_op(op, old, rhs)?;
+            // The compound result is still a write through the declared
+            // variable's cell.  User infix dispatch can take this fused path
+            // instead of the ordinary typed assignment path, so enforce the
+            // cell-carried constraint before publishing the new value.
+            self.check_container_cell_constraint(&arc, &new_val)?;
             *guard = new_val.clone();
             drop(guard);
             self.stack.push(new_val);

--- a/t/routines/call/typed-compound-capture-writeback.t
+++ b/t/routines/call/typed-compound-capture-writeback.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+# A captured typed scalar is boxed into a ContainerRef so a block's compound
+# assignment can write back to the declaring scope. The cell must retain the
+# declared constraint when the compound operator dispatches to a user infix.
+
+plan 2;
+
+class V {
+    has $.n;
+}
+
+subset Unit of V where { .n == 1 };
+multi infix:<+>(V $a, V $b) { V.new(n => $a.n + $b.n) }
+
+my Unit $u = V.new(n => 1);
+my $block = { $u += V.new(n => 5) };
+
+throws-like { $block() }, X::TypeCheck::Assignment,
+    'a user-infix compound assignment checks the captured scalar type';
+is $u.n, 1, 'the rejected compound assignment does not write through the cell';


### PR DESCRIPTION
## Summary

- Preserve declared scalar constraints when captured variables are promoted to shared container cells.
- Check the result before publishing fused compound assignments through a container cell.
- Add a regression test for user-defined infix dispatch inside a nested block.

Fixes #8007

## Tests

- `cargo fmt --all`
- `make lint`
- `make check-t-layout`
- `make test`
- `make roast`
- `scripts/run-t-test.sh t/routines/call/typed-compound-capture-writeback.t`
- `raku t/routines/call/typed-compound-capture-writeback.t`
