### PR TITLE
perf(end-phaser): refresh only the names a closure call could have changed

### DIFF
--- a/news/2026-09/end-phaser-refresh-only-what-the-call-changed.md
+++ b/news/2026-09/end-phaser-refresh-only-what-the-call-changed.md
@@ -1,0 +1,110 @@
+# The END-phaser refresh stops re-proving that nothing changed
+
+Next slice of [#7565](https://github.com/tokuhirom/mutsu/issues/7565) ("`use Test`
+taxes every hot loop in the file that loads it"). The previous four slices
+(#7656, #7707, #7964, #8019) worked the closure *capture*: what goes into it and
+what the filter walks to build it. This one is about what happens on the way
+back out.
+
+## Where the tax actually sits now
+
+A per-function instruction-slope profile of the ticket's loop, taken against
+`main` at `f4b55d7`, puts the biggest single term somewhere none of the earlier
+notes looked: `Env::get_sym` is called **32 times per loop iteration from
+`call_compiled_closure_in_unit`**, for 2 053 instructions of self cost, and
+every one of those calls is part of the END-phaser refresh at the end of the
+closure-return path. It is pure tax — the same loop without `use Test`
+registers no `END` at all, so the refresh never runs and the term is zero.
+
+The refresh exists to keep an `END` phaser's captured copy of a lexical current:
+the phaser holds a *copy* of the scope it closed over, so when a closure mutates
+a captured lexical whose declaring frame dies before exit, that copy is the
+phaser's only surviving binding. Two things made it far more expensive than that
+purpose needs:
+
+1. **It iterated the whole capture.** The capture's width is set by the
+   *creating scope*, not by the closure, so `use Test` alone made it ~35 names
+   per return — and a reflective program's whole-env snapshot makes it hundreds.
+2. **It re-stored every one of them**, whether or not the value had changed.
+   Upstream `Test.rakumod` registers an `END` (its plan check), and the names a
+   wide import list leaves in a capture are dominated by things no call ever
+   rebinds: the ~19 built-in dynamics, `Any`, `?FILE`, the topic.
+
+## Two changes
+
+**Skip a write whose value is already there.** `update_end_phaser_envs_for_keys`
+now compares by binding identity (`Value::same_binding`, an O(1) word compare)
+and returns early instead of re-storing the very `Value` the phaser env already
+holds. `same_binding` is the right test and a deep `==` would not be: it walks
+container contents, and a container mutated in place keeps its binding — which
+is precisely the case where the phaser's entry *is* that same container and
+already sees the mutation.
+
+**Consider only the names the call could have changed.** Every caller-visible
+write a closure call makes passes through that frame's own overlay tier — the
+closure-return writeback loop is an iteration of exactly that tier, and a value
+that never reached it cannot have reached the restored caller env either. So the
+overlay's own keys, intersected with the capture, bound the refresh: after a bare
+`use Test` that is about 6 names instead of ~35. Three things widen it back:
+`cc.free_var_syms` is added unconditionally (a slot-authoritative write to a free
+variable need not have mirrored into `env` at all); a by-name write whose target
+only exists at run time (an `EVAL`'d `$a = 32`, merged from a side channel by
+`propagate_pending_caller_writes`) and a resume-safe `CONTROL` handler's write
+into an ancestor frame both fall back to the whole capture. So does a frame whose
+env is not a scoped overlay, where `keys()` is the whole env and the narrowing
+would cost more than it saves.
+
+The runtime overlay is the right source rather than any compile-time set: a write
+made by a routine *called from* the closure body is named by no free-variable set
+of the closure, and reaches the caller only through that routine's own writeback
+into this frame — which is to say, through this overlay. `t/routines/closure/end-phaser-closure-capture-refresh.t`
+pins that case along with five others.
+
+## Numbers
+
+Warm-run callgrind instruction slopes between 6 000 and 14 000 iterations,
+`MUTSU_JIT=off MUTSU_GC=off`, release, on two shapes of the ticket's loop: the
+original (a leaf closure, which skips the caller-writeback scan) and a variant
+whose closure makes a call.
+
+| | base | after | |
+| --- | --- | --- | --- |
+| leaf loop, no `use Test` (the floor) | 75 954 | 76 007 | |
+| leaf loop `+ use Test` | 96 926 | 88 009 | -9.2% |
+| **its tax** | **20 972** | **12 002** | **-42.8%** |
+| calling loop, no `use Test` | 82 595 | 82 618 | |
+| calling loop `+ use Test` | 106 196 | 97 181 | -8.5% |
+| **its tax** | **23 601** | **14 563** | **-38.3%** |
+
+Ablated in a separate gated build (its baseline carries ~1.3k of gate overhead,
+so these rank the two changes rather than restate the table above): the
+equal-write skip alone is 29% of the tax, and deleting the refresh outright —
+the ceiling — is 48%. Shipping both reaches **88% of that ceiling** while
+keeping the mechanism.
+
+## What is left
+
+Revised from the list in #8019's note:
+
+1. **The no-op capture merge.** Unchanged and now the largest remaining term:
+   gating it out entirely is worth 4 821 instructions per iteration on the leaf
+   loop (measured here, higher than the 2 635 the previous note reported because
+   the profile has moved). Still the design change #8019 described — chaining the
+   capture *under* the caller as a fallback tier rather than merging it key by
+   key — and still an ADR rather than a perf slice. A cheap identity token for
+   "the caller chain is the chain this capture was filtered out of" is the
+   tempting shortcut and it is **not** cheap: the only sound token pins the
+   creating frame's overlay `Arc`, which forces a copy-on-write clone of that
+   overlay on the very next write to it — and in this loop that write is the
+   `my &return = ...` that stores the closure itself.
+2. **`skip_env_write`'s process-global latch** (`vm_var_assign_set_local.rs`),
+   with the `EVAL`-scope question #8019's note spelled out. Gates 3.
+3. **The `filtered_flat` walk**, still the largest self cost in the program
+   (5 024 instructions per iteration on the leaf loop with `use Test`, against
+   2 121 without). Needs 2 first.
+4. **The ~20 built-in dynamics** — floor, not tax.
+
+One measurement note for whoever takes these: the equal-write skip means a
+profile of the refresh now under-reports its *potential*, because the writes it
+used to make were the cheap half. Measure a change to it against the numbers in
+the table above, not against any earlier note's.

--- a/src/runtime/end_phasers.rs
+++ b/src/runtime/end_phasers.rs
@@ -269,8 +269,8 @@ impl Interpreter {
         }
     }
 
-    /// True when at least one key of `captured` names a live (non-frozen) entry
-    /// of some END phaser's captured env — i.e. when
+    /// True when at least one of `keys` names a live (non-frozen) entry of some
+    /// END phaser's captured env — i.e. when
     /// [`Self::update_end_phaser_envs_for_keys`] has anything at all to do.
     ///
     /// This is the cheap half of that update: it asks the same two membership
@@ -280,19 +280,18 @@ impl Interpreter {
     /// phaser — the overwhelmingly common case, and every case at all once a
     /// module with a wide export list has widened the capture — then costs two
     /// integer-keyed lookups per captured name instead of a whole-env flatten.
-    pub(crate) fn end_phasers_watch_any(&self, captured: &Env) -> bool {
+    pub(crate) fn end_phasers_watch_any(&self, keys: &[Symbol]) -> bool {
         self.end_phasers.iter().any(|phaser| {
-            captured
-                .keys()
+            keys.iter()
                 .any(|k| !phaser.dead_keys.contains(k) && phaser.env.contains_key_sym(*k))
         })
     }
 
-    /// Update captured envs of ALL END phasers, but only for the names
-    /// `captured` holds.  Used after closure calls to propagate changes to
-    /// captured variables without overwriting unrelated variables.
+    /// Update captured envs of ALL END phasers, but only for `keys`.  Used
+    /// after closure calls to propagate changes to captured variables without
+    /// overwriting unrelated variables.
     ///
-    /// `captured` is the *calling closure's* own captured env, whose names only
+    /// `keys` are names of the *calling closure's* own captured env, which only
     /// coincidentally share a name with a phaser's captured entry — they
     /// are not necessarily the same binding (a same-named `my` in a sibling
     /// scope is a common case: `{ my $a = 42; END { say $a } }; my $a = 0;
@@ -303,23 +302,35 @@ impl Interpreter {
     /// binding for that name and must never be overwritten by an unrelated
     /// same-named capture from elsewhere.
     ///
-    /// The names are taken as interned [`Symbol`]s straight off `captured`'s
-    /// own overlay, never resolved back to strings. This runs on EVERY closure
-    /// return once any END phaser exists, over a capture whose width is set by
-    /// the *creating scope* rather than by the closure — so a program that
-    /// `use`s a module with a wide export list, or one the reflective latch has
-    /// widened to a whole-env snapshot, walks hundreds of names here per call.
-    /// Resolving each to a `String` and re-interning it three times over
+    /// The names are interned [`Symbol`]s, never resolved back to strings. This
+    /// runs on EVERY closure return once any END phaser exists, so both the
+    /// size of `keys` and the per-key cost are on the hot path of any program
+    /// that loaded a module registering an `END` — which `use Test` does.
+    /// Resolving each name to a `String` and re-interning it three times over
     /// (`dead_keys`, the phaser env, the live env) made this ~30% of the hot
-    /// loop of a program that merely had `use Test` at the top (#7565).
-    pub(crate) fn update_end_phaser_envs_for_keys(&mut self, captured: &Env, current_env: &Env) {
+    /// loop of a program that merely had `use Test` at the top (#7565). The
+    /// caller is what keeps `keys` small: it passes the names the call could
+    /// actually have CHANGED, not the whole capture — see the collection of
+    /// `end_refresh_keys` in `call_compiled_closure_in_unit`.
+    ///
+    /// **A write whose value is already there is skipped**, by binding identity
+    /// rather than by `==`: re-storing the very `Value` the phaser env already
+    /// holds cannot change what the phaser reads, and a capture widened by an
+    /// import list is dominated by names (`$*IN`, `$*OUT`, `Any`, `?FILE`, the
+    /// built-in dynamics) that no call ever rebinds. `same_binding` is the
+    /// right test and `==` is not: it is O(1) where a deep `==` walks container
+    /// contents, and a container mutated in place keeps its binding — which is
+    /// exactly the case where the phaser's own entry is that same container and
+    /// so already sees the mutation.
+    pub(crate) fn update_end_phaser_envs_for_keys(&mut self, keys: &[Symbol], current_env: &Env) {
         for phaser in self.end_phasers.iter_mut() {
-            for k in captured.keys() {
+            for k in keys {
                 if phaser.dead_keys.contains(k) {
                     continue;
                 }
-                if phaser.env.contains_key_sym(*k)
+                if let Some(old) = phaser.env.get_sym(*k)
                     && let Some(v) = current_env.get_sym(*k)
+                    && !old.same_binding(v)
                 {
                     let v = v.clone();
                     phaser.env.insert_sym(*k, v);

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1764,6 +1764,54 @@ impl Interpreter {
             self.propagate_pending_caller_writes(&mut restored_env, &callee_private);
         }
 
+        // The names the END-phaser refresh below has to consider: the captured
+        // names this call can have CHANGED in the caller. Collected here, while
+        // `self.env()` is still the callee frame, because the refresh itself has
+        // to read the restored caller env.
+        //
+        // Every caller-visible write a closure call makes passes through this
+        // frame's own overlay tier — the writeback loop above is an iteration of
+        // exactly that tier, and a value that never reached it cannot have
+        // reached `restored_env` either. So the overlay's own keys bound the
+        // set, and after a `use Test` that is ~6 names against the capture's
+        // ~35 (#7565). Three things widen it back:
+        //
+        // * `cc.free_var_syms`, because a slot-authoritative write to a free
+        //   variable need not have mirrored into `env` at all (the `(B)`
+        //   per-store skip in `vm_var_assign_set_local.rs`);
+        // * a by-name write whose target only exists at run time (an `EVAL`'d
+        //   `$a = 32`), which `propagate_pending_caller_writes` merges from a
+        //   side channel rather than from the overlay;
+        // * a resume-safe CONTROL handler's write into an ancestor frame.
+        //
+        // The last two fall back to the whole capture, as does a frame whose
+        // env is not a scoped overlay at all (then `keys()` is the whole env,
+        // so the narrowing would cost more than it saves).
+        let end_refresh_keys: Vec<Symbol> = if self.has_end_phasers() && !data.env.is_empty() {
+            if self.pending_runtime_name_writes.is_empty()
+                && self.inline_control_env_writes.len() == inline_control_writes_at_entry
+                && self.env().len() < data.env.len()
+            {
+                let captured = data.env.inner();
+                // Sized up front: the `filter` hides the exact size hint the
+                // two iterators have, so `collect` would otherwise walk
+                // hashbrown's growth ladder for a handful of names.
+                let mut keys = Vec::with_capacity(self.env().len() + cc.free_var_syms.len());
+                keys.extend(
+                    self.env()
+                        .keys()
+                        .copied()
+                        .chain(cc.free_var_syms.iter().copied())
+                        .filter(|k| captured.contains_key(k)),
+                );
+                keys
+            } else {
+                data.env.keys().copied().collect()
+            }
+        } else {
+            Vec::new()
+        };
+
         *self.env_mut() = restored_env;
 
         // After a closure returns, update captured envs of END phasers for
@@ -1776,7 +1824,7 @@ impl Interpreter {
         // names, and asking first is what keeps the `clone_env()` flatten below
         // off every closure return in a program that merely declares an `END`
         // (#7565).
-        if self.has_end_phasers() && !data.env.is_empty() && self.end_phasers_watch_any(&data.env) {
+        if !end_refresh_keys.is_empty() && self.end_phasers_watch_any(&end_refresh_keys) {
             // The refresh reads the live env ONE KEY AT A TIME
             // (`current_env.get_sym`), and a scoped env's `get_sym` already
             // walks its parent chain — so it needs the full lexical *view*, not
@@ -1786,7 +1834,7 @@ impl Interpreter {
             // instructions per iteration of a loop in a file that had done
             // nothing but `use Test` (#7565).
             let current = self.take_env();
-            self.update_end_phaser_envs_for_keys(&data.env, &current);
+            self.update_end_phaser_envs_for_keys(&end_refresh_keys, &current);
             self.set_env(current);
         }
 

--- a/t/routines/closure/end-phaser-closure-capture-refresh.t
+++ b/t/routines/closure/end-phaser-closure-capture-refresh.t
@@ -1,0 +1,49 @@
+use lib 'roast/packages/Test-Helpers/lib';
+use Test;
+use Test::Util;
+
+# An END phaser holds a *copy* of the scope it closed over. When a closure
+# mutates a captured lexical whose declaring frame dies before exit, that copy
+# is the phaser's only surviving binding, so the closure's return has to
+# refresh it (`update_end_phaser_envs_for_keys`).
+#
+# #7565: that refresh used to walk the whole capture on EVERY closure return —
+# a set whose width is the *creating scope's*, so `use Test` alone made it
+# hundreds of names — and to re-store every one of them even when the value was
+# the very same binding it already held. It now considers only the names the
+# call could have changed. These pin the cases that narrowing must keep.
+
+plan 6;
+
+is_run 'my $x = 1; END { say $x }; my &c = { $x = 42 }; c();',
+    { :out("42\n") },
+    'a closure writing a captured mainline lexical refreshes the END capture';
+
+is_run 'sub f() { my $x = 1; END { say $x }; my &c = { $x = 42 }; c() }; f();',
+    { :out("42\n") },
+    'and when the declaring frame dies before exit, so the copy is all there is';
+
+# The write is made by a *called* routine, not by the closure body itself, so
+# no compile-time free-variable set of the closure names it: only the runtime
+# writeback does.
+is_run 'sub f() { my $x = 1; END { say $x }; sub w() { $x = 7 }; my &c = { w() }; c() }; f();',
+    { :out("7\n") },
+    'a write made through a call inside the closure still reaches the capture';
+
+# A closure that writes nothing must not drag an unrelated live value into a
+# phaser's capture — and the phaser must still read the mainline's final value,
+# which it gets from the live exit-time env rather than from its copy.
+is_run 'my $x = 1; END { say $x }; my &c = { 0 }; $x = 5; c();',
+    { :out("5\n") },
+    'a non-writing closure leaves the mainline value to the live exit env';
+
+# A same-named lexical in a sibling scope must never clobber the phaser's own
+# captured binding.
+is_run 'sub f() { my $a = 1; END { say $a } }; f(); my $a = 99; my &c = { $a }; c();',
+    { :out("1\n") },
+    'an unrelated same-named capture does not overwrite a frozen phaser key';
+
+# Repeated calls keep tracking: the refresh is not a once-only latch.
+is_run 'sub f() { my $n = 0; END { say $n }; my &c = { $n = $n + 1 }; c(); c(); c() }; f();',
+    { :out("3\n") },
+    'every call refreshes, so the last write is the one the phaser sees';


### PR DESCRIPTION
Next slice of [#7565](https://github.com/tokuhirom/mutsu/issues/7565). The previous four slices (#7656, #7707, #7964, #8019) worked the closure *capture* — what goes into it and what the filter walks to build it. This one is about what happens on the way back out.

## Where the tax actually sits now

A per-function instruction-slope profile of the ticket's loop against `main` at `f4b55d7` puts the biggest single term somewhere none of the earlier notes looked: **`Env::get_sym` runs 32 times per loop iteration from `call_compiled_closure_in_unit`**, 2 053 instructions of self cost, and every one of those calls is part of the END-phaser refresh on the closure-return path. It is pure tax — the same loop without `use Test` registers no `END` at all, so the refresh never runs and the term is zero.

The refresh keeps an `END` phaser's captured *copy* of a lexical current: the phaser holds a copy of the scope it closed over, so when a closure mutates a captured lexical whose declaring frame dies before exit, that copy is the phaser's only surviving binding. Two things made it far more expensive than that purpose needs:

1. **It iterated the whole capture**, whose width is set by the *creating scope* rather than by the closure — ~35 names after a bare `use Test`, hundreds under a reflective whole-env snapshot.
2. **It re-stored every one of them**, changed or not. Upstream `Test.rakumod` registers an `END` (its plan check), and the names a wide import list leaves in a capture are dominated by things no call ever rebinds: the ~19 built-in dynamics, `Any`, `?FILE`, the topic.

## Two changes

**Skip a write whose value is already there.** `update_end_phaser_envs_for_keys` compares by binding identity (`Value::same_binding`, an O(1) word compare) and returns early instead of re-storing the very `Value` the phaser env already holds. `same_binding` is the right test and a deep `==` would not be: it walks container contents, and a container mutated in place keeps its binding — precisely the case where the phaser's entry *is* that container and already sees the mutation.

**Consider only the names the call could have changed.** Every caller-visible write a closure call makes passes through that frame's own overlay tier — the closure-return writeback loop is an iteration of exactly that tier, and a value that never reached it cannot have reached the restored caller env either. So the overlay's keys, intersected with the capture, bound the refresh: about **6 names instead of ~35**. Three things widen it back:

- `cc.free_var_syms`, added unconditionally, because a slot-authoritative write to a free variable need not have mirrored into `env` at all (the `(B)` per-store skip in `vm_var_assign_set_local.rs`);
- a by-name write whose target only exists at run time (an `EVAL`'d `$a = 32`), merged from a side channel by `propagate_pending_caller_writes`;
- a resume-safe `CONTROL` handler's write into an ancestor frame.

The last two fall back to the whole capture, as does a frame whose env is not a scoped overlay at all (there `keys()` is the whole env, so the narrowing would cost more than it saves).

The **runtime** overlay is the right source rather than any compile-time set: a write made by a routine *called from* the closure body is named by no free-variable set of the closure, and reaches the caller only through that routine's own writeback into this frame.

## Numbers

Warm-run callgrind instruction slopes between 6 000 and 14 000 iterations, `MUTSU_JIT=off MUTSU_GC=off`, release, on two shapes of the ticket's loop: the original (a leaf closure, which skips the caller-writeback scan) and a variant whose closure makes a call.

| | base | after | |
| --- | --- | --- | --- |
| leaf loop, no `use Test` (the floor) | 75 954 | 76 007 | |
| leaf loop `+ use Test` | 96 926 | 88 009 | -9.2% |
| **its tax** | **20 972** | **12 002** | **-42.8%** |
| calling loop, no `use Test` | 82 595 | 82 618 | |
| calling loop `+ use Test` | 106 196 | 97 181 | -8.5% |
| **its tax** | **23 601** | **14 563** | **-38.3%** |

Ablated in a separate gated build (its baseline carries ~1.3k of gate overhead, so these rank the two changes rather than restate the table): the equal-write skip alone is 29% of the tax, and deleting the refresh outright — the ceiling — is 48%. Shipping both reaches **88% of that ceiling** while keeping the mechanism.

## Tests

`t/routines/closure/end-phaser-closure-capture-refresh.t` pins six cases the narrowing has to keep, each checked against rakudo first: a closure writing a captured mainline lexical; the same where the declaring frame dies before exit; a write made through a *call* inside the closure (the case no compile-time set names); a non-writing closure leaving the mainline value to the live exit env; an unrelated same-named capture not overwriting a frozen phaser key; and repeated calls still tracking the last write.

`cargo fmt --all`, `make lint`, `make test` (4034 files / 42 927 tests, PASS) and `make roast` all run locally. `make roast` is red only on the three files [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) documents as container artefacts, each matching its documented signature exactly: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, runs as uid 0), `roast/S16-filehandles/filetest.t` (`Failed: 25`, uid 0) and `roast/S32-io/IO-Socket-Async.t` (exit 124, ran 17, sandboxed network).

## Left for the next slice

The news entry records this in full. In short, revised from #8019's list:

1. **The no-op capture merge**, now the largest remaining term: gating it out entirely is worth 4 821 instructions per iteration on the leaf loop (measured here — higher than the 2 635 the previous note reported, because the profile has moved). Still the design change #8019 described, and still an ADR rather than a perf slice. A cheap identity token for "the caller chain is the chain this capture was filtered out of" is the tempting shortcut and it is **not** cheap: the only sound token pins the creating frame's overlay `Arc`, which forces a copy-on-write clone of that overlay on the very next write to it — and in this loop that write is the `my &return = ...` that stores the closure itself.
2. **`skip_env_write`'s process-global latch**, with the `EVAL`-scope question #8019 spelled out. Gates 3.
3. **The `filtered_flat` walk**, still the largest self cost in the program (5 024 instructions per iteration with `use Test` against 2 121 without). Needs 2 first.
4. **The ~20 built-in dynamics** — floor, not tax.

Leaving #7565 open: the tax is down, not gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8)_