### PR TITLE
fix(parser): complete L10N vocabulary coverage

### DIFF
--- a/news/2026-09/l10n-vocabulary-followup.md
+++ b/news/2026-09/l10n-vocabulary-followup.md
@@ -1,0 +1,12 @@
+# Complete L10N vocabulary parsing coverage
+
+mutsu now applies generated L10N vocabulary entries at their parser seams:
+localized infix operators, named arguments, quote and regex adverbs,
+postcircumfix adverbs, and the `now`/`time`/`rand` terms are translated to the
+canonical parser names. `use L10N::XX` activation is detected from the module's
+`$*LANG.define_slang` AST call, so generated L10N distributions work without a
+direct `use Slangify` declaration.
+
+Metaoperator and quote-language entries remain intentionally unsupported; they
+are reported as inert vocabulary residue rather than being given an incorrect
+meaning.

--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -201,6 +201,14 @@ pub(super) fn parse_pure_concat_op(r: &str) -> Option<(ConcatOp, usize)> {
 
 /// Parse replication operators (x, xx, o) — higher precedence than ~.
 pub(super) fn parse_replication_op(r: &str) -> Option<(ConcatOp, usize)> {
+    if let Some((canonical, len)) = crate::parser::stmt::simple::l10n_match_infix(r) {
+        return match canonical.as_str() {
+            "x" => Some((ConcatOp::Repeat, len)),
+            "xx" => Some((ConcatOp::ListRepeat, len)),
+            "o" => Some((ConcatOp::Compose, len)),
+            _ => None,
+        };
+    }
     if r.starts_with("xx")
         && !is_ident_char(r.as_bytes().get(2).copied())
         && r.as_bytes().get(2).copied() != Some(b'=')
@@ -273,6 +281,15 @@ fn word_infix_at(r: &str, kw: &str) -> bool {
 }
 
 pub(super) fn parse_multiplicative_op(r: &str) -> Option<(MultiplicativeOp, usize)> {
+    if let Some((canonical, len)) = crate::parser::stmt::simple::l10n_match_infix(r) {
+        return match canonical.as_str() {
+            "div" => Some((MultiplicativeOp::IntDiv, len)),
+            "mod" => Some((MultiplicativeOp::IntMod, len)),
+            "gcd" => Some((MultiplicativeOp::Gcd, len)),
+            "lcm" => Some((MultiplicativeOp::Lcm, len)),
+            _ => None,
+        };
+    }
     // Unicode: multiply (U+00D7) -- skip if user-defined infix exists (the caller
     // then parses it as a multiplicative-precedence `infix:<×>` call so the user
     // candidate dispatches), and (like the ASCII `*` below) leave `×=` for the
@@ -643,6 +660,13 @@ fn starts_with_caret_flipflop(input: &str) -> bool {
 }
 
 pub(super) fn parse_or_or_op(input: &str) -> Option<(LogicalOp, usize)> {
+    if let Some((canonical, len)) = crate::parser::stmt::simple::l10n_match_infix(input) {
+        return match canonical.as_str() {
+            "min" => Some((LogicalOp::Min, len)),
+            "max" => Some((LogicalOp::Max, len)),
+            _ => None,
+        };
+    }
     if input.starts_with("||") && !input.starts_with("||=") {
         Some((LogicalOp::OrOr, 2))
     } else if input.starts_with("^^") && !input.starts_with("^^=") {
@@ -692,6 +716,17 @@ pub(super) fn parse_negated_logical_op(input: &str) -> Option<(LogicalOp, usize)
 }
 
 pub(in crate::parser) fn parse_word_logical_op(input: &str) -> Option<(LogicalOp, usize)> {
+    if let Some((canonical, len)) = crate::parser::stmt::simple::l10n_match_infix(input) {
+        return match canonical.as_str() {
+            "or" => Some((LogicalOp::Or, len)),
+            "xor" => Some((LogicalOp::XorXor, len)),
+            "orelse" => Some((LogicalOp::OrElse, len)),
+            "and" => Some((LogicalOp::And, len)),
+            "andthen" => Some((LogicalOp::AndThen, len)),
+            "notandthen" => Some((LogicalOp::NotAndThen, len)),
+            _ => None,
+        };
+    }
     // Helper: check that the keyword is followed by a word boundary AND is not
     // immediately followed by `=` (which would make it a compound assignment
     // like `or=`, `and=`, `orelse=`, etc.).

--- a/src/parser/expr/postfix/adverb.rs
+++ b/src/parser/expr/postfix/adverb.rs
@@ -8,6 +8,22 @@ use crate::value::Value;
 /// Try to parse a secondary adverb after :exists/:!exists.
 /// Returns (remaining_input, adverb).
 pub(crate) fn parse_exists_secondary_adverb(input: &str) -> (&str, ExistsAdverb) {
+    if let Some((canonical, negated, rest)) =
+        crate::parser::stmt::simple::l10n_match_adverb("adverb-pc", input)
+    {
+        let adverb = match (canonical.as_str(), negated) {
+            ("kv", false) => ExistsAdverb::Kv,
+            ("kv", true) => ExistsAdverb::NotKv,
+            ("p", false) => ExistsAdverb::P,
+            ("p", true) => ExistsAdverb::NotP,
+            ("v", false) => ExistsAdverb::InvalidV,
+            ("v", true) => ExistsAdverb::NotV,
+            ("k", false) => ExistsAdverb::InvalidK,
+            ("k", true) => ExistsAdverb::InvalidNotK,
+            _ => return (input, ExistsAdverb::None),
+        };
+        return (rest, adverb);
+    }
     if input.starts_with(":!kv") && !is_ident_char(input.as_bytes().get(4).copied()) {
         return (&input[4..], ExistsAdverb::NotKv);
     }
@@ -50,8 +66,10 @@ pub(crate) fn parse_dynamic_subscript_adverb(input: &str) -> Option<&str> {
         return None;
     }
     let name = &r[..end];
+    let name = crate::parser::stmt::simple::l10n_adverb_alias("adverb-pc", name)
+        .unwrap_or_else(|| name.to_string());
     // Only recognize known subscript adverb names
-    match name {
+    match name.as_str() {
         "delete" | "exists" => Some(&r[end..]),
         _ => None,
     }
@@ -64,6 +82,47 @@ pub(crate) fn parse_dynamic_subscript_adverb(input: &str) -> Option<&str> {
 pub(crate) fn parse_subscript_adverb_with_expr(
     input: &str,
 ) -> Option<(&str, &'static str, Option<Expr>)> {
+    if let Some((canonical, negated, rest)) =
+        crate::parser::stmt::simple::l10n_match_adverb("adverb-pc", input)
+    {
+        let mode = match (canonical.as_str(), negated) {
+            ("kv", true) => "not-kv",
+            ("kv", false) => "kv",
+            ("p", true) => "not-p",
+            ("p", false) => "p",
+            ("k", true) => "not-k",
+            ("k", false) => "k",
+            ("v", true) => "not-v",
+            ("v", false) => "v",
+            _ => return None,
+        };
+        if let Some(rest) = rest.strip_prefix("(0)") {
+            return Some((
+                rest,
+                match mode {
+                    "kv" => "kv0",
+                    "p" => "p0",
+                    "k" => "k0",
+                    "v" => "v0",
+                    _ => mode,
+                },
+                None,
+            ));
+        }
+        if let Some(rest) = rest.strip_prefix("(1)") {
+            return Some((rest, mode, None));
+        }
+        if !negated
+            && rest.starts_with('(')
+            && let Some((after, expr)) = try_parse_adverb_expr(rest)
+        {
+            return Some((after, mode, Some(expr)));
+        }
+        if rest.starts_with('(') {
+            return None;
+        }
+        return Some((rest, mode, None));
+    }
     if input.starts_with(":!kv") && !is_ident_char(input.as_bytes().get(4).copied()) {
         return Some((&input[4..], "not-kv", None));
     }
@@ -420,6 +479,26 @@ pub(crate) fn apply_delete_to_exists(expr: Expr) -> Expr {
 }
 
 pub(crate) fn parse_delete_adverb(input: &str) -> Option<(&str, DeleteAdverb)> {
+    if let Some((canonical, negated, rest)) =
+        crate::parser::stmt::simple::l10n_match_adverb("adverb-pc", input)
+        && canonical == "delete"
+    {
+        if negated {
+            return Some((rest, DeleteAdverb::NoDelete));
+        }
+        if let Some(r_stripped) = rest.strip_prefix('(')
+            && let Ok((r2, _)) = ws(r_stripped)
+            && let Ok((r2, cond)) = expression(r2)
+            && let Ok((r2, _)) = ws(r2)
+            && let Ok((r2, _)) = parse_char(r2, ')')
+        {
+            return Some((r2, DeleteAdverb::Delete(Some(cond))));
+        }
+        if rest.starts_with('(') {
+            return None;
+        }
+        return Some((rest, DeleteAdverb::Delete(None)));
+    }
     if input.starts_with(":!delete") && !is_ident_char(input.as_bytes().get(8).copied()) {
         return Some((&input[8..], DeleteAdverb::NoDelete));
     }
@@ -537,8 +616,12 @@ pub(crate) fn subscript_adverb_expr_with_cond(
 /// Returns (remaining_input, exists_expr) or None if no adverb found.
 pub(crate) fn try_parse_exists_adverb(input: &str, target: Expr) -> Option<(&str, Expr)> {
     let r = input;
-    let (r, negated) = if r.starts_with(":!exists") && !is_ident_char(r.as_bytes().get(8).copied())
+    let (r, negated) = if let Some((canonical, negated, rest)) =
+        crate::parser::stmt::simple::l10n_match_adverb("adverb-pc", r)
+        && canonical == "exists"
     {
+        (rest, negated)
+    } else if r.starts_with(":!exists") && !is_ident_char(r.as_bytes().get(8).copied()) {
         (&r[8..], true)
     } else if r.starts_with(":exists") && !is_ident_char(r.as_bytes().get(7).copied()) {
         (&r[7..], false)

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1257,6 +1257,9 @@ fn postfix_expr_loop_from(
             let r = ws(r).map_or(r, |(r_ws, _)| r_ws);
             if let Ok((r, parsed_name)) = crate::parser::primary::var::parse_ident_with_hyphens(r) {
                 let mut method_name = parsed_name.to_string();
+                if let Some(canonical) = crate::parser::stmt::simple::l10n_alias(&method_name) {
+                    method_name = canonical;
+                }
                 let mut trailing_postfix: Option<TokenKind> = None;
                 if !r.starts_with('(') {
                     if method_name.ends_with("++") && method_name.len() > 2 {
@@ -3203,6 +3206,7 @@ fn postfix_expr_loop_from(
                 parsed_static_name
             };
             if let Some((r, name)) = parsed_static_name {
+                let name = crate::parser::stmt::simple::l10n_alias(&name).unwrap_or(name);
                 // Bare (non-dotted) hyper postfix on a builtin wordy postfix
                 // operator (currently just `i`, e.g. `@a»i`) calls the
                 // *operator* (`&postfix:<i>`), not a method — `i` is not a

--- a/src/parser/expr/precedence/chain_cmp.rs
+++ b/src/parser/expr/precedence/chain_cmp.rs
@@ -54,6 +54,25 @@ pub(in crate::parser::expr) fn parse_comparison_op(r: &str) -> Option<(Compariso
     if crate::parser::stmt_ending_brace::infix_barred_by_stmt_ending_brace(r) {
         return None;
     }
+    if let Some((canonical, len)) = crate::parser::stmt::simple::l10n_match_infix(r) {
+        let op = match canonical.as_str() {
+            "eq" => ComparisonOp::StrEq,
+            "ne" => ComparisonOp::StrNe,
+            "lt" => ComparisonOp::StrLt,
+            "gt" => ComparisonOp::StrGt,
+            "le" => ComparisonOp::StrLe,
+            "ge" => ComparisonOp::StrGe,
+            "leg" => ComparisonOp::Leg,
+            "cmp" => ComparisonOp::Cmp,
+            "coll" => ComparisonOp::Coll,
+            "unicmp" => ComparisonOp::Unicmp,
+            "eqv" => ComparisonOp::Eqv,
+            "before" => ComparisonOp::Before,
+            "after" => ComparisonOp::After,
+            _ => return None,
+        };
+        return Some((op, len));
+    }
     // Unicode comparison operators
     if r.starts_with('\u{2A75}') {
         // ⩵ (U+2A75) — numeric equality (alias for ==)

--- a/src/parser/expr/precedence/custom_infix.rs
+++ b/src/parser/expr/precedence/custom_infix.rs
@@ -1,6 +1,16 @@
 use super::*;
 
 pub(crate) fn parse_custom_infix_word(input: &str) -> Option<(String, usize)> {
+    // L10N infix entries are aliases of the canonical operator name. The
+    // dedicated precedence parsers consume built-ins first; this fallback is
+    // for list-level operators such as `minmax` and set-style names that do
+    // not have a tighter hand-written parser.
+    if let Some((canonical, len)) = crate::parser::stmt::simple::l10n_match_infix(input) {
+        if crate::parser::primary::ident::is_infix_word_op(&canonical) {
+            return None;
+        }
+        return Some((canonical, len));
+    }
     let mut word_match: Option<(String, usize)> = None;
 
     // Try word-like operators (alphabetic/underscore start)
@@ -63,6 +73,14 @@ pub(crate) fn parse_custom_infix_word(input: &str) -> Option<(String, usize)> {
 }
 
 pub(crate) fn parse_flipflop_infix(input: &str) -> Option<(String, usize)> {
+    if let Some((canonical, len)) = crate::parser::stmt::simple::l10n_match_infix(input)
+        && matches!(
+            canonical.as_str(),
+            "ff" | "ff^" | "fff" | "fff^" | "^ff" | "^ff^" | "^fff" | "^fff^"
+        )
+    {
+        return Some((canonical, len));
+    }
     const OPS: &[&str] = &["^fff^", "^fff", "fff^", "fff", "^ff^", "^ff", "ff^", "ff"];
     for op in OPS {
         if let Some(rest) = input.strip_prefix(op)

--- a/src/parser/expr/precedence_meta_ops/set_ops.rs
+++ b/src/parser/expr/precedence_meta_ops/set_ops.rs
@@ -8,6 +8,13 @@ use super::hyper_concat::concat_expr;
 use super::meta_bracket::block_newline_terminates;
 
 fn parse_set_op(input: &str) -> Option<(TokenKind, usize)> {
+    if let Some((canonical, len)) = crate::parser::stmt::simple::l10n_match_infix(input) {
+        match canonical.as_str() {
+            "(elem)" => return Some((TokenKind::SetElem, len)),
+            "(cont)" => return Some((TokenKind::SetCont, len)),
+            _ => {}
+        }
+    }
     if input.starts_with("(==)") {
         Some((TokenKind::Ident("(==)".to_string()), 4))
     } else if input.starts_with('≡') {
@@ -138,8 +145,20 @@ pub(crate) fn structural_expr(input: &str) -> PResult<'_, Expr> {
         if block_newline_terminates(input, rest, r) {
             break;
         }
-        if r.starts_with("but") && !is_ident_char(r.as_bytes().get(3).copied()) {
-            let r = &r[3..];
+        let localized = crate::parser::stmt::simple::l10n_match_infix(r);
+        let (but_len, does_len) = match localized.as_ref().map(|(name, len)| (name.as_str(), *len))
+        {
+            Some(("but", len)) => (len, 0),
+            Some(("does", len)) => (0, len),
+            _ => (0, 0),
+        };
+        if (but_len > 0)
+            || (but_len == 0
+                && r.starts_with("but")
+                && !is_ident_char(r.as_bytes().get(3).copied()))
+        {
+            let len = if but_len > 0 { but_len } else { 3 };
+            let r = &r[len..];
             let (r, _) = ws(r)?;
             let (r, right) = concat_expr(r).map_err(|err| {
                 enrich_expected_error(err, "expected expression after 'but'", r.len())
@@ -152,8 +171,13 @@ pub(crate) fn structural_expr(input: &str) -> PResult<'_, Expr> {
             rest = r;
             continue;
         }
-        if r.starts_with("does") && !is_ident_char(r.as_bytes().get(4).copied()) {
-            let r = &r[4..];
+        if (does_len > 0)
+            || (does_len == 0
+                && r.starts_with("does")
+                && !is_ident_char(r.as_bytes().get(4).copied()))
+        {
+            let len = if does_len > 0 { does_len } else { 4 };
+            let r = &r[len..];
             let (r, _) = ws(r)?;
             let (r, right) = concat_expr(r).map_err(|err| {
                 enrich_expected_error(err, "expected expression after 'does'", r.len())

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -12,5 +12,5 @@ pub(super) use identifier_call::identifier_or_call;
 pub(in crate::parser) use listop::{
     colon_starts_colonpair, expr_is_colonpair, parse_expr_listop_args, try_adjacent_colonpair_arg,
 };
-pub(in crate::parser) use predicates::is_keyword;
+pub(in crate::parser) use predicates::{is_infix_word_op, is_keyword};
 pub(super) use term_literals::{class_literal, declared_term_symbol, keyword_literal, whatever};

--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -532,6 +532,18 @@ pub(crate) fn next_word_is_listop_bareword_arg(input: &str) -> bool {
 
 /// Check if a name is an infix word operator (should not be treated as a listop call).
 pub(crate) fn is_infix_word_op(name: &str) -> bool {
+    // Infix vocabulary entries have their own position-specific map. This is
+    // important when a localized spelling is also used by another category,
+    // such as JA's `と` (`infix-and` and `modifier-with`): the generic
+    // canonical map cannot express which grammar position is being checked.
+    if let Some((canonical, length)) = crate::parser::stmt::simple::l10n_match_infix(name)
+        && length == name.len()
+    {
+        return is_infix_word_op(&canonical);
+    }
+    if let Some(canonical) = crate::parser::stmt::simple::l10n_canonical_keyword(name) {
+        return is_infix_word_op(&canonical);
+    }
     matches!(
         name,
         "Z" | "X"

--- a/src/parser/primary/ident/term_literals.rs
+++ b/src/parser/primary/ident/term_literals.rs
@@ -380,7 +380,23 @@ pub(crate) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
             return Ok(r);
         }
     }
-    // rand — generates a random number (term)
+    // rand — generates a random number (term). `term-rand` is a generated
+    // L10N alias, but this term has a hand-rolled parser rather than going
+    // through `keyword_literal`, so consult the vocabulary before the ASCII
+    // fast path.
+    if let Some(rest) = crate::parser::stmt::simple::l10n_match_keyword("rand", input).flatten() {
+        let after = rest.trim_start();
+        if after.starts_with('(') {
+            return Err(PError::obsolete("rand()", "rand"));
+        }
+        return Ok((
+            rest,
+            Expr::Call {
+                name: Symbol::intern("rand"),
+                args: vec![],
+            },
+        ));
+    }
     if input.starts_with("rand")
         && !input[4..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-')
     {
@@ -424,6 +440,27 @@ pub(crate) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
     }
 
     // now — returns current time as Instant (term)
+    if let Some(rest) = crate::parser::stmt::simple::l10n_match_keyword("now", input).flatten() {
+        let after = rest.trim_start();
+        if after.starts_with('(') && !crate::parser::stmt::simple::is_user_declared_sub("now") {
+            return Err(PError::fatal_at(
+                format!(
+                    "X::Undeclared::Symbols: Undeclared routine:\n    now used at line {}",
+                    current_line_number(input)
+                ),
+                input,
+            ));
+        }
+        if !after.starts_with("=>") || after.starts_with("==>") {
+            return Ok((
+                rest,
+                Expr::Call {
+                    name: Symbol::intern("now"),
+                    args: vec![],
+                },
+            ));
+        }
+    }
     if input.starts_with("now")
         && !input[3..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-')
     {
@@ -451,6 +488,27 @@ pub(crate) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
         }
     }
     // time — returns current epoch time as Int (term)
+    if let Some(rest) = crate::parser::stmt::simple::l10n_match_keyword("time", input).flatten() {
+        let after = rest.trim_start();
+        if after.starts_with('(') && !crate::parser::stmt::simple::is_user_declared_sub("time") {
+            return Err(PError::fatal_at(
+                format!(
+                    "X::Undeclared::Symbols: Undeclared routine:\n    time used at line {}",
+                    current_line_number(input)
+                ),
+                input,
+            ));
+        }
+        if !after.starts_with("=>") || after.starts_with("==>") {
+            return Ok((
+                rest,
+                Expr::Call {
+                    name: Symbol::intern("time"),
+                    args: vec![],
+                },
+            ));
+        }
+    }
     if input.starts_with("time")
         && !input[4..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-')
     {

--- a/src/parser/primary/misc/colonpair.rs
+++ b/src/parser/primary/misc/colonpair.rs
@@ -446,14 +446,20 @@ pub(crate) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
         ));
     }
     // :name(expr) or :name (boolean true pair)
-    let (mut rest, name) = parse_ident_with_hyphens(r)?;
+    let (mut rest, parsed_name) = parse_ident_with_hyphens(r)?;
+    // Generated L10N roles keep named-argument translations in `named2str`,
+    // because a named argument is a colonpair key rather than a bareword
+    // term. Store the canonical key in the AST so named dispatch sees the
+    // same name it would have seen in ordinary Raku source.
+    let name = crate::parser::stmt::simple::l10n_named_alias(parsed_name)
+        .unwrap_or_else(|| parsed_name.to_string());
     if rest.starts_with('?') || rest.starts_with('!') {
         rest = &rest[1..];
     }
     // Don't parse statement-modifier keywords as bare colonpairs (`:when`),
     // but allow them when followed by a value (`:when<now>`, `:if(True)`, etc.)
     if matches!(
-        name,
+        name.as_str(),
         "if" | "unless" | "for" | "while" | "until" | "given" | "when"
     ) && !rest.starts_with('(')
         && !rest.starts_with('[')

--- a/src/parser/primary/quote_adverbs.rs
+++ b/src/parser/primary/quote_adverbs.rs
@@ -171,6 +171,9 @@ pub(super) fn parse_colon_adverbs<'a>(mut input: &'a str, flags: &mut QuoteFlags
             break;
         }
         let adverb_name = &r[..end];
+        let localized_name =
+            crate::parser::stmt::simple::l10n_adverb_alias("adverb-q", adverb_name);
+        let adverb_name = localized_name.as_deref().unwrap_or(adverb_name);
         if negated {
             // When negating in qq mode, expand qq_mode into individual flags first
             // so that selective negation works (e.g. qq:!a:!c disables array+closure

--- a/src/parser/primary/regex/adverbs.rs
+++ b/src/parser/primary/regex/adverbs.rs
@@ -225,6 +225,10 @@ pub(super) fn parse_match_adverbs(input: &str) -> PResult<'_, MatchAdverbs> {
         if name.is_empty() {
             break;
         }
+        if let Some(canonical) = crate::parser::stmt::simple::l10n_adverb_alias("adverb-rx", &name)
+        {
+            name = canonical;
+        }
 
         let mut arg: Option<&str> = None;
         if r.starts_with('(') {

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -47,8 +47,8 @@ pub use lib_paths::{
 // `pub(crate)` re-exports.
 pub(crate) use compile_consts::is_imported_function;
 pub(crate) use l10n::{
-    L10nVocabulary, l10n_alias, l10n_canonical_keyword, l10n_match_keyword, set_l10n_preseed,
-    set_l10n_vocabulary,
+    L10nVocabulary, l10n_adverb_alias, l10n_alias, l10n_canonical_keyword, l10n_match_adverb,
+    l10n_match_infix, l10n_match_keyword, l10n_named_alias, set_l10n_preseed, set_l10n_vocabulary,
 };
 pub(crate) use registry::{
     current_language_version, current_language_version_starts_with, set_current_language_version,

--- a/src/parser/stmt/simple/l10n.rs
+++ b/src/parser/stmt/simple/l10n.rs
@@ -20,13 +20,13 @@
 //! - **Alias** (`core-say` → `言う`): the localized spelling is an *additional*
 //!   name for a core routine. Both `say 42` and `言う 42` parse.
 //!
-//! Only the categories whose parser production mutsu consults here are wired
-//! up; the rest (`infix-`, `named-`, `adverb-`, `meta-`, `quote-lang-`) are
-//! accepted and recorded as inert. An inert entry means source written with
-//! that localized spelling fails to *parse*, loudly — it can never make
-//! existing syntax silently mean something else, which is the failure mode
-//! ADR-0026's hard-error rule exists to prevent. The residue is tracked in
-//! <https://github.com/tokuhirom/mutsu/issues/7990>.
+//! The parser reaches the remaining categories through their natural seams:
+//! infix operators through the precedence parsers, named arguments through
+//! colonpairs, and quote/regex/postcircumfix adverbs through their respective
+//! adverb parsers. The metaoperator and quote-language categories remain
+//! inert: source written with one of those spellings still fails loudly rather
+//! than silently acquiring the wrong meaning. The remaining residue is
+//! tracked in <https://github.com/tokuhirom/mutsu/issues/7990>.
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -64,16 +64,19 @@ const REPLACEMENT_CATEGORIES: &[&str] = &[
 const ALIAS_CATEGORIES: &[&str] = &["core-", "enum-", "term-", "system-", "pragma-", "trait-is-"];
 
 /// Categories that belong to the L10N schema but whose grammatical position
-/// mutsu's parser does not consult yet: word infix operators, metaoperators,
-/// quote-language names, named arguments and adverbs. Recognized so a role
-/// declaring them is still a valid vocabulary — see the module docs on why
-/// inert is safe where an unknown *production* override is not.
-const INERT_CATEGORIES: &[&str] = &["infix-", "meta-", "quote-lang-", "named-", "adverb-"];
+/// mutsu's parser does not consult yet: metaoperators and quote-language
+/// names. Recognized so a role declaring them is still a valid vocabulary —
+/// see the module docs on why inert is safe where an unknown *production*
+/// override is not.
+const INERT_CATEGORIES: &[&str] = &["meta-", "quote-lang-"];
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum Category {
     Replacement,
     Alias,
+    Infix,
+    Named,
+    Adverb,
     Inert,
 }
 
@@ -99,6 +102,13 @@ pub(crate) struct L10nVocabulary {
     keywords: HashMap<String, KeywordSpellings>,
     /// Localized bareword → the canonical routine/term/enum name.
     aliases: HashMap<String, String>,
+    /// Localized word/symbol infix spelling → canonical operator spelling.
+    infix_aliases: HashMap<String, String>,
+    /// Localized named-argument spelling → canonical named parameter.
+    named_aliases: HashMap<String, String>,
+    /// Localized adverb spelling → canonical adverb, separated by the
+    /// grammar position whose generated L10N method supplied the map.
+    adverb_aliases: HashMap<String, HashMap<String, String>>,
     /// Every localized spelling → the canonical keyword it stands for, the
     /// reverse of `keywords`. Answers "is this word reserved?".
     canonical: HashMap<String, String>,
@@ -145,6 +155,15 @@ impl L10nVocabulary {
             Category::Alias => {
                 self.insert_alias(literal, canonical);
             }
+            Category::Infix => {
+                self.insert_infix_alias(literal, canonical);
+            }
+            Category::Named => {
+                self.insert_named_alias(literal, canonical);
+            }
+            Category::Adverb => {
+                self.insert_adverb_alias("pc", literal, canonical);
+            }
             Category::Inert => unreachable!("handled above"),
         }
         true
@@ -165,6 +184,31 @@ impl L10nVocabulary {
         }
     }
 
+    /// Add a generated `<category>2str` map. These methods are used for the
+    /// grammatical positions whose localized spellings cannot be represented
+    /// by a `token <category>-<name>` declaration.
+    pub(crate) fn insert_position_aliases<'a>(
+        &mut self,
+        method_name: &str,
+        pairs: impl Iterator<Item = (&'a str, &'a str)>,
+    ) {
+        let Some(category) = method_name.strip_suffix("2str") else {
+            return;
+        };
+        for (localized, canonical) in pairs {
+            if localized.is_empty() || canonical.is_empty() || localized == canonical {
+                continue;
+            }
+            match category {
+                "named" => self.insert_named_alias(localized, canonical),
+                "adverb-pc" | "adverb-q" | "adverb-rx" => {
+                    self.insert_adverb_alias(category, localized, canonical)
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn insert_alias(&mut self, localized: &str, canonical: &str) {
         self.aliases
             .insert(localized.to_string(), canonical.to_string());
@@ -177,8 +221,38 @@ impl L10nVocabulary {
             .insert(localized.to_string(), canonical.to_string());
     }
 
+    fn insert_infix_alias(&mut self, localized: &str, canonical: &str) {
+        let canonical = canonical_infix_name(canonical);
+        // Native spellings already have a parser path. Keeping an identity
+        // entry here would make position checks recurse forever (`and` →
+        // `and`), while also serving no localization purpose.
+        if localized == canonical {
+            return;
+        }
+        self.infix_aliases
+            .insert(localized.to_string(), canonical.to_string());
+        self.canonical
+            .insert(localized.to_string(), canonical.to_string());
+    }
+
+    fn insert_named_alias(&mut self, localized: &str, canonical: &str) {
+        self.named_aliases
+            .insert(localized.to_string(), canonical.to_string());
+    }
+
+    fn insert_adverb_alias(&mut self, category: &str, localized: &str, canonical: &str) {
+        self.adverb_aliases
+            .entry(category.to_string())
+            .or_default()
+            .insert(localized.to_string(), canonical.to_string());
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
-        self.keywords.is_empty() && self.aliases.is_empty()
+        self.keywords.is_empty()
+            && self.aliases.is_empty()
+            && self.infix_aliases.is_empty()
+            && self.named_aliases.is_empty()
+            && self.adverb_aliases.is_empty()
     }
 
     /// Token keys this implementation recorded but does not consult.
@@ -204,6 +278,15 @@ fn categorize(key: &str) -> Option<(Category, &str)> {
         .iter()
         .map(|c| (Category::Replacement, *c))
         .chain(ALIAS_CATEGORIES.iter().map(|c| (Category::Alias, *c)))
+        .chain(
+            [
+                ("infix-", Category::Infix),
+                ("named-", Category::Named),
+                ("adverb-", Category::Adverb),
+            ]
+            .into_iter()
+            .map(|(prefix, category)| (category, prefix)),
+        )
         .chain(INERT_CATEGORIES.iter().map(|c| (Category::Inert, *c)));
     for (category, prefix) in candidates {
         let Some(rest) = key.strip_prefix(prefix) else {
@@ -217,6 +300,23 @@ fn categorize(key: &str) -> Option<(Category, &str)> {
         }
     }
     best.map(|(category, rest, _)| (category, rest))
+}
+
+/// The generated L10N names for the endpoint-excluding flip-flops use the
+/// same short names as Rakudo's grammar tokens, while the parser's operator
+/// spelling includes the caret markers.
+fn canonical_infix_name(name: &str) -> &str {
+    match name {
+        "pcontp" => "(cont)",
+        "pelemp" => "(elem)",
+        "cff" => "^ff",
+        "cffc" => "^ff^",
+        "cfff" => "^fff",
+        "cfffc" => "^fff^",
+        "ffc" => "ff^",
+        "fffc" => "fff^",
+        _ => name,
+    }
 }
 
 /// Reduce a token body to the literal spelling it matches, or `None` when the
@@ -352,6 +452,72 @@ pub(crate) fn l10n_alias(name: &str) -> Option<String> {
     L10N_VOCABULARY.with(|v| v.borrow().as_ref()?.aliases.get(name).cloned())
 }
 
+pub(crate) fn l10n_named_alias(name: &str) -> Option<String> {
+    if !L10N_ACTIVE.with(Cell::get) {
+        return None;
+    }
+    L10N_VOCABULARY.with(|v| v.borrow().as_ref()?.named_aliases.get(name).cloned())
+}
+
+pub(crate) fn l10n_adverb_alias(category: &str, name: &str) -> Option<String> {
+    if !L10N_ACTIVE.with(Cell::get) {
+        return None;
+    }
+    L10N_VOCABULARY.with(|v| {
+        v.borrow()
+            .as_ref()?
+            .adverb_aliases
+            .get(category)?
+            .get(name)
+            .cloned()
+    })
+}
+
+/// Match a localized colon-adverb name, returning `(canonical, negated,
+/// remainder)`. The caller owns the canonical name because it is translated
+/// out of a thread-local vocabulary; the source remainder remains borrowed.
+pub(crate) fn l10n_match_adverb<'a>(
+    category: &str,
+    input: &'a str,
+) -> Option<(String, bool, &'a str)> {
+    if !L10N_ACTIVE.with(Cell::get) {
+        return None;
+    }
+    let after_colon = input.strip_prefix(':')?;
+    let (negated, after_bang) = after_colon
+        .strip_prefix('!')
+        .map_or((false, after_colon), |rest| (true, rest));
+    let end = after_bang
+        .char_indices()
+        .find(|(_, c)| !c.is_alphanumeric() && *c != '_' && *c != '-')
+        .map_or(after_bang.len(), |(idx, _)| idx);
+    if end == 0 {
+        return None;
+    }
+    let name = &after_bang[..end];
+    let canonical = l10n_adverb_alias(category, name)?;
+    Some((canonical, negated, &after_bang[end..]))
+}
+
+/// Match the longest localized infix spelling at the start of `input`,
+/// returning its canonical spelling and the bytes consumed from the source.
+pub(crate) fn l10n_match_infix(input: &str) -> Option<(String, usize)> {
+    if !L10N_ACTIVE.with(Cell::get) {
+        return None;
+    }
+    L10N_VOCABULARY.with(|v| {
+        let borrowed = v.borrow();
+        let vocabulary = borrowed.as_ref()?;
+        vocabulary
+            .infix_aliases
+            .iter()
+            .filter_map(|(localized, canonical)| {
+                match_spelling(localized, input).map(|_| (canonical.clone(), localized.len()))
+            })
+            .max_by_key(|(_, len)| *len)
+    })
+}
+
 /// The canonical Raku keyword a localized spelling stands for, for the checks
 /// that ask "is this word reserved?" rather than "does this word appear here?".
 ///
@@ -478,9 +644,9 @@ mod tests {
     }
 
     #[test]
-    fn unwired_categories_are_recorded_inert_not_rejected() {
+    fn only_unwired_categories_are_recorded_inert_not_rejected() {
         let vocabulary = ja();
-        assert_eq!(vocabulary.inert(), ["infix-pcontp"]);
+        assert!(vocabulary.inert().is_empty());
     }
 
     #[test]
@@ -494,7 +660,23 @@ mod tests {
             categorize("traitmod-is"),
             Some((Category::Replacement, "is"))
         );
-        assert_eq!(categorize("infix-and"), Some((Category::Inert, "and")));
+        assert_eq!(categorize("infix-and"), Some((Category::Infix, "and")));
         assert_eq!(categorize("methodop"), None);
+    }
+
+    #[test]
+    fn position_maps_are_kept_separate_from_identifier_aliases() {
+        let mut vocabulary = L10nVocabulary::default();
+        vocabulary.insert_position_aliases("adverb-rx2str", [("グローバル", "global")].into_iter());
+        vocabulary.insert_position_aliases("named2str", [("インチ", "in")].into_iter());
+        assert_eq!(
+            vocabulary.adverb_aliases["adverb-rx"].get("グローバル"),
+            Some(&"global".to_string())
+        );
+        assert_eq!(
+            vocabulary.named_aliases.get("インチ"),
+            Some(&"in".to_string())
+        );
+        assert_eq!(vocabulary.aliases.get("グローバル"), None);
     }
 }

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ast::CallArg;
 use std::cell::Cell;
 use std::rc::Rc;
 
@@ -182,7 +183,12 @@ pub(crate) fn register_module_exports(module: &str) {
         m.borrow_mut().remove(module);
     });
     if let Some(scan) = scan {
-        record_use_scan_outcome(module, scan.uses_slangify);
+        // Slangify is the activation helper, not a slang to activate by
+        // itself. Its EXPORT implementation contains the same
+        // `$*LANG.define_slang` call that L10N modules use, but running it as
+        // a zero-argument slang activation would call its four-argument
+        // EXPORT with no arguments and fail every Slangify-based module.
+        record_use_scan_outcome(module, module != "Slangify" && scan.uses_slangify);
         apply_scan_types(&scan);
         apply_module_exports(&scan.exports);
         for (keyword, how_type) in &scan.declare_keywords {
@@ -604,10 +610,17 @@ fn scan_module_source(source: &str, path: &str) -> ModuleScanResult {
     result.sort_by(|a, b| a.name.cmp(&b.name));
     let mut declare_keywords = Vec::new();
     collect_exporthow_declare(&stmts, &mut declare_keywords);
-    let uses_slangify = stmts.iter().any(|s| {
-        matches!(s, Stmt::Use { module, .. }
+    // L10N distributions do not `use Slangify` themselves. Their generated
+    // EXPORT hook calls `$*LANG.define_slang(...)` instead, so inspect the
+    // parsed AST for that method call. This deliberately operates on AST
+    // nodes rather than source text: a comment mentioning `define_slang` must
+    // not cause an arbitrary module to execute in the parse-time interpreter.
+    let defines_slang = contains_define_slang(&stmts);
+    let uses_slangify = defines_slang
+        || stmts.iter().any(|s| {
+            matches!(s, Stmt::Use { module, .. }
             if module == "Slangify" || module.starts_with("Slangify:"))
-    });
+        });
     ModuleScanResult {
         exports: result,
         type_names,
@@ -616,6 +629,268 @@ fn scan_module_source(source: &str, path: &str) -> ModuleScanResult {
         declare_keywords,
         type_index_incomplete,
         uses_slangify,
+    }
+}
+
+fn contains_define_slang(stmts: &[Stmt]) -> bool {
+    stmts.iter().any(contains_define_slang_stmt)
+}
+
+fn contains_define_slang_stmt(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::VarDecl {
+            expr,
+            where_constraint,
+            custom_traits,
+            ..
+        } => {
+            contains_define_slang_expr(expr)
+                || where_constraint
+                    .as_deref()
+                    .is_some_and(contains_define_slang_expr)
+                || custom_traits
+                    .iter()
+                    .filter_map(|(_, arg)| arg.as_ref())
+                    .any(contains_define_slang_expr)
+        }
+        Stmt::Assign { expr, .. }
+        | Stmt::Return(expr)
+        | Stmt::Die(expr)
+        | Stmt::Fail(expr)
+        | Stmt::Goto(expr) => contains_define_slang_expr(expr),
+        Stmt::Take(expr, _) => contains_define_slang_expr(expr),
+        Stmt::SubDecl {
+            body,
+            signature_alternates,
+            ..
+        } => {
+            contains_define_slang(body)
+                || signature_alternates
+                    .iter()
+                    .flat_map(|(_, defs)| defs)
+                    .any(|def| {
+                        def.default.as_ref().is_some_and(contains_define_slang_expr)
+                            || def
+                                .where_constraint
+                                .as_deref()
+                                .is_some_and(contains_define_slang_expr)
+                    })
+        }
+        Stmt::MethodDecl { body, .. }
+        | Stmt::TokenDecl { body, .. }
+        | Stmt::RuleDecl { body, .. }
+        | Stmt::ProtoDecl { body, .. }
+        | Stmt::Package { body, .. }
+        | Stmt::ClassDecl { body, .. }
+        | Stmt::AugmentClass { body, .. }
+        | Stmt::RoleDecl { body, .. }
+        | Stmt::Block(body)
+        | Stmt::SyntheticBlock(body)
+        | Stmt::Default(body)
+        | Stmt::Catch(body)
+        | Stmt::Control(body)
+        | Stmt::React { body }
+        | Stmt::Phaser { body, .. } => contains_define_slang(body),
+        Stmt::EnumDecl { variants, .. } => variants
+            .iter()
+            .filter_map(|(_, expr)| expr.as_ref())
+            .any(contains_define_slang_expr),
+        Stmt::SubsetDecl { predicate, .. } => {
+            predicate.as_ref().is_some_and(contains_define_slang_expr)
+        }
+        Stmt::HasDecl { default, .. } => default.as_ref().is_some_and(contains_define_slang_expr),
+        Stmt::Expr(expr) => contains_define_slang_expr(expr),
+        Stmt::Say(exprs) | Stmt::Put(exprs) | Stmt::Print(exprs) | Stmt::Note(exprs) => {
+            exprs.iter().any(contains_define_slang_expr)
+        }
+        Stmt::Call { args, .. } => args.iter().any(contains_define_slang_call_arg),
+        Stmt::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            contains_define_slang_expr(cond)
+                || contains_define_slang(then_branch)
+                || contains_define_slang(else_branch)
+        }
+        Stmt::While { cond, body, .. } => {
+            contains_define_slang_expr(cond) || contains_define_slang(body)
+        }
+        Stmt::Loop {
+            init,
+            cond,
+            step,
+            body,
+            ..
+        } => {
+            init.as_deref().is_some_and(contains_define_slang_stmt)
+                || cond.as_ref().is_some_and(contains_define_slang_expr)
+                || step.as_ref().is_some_and(contains_define_slang_expr)
+                || contains_define_slang(body)
+        }
+        Stmt::For { iterable, body, .. } => {
+            contains_define_slang_expr(iterable) || contains_define_slang(body)
+        }
+        Stmt::Given { topic, body, .. }
+        | Stmt::When {
+            cond: topic, body, ..
+        } => contains_define_slang_expr(topic) || contains_define_slang(body),
+        Stmt::Whenever { supply, body, .. } => {
+            contains_define_slang_expr(supply) || contains_define_slang(body)
+        }
+        Stmt::Label { stmt, .. } => contains_define_slang_stmt(stmt),
+        Stmt::Let { index, value, .. } => {
+            index.as_deref().is_some_and(contains_define_slang_expr)
+                || value.as_deref().is_some_and(contains_define_slang_expr)
+        }
+        Stmt::TempMethodAssign {
+            method_args, value, ..
+        } => {
+            method_args.iter().any(contains_define_slang_expr) || contains_define_slang_expr(value)
+        }
+        _ => false,
+    }
+}
+
+fn contains_define_slang_call_arg(arg: &CallArg) -> bool {
+    match arg {
+        CallArg::Positional(expr) | CallArg::Slip(expr) | CallArg::Invocant(expr) => {
+            contains_define_slang_expr(expr)
+        }
+        CallArg::Named { value, .. } => value.as_ref().is_some_and(contains_define_slang_expr),
+    }
+}
+
+fn contains_define_slang_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Call { args, .. } | Expr::UserRoutineCall { args, .. } => {
+            args.iter().any(contains_define_slang_expr)
+        }
+        Expr::AssignExpr { expr, .. }
+        | Expr::Grouped(expr)
+        | Expr::ZenSlice(expr)
+        | Expr::Eager(expr)
+        | Expr::Itemize(expr)
+        | Expr::DeitemizeForBind(expr)
+        | Expr::PositionalPair(expr)
+        | Expr::IndirectTypeLookup(expr)
+        | Expr::Unary { expr, .. }
+        | Expr::PostfixOp { expr, .. }
+        | Expr::Reduction { expr, .. }
+        | Expr::WhateverCurry(expr) => contains_define_slang_expr(expr),
+        Expr::Binary { left, right, .. }
+        | Expr::HyperOp { left, right, .. }
+        | Expr::HyperFuncOp { left, right, .. }
+        | Expr::MetaOp { left, right, .. } => {
+            contains_define_slang_expr(left) || contains_define_slang_expr(right)
+        }
+        Expr::ChainedCompare { operands, .. } => operands.iter().any(contains_define_slang_expr),
+        Expr::InfixFunc { left, right, .. } => {
+            contains_define_slang_expr(left) || right.iter().any(contains_define_slang_expr)
+        }
+        Expr::Feed { source, sink, .. } => {
+            contains_define_slang_expr(source) || contains_define_slang_expr(sink)
+        }
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => {
+            contains_define_slang_expr(cond)
+                || contains_define_slang_expr(then_expr)
+                || contains_define_slang_expr(else_expr)
+        }
+        Expr::MethodCall {
+            target, args, name, ..
+        }
+        | Expr::HyperMethodCall {
+            target, args, name, ..
+        } => {
+            name.resolve() == "define_slang"
+                || contains_define_slang_expr(target)
+                || args.iter().any(contains_define_slang_expr)
+        }
+        Expr::DynamicMethodCall {
+            target,
+            name_expr,
+            args,
+            ..
+        }
+        | Expr::HyperMethodCallDynamic {
+            target,
+            name_expr,
+            args,
+            ..
+        } => {
+            contains_define_slang_expr(target)
+                || contains_define_slang_expr(name_expr)
+                || args.iter().any(contains_define_slang_expr)
+        }
+        Expr::CallOn { target, args } => {
+            contains_define_slang_expr(target) || args.iter().any(contains_define_slang_expr)
+        }
+        Expr::Index { target, index, .. } => {
+            contains_define_slang_expr(target) || contains_define_slang_expr(index)
+        }
+        Expr::MultiDimIndex {
+            target, dimensions, ..
+        } => {
+            contains_define_slang_expr(target) || dimensions.iter().any(contains_define_slang_expr)
+        }
+        Expr::MultiDimIndexAssign {
+            target,
+            dimensions,
+            value,
+            ..
+        } => {
+            contains_define_slang_expr(target)
+                || dimensions.iter().any(contains_define_slang_expr)
+                || contains_define_slang_expr(value)
+        }
+        Expr::IndexAssign {
+            target,
+            index,
+            value,
+            ..
+        } => {
+            contains_define_slang_expr(target)
+                || contains_define_slang_expr(index)
+                || contains_define_slang_expr(value)
+        }
+        Expr::Exists { target, arg, .. } => {
+            contains_define_slang_expr(target)
+                || arg.as_deref().is_some_and(contains_define_slang_expr)
+        }
+        Expr::SymbolicDeref { expr, .. } => contains_define_slang_expr(expr),
+        Expr::SymbolicDerefAssign { expr, value, .. }
+        | Expr::IndirectTypeLookupAssign { expr, value } => {
+            contains_define_slang_expr(expr) || contains_define_slang_expr(value)
+        }
+        Expr::IndirectCodeLookup { package, .. }
+        | Expr::HyperSlice {
+            target: package, ..
+        } => contains_define_slang_expr(package),
+        Expr::ArrayLiteral(items)
+        | Expr::BracketArray(items, _)
+        | Expr::CaptureLiteral(items)
+        | Expr::StringInterpolation(items) => items.iter().any(contains_define_slang_expr),
+        Expr::Hash(pairs) => pairs
+            .iter()
+            .filter_map(|(_, value)| value.as_ref())
+            .any(contains_define_slang_expr),
+        Expr::Block(body)
+        | Expr::Gather(body)
+        | Expr::DoBlock { body, .. }
+        | Expr::Once { body }
+        | Expr::PhaserExpr { body, .. }
+        | Expr::AnonSub { body, .. } => contains_define_slang(body),
+        Expr::AnonSubParams { body, .. } | Expr::Lambda { body, .. } => contains_define_slang(body),
+        Expr::Try { body, catch } => {
+            contains_define_slang(body) || catch.as_deref().is_some_and(contains_define_slang)
+        }
+        Expr::DoStmt(stmt) => contains_define_slang_stmt(stmt),
+        _ => false,
     }
 }
 
@@ -1061,5 +1336,20 @@ mod test_exports_tests {
             declared, scanned,
             "TEST_EXPORTS has drifted from modules/Rakudo-Core/lib/Test.rakumod"
         );
+    }
+
+    #[test]
+    fn slang_activation_scan_uses_ast_not_source_comments() {
+        let commented = super::scan_module_source(
+            "# $*LANG.define_slang(\"MAIN\", $grammar)\nmy sub exported() { 1 }",
+            "<test>",
+        );
+        assert!(!commented.uses_slangify);
+
+        let registered = super::scan_module_source(
+            "my sub EXPORT() { $*LANG.define_slang(\"MAIN\", $grammar) }",
+            "<test>",
+        );
+        assert!(registered.uses_slangify);
     }
 }

--- a/src/parser/stmt/simple/slang_use.rs
+++ b/src/parser/stmt/simple/slang_use.rs
@@ -33,11 +33,15 @@ pub(crate) fn apply_slang_overrides(
             continue;
         }
         if !over.aliases.is_empty() {
-            vocabulary.insert_aliases(
-                over.aliases
-                    .iter()
-                    .map(|(localized, canonical)| (localized.as_str(), canonical.as_str())),
-            );
+            let aliases = over
+                .aliases
+                .iter()
+                .map(|(localized, canonical)| (localized.as_str(), canonical.as_str()));
+            if over.name.ends_with("2str") {
+                vocabulary.insert_position_aliases(&over.name, aliases);
+            } else {
+                vocabulary.insert_aliases(aliases);
+            }
             continue;
         }
         if vocabulary.try_insert_token(&over.name, over.body.as_deref()) {

--- a/src/runtime/slang_activation.rs
+++ b/src/runtime/slang_activation.rs
@@ -218,7 +218,10 @@ impl Interpreter {
         // names, `is` trait arguments) through a `<category>2ast` method rather
         // than through a token, so read those maps too.
         for (method_name, defs) in &def.methods {
-            let Some(category) = method_name.strip_suffix("2ast") else {
+            let Some(category) = method_name
+                .strip_suffix("2ast")
+                .or_else(|| method_name.strip_suffix("2str"))
+            else {
                 continue;
             };
             if category.is_empty() {

--- a/t/lib/L10N/Testish.rakumod
+++ b/t/lib/L10N/Testish.rakumod
@@ -20,11 +20,15 @@ role L10N::Testish {
     token package-class { klass }
     token routine-sub { subby }
     token enum-True { yes }
-    # An inert category: mutsu records word-infix translations but does not
-    # consult them yet, and that must not make the whole vocabulary fail.
-    token infix-eq { samesame }
+    token infix-and { both }
+    token infix-div { quotient }
+    token infix-eq { same }
+    token infix-x { times }
+    token term-now { current }
+    token term-rand { chance }
+    token term-time { clock }
     method core2ast {
-        my constant %mapping = "yell", "say", "howmany", "elems";
+        my constant %mapping = "yell", "say", "howmany", "elems", "length", "chars";
         my $ast := self.ast;
         my $name := $ast ?? $ast.simple-identifier !! self.Str;
         if %mapping{$name} -> $original {
@@ -33,6 +37,22 @@ role L10N::Testish {
         else {
             $ast // RakuAST::Name.from-identifier($name)
         }
+    }
+    method adverb-pc2str {
+        my constant %mapping = "kvp", "kv";
+        %mapping{self.Str} // self.Str
+    }
+    method adverb-q2str {
+        my constant %mapping = "worded", "words";
+        %mapping{self.Str} // self.Str
+    }
+    method adverb-rx2str {
+        my constant %mapping = "globalized", "global";
+        %mapping{self.Str} // self.Str
+    }
+    method named2str {
+        my constant %mapping = "inside", "in";
+        %mapping{self.Str} // self.Str
     }
 }
 

--- a/t/modules/import-export/l10n-use.t
+++ b/t/modules/import-export/l10n-use.t
@@ -1,0 +1,27 @@
+use v6;
+use lib 't/lib';
+use Test;
+use L10N::Testish;
+
+# A generated L10N module registers its slang from EXPORT by calling
+# `$*LANG.define_slang`; it does not need to use Slangify itself.
+plan 12;
+
+is (1 both 1), 1, 'a localized logical infix is parsed';
+is (6 quotient 3), 2, 'a localized multiplicative infix is parsed';
+is (1 same 1), True, 'a localized comparison infix is parsed';
+is (3 times 2), '33', 'a localized replication infix is parsed';
+ok current.defined, 'a localized now term is parsed';
+ok clock.defined, 'a localized time term is parsed';
+ok chance >= 0, 'a localized rand term is parsed';
+is 'abc'.length, 3, 'a core alias is applied to a method name';
+
+sub accepts-in(:$in) { $in }
+is accepts-in(:inside(7)), 7, 'a localized named argument is canonicalized';
+is ('a a' ~~ m:globalized/a/).elems, 2,
+    'a localized regex adverb is canonicalized';
+is q:worded<a b>.List, ('a', 'b'),
+    'a localized quote adverb is canonicalized';
+my @values = <x>;
+is (@values[0]:kvp).elems, 2,
+    'a localized postcircumfix adverb is canonicalized';


### PR DESCRIPTION
Closes #7990

## Summary
- parse generated L10N infix vocabulary at the matching operator precedence seams
- apply generated named-argument, quote/regex/postcircumfix adverb, and localized term aliases
- detect generated L10N activation from the `$*LANG.define_slang` AST call
- keep metaoperator and quote-language entries explicitly inert

## Tests
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast