### PR TITLE
fix: close the capture dichotomy over callables and container parameters

### DIFF
--- a/ecosystem/dists/A/Algorithm--LCS~1ff664b2.json
+++ b/ecosystem/dists/A/Algorithm--LCS~1ff664b2.json
@@ -9,23 +9,22 @@
   "dist": "Algorithm::LCS",
   "files": [
     {
-      "cmp": "regression",
+      "cmp": "parity",
       "mutsu": {
-        "first_failure": "thread 'mutsu-main' (3) has overflowed its stack",
         "nok": 0,
-        "ok": 0,
+        "ok": 17,
         "plan": 17,
-        "secs": 2.8,
+        "secs": 0.12,
         "skip": 0,
         "todo": 0,
-        "verdict": "die"
+        "verdict": "pass"
       },
       "path": "t/01-basic.rakutest",
       "raku": {
         "nok": 0,
         "ok": 17,
         "plan": 17,
-        "secs": 1.62,
+        "secs": 1.39,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -37,10 +36,10 @@
   },
   "measured": {
     "attempts": 3,
-    "date": "2026-09-11",
-    "harness": 1,
-    "host": "gha-ubuntu24-4c",
-    "mutsu_commit": "7807eb5",
+    "date": "2026-09-12",
+    "harness": 2,
+    "host": "linux-x86_64",
+    "mutsu_commit": "80a7bc82",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
@@ -51,13 +50,13 @@
     "index": "fez",
     "url": "https://360.zef.pm/A/LG/ALGORITHM_LCS/c285f92754cbd0a5dd10b9c937754d95467b6814.tar.gz"
   },
-  "status": "red",
+  "status": "green",
   "totals": {
     "baseline_assertions": 17,
     "baseline_files": 1,
-    "mutsu_assertions": 0,
-    "parity_files": 0,
-    "regressed_files": 1
+    "mutsu_assertions": 17,
+    "parity_files": 1,
+    "regressed_files": 0
   },
   "version": "0.1.1"
 }

--- a/news/2026-09/closure-capture-dichotomy-closes-over-callables-and-container-params.md
+++ b/news/2026-09/closure-capture-dichotomy-closes-over-callables-and-container-params.md
@@ -1,0 +1,78 @@
+# The closure-capture dichotomy closes over callables and container parameters
+
+`Algorithm::LCS` 0.1.1 died with a stack overflow before its first assertion.
+The root cause was not recursion in the distribution: it was two holes in
+ADR-0055's capture dichotomy, and closing them took the suite from 0 to 17 of
+17 — parity with rakudo.
+
+## The dichotomy, and what fell out of it
+
+ADR-0055 §7.3 states that an escaping-captured lexical is **either**
+authoritative — the creating frame vouches for it, so the capture installs with
+overwrite semantics — **or** a shared cell. The two halves are meant to be
+exhaustive, because a capture with neither defence is indistinguishable from a
+same-named lexical in whatever frame happens to be calling the closure, and the
+closure-call merge's don't-overwrite default then lets the caller's binding win.
+The free variable stops being lexical and starts being dynamic.
+
+A capture that is *mutated* is refused the vouch, and rightly so: a by-value
+install would go stale. That makes the cell mandatory for it. Two families were
+refused the cell as well, and so had no defence at all.
+
+**Callables.** `ValueView::Sub` sat in the value-kind refusal list in
+`box_captured_lexicals`, `&`-sigil names were skipped at the same site, and `&`
+was excluded from `needs_cell_unvouched_locals` too. So a reassigned callable —
+either `my &f` or a `$f` holding a `Sub` — captured by an escaping closure
+resolved by name up the live frame chain. ADR-0025's note for that refusal reads
+"`Sub`: the `&` lane has its own registries. Keep.", and `opcode.rs` restated it
+as "rebinding `&f` is a name-write the vouch already sees". The second half is
+exactly backwards: the vouch *does* see the name-write, and therefore refuses,
+leaving nothing behind it. `Sub` was the last unargued entry in that list —
+`Package`, `Array` and `Hash` had already left it under ADR-0055 slice 1 on the
+same reasoning.
+
+In `Algorithm::LCS` this was self-referential, which is why it crashed rather
+than merely answering wrongly. `lcs` assigns its `:&compare-i is copy`
+parameter and hands closures over it to `strip-prefix`, whose own parameter is
+also named `&compare-i`. The closure resolved to *itself* and recursed until the
+stack ran out.
+
+**Container parameters.** The `@`/`%` half of the complement,
+`needs_cell_unvouched_containers`, is delivered at the *declaration* site —
+ADR-0039 measured per-capture boxing as too expensive, taking
+`roast/S15-nfg/concat-stable.t` from 2s to 31s. A parameter has no declaration
+store, so that delivery site never ran for one. An `@` parameter captured by an
+escaping closure, and handed to a call (so unvouchable, since an `is rw` param
+could write it back), reached neither half.
+
+That was the second `Algorithm::LCS` failure, worth 6 of the 17 assertions once
+the crash was gone: `lcs`'s default comparator closes over `lcs`'s `@a`/`@b`
+parameters but runs inside `strip-prefix`, whose same-named parameters hold the
+*reversed* arrays. The comparator indexed the wrong sequences — and past their
+ends, where two `Nil`s compare equal, so it reported spurious matches.
+
+## The fix
+
+`&` joins `needs_cell_unvouched_locals`, and the `Sub` value-kind refusal is
+lifted for that trigger only. Because the `&` lane resolves names to callables
+in its own way, four chokepoints now read through the cell rather than handing
+it on: `resolve_code_var`, `lexical_amp_var_callable`, `exec_get_code_var_op`,
+and the local-slot fallback in `exec_call_on_code_var_op`. ADR-0067's rw-arg
+machinery already assumed a resolved callee could be a `ContainerRef`, so this
+follows an existing precedent rather than inventing one.
+
+A container *parameter* takes its cell from `box_captured_lexicals`, scoped to
+`code.param_local_slots`. An ordinary `my @a` still takes the declaration site,
+so ADR-0039's measured cost is unchanged — only the case that had no site at all
+is new.
+
+Pinned by `t/routines/closure/closure-capture-sub-valued-cell.t` and
+`t/routines/closure/closure-capture-container-arg-cell.t`, which cover both
+sigils, the self-referential shape, a block-level shadower as well as a
+parameter, and the mutation-visibility property that makes the cell mandatory
+rather than a snapshot.
+
+## Ledger
+
+`Algorithm::LCS` 0.1.1 goes `red` (0 of 17 assertions, `t/01-basic.rakutest`
+dying) to `green` (17 of 17, matching rakudo's baseline exactly).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4823,10 +4823,21 @@ pub(crate) struct CompiledCode {
     /// `needs_cell_locals` it does NOT require `captured_mutated_locals`
     /// membership (the whole point is the mutation analysis never saw the write).
     ///
-    /// SCALARS only. The `@`/`%` half of the same complement is
+    /// SCALARS and `&` code lexicals. The `@`/`%` half of the same complement is
     /// `needs_cell_unvouched_containers` — same rule, different delivery site.
-    /// `&` is in neither (a `Sub` value must not be boxed, and rebinding `&f` is
-    /// a name-write the vouch already sees).
+    ///
+    /// `&` used to be in NEITHER set, on the reasoning that "a `Sub` value must
+    /// not be boxed, and rebinding `&f` is a name-write the vouch already sees".
+    /// The second half of that is exactly backwards: the vouch does see the
+    /// name-write, and therefore REFUSES to vouch — leaving nothing behind it.
+    /// With no decl-site container cell to fall back on either, a reassigned
+    /// `&f` captured by an escaping closure had no defence at all and resolved
+    /// by name up the live frame chain (Algorithm::LCS 0.1.1 recursed into the
+    /// callee's own same-named `&` parameter until the stack overflowed). The
+    /// `Sub` value-kind refusal in `box_captured_lexicals` is likewise lifted
+    /// for this trigger only — it is ADR-0025's last unargued "keep", and the
+    /// same argument that retired `Package`/`Array`/`Hash` applies to it.
+    /// See `t/routines/closure/closure-capture-sub-valued-cell.t`.
     ///
     /// INCLUDES this frame's own parameters. They were excluded when the set
     /// first shipped, because boxing one leaked state between two invocations of
@@ -4858,7 +4869,16 @@ pub(crate) struct CompiledCode {
     ///
     /// Delivered at the DECLARATION site (`exec_set_local_op` ->
     /// `box_decl_local_container_cell`), not at each capture like the scalar
-    /// lane. That is ADR-0039's mechanism, and it is also the only affordable
+    /// lane — EXCEPT for a PARAMETER, which has no declaration store, so that
+    /// site never ran for one and it reached neither half of the dichotomy (the
+    /// Algorithm::LCS 0.1.1 comparator closed over `lcs`'s `@a`/`@b` parameters
+    /// but ran inside `strip-prefix`, whose same-named parameters hold the
+    /// REVERSED arrays). A parameter takes its cell from `box_captured_lexicals`
+    /// instead, scoped to `code.param_local_slots` so an ordinary `my @a` keeps
+    /// the decl site and the cost measured below is unchanged. See
+    /// `t/routines/closure/closure-capture-container-arg-cell.t`.
+    ///
+    /// That is ADR-0039's mechanism, and it is also the only affordable
     /// one: a `@o.shift xx $_` thunk is created once per repetition, so boxing
     /// from `box_captured_lexicals` ran the whole per-free-var loop 720k times
     /// for 1.2k declarations and took `roast/S15-nfg/concat-stable.t` from 2s to
@@ -7526,11 +7546,18 @@ impl CompiledCode {
             .filter(|sym| !vouched.contains(sym))
             .filter(|sym| {
                 sym.with_str(|s| {
-                    // `box_captured_lexicals` only boxes `$` scalars; an
+                    // `box_captured_lexicals` boxes `$` scalars and, for this
+                    // unvouched-escaping case only, `&` code lexicals; an
                     // `@`/`%` lexical takes the decl-site container cell
-                    // instead (`needs_cell_unvouched_containers`, just below),
-                    // and a `&` lexical is never boxed at all.
-                    crate::env::is_plain_user_lexical(s) && !s.starts_with(['@', '%', '&'])
+                    // instead (`needs_cell_unvouched_containers`, just below).
+                    //
+                    // `&` used to be excluded here alongside `@`/`%`, but it has
+                    // no decl-site cell to fall back on, so it landed in NEITHER
+                    // complement: a reassigned `&f` captured by an escaping
+                    // closure had neither the vouch nor a cell, and a same-named
+                    // `&` lexical in the calling frame won. That is exactly the
+                    // hole the dichotomy exists to close.
+                    crate::env::is_plain_user_lexical(s) && !s.starts_with(['@', '%'])
                 })
             })
             .collect();

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -411,6 +411,16 @@ impl Interpreter {
         // Check if stored as a variable first (my &f = ...)
         let var_key = format!("&{}", bare_name);
         if let Some(val) = self.env.get(&var_key) {
+            // An `&` lexical may be a shared cell (the unvouched-escaping
+            // capture, ADR-0055 §7.3): read through it, never hand the cell to
+            // a caller that expects a callable. Branch rather than calling
+            // `deref_container` unconditionally — this is a hot resolution path
+            // and the non-cell case must keep its single clone.
+            let val = if val.is_container_ref() {
+                val.deref_container()
+            } else {
+                val.clone()
+            };
             // Upgrade WeakSub references (e.g., &?BLOCK) to strong Sub
             if let ValueView::WeakSub(weak) = val.view() {
                 return match weak.upgrade() {
@@ -418,7 +428,7 @@ impl Interpreter {
                     None => Value::NIL,
                 };
             }
-            return val.clone();
+            return val;
         }
         // `return` is a control-flow keyword that also resolves as &return
         // so that it can be rebound (proxied return pattern).

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -226,7 +226,10 @@ impl Interpreter {
         let ampname = format!("&{}", name);
         let candidate = code
             .and_then(|c| self.locals_get_by_name(c, &ampname))
-            .or_else(|| self.env().get(&ampname).cloned());
+            .or_else(|| self.env().get(&ampname).cloned())
+            // An `&` lexical may be a shared cell (ADR-0055 §7.3); the shape
+            // filter below must classify the CALLABLE, not the cell.
+            .map(|v| v.into_deref());
         candidate.filter(|v| {
             matches!(v.view(), ValueView::Sub(_) | ValueView::WeakSub(_))
                 || matches!(v.view(), ValueView::Routine { .. })
@@ -1447,7 +1450,8 @@ impl Interpreter {
             && let Some(val) = self.locals.get(slot)
             && !val.is_nil()
         {
-            target = val.clone();
+            // Read through a shared cell (ADR-0055 §7.3) before dispatch.
+            target = val.clone().into_deref();
         }
         // Fallback for fast-path method dispatch (skip_env_setup=true):
         // &!attr is not set in env, so read directly from self's instance

--- a/src/vm/vm_misc_codevar.rs
+++ b/src/vm/vm_misc_codevar.rs
@@ -63,7 +63,10 @@ impl Interpreter {
         // against the executing frame's own `code.locals`, so it can never
         // pick up an enclosing frame's slot numbering.
         if let Some(slot) = self.find_local_slot(code, &format!("&{}", name)) {
-            let slot_val = self.locals[slot].clone();
+            // Read through a shared cell (ADR-0055 §7.3): `&cb` as a VALUE
+            // (`.defined`, `~~ Callable`, passed as an argument) must be the
+            // callable, not the cell holding it.
+            let slot_val = self.locals[slot].clone().into_deref();
             if !slot_val.is_nil() {
                 self.stack.push(slot_val);
                 return Ok(());

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1442,7 +1442,16 @@ impl Interpreter {
         // Trigger (E) is independent of `captured_mutated_locals` on purpose (see
         // `needs_cell_unvouched_locals`), so it must bypass the early return.
         let has_unvouched = !code.needs_cell_unvouched_locals.is_empty();
+        // A `@`/`%` PARAMETER in the unvouched-container set has no declaration
+        // store, so `box_decl_local_container_cell`'s usual delivery site
+        // (`exec_set_local_op`) never runs for it — it reached neither half of
+        // the dichotomy. Its cell is delivered here instead. Scoped to parameter
+        // slots on purpose: an ordinary `my @a` still takes the decl site, so
+        // the per-capture cost ADR-0039 measured (`@o.shift xx $_`) is unchanged.
+        let has_unvouched_param_container =
+            !code.needs_cell_unvouched_containers.is_empty() && !code.param_local_slots.is_empty();
         if !has_unvouched
+            && !has_unvouched_param_container
             && ((code.captured_mutated_locals.is_empty() && !has_mutated_instance_capture)
                 || (self.loop_local_vars.is_empty()
                     && code.needs_cell_locals.is_empty()
@@ -1476,7 +1485,25 @@ impl Interpreter {
             // can run orders of magnitude more often than the declaration it
             // captures (`@o.shift xx $_` creates one thunk per repetition), so
             // per-capture boxing is the wrong site for a per-binding decision.
-            if s.starts_with('@') || s.starts_with('%') || s.starts_with('&') {
+            // `&` is admitted for the unvouched-escaping case (E) only: unlike
+            // `@`/`%` it has no decl-site container cell to fall back on, so
+            // without this it has no defence at all (see
+            // `needs_cell_unvouched_locals`).
+            if s.starts_with('@') || s.starts_with('%') {
+                // ... except a PARAMETER, which has no decl site either: deliver
+                // its unvouched-container cell here (see the flag above).
+                if has_unvouched_param_container
+                    && code.needs_cell_unvouched_containers.contains(sym)
+                    && !cc.authoritative_free_vars.contains(sym)
+                    && let Some(idx) =
+                        Self::resolve_capture_slot(code, &cc.free_var_parent_slots, fv_i, *sym)
+                    && code.param_local_slots.contains(&(idx as u32))
+                {
+                    self.box_decl_local_container_cell(code, idx, true);
+                }
+                continue;
+            }
+            if s.starts_with('&') && !unvouched_escaping {
                 continue;
             }
             let is_loop_local = self.loop_local_vars.iter().any(|set| set.contains(sym));
@@ -1562,16 +1589,21 @@ impl Interpreter {
             // staleness bug, so the cell is mandatory. Note this boxes the `$`
             // SCALAR container, not the Array/Hash itself — `@a`/`%h` sigil
             // locals still take `box_decl_local_container_cell`.
+            // A Sub is refused a cell on the ordinary paths, but NOT when it is
+            // the unvouched-escaping case (E): there the cell is the only thing
+            // distinguishing this binding from a same-named caller lexical, so
+            // refusing it reopens the very hole the dichotomy exists to close.
+            let refuse_sub = matches!(cur.view(), ValueView::Sub(..)) && !unvouched_escaping;
             if !cur.is_any_type_object()
-                && matches!(
-                    cur.view(),
-                    ValueView::Sub(..)
-                        | ValueView::Proxy { .. }
-                        | ValueView::Seq(..)
-                        | ValueView::HyperSeq(..)
-                        | ValueView::RaceSeq(..)
-                        | ValueView::Slip(..)
-                )
+                && (refuse_sub
+                    || matches!(
+                        cur.view(),
+                        ValueView::Proxy { .. }
+                            | ValueView::Seq(..)
+                            | ValueView::HyperSeq(..)
+                            | ValueView::RaceSeq(..)
+                            | ValueView::Slip(..)
+                    ))
             {
                 continue;
             }

--- a/t/routines/closure/closure-capture-container-arg-cell.t
+++ b/t/routines/closure/closure-capture-container-arg-cell.t
@@ -1,0 +1,82 @@
+use Test;
+
+plan 5;
+
+# The container half of ADR-0055's dichotomy (`needs_cell_unvouched_containers`)
+# is delivered at the DECLARATION site -- `exec_set_local_op` ->
+# `box_decl_local_container_cell` -- rather than at each capture, because boxing
+# per capture is what ADR-0039 measured as too expensive.
+#
+# A PARAMETER has no declaration store, so that delivery site never ran for one:
+# an `@`/`%` parameter that an escaping closure captures, and that the frame
+# cannot vouch for (it was handed to a call, so an `is rw` param could write it
+# back), reached NEITHER half of the dichotomy. Its capture then resolved by
+# name up the live frame chain and a same-named container in the calling frame
+# won.
+#
+# Found in Algorithm::LCS 0.1.1 (t/01-basic.rakutest): `lcs`'s default
+# `&compare-i` closes over `lcs`'s `@a`/`@b` parameters, but runs inside
+# `strip-prefix`, whose own `@a`/`@b` hold the REVERSED arrays -- so the
+# comparator indexed the wrong sequences and 6 of 17 assertions failed.
+
+{
+    my sub inner(@a, &cb) { &cb() }
+    my sub top(@a) {
+        my &cb = -> { @a.join(' ') };
+        inner(@a, &cb);                      # makes @a a call-arg source
+        inner(@a.reverse, -> { &cb() });     # callee's @a is a DIFFERENT array
+    }
+    is top(<A B C D>), 'A B C D',
+        'an `@` parameter capture is not hijacked by a same-named callee parameter';
+}
+
+{
+    my sub inner(%h, &cb) { &cb() }
+    my sub top(%h) {
+        my &cb = -> { %h<k> };
+        inner(%h, &cb);
+        inner({ k => 'WRONG' }, -> { &cb() });
+    }
+    is top({ k => 'CORRECT' }), 'CORRECT',
+        'a `%` parameter capture is not hijacked by a same-named callee parameter';
+}
+
+# An ordinary `my @a` already took the decl-site cell -- pin that it still does.
+{
+    my sub inner(@a, &cb) { &cb() }
+    my sub top() {
+        my @a = <A B C D>;
+        my &cb = -> { @a.join(' ') };
+        inner(@a, &cb);
+        inner(@a.reverse, -> { &cb() });
+    }
+    is top(), 'A B C D',
+        'a `my @` declaration keeps resolving to its own binding';
+}
+
+# The cell must not freeze the array: a later push is visible to the capture.
+{
+    my sub inner(@a, &cb) { &cb() }
+    my sub top(@a) {
+        my &cb = -> { @a.join(' ') };
+        inner(@a, &cb);
+        @a.push('E');
+        inner(@a.reverse, -> { &cb() });
+    }
+    is top([<A B C D>]), 'A B C D E',
+        'the captured `@` parameter still observes a later push';
+}
+
+# Two levels of closure nesting between the capture and the call -- the shape
+# Algorithm::LCS actually has (lcs -> strip-suffix -> strip-prefix).
+{
+    my sub inner(@a, @b, &cb) { &cb() }
+    my sub mid(@a, @b, &cb) { inner(@a.reverse, @b.reverse, -> { &cb() }) }
+    my sub top(@a, @b) {
+        my &cb = -> { @a.join('') ~ '/' ~ @b.join('') };
+        inner(@a, @b, &cb);
+        mid(@a[1 .. *], @b[1 .. *], -> { &cb() });
+    }
+    is top(<A B C D>, <P Q R>), 'ABCD/PQR',
+        'the capture survives two nested closures over same-named containers';
+}

--- a/t/routines/closure/closure-capture-sub-valued-cell.t
+++ b/t/routines/closure/closure-capture-sub-valued-cell.t
@@ -1,0 +1,99 @@
+use Test;
+
+plan 6;
+
+# ADR-0055's dichotomy: an escaping-captured lexical is EITHER authoritative
+# (the creating frame vouches for it, so the capture installs with overwrite
+# semantics) OR a shared cell. A capture that is ALSO mutated is refused the
+# vouch -- correctly, since a by-value install would go stale -- so the cell is
+# the only thing left distinguishing it from a same-named lexical in whatever
+# frame happens to be calling the closure.
+#
+# Sub-valued and `&`-sigil bindings fell out of BOTH halves: `ValueView::Sub`
+# sat in the value-kind refusal list, `&` was skipped at the boxing site, and
+# `&` was excluded from `needs_cell_unvouched_locals` as well. A reassigned
+# callable captured by an escaping closure therefore had no defence at all, and
+# the closure's free variable resolved by NAME up the live frame chain instead
+# of to its own binding.
+#
+# Found in Algorithm::LCS 0.1.1 (t/01-basic.rakutest): `lcs` assigns its
+# `:&compare-i is copy` parameter and hands closures over it to `strip-prefix`,
+# whose own parameter is also named `&compare-i` -- so the closure resolved to
+# ITSELF and the suite died with a stack overflow before test 1.
+
+# --- `&`-sigil, reassigned, shadowed by a same-named callee parameter --------
+{
+    my sub inner(&cb, &run) { &run(1) }
+    my sub outer() {
+        my &cb = -> $x { "FIRST $x" };
+        &cb = -> $x { "CORRECT $x" };
+        inner(-> $x { "WRONG $x" }, -> $x { &cb($x) });
+    }
+    is outer(), 'CORRECT 1',
+        'a reassigned `&` lexical resolves to its own binding, not the callee parameter';
+}
+
+# The self-referential shape that produced the stack overflow: the closure's
+# captured `&cb` IS the callee's parameter, so a name resolution recurses.
+{
+    my sub inner(&cb) { &cb(1) }
+    my sub outer(&cb is copy) {
+        &cb = -> $x { "base $x" } unless &cb.defined;
+        inner(-> $x { &cb($x) });
+    }
+    is outer(Callable), 'base 1',
+        'a closure over an assigned `&` param does not recurse into the callee parameter';
+}
+
+# A `$`-sigil lexical HOLDING a Sub is the same hole by a different exclusion.
+{
+    my sub inner($cb, &run) { &run(1) }
+    my sub outer() {
+        my $cb = sub ($x) { "FIRST $x" };
+        $cb = sub ($x) { "CORRECT $x" };
+        inner(sub ($x) { "WRONG $x" }, -> $x { $cb($x) });
+    }
+    is outer(), 'CORRECT 1',
+        'a reassigned Sub-valued `$` lexical resolves to its own binding';
+}
+
+# The shadower need not be a parameter -- a nested block`s `my &cb` shadows too.
+{
+    my sub outer() {
+        my &cb = -> $x { "FIRST $x" };
+        &cb = -> $x { "CORRECT $x" };
+        my &run = -> $x { &cb($x) };
+        my $got;
+        { my &cb = -> $x { "WRONG $x" }; $got = &run(1); }
+        $got;
+    }
+    is outer(), 'CORRECT 1',
+        'a nested block`s same-named `my &` does not hijack the capture either';
+}
+
+# The cell must track later mutation -- that is why the vouch refuses a mutated
+# capture and the cell is mandatory rather than a by-value snapshot.
+{
+    my sub outer() {
+        my &cb = -> { 'first' };
+        my &run = -> { &cb() };
+        &cb = -> { 'second' };          # AFTER the capture
+        &run();
+    }
+    is outer(), 'second',
+        'the capture observes a mutation made after the closure was created';
+}
+
+# Calling the callable back out of the binding still works (the `&` lane has to
+# read THROUGH the cell wherever it resolves a name to a callable).
+{
+    my sub outer() {
+        my &cb = -> $x { "v$x" };
+        &cb = -> $x { "w$x" };
+        my $shape = (&cb.defined, &cb ~~ Callable, &cb(1), cb(2)).join(',');
+        my &pass = -> &f { f(3) };
+        ($shape, pass(&cb)).join('|');
+    }
+    is outer(), 'True,True,w1,w2|w3',
+        '`&cb` as a value -- .defined, ~~ Callable, call, bare call, passed on';
+}


### PR DESCRIPTION
## Distribution

`Algorithm::LCS` 0.1.1 (axis `pure`), 1 baseline file.

| | before | after |
|---|---|---|
| `t/01-basic.rakutest` | `regression` — 0 of 17, died on a stack overflow before test 1 | `parity` — **17 of 17** |
| record `status` | `red` | **`green`** |

rakudo's baseline for the same file is 17/17, so this is exact parity. No issues filed: nothing is left red.

## Root cause

Two holes in the **same** architectural invariant — ADR-0055 §7.3's capture dichotomy, which holds that an escaping-captured lexical is *either* authoritative (the creating frame vouches for it, so the capture installs with overwrite semantics) *or* a shared cell. A capture that is also **mutated** is refused the vouch — correctly, since a by-value install would go stale — which makes the cell mandatory for it. Two families were refused the cell as well, so they had **neither** defence, and their free variables resolved by *name* up the live frame chain instead of to their own binding. The variable silently stops being lexical and becomes dynamic.

### 1. Callables

`ValueView::Sub` sat in the value-kind refusal list in `box_captured_lexicals`, `&`-sigil names were skipped at that same site, and `&` was excluded from `needs_cell_unvouched_locals`.

ADR-0025 justified the `Sub` entry only as *"the `&` lane has its own registries. Keep."*, and `opcode.rs` restated the `&` exclusion as *"rebinding `&f` is a name-write the vouch already sees"*. That second reason is exactly backwards: the vouch **does** see the name-write, and therefore **refuses** — leaving nothing behind it. `Sub` was the last unargued entry in that list; `Package`, `Array` and `Hash` left it under ADR-0055 slice 1 on precisely this argument.

```raku
my sub inner(&cb, &run) { &run(1) }
my sub outer() {
    my &cb = -> $x { "FIRST $x" };
    &cb = -> $x { "CORRECT $x" };            # the reassignment is the trigger
    inner(-> $x { "WRONG $x" }, -> $x { &cb($x) });
}
say outer();
```

| | output |
|---|---|
| `raku` 2026.07 | `CORRECT 1` |
| `mutsu` (before) | `WRONG 1` |

The same hole reaches a `$`-sigil lexical *holding* a `Sub`. In `Algorithm::LCS` it was self-referential, which is why it crashed rather than merely answering wrongly: `lcs` assigns its `:&compare-i is copy` parameter and hands closures over it to `strip-prefix`, whose own parameter is **also** named `&compare-i` — so the closure resolved to *itself* and recursed until the stack died.

### 2. Container parameters

The `@`/`%` half of the complement, `needs_cell_unvouched_containers`, is delivered at the **declaration** site, because ADR-0039 measured per-capture boxing taking `roast/S15-nfg/concat-stable.t` from 2s to 31s. A *parameter* has no declaration store, so that delivery site never ran for one — and a container parameter handed to a call is unvouchable (an `is rw` param could write it back), so it reached neither half either.

```raku
my sub inner(@a, &cb) { &cb() }
my sub top(@a) {
    my &cb = -> { @a.join(' ') };
    inner(@a, &cb);                   # makes @a a call-arg source -> unvouched
    inner(@a.reverse, -> { &cb() });  # callee's @a is a DIFFERENT array
}
say top(<A B C D>);
```

| | output |
|---|---|
| `raku` 2026.07 | `A B C D` |
| `mutsu` (before) | `D C B A` |

This was worth 6 of the 17 assertions once the crash was gone: `lcs`'s default comparator closes over `lcs`'s `@a`/`@b` parameters but runs inside `strip-prefix`, whose same-named parameters hold the **reversed** arrays. It indexed past the ends, where two `Nil`s compare equal — so it reported spurious matches and `lcs(<A B C D E F G>, <A C E G>)` returned `A C F G` instead of `A C E G`.

## The fix

`&` joins `needs_cell_unvouched_locals`, and the `Sub` value-kind refusal is lifted **for that trigger only**. Because the `&` lane resolves names to callables its own way, four chokepoints now read through the cell rather than passing it on: `resolve_code_var`, `lexical_amp_var_callable`, `exec_get_code_var_op`, and the local-slot fallback in `exec_call_on_code_var_op`. ADR-0067's rw-arg machinery already assumed a resolved callee could be a `ContainerRef`, so this follows an existing precedent rather than inventing one. `resolve_code_var` branches on `is_container_ref()` rather than calling `deref_container` unconditionally, to keep its single clone on that hot path.

A container **parameter** takes its cell from `box_captured_lexicals`, scoped to `code.param_local_slots`. An ordinary `my @a` still takes the declaration site, so ADR-0039's measured cost is unchanged — only the case that had no site at all is new.

Net non-comment change is ~25 lines; the rest is the two doc comments whose stated rationale this disproves.

## Tests

- `t/routines/closure/closure-capture-sub-valued-cell.t` (6) — both sigils, the self-referential shape, a block-level shadower as well as a parameter, mutation-after-capture visibility, and `&cb` used as a value (`.defined`, `~~ Callable`, called, passed on).
- `t/routines/closure/closure-capture-container-arg-cell.t` (5) — `@` and `%` parameters, the `my @a` decl path still working, a later `push` staying visible, and the two-level nesting `Algorithm::LCS` actually has.

Both files pass under **rakudo** as well as mutsu, so the expectations are checked against the oracle rather than asserted.

## Verification

- `make test` — green (exit 0, zero `not ok`).
- `make roast` — the only failures are the three documented environment-only ones, matching [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) exactly by name and count: `6.c/S32-io/file-tests.t` (Failed: 4, tests 6-8/10) and `S16-filehandles/filetest.t` (Failed: 25) both from running as `uid 0`, and `S32-io/IO-Socket-Async.t` (exit 124) from the sandboxed network.
- `make lint` — green across all four configurations.
- Ledger re-measured with the release binary via `--only`; `index-snapshot.json` left unchanged.

## Note on scope

The container-parameter fix keys on `code.param_local_slots`, which has a documented fallback path suggesting it can be empty for some frames. Coverage may therefore be narrower than the general rule states; the worst case is the previous behaviour, not a regression.

Neighbour records that also fail with a stack overflow were re-measured by root cause. `Smooth::Numbers` still dies and `XDG::GuaranteedResources` is `no_baseline`, so neither shares this cause — their records are deliberately **not** included, since re-measuring here would replace canonical GHA provenance with this container's without improving the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQpgde68jN4BhLLKuFxbiv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQpgde68jN4BhLLKuFxbiv)_