### PR TITLE
fix(modules,vm): a `my constant` in a unit module, and enum values as subscripts

### DIFF
--- a/ecosystem/dists/B/Business--CreditCard~a8bd3cbe.json
+++ b/ecosystem/dists/B/Business--CreditCard~a8bd3cbe.json
@@ -9,46 +9,44 @@
   "dist": "Business::CreditCard",
   "files": [
     {
-      "cmp": "partial",
+      "cmp": "parity",
       "mutsu": {
-        "first_failure": "5100-2222 3333 4414 -> NotACreditCard",
-        "nok": 22,
-        "ok": 35,
+        "nok": 0,
+        "ok": 57,
         "plan": 57,
-        "secs": 0.28,
+        "secs": 0.18,
         "skip": 0,
         "todo": 0,
-        "verdict": "fail"
+        "verdict": "pass"
       },
       "path": "t/01-original-tests.rakutest",
       "raku": {
         "nok": 0,
         "ok": 57,
         "plan": 57,
-        "secs": 1.73,
+        "secs": 1.8,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
       }
     },
     {
-      "cmp": "partial",
+      "cmp": "parity",
       "mutsu": {
-        "first_failure": "did '5212345678901234' produce 'MasterCard'",
-        "nok": 26,
-        "ok": 4,
+        "nok": 0,
+        "ok": 30,
         "plan": 30,
-        "secs": 0.3,
+        "secs": 0.15,
         "skip": 0,
         "todo": 0,
-        "verdict": "fail"
+        "verdict": "pass"
       },
       "path": "t/02-cpan-tests.rakutest",
       "raku": {
         "nok": 0,
         "ok": 30,
         "plan": 30,
-        "secs": 0.48,
+        "secs": 0.38,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -60,10 +58,10 @@
   },
   "measured": {
     "attempts": 3,
-    "date": "2026-09-11",
-    "harness": 1,
-    "host": "gha-ubuntu24-4c",
-    "mutsu_commit": "7807eb5",
+    "date": "2026-09-12",
+    "harness": 2,
+    "host": "linux-x86_64",
+    "mutsu_commit": "2c9146a8",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
@@ -74,13 +72,13 @@
     "index": "fez",
     "url": "https://360.zef.pm/B/US/BUSINESS_CREDITCARD/23fb2f85d615c2934cacdf6c86b400b0a714bc5a.tar.gz"
   },
-  "status": "red",
+  "status": "green",
   "totals": {
     "baseline_assertions": 87,
     "baseline_files": 2,
-    "mutsu_assertions": 39,
-    "parity_files": 0,
-    "regressed_files": 2
+    "mutsu_assertions": 87,
+    "parity_files": 2,
+    "regressed_files": 0
   },
   "version": "0.2"
 }

--- a/ecosystem/dists/L/Locale--US~7591b770.json
+++ b/ecosystem/dists/L/Locale--US~7591b770.json
@@ -11,11 +11,10 @@
     {
       "cmp": "regression",
       "mutsu": {
-        "first_failure": "No such method 'uc' for invocant of type 'Any'",
         "nok": 0,
         "ok": 1,
         "plan": 60,
-        "secs": 0.1,
+        "secs": 0.08,
         "skip": 0,
         "todo": 0,
         "verdict": "die"
@@ -25,7 +24,7 @@
         "nok": 0,
         "ok": 60,
         "plan": 60,
-        "secs": 1.11,
+        "secs": 1.23,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -37,10 +36,10 @@
   },
   "measured": {
     "attempts": 3,
-    "date": "2026-09-11",
-    "harness": 1,
-    "host": "gha-ubuntu24-4c",
-    "mutsu_commit": "7807eb5",
+    "date": "2026-09-12",
+    "harness": 2,
+    "host": "linux-x86_64",
+    "mutsu_commit": "2c9146a8",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",

--- a/news/2026-09/my-constant-in-a-unit-module-read-as-nil-by-its-own-routines.md
+++ b/news/2026-09/my-constant-in-a-unit-module-read-as-nil-by-its-own-routines.md
@@ -1,0 +1,122 @@
+# A `my constant` in a `unit module` read as Nil from that module's own routines
+
+`Business::CreditCard` classified every card number as `NotACreditCard`. The
+distribution's suite ran to completion — 39 of 87 assertions passed, so nothing
+crashed — but `cardtype` never recognised anything. Both of the two bugs behind
+that turned out to be general interpreter gaps with nothing to do with credit
+cards, and the distribution is green on both counts now.
+
+## A `constant` lost depending on how its scope was spelled
+
+`Business::CreditCard` builds four lookup tables at compile time:
+
+```raku
+my constant @lookup     = do { ... };
+my constant @renamed    = NotACreditCard, AmericanExpress, ...;
+my constant %CUPcountry = <US MX AI ...>.map(* => Discover);
+my constant %JCBcountry = <US PR VI ...>.map(* => Discover);
+```
+
+Read from `cardtype`, every one of them was `Nil` — so `@lookup[$card.chars]`
+was falsy and the `elsif`/`else` chain fell through to `NotACreditCard`.
+Reduced, the gap is not about `do` blocks, `.Map`, or binding into array
+elements, all of which worked:
+
+```raku
+# lib/M.rakumod
+unit module M;
+my constant @my-k   = 10, 20, 30;
+constant    @bare-k = 40, 50, 60;
+our sub probe() {
+    say @my-k.raku;    # raku: (10, 20, 30)   mutsu: Nil
+    say @bare-k.raku;  # raku: (40, 50, 60)   mutsu: (40, 50, 60)  -- fine
+}
+```
+
+The two spellings behaved differently, for every sigil. A `unit` compunit's
+file-scope `constant`s are package symbols of that compunit rather than names
+the importer sees bare (#7787), so `import_module` strips their plain `env`
+binding and leaves the value in `module_scope_names` — which is exactly where
+the module's own routines read them from. Separately, the compunit's `my`
+lexicals are moved out of `env` into `unit_lexicals`, and are *removed* from
+`module_scope_names` so there is a single authoritative store for them.
+
+A `my constant` matched both collectors, and the `my`-lexical one ran second.
+The value was taken out of the store its own routines read and filed as a
+compunit lexical instead, so every read answered `Nil`.
+
+The two collectors disagreed because they identified a `constant` differently.
+`collect_unit_package_scope_names` discriminates on the `__constant` trait, and
+documents why: a `constant` parses as `VarDecl { is_our: true }`, which `is_our`
+alone cannot tell from an ordinary `our $x`. `collect_unit_lexical_names`
+skipped constants only incidentally — via that same `is_our: true` — and `my
+constant` parses with `is_our: false`, so it slipped straight through.
+`collect_unit_lexical_names` now tests the `__constant` trait too, which is the
+fact it meant to test all along rather than a scope keyword that happened to
+line up.
+
+## An enum value as an array subscript
+
+With the tables populated, `t/01-original-tests.rakutest` went from 22 failures
+to 1 and `t/02-cpan-tests.rakutest` still failed 28 of 30. The remaining
+failures all reached the last line of `cardtype`:
+
+```raku
+$obsolete ?? $found !! @renamed[$found];
+```
+
+`@renamed` had its 36 elements and `$found.Int` was a valid index, but
+`@renamed[$found]` was `Any` — and `@renamed[$found.Int]` was correct. An enum
+value is a `Cool`, so as a positional subscript it numifies to its value;
+mutsu numified neither side of the subscript protocol:
+
+```raku
+enum Color <Red Green Blue>;
+my @a = 'zero', 'one', 'two';
+say @a[Green];      # raku: one     mutsu: Nil
+my @b = 'a','b','c';
+@b[Green] = 'X';    # raku: ok      mutsu: Index out of bounds
+```
+
+The read path left the enum alone. The write path went through
+`index_to_usize`, whose last resort is to parse the value's string form — which
+for an enum is its *key* (`"Green"`), so the parse failed and the write reported
+"Index out of bounds". Both sides numify now, gated on the subscript being
+positional: an associative subscript keeps the enum value itself as the key
+(`%h{Green}` is keyed by the enum, not by its ordinal), and numifying there
+would have broken the matching write.
+
+Two neighbours of that rule came along with it, because they are the same rule:
+
+* `Bool` is `enum Bool <False True>`, so `@a[True]` is `@a[1]`. It reaches the
+  subscript as a plain `ValueView::Bool` rather than a `ValueView::Enum`, so it
+  had the identical gap on both paths and needed its own arm on each.
+* A *string*-valued enum (`enum E (S => 'x')`) must NOT numify. `EnumValue`'s
+  existing `as_i64` answers `0` for one, because its callers want a total
+  function — folding `@a[S]` to element 0 would be a silently wrong read where
+  raku dies with `X::Str::Numeric`. Both subscript sites use a new
+  `EnumValue::as_index_i64`, which is `Option`-returning precisely so the
+  non-numeric case stays on the pre-existing path instead of inventing an
+  answer. Negative-valued enum members fall through the same way, and are
+  rejected as out of range exactly as a literal `@a[-1]` is.
+
+The 01 suite mostly survived this second bug because it passes `:obsolete`,
+which takes the ternary's other branch and never indexes `@renamed`.
+
+## Result
+
+`Business::CreditCard` 0.2 goes `red` -> `green`: 2 of 2 baseline files, 87 of
+87 assertions, matching rakudo exactly. Pinned by
+`t/modules/import-export/unit-my-constant-visible-to-own-routines.t` (both
+spellings, every sigil, plus the #7787 non-leak assertions that must keep
+holding) and `t/types/enum-subset/enum-value-as-positional-index.t` (read,
+write, slice, autovivification, explicitly-valued enums, `Bool`, the
+string-valued enum that must *not* fold to 0, and the associative subscript that
+must *not* numify).
+
+One finding from the same investigation is filed rather than fixed: a `-->`
+return type naming an enum value (`multi sub cardtype($, *% --> NotACreditCard)
+{ }`) returns `Nil` instead of that value, while `--> 42` and `--> "lit"` are
+correct (#8022). The distribution's own suite does not exercise that candidate,
+and the discriminator involved is shared by a compiler and a runtime copy that
+have to agree, so it is a slice of its own.

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -1348,12 +1348,31 @@ impl Interpreter {
                 is_our,
                 is_dynamic,
                 is_export,
+                custom_traits,
                 ..
             } = s
             else {
                 continue;
             };
             if *is_our || *is_dynamic || *is_export || name.contains("::") {
+                continue;
+            }
+            // A `constant` is NOT a compunit lexical, whichever way it is
+            // spelled. [`Interpreter::collect_unit_package_scope_names`] owns
+            // those: they keep their value in `module_scope_names` (and hence in
+            // the package-keyed `module_scope_lexicals`, where the module's own
+            // routines read them) and lose only their bare `env` binding.
+            // Moving one into `unit_lexicals` instead takes it OUT of
+            // `module_scope_names`, and the module's own routines then read it
+            // as `Nil`.
+            //
+            // The `is_our` test above catches the bare `constant @a = ...`
+            // spelling, which parses as `VarDecl { is_our: true }`, but NOT
+            // `my constant @a = ...`, which parses with `is_our: false` — so
+            // discriminate on the `__constant` trait the same way
+            // `collect_unit_package_scope_names` does, rather than on a
+            // scope keyword that only incidentally lines up.
+            if custom_traits.iter().any(|(t, _)| t == "__constant") {
                 continue;
             }
             // Anonymous container slots (`@__ANON_ARRAY__`/`%__ANON_HASH__`)

--- a/src/value/value_enum.rs
+++ b/src/value/value_enum.rs
@@ -23,6 +23,30 @@ impl EnumValue {
         }
     }
 
+    /// The integer to use when this enum value is a *subscript*, or `None` when
+    /// it has no numeric value at all.
+    ///
+    /// Distinct from [`EnumValue::as_i64`], which answers `0` for a string enum
+    /// because its callers want a total function. A subscript must not: raku
+    /// numifies an enum value used as a positional index (`@a[Green]` is
+    /// `@a[1]`), but a STRING-valued enum (`enum E (S => 'x')`) numifies through
+    /// `Str.Int` and dies with `X::Str::Numeric`. Answering `0` there would
+    /// silently read element 0 instead, so the string case returns `None` and
+    /// leaves the caller on its existing non-numeric path.
+    pub fn as_index_i64(&self) -> Option<i64> {
+        match self {
+            EnumValue::Int(i) => Some(*i),
+            EnumValue::Str(_) => None,
+            EnumValue::Generic(v) => match v.view() {
+                ValueView::Int(i) => Some(i),
+                ValueView::BigInt(n) => n.to_i64(),
+                ValueView::Num(f) => Some(f as i64),
+                ValueView::Bool(b) => Some(i64::from(b)),
+                _ => None,
+            },
+        }
+    }
+
     /// Return the string representation for `.Str` coercion.
     pub fn to_str_value(&self) -> String {
         match self {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -662,6 +662,33 @@ impl Interpreter {
             self.stack.push(index);
             return self.exec_index_op_with_positional(is_positional);
         }
+        // An enum value used as a POSITIONAL subscript numifies to its value
+        // (`@a[Green]` is `@a[1]`): an enum value is a `Cool`, and the subscript
+        // protocol numifies its index, exactly as the explicit `@a[+Green]` /
+        // `@a[Green.Int]` spellings already did. Business::CreditCard indexes its
+        // obsolete-brand table by the card type it just looked up
+        // (`@renamed[$found]`), which answered `Nil` for every card.
+        //
+        // Gated on `is_positional` so an ASSOCIATIVE subscript keeps the enum
+        // itself as the key — `%h{Green}` is keyed by the enum value, not by its
+        // ordinal, and numifying it there would break the matching write.
+        //
+        // `as_index_i64` (not `as_i64`) so a STRING-valued enum is left alone
+        // rather than folded to element 0: raku numifies it through `Str.Int`
+        // and dies with X::Str::Numeric.
+        if is_positional
+            && let ValueView::Enum { value, .. } = index.view()
+            && let Some(i) = value.as_index_i64()
+        {
+            index = Value::int(i);
+        }
+        // `Bool` is `enum Bool <False True>`, so the same rule gives
+        // `@a[True] == @a[1]` and `@a[False] == @a[0]`. It is a distinct
+        // `ValueView`, never `ValueView::Enum`, so it needs its own arm.
+        // Positional-only for the same reason: `%h{True}` is keyed by the Bool.
+        if is_positional && let ValueView::Bool(b) = index.view() {
+            index = Value::int(i64::from(b));
+        }
         // A user object used as a positional subscript coerces via its `.Int`
         // method (`@a[$obj]` where `$obj` defines `method Int`, Raku subscript
         // protocol). Gate on an array-like target so an associative `%h{...}`

--- a/src/vm/vm_var_multidim_helpers.rs
+++ b/src/vm/vm_var_multidim_helpers.rs
@@ -31,6 +31,26 @@ impl Interpreter {
         // every caller sees `None` (see `@a[Inf] = ...` in S02-types/array.t).
         match idx.view() {
             ValueView::Int(i) if i >= 0 => Some(i as usize),
+            // An enum value is a `Cool`, so as an ARRAY index it numifies to its
+            // value (`@a[Green] = ...` is `@a[1] = ...`). Without this the
+            // `to_string_value()` fallback below parsed the enum's KEY
+            // ("Green"), failed, and the write reported "Index out of bounds".
+            // The read path numifies in `exec_index_op_with_positional`; every
+            // caller here is already an array-positional site.
+            //
+            // `as_index_i64` (not `as_i64`) so a STRING-valued enum stays on the
+            // fallback path rather than silently indexing element 0 — raku dies
+            // with X::Str::Numeric there. A negative value falls through too,
+            // and is rejected as out of range exactly as a literal `@a[-1]` is.
+            ValueView::Enum { value, .. } if value.as_index_i64().is_some_and(|i| i >= 0) => {
+                value.as_index_i64().map(|i| i as usize)
+            }
+            // `Bool` is `enum Bool <False True>`, so it numifies as a subscript
+            // the same way: `@a[True]` is `@a[1]`. It reaches here as a plain
+            // `ValueView::Bool`, never as `ValueView::Enum`, so it needs its own
+            // arm — without it `to_string_value()` produced "True" and the parse
+            // failed.
+            ValueView::Bool(b) => Some(usize::from(b)),
             ValueView::Num(f) if f >= 0.0 && f.is_finite() => Some(f as usize),
             ValueView::Rat(n, d) if d != 0 => {
                 let f = n as f64 / d as f64;

--- a/t/lib/UnitMyConstant.rakumod
+++ b/t/lib/UnitMyConstant.rakumod
@@ -1,0 +1,27 @@
+# Fixture for t/modules/unit-my-constant-visible-to-own-routines.t.
+#
+# A `unit` compunit's file-scope `constant`s are package symbols of the
+# compunit, not names the importer sees bare — but the compunit's OWN routines
+# must still read them. Both spellings (`my constant` and a bare `constant`)
+# have to behave identically; mutsu used to divert the `my constant` spelling
+# into the per-compunit lexical store, taking it out of the store its own
+# routines read and making every such read answer `Nil`.
+unit module UnitMyConstant;
+
+my constant @MY-ARRAY  = 10, 20, 30;
+my constant %MY-HASH   = (a => 1, b => 2);
+my constant $MY-SCALAR = 99;
+my constant MY-BARE    = 'sigilless';
+
+constant @BARE-ARRAY  = 40, 50, 60;
+constant %BARE-HASH   = (c => 3);
+constant $BARE-SCALAR = 77;
+
+our sub my-array()   is export { @MY-ARRAY }
+our sub my-hash()    is export { %MY-HASH }
+our sub my-scalar()  is export { $MY-SCALAR }
+our sub my-bare()    is export { MY-BARE }
+
+our sub bare-array()  is export { @BARE-ARRAY }
+our sub bare-hash()   is export { %BARE-HASH }
+our sub bare-scalar() is export { $BARE-SCALAR }

--- a/t/modules/import-export/unit-my-constant-visible-to-own-routines.t
+++ b/t/modules/import-export/unit-my-constant-visible-to-own-routines.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+use lib 't/lib';
+use UnitMyConstant;
+
+# A `unit module`'s file-scope `constant` must be readable from that module's
+# own routines, for every sigil and for both the `my constant` and bare
+# `constant` spellings.
+#
+# mutsu treated the two spellings differently: a `constant` parses as
+# `VarDecl { is_our: true }` but `my constant` parses with `is_our: false`, and
+# the compunit-lexical collector discriminated on `is_our` rather than on the
+# `__constant` trait. So a `my constant` was moved into `unit_lexicals` and
+# thereby REMOVED from the module-scope store its own routines read, and every
+# such read answered `Nil`.
+#
+# Found via the Business::CreditCard distribution, whose `cardtype` reads four
+# `my constant` lookup tables (`@lookup`, `@renamed`, `%CUPcountry`,
+# `%JCBcountry`) and so classified every card as `NotACreditCard`.
+
+plan 14;
+
+is-deeply my-array(), (10, 20, 30), 'my constant @array read from own routine';
+is my-array().elems, 3, 'my constant @array has its elements';
+is-deeply my-hash().Hash, {a => 1, b => 2}, 'my constant %hash read from own routine';
+is my-hash().elems, 2, 'my constant %hash has its elements';
+is my-scalar(), 99, 'my constant $scalar read from own routine';
+is my-bare(), 'sigilless', 'my constant sigilless read from own routine';
+
+is-deeply bare-array(), (40, 50, 60), 'bare constant @array read from own routine';
+is bare-array().elems, 3, 'bare constant @array has its elements';
+is-deeply bare-hash().Hash, {c => 3}, 'bare constant %hash read from own routine';
+is bare-scalar(), 77, 'bare constant $scalar read from own routine';
+
+# The importer does NOT see a unit compunit's file-scope constants bare
+# (#7787) — the fix must not have made them leak into the loading scope.
+nok ::('@MY-ARRAY') ~~ Positional, 'my constant @array does not leak to importer';
+nok ::('MY-BARE').defined, 'my constant sigilless does not leak to importer';
+nok ::('@BARE-ARRAY') ~~ Positional, 'bare constant @array does not leak to importer';
+nok ::('$BARE-SCALAR').defined, 'bare constant $scalar does not leak to importer';

--- a/t/types/enum-subset/enum-value-as-positional-index.t
+++ b/t/types/enum-subset/enum-value-as-positional-index.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# An enum value is a `Cool`, so as a POSITIONAL subscript it numifies to its
+# value: `@a[Green]` is `@a[1]`, exactly like the explicit `@a[+Green]` and
+# `@a[Green.Int]` spellings. An ASSOCIATIVE subscript is different — there the
+# enum value is the KEY itself, not its ordinal.
+#
+# mutsu numified neither: the read path left the enum alone (so `@a[Green]`
+# answered `Nil`) and `index_to_usize` fell through to parsing the enum's KEY
+# ("Green") as a number, so a write reported "Index out of bounds".
+#
+# Found via the Business::CreditCard distribution, which maps an obsolete card
+# brand to its current one by indexing a table with the card type it just
+# looked up (`@renamed[$found]`).
+
+plan 21;
+
+enum Color <Red Green Blue>;
+
+my @a = 'zero', 'one', 'two';
+
+# --- read ---
+is @a[Green], 'one', 'enum value as array subscript numifies to its value';
+is @a[Red], 'zero', 'first enum value indexes element 0';
+is @a[Blue], 'two', 'last enum value indexes the last element';
+
+my $c = Green;
+is @a[$c], 'one', 'enum value held in a scalar indexes the same';
+is @a[+Green], 'one', 'explicit numification agrees';
+is @a[Green.Int], 'one', 'explicit .Int agrees';
+
+# --- a constant array (the shape Business::CreditCard uses) ---
+my constant @k = 'zero', 'one', 'two';
+is @k[Green], 'one', 'enum value indexes a constant array';
+
+# --- a List ---
+my $l = (1, 2, 3);
+is $l[Green], 2, 'enum value indexes a List';
+
+# --- slice ---
+is-deeply @a[Red, Blue], ('zero', 'two'), 'enum values as a slice';
+
+# --- write ---
+my @w = 'a', 'b', 'c';
+@w[Green] = 'X';
+is-deeply @w, ['a', 'X', 'c'], 'enum value as an assignment subscript';
+
+my @auto;
+@auto[Blue] = 'grown';
+is @auto.elems, 3, 'enum value autovivifies to its ordinal length';
+is @auto[2], 'grown', 'autovivified element landed at the ordinal';
+
+# --- an enum with explicit (non-ordinal) values numifies to the VALUE ---
+enum Sized (Small => 3, Big => 5);
+my @s = ^8;
+is @s[Small], 3, 'explicitly-valued enum indexes by its value, not its position';
+is @s[Big], 5, 'explicitly-valued enum indexes by its value (second)';
+
+# --- an associative subscript keeps the enum as the KEY ---
+my %h;
+%h{Green} = 'g';
+is %h{Green}, 'g', 'enum value as a hash key round-trips';
+is-deeply %h.keys.List, ('Green',), 'hash key is the enum, not its ordinal';
+
+# --- Bool is `enum Bool <False True>`, so it numifies the same way ---
+is @a[True], 'one', 'True as a positional subscript is index 1';
+is @a[False], 'zero', 'False as a positional subscript is index 0';
+my @bw = 'a', 'b', 'c';
+@bw[True] = 'Y';
+is-deeply @bw, ['a', 'Y', 'c'], 'True as an assignment subscript';
+my %bh;
+%bh{True} = 't';
+is-deeply %bh.keys.List, ('True',), 'associative subscript keeps the Bool as key';
+
+# --- a STRING-valued enum has no numeric value, so it must NOT fold to 0 ---
+enum Stringy (Ess => 'x');
+nok (try @a[Ess]).defined, 'string-valued enum does not silently index element 0';


### PR DESCRIPTION
`Business::CreditCard` 0.2 classified **every** card number as
`NotACreditCard`. Two general interpreter gaps were behind it; neither is about
credit cards, and the distribution itself is unchanged.

**`Business::CreditCard` 0.2: `red` -> `green`.** 2/2 baseline files, 87/87
assertions (was 39/87 across two `partial` files), matching rakudo exactly.

## 1. A `my constant` in a `unit module` read as `Nil` from that module's own routines

The module builds four lookup tables at compile time (`my constant @lookup`,
`@renamed`, `%CUPcountry`, `%JCBcountry`). Read back from `cardtype`, every one
was `Nil` — so `@lookup[$card.chars]` was falsy and the chain fell through to
`NotACreditCard`. Reduced, it is not about `do` blocks, `.Map`, or binding into
array elements, all of which worked:

```raku
unit module M;
my constant @my-k   = 10, 20, 30;
constant    @bare-k = 40, 50, 60;
our sub probe() {
    say @my-k.raku;    # raku: (10, 20, 30)   mutsu: Nil
    say @bare-k.raku;  # raku: (40, 50, 60)   mutsu: (40, 50, 60)  -- fine
}
```

The two spellings behaved differently, for every sigil. A `unit` compunit's
file-scope constants are package symbols of that compunit rather than names the
importer sees bare (#7787), so `import_module` strips their plain `env` binding
and leaves the value in `module_scope_names` — which is exactly where the
module's own routines read them. Separately, the compunit's `my` lexicals are
moved into `unit_lexicals` and *removed* from `module_scope_names`.

`my constant` matched both collectors, and the `my`-lexical one ran second,
taking the value out of the store its own routines read. The two disagreed
because they identify a constant differently:
`collect_unit_package_scope_names` tests the `__constant` trait, and documents
why (`is_our` alone cannot tell a `constant` from an ordinary `our $x`);
`collect_unit_lexical_names` excluded constants only *incidentally*, via that
same `is_our: true` — which a bare `constant` has and `my constant` does not.
It now tests the `__constant` trait too, which is the fact it meant to test.

## 2. An enum value used as a positional subscript did not numify

With the tables populated, file 01 went 22 failures -> 1 and file 02 still
failed 28/30. All of them reached `cardtype`'s last line,
`$obsolete ?? $found !! @renamed[$found]`: `@renamed` had its 36 elements and
`$found.Int` was a valid index, but `@renamed[$found]` was `Any`.

```raku
enum Color <Red Green Blue>;
my @a = 'zero', 'one', 'two';
say @a[Green];      # raku: one     mutsu: Nil
my @b = 'a','b','c';
@b[Green] = 'X';    # raku: ok      mutsu: Index out of bounds
```

An enum value is a `Cool`, so the subscript protocol numifies it — exactly as
the explicit `@a[+Green]` / `@a[Green.Int]` spellings already did. The read path
left the enum alone; the write path fell through `index_to_usize` to parsing the
value's string form, which for an enum is its **key** (`"Green"`). Both sites
numify now, gated on the subscript being **positional**: an associative
subscript keeps the enum value itself as the key (`%h{Green}`), and numifying
there would break the matching write.

Two neighbours of the same rule came along, because they are the same rule:

* **`Bool` is `enum Bool <False True>`**, so `@a[True]` is `@a[1]`. It arrives
  as a distinct `ValueView`, never `ValueView::Enum`, so it had the identical
  gap on both paths and needed its own arm on each.
* **A string-valued enum must NOT numify.** `EnumValue::as_i64` answers `0` for
  one (its callers want a total function), which would have made `@a[S]`
  silently read element 0 where raku dies with `X::Str::Numeric`. Both subscript
  sites use a new `Option`-returning `EnumValue::as_index_i64` so the
  non-numeric case stays on the pre-existing path instead of inventing an
  answer. Negative-valued members fall through the same way and are rejected as
  out of range, exactly as a literal `@a[-1]` is.

File 01 mostly survived bug 2 because it passes `:obsolete`, which takes the
ternary's other branch and never indexes `@renamed`.

## Tests

- `t/modules/import-export/unit-my-constant-visible-to-own-routines.t` — both
  spellings, every sigil, plus the #7787 non-leak assertions that must keep
  holding.
- `t/types/enum-subset/enum-value-as-positional-index.t` — read, write, slice,
  autovivification, explicitly-valued enums, `Bool`, the string-valued enum that
  must *not* fold to 0, and the associative subscript that must *not* numify.

Both files pass identically under `raku` and under mutsu.

## Findings filed rather than fixed

- **#8022** — a `-->` return type naming an enum value returns `Nil` instead of
  that value (`--> 42` and `--> "lit"` are correct). The distribution's own
  suite does not exercise its `--> NotACreditCard` candidate. The discriminator
  is shared by a compiler and a runtime copy that must agree, so it is a slice
  of its own.
- **#8027** — an importer's `my @x` reads empty when a used unit module has a
  file-scope `my constant @x` of the same name. **Not a regression**: measured
  on both sides of this change (before: `1`; after: `0`; raku: `3`).

## Neighbour re-measured

`Locale::US` 0.0.2 is the root-cause neighbour — the only other ledger
distribution downloaded and grepped that uses the `my constant`-at-unit-scope
idiom (List::Divvy, Lingua::EN::Numbers, Acme::Cow and Heap were checked and do
not). Its module is correct under mutsu now — the recorded `first_failure`, "No
such method 'uc' for invocant of type 'Any'", is gone; `all-state-names().elems`
is 59 and `state-to-code("CALIFORNIA")` is `CA` — but the record stays `red` at
1/60, because its test file opens with `my @states = all-state-names;` /
`my @codes = all-state-codes;`, whose names collide with the module's own
`my constant @states` / `@codes`. That is #8027, and it is the whole remaining
distance to green for that distribution.

`ecosystem/index-snapshot.json` is deliberately untouched (targeted `--only`
runs).

## Verification

`cargo fmt --all`, `make lint` (all four configurations), `make test`
(4037 files, 42969 tests, `Result: PASS`) and `make roast` (1437 files, 219635
tests) all run locally on the final rebased state.

`make roast`'s three failures are exactly the container-only set documented in
[docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md),
matching by name *and* by failure count: `roast/6.c/S32-io/file-tests.t`
(Failed: 4, tests 6-8/10 — `uid 0`), `roast/S16-filehandles/filetest.t`
(Failed: 25 — `uid 0`), and `roast/S32-io/IO-Socket-Async.t` (exit 124 at 17
tests — sandboxed network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmWQPfMoJyyRx7HywDCrPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmWQPfMoJyyRx7HywDCrPJ)_