### PR TITLE
fix: parse sigilless ternary cache initializers

### DIFF
--- a/news/2026-09/terminal-widgets-sigilless-ternary-cache.md
+++ b/news/2026-09/terminal-widgets-sigilless-ternary-cache.md
@@ -1,0 +1,8 @@
+# Terminal::Widgets sigilless ternary cache initializer
+
+mutsu now parses assignments in the else branch of a ternary used by a
+sigilless declaration initializer. This fixes the `%colors<name> //= color`
+shape in `Terminal::Widgets::Widget` and unblocks the distribution's parser
+from reaching the following `for` block.
+
+Closes #7999.

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -17,7 +17,7 @@ mod tests_postfix;
 
 use super::memo::{MemoEntry, MemoKey, MemoStats, ParseMemo};
 use super::parse_result::PResult;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
 use crate::ast::{Expr, Stmt};
@@ -53,6 +53,29 @@ use whatever_wrap::{try_wrap_whatevercode_call_chain, wrap_composition_operands}
 thread_local! {
     static EXPR_MEMO_TLS: RefCell<HashMap<MemoKey, MemoEntry<Expr>>> = RefCell::new(HashMap::new());
     static EXPR_MEMO_STATS_TLS: RefCell<MemoStats> = RefCell::new(MemoStats::default());
+    /// A sigilless declaration's initializer permits an assignment in the
+    /// else branch of its ternary (`my \\x = cond ?? a !! %h<k> //= b`).
+    /// This is a parser-context distinction, so expression memoization must
+    /// not reuse results across the boundary.
+    static ALLOW_TERNARY_ELSE_ASSIGNMENT: Cell<bool> = const { Cell::new(false) };
+}
+
+pub(in crate::parser) fn allow_ternary_else_assignment() -> bool {
+    ALLOW_TERNARY_ELSE_ASSIGNMENT.with(Cell::get)
+}
+
+pub(in crate::parser) fn with_ternary_else_assignment<T>(f: impl FnOnce() -> T) -> T {
+    struct Restore(bool);
+
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            ALLOW_TERNARY_ELSE_ASSIGNMENT.with(|enabled| enabled.set(self.0));
+        }
+    }
+
+    let previous = ALLOW_TERNARY_ELSE_ASSIGNMENT.with(|enabled| enabled.replace(true));
+    let _restore = Restore(previous);
+    f()
 }
 
 static EXPR_MEMO: ParseMemo<Expr> = ParseMemo::new(&EXPR_MEMO_TLS, &EXPR_MEMO_STATS_TLS);
@@ -66,7 +89,12 @@ pub(super) fn expression_memo_stats() -> (usize, usize, usize) {
 }
 
 pub(super) fn expression(input: &str) -> PResult<'_, Expr> {
-    if let Some(cached) = EXPR_MEMO.get(input) {
+    // The sigilless-declaration initializer grammar has one context-sensitive
+    // exception for assignments in a ternary's else branch. Do not reuse an
+    // expression parsed outside that context (or cache this context's result
+    // for an ordinary expression).
+    let use_memo = !allow_ternary_else_assignment();
+    if use_memo && let Some(cached) = EXPR_MEMO.get(input) {
         return cached;
     }
     let result = (|| {
@@ -149,7 +177,9 @@ pub(super) fn expression(input: &str) -> PResult<'_, Expr> {
         }
         Ok((rest, expr))
     })();
-    EXPR_MEMO.store(input, &result);
+    if use_memo {
+        EXPR_MEMO.store(input, &result);
+    }
     result
 }
 

--- a/src/parser/expr/precedence/list_infix_top.rs
+++ b/src/parser/expr/precedence/list_infix_top.rs
@@ -82,7 +82,10 @@ pub(crate) fn item_expr(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             &spelled_assign_operator(after_q),
         ));
     }
-    if is_assignment_expr(&else_expr) && !assign_operator_is_tight(&else_expr) {
+    if !crate::parser::expr::allow_ternary_else_assignment()
+        && is_assignment_expr(&else_expr)
+        && !assign_operator_is_tight(&else_expr)
+    {
         return Err(conditional_precedence_too_loose_error(
             &spelled_assign_operator(after_bang),
         ));

--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -294,7 +294,15 @@ pub(crate) fn call_arg_ternary_expr(input: &str) -> PResult<'_, Expr> {
 /// because its no-`??` fallback (`or_expr_mode`) includes assignment, which would
 /// swallow the default value (e.g. `$x where Int = 9`).
 pub(crate) fn ternary_no_assign(input: &str) -> PResult<'_, Expr> {
-    let (rest, cond) = or_expr_no_assign_mode(input, ExprMode::Full)?;
+    let (rest, cond) = if crate::parser::expr::allow_ternary_else_assignment() {
+        // A sigilless declaration initializer is the one Raku grammar context
+        // where an assignment may be nested in the else branch of `?? !!`.
+        // Parse that branch at the ordinary expression precedence so indexed
+        // compound assignments such as `%cache<key> //= value` are consumed.
+        or_expr_mode(input, ExprMode::Full)?
+    } else {
+        or_expr_no_assign_mode(input, ExprMode::Full)?
+    };
     let (rest_ws, _) = ws(rest)?;
     if rest_ws.starts_with("??") {
         // A conditional constraint: the full ternary parser is safe because a
@@ -396,7 +404,10 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
                 &spelled_assign_operator(then_src),
             ));
         }
-        if is_assignment_expr(&else_expr) && !assign_operator_is_tight(&else_expr) {
+        if !crate::parser::expr::allow_ternary_else_assignment()
+            && is_assignment_expr(&else_expr)
+            && !assign_operator_is_tight(&else_expr)
+        {
             return Err(conditional_precedence_too_loose_error(
                 &spelled_assign_operator(else_src),
             ));

--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -89,7 +89,8 @@ pub(super) fn parse_sigilless_decl(
     let (r, _) = ws(r)?;
     if let Some(r) = r.strip_prefix("::=").or_else(|| r.strip_prefix(":=")) {
         let (r, _) = ws(r)?;
-        let (r, expr) = parse_assign_expr_or_comma(r)?;
+        let (r, expr) =
+            crate::parser::expr::with_ternary_else_assignment(|| parse_assign_expr_or_comma(r))?;
         let stmt = build_sigilless_bind_stmt(name, expr, type_constraint.clone(), is_state, is_our);
         if apply_modifier {
             return parse_statement_modifier(r, stmt);
@@ -151,7 +152,8 @@ pub(super) fn parse_sigilless_decl(
     if r.starts_with('=') && !r.starts_with("==") && !r.starts_with("=>") {
         let r = &r[1..];
         let (r, _) = ws(r)?;
-        let (r, expr) = parse_assign_expr_or_comma(r)?;
+        let (r, expr) =
+            crate::parser::expr::with_ternary_else_assignment(|| parse_assign_expr_or_comma(r))?;
         let stmt = build_sigilless_bind_stmt(name, expr, type_constraint.clone(), is_state, is_our);
         if apply_modifier {
             return parse_statement_modifier(r, stmt);

--- a/t/control/ternary-sigilless-compound-assign.t
+++ b/t/control/ternary-sigilless-compound-assign.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+plan 5;
+
+# A sigilless declaration initializer has a special binding grammar. In that
+# context an assignment in the else branch of a ternary is valid Raku syntax;
+# this is the minimized shape from Terminal::Widgets::Widget's `sgr` cache.
+my %cache;
+my \value = False ?? 1 !! %cache<answer> //= 2;
+is value, 2, 'sigilless ternary initializer evaluates the else assignment';
+is %cache<answer>, 2, 'the indexed //= writes through the hash element';
+
+my \kept = True ?? 3 !! %cache<untouched> //= 4;
+is kept, 3, 'the selected ternary branch remains the sigilless value';
+ok !%cache<untouched>.defined, 'the unselected short-circuit branch is untouched';
+
+class Renderer {
+    method render(@line) {
+        my %colors;
+        my \sgr = False ?? 'hot' !! %colors<default> //= 'cold';
+        my @seen;
+        for @line {
+            @seen.push("$_:$sgr");
+        }
+        @seen.join(' ')
+    }
+}
+
+is Renderer.new.render(<one two>), 'one:cold two:cold',
+    'a following for block parses after the sigilless ternary initializer';
+
+done-testing;


### PR DESCRIPTION
Closes #7999

## Summary
- allow assignments in the else branch of a ternary within sigilless declaration initializers
- keep expression memoization isolated from the context-sensitive grammar
- add a regression test for Terminal::Widgets::Widget's `%colors<name> //= color` shape and a news entry

## Tests
- `make check-t-layout`
- `make lint`
- `make test`
- `make roast`