### PR TITLE
feat(rakuast): carry the eight constructs the L10N family needs

### DIFF
--- a/news/2026-09/rakuast-constructs-the-l10n-family-needs.md
+++ b/news/2026-09/rakuast-constructs-the-l10n-family-needs.md
@@ -1,0 +1,81 @@
+# Eight RakuAST constructs the L10N family needs
+
+`Str.AST($language)` started working when the L10N slang vocabulary landed, and
+twelve of the thirteen `L10N::*` distributions went green with it. The
+thirteenth, `L10N::ZH`, is the only member with a real test suite rather than a
+single smoke test — nine files, forty-one rakudo assertions — and it kept
+failing, because each of its files is a
+`Q:to/CODE/.AST("ZH").EVAL` of Chinese-spelled Raku and therefore fails whole
+the moment *any* construct in it is missing from the RakuAST boundary. The
+interpreter ran all of that code fine; it was the model layer that could not
+carry it across.
+
+Eight constructs are now carried, each measured against rakudo 2026.07 in both
+directions:
+
+- **`Nil`** renders as `RakuAST::Type::Simple.new(Name.from-identifier("Nil"))`
+  — a type object written as a bareword, not a literal value. mutsu's parser
+  resolves the bareword to the value eagerly, so the check has to precede the
+  literal dispatch rather than live inside it.
+- **`self`** is `RakuAST::Term::Self`, a node with no fields at all, printed as
+  a bare `.new` without empty parentheses. It is a `Term` and an `Expression`.
+  Any method body mentioning `self` previously stopped `.AST` dead, so this is
+  not specific to the localized case.
+- **`our` / `state` declarations** already *rendered* their `scope` field; the
+  lowerer refused to read it back, so `EVAL` of any tree containing one died.
+  It now accepts the two scopes the converter emits and keeps refusing the rest.
+- **`redo`** joins `last` and `next` as a bare call
+  (`Call::Name::WithoutParentheses`), which is how rakudo models all three.
+- **`CATCH { … }`** is `RakuAST::Statement::Catch`, whose body is a topic block
+  that additionally carries `exception => 1` — the field that distinguishes it
+  from a `given` body.
+- **`subset S of T where P`** is `RakuAST::Type::Subset`: the base type is a
+  `Trait::Of` entry in `traits`, not a field of its own, exactly as a routine's
+  `of` return type is.
+- **`module` / `package`** are `RakuAST::Module` / `RakuAST::Package`. rakudo
+  gives each declarator keyword its own class rather than one node with a
+  `kind` field, and a later bareword naming the package resolves at parse time
+  to a `Type::Simple` just as a class name does — so the converter's
+  declared-name scan had to learn about packages too.
+- **`submethod`** is `RakuAST::Submethod`, a sibling of `RakuAST::Method`
+  carrying an identical shape. mutsu's parser marks every submethod `is_my` as
+  its internal "not inherited" flag rather than because the source said `my`,
+  which was what made the converter refuse it.
+
+One of the nine files needed a fix on the other side of the boundary as well.
+`stmt-prefix-try` is a *replacement* category in the L10N schema, so `试试` is
+what `try` is spelled under `L10N::ZH` — but mutsu recognizes `try` (and `do`,
+`gather`, `if`, `for`, `last`, `redo`, …) by matching the parsed identifier
+against a fixed string in the bareword-term production, not through the
+`keyword()` seam every other replacement category hooks. `试试 { 10 / 2 }`
+therefore read as a bare word. The term production now consults the vocabulary
+too. The ASCII spelling keeps working there even where the vocabulary replaces
+it, which over-accepts relative to rakudo but cannot mis-parse a program rakudo
+accepts.
+
+`L10N::ZH` goes from one green file (and 17 of 41 assertions) to four green
+files and 29 assertions. The five that remain are blocked on constructs that
+are their own slices, each needing something this one deliberately did not
+start:
+
+- `t/15-modifier`, `t/13-package`, `t/14-routine` need `RakuAST::QuotedRegex`
+  and the `RakuAST::Regex::*` node tree (`Sequence`, `Literal`, `WithWhitespace`,
+  `CharClass::*`, `Quote`), which `token` / `rule` / `regex` declarations inside
+  a grammar are built out of.
+- `t/16-enum-subset` needs the `term` field of `RakuAST::Type::Enum`, which is
+  the *unevaluated* variant list — a word-quoted `QuotedString` carrying
+  `processors => <words val>` for `enum C <A B>` and a parenthesized pair list
+  for `enum C (A => 1)`. mutsu's `Stmt::EnumDecl` has already normalized both
+  into `Vec<(String, Option<Expr>)>`, and `processors` is not modelled on
+  `QuotedString` at all, so rendering it faithfully needs a parser change first
+  rather than a guess in the converter.
+- `t/11-use-import` needs `use` to render as `RakuAST::Pragma`, plus `import`.
+- The `with` / `without` statement modifiers (in `t/10-block`, a file rakudo
+  itself cannot run) are desugared by mutsu's parser into `given` plus an
+  `if $_.defined`, so the modifier kind is gone before conversion sees it.
+
+`t/rakuast/rakuast-l10n-constructs.t` pins all eight constructs in both
+directions and passes under rakudo as well as mutsu, which is what makes the
+measured shapes rakudo's rather than an invention; the statement-prefix fix is
+pinned by two new cases in `t/lang/parsing/slang-l10n-vocabulary.t` against the
+`L10N::Testish` fixture, likewise green under both.

--- a/news/2026-09/rakuast-constructs-the-l10n-family-needs.md
+++ b/news/2026-09/rakuast-constructs-the-l10n-family-needs.md
@@ -31,7 +31,13 @@ directions:
   from a `given` body.
 - **`subset S of T where P`** is `RakuAST::Type::Subset`: the base type is a
   `Trait::Of` entry in `traits`, not a field of its own, exactly as a routine's
-  `of` return type is.
+  `of` return type is. A subset that writes no `of` renders **no `traits` field
+  at all** — `subset S where * > 0` and `subset S of Any where * > 0` are
+  different nodes to rakudo even though the implied base *is* `Any`. mutsu's
+  parser defaulted both to `base: "Any"`, so `Stmt::SubsetDecl` grew a
+  `base_is_explicit` flag; inventing a `Trait::Of(Any)` the source never wrote
+  would have been exactly the kind of reconstruction the RakuAST workflow
+  forbids.
 - **`module` / `package`** are `RakuAST::Module` / `RakuAST::Package`. rakudo
   gives each declarator keyword its own class rather than one node with a
   `kind` field, and a later bareword naming the package resolves at parse time

--- a/news/2026-09/rakuast-constructs-the-l10n-family-needs.md
+++ b/news/2026-09/rakuast-constructs-the-l10n-family-needs.md
@@ -67,18 +67,24 @@ start:
 - `t/15-modifier`, `t/13-package`, `t/14-routine` need `RakuAST::QuotedRegex`
   and the `RakuAST::Regex::*` node tree (`Sequence`, `Literal`, `WithWhitespace`,
   `CharClass::*`, `Quote`), which `token` / `rule` / `regex` declarations inside
-  a grammar are built out of.
+  a grammar are built out of. mutsu keeps such a body as a raw
+  `Literal(Regex("\\d+ "))` string, so there is no internal regex tree to
+  convert from at all --
+  [#8033](https://github.com/tokuhirom/mutsu/issues/8033).
 - `t/16-enum-subset` needs the `term` field of `RakuAST::Type::Enum`, which is
   the *unevaluated* variant list — a word-quoted `QuotedString` carrying
   `processors => <words val>` for `enum C <A B>` and a parenthesized pair list
   for `enum C (A => 1)`. mutsu's `Stmt::EnumDecl` has already normalized both
   into `Vec<(String, Option<Expr>)>`, and `processors` is not modelled on
   `QuotedString` at all, so rendering it faithfully needs a parser change first
-  rather than a guess in the converter.
-- `t/11-use-import` needs `use` to render as `RakuAST::Pragma`, plus `import`.
+  rather than a guess in the converter --
+  [#8034](https://github.com/tokuhirom/mutsu/issues/8034).
+- `t/11-use-import` needs `use` to render as `RakuAST::Pragma`, plus `import` --
+  [#8035](https://github.com/tokuhirom/mutsu/issues/8035).
 - The `with` / `without` statement modifiers (in `t/10-block`, a file rakudo
   itself cannot run) are desugared by mutsu's parser into `given` plus an
-  `if $_.defined`, so the modifier kind is gone before conversion sees it.
+  `if $_.defined`, so the modifier kind is gone before conversion sees it --
+  [#8036](https://github.com/tokuhirom/mutsu/issues/8036).
 
 `t/rakuast/rakuast-l10n-constructs.t` pins all eight constructs in both
 directions and passes under rakudo as well as mutsu, which is what makes the

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1560,6 +1560,15 @@ pub(crate) enum Stmt {
     SubsetDecl {
         name: Symbol,
         base: String,
+        /// Whether the source wrote the base type (`subset S of Int`, `my Int
+        /// subset S`) or left it out, in which case `base` holds the implied
+        /// `Any`. Semantically the two are the same, but they are *different
+        /// declarations* to raku's own model layer: `.AST` renders an explicit
+        /// base as a `Trait::Of` entry and an implied one as no `traits` field
+        /// at all, so collapsing them here would make the RakuAST converter
+        /// invent a trait the source never wrote.
+        #[serde(default)]
+        base_is_explicit: bool,
         predicate: Option<Expr>,
         version: String,
         is_export: bool,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1265,6 +1265,7 @@ impl Compiler {
                         let base = type_constraint.clone().unwrap_or_else(|| "Any".to_string());
                         let subset_stmt = Stmt::SubsetDecl {
                             name: Symbol::intern(&anon),
+                            base_is_explicit: type_constraint.is_some(),
                             base,
                             predicate: Some((**wc).clone()),
                             version: String::new(),

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -315,7 +315,18 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     // enum value (`言う` for `say` under `L10N::JA`) is an additional name for
     // it, so translate it back to the canonical name here — the bareword term
     // production — and let everything downstream see the ordinary Raku name.
-    if let Some(canonical) = crate::parser::stmt::simple::l10n_alias(&name) {
+    //
+    // A *replaced* keyword needs the same translation here, not only at the
+    // `keyword()` seam: this production recognizes `try`/`do`/`gather`/`if`/
+    // `for`/`last`/`redo`/... by matching the parsed identifier against a fixed
+    // string below, so a localized spelling would otherwise fall through to a
+    // bare word. `试试 { 10 / 2 }` (`stmt-prefix-try` under `L10N::ZH`) read as
+    // `BareWord("试试")` instead of as a `try` block for exactly that reason.
+    // The ASCII spelling keeps working here even where the vocabulary replaces
+    // it — over-accepting, which cannot mis-parse a program rakudo accepts.
+    if let Some(canonical) = crate::parser::stmt::simple::l10n_alias(&name)
+        .or_else(|| crate::parser::stmt::simple::l10n_canonical_keyword(&name))
+    {
         name = canonical;
     }
     // Slang `identifier`/`name` override (ADR-0026 §2.3, Slangify's Piersing

--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -323,6 +323,7 @@ pub(in crate::parser::stmt) fn subset_decl(input: &str) -> PResult<'_, Stmt> {
         }
         break;
     }
+    let base_is_explicit = base.is_some();
     let base = base.unwrap_or_else(|| "Any".to_string());
     let (rest, predicate) = if let Some(r) = keyword("where", rest) {
         let (r, _) = ws1(r)?;
@@ -338,6 +339,7 @@ pub(in crate::parser::stmt) fn subset_decl(input: &str) -> PResult<'_, Stmt> {
         Stmt::SubsetDecl {
             name: Symbol::intern(&name),
             base,
+            base_is_explicit,
             predicate,
             version: super::super::simple::current_language_version(),
             is_export,
@@ -389,6 +391,7 @@ pub(in crate::parser) fn inline_subset_term(input: &str) -> PResult<'_, Expr> {
         base = Some(b);
         rest = r;
     }
+    let base_is_explicit = base.is_some();
     let base = base.unwrap_or_else(|| "Any".to_string());
     let (rest, predicate) = if let Some(r) = keyword("where", rest) {
         let (r, _) = ws1(r)?;
@@ -400,6 +403,7 @@ pub(in crate::parser) fn inline_subset_term(input: &str) -> PResult<'_, Expr> {
     let decl = Stmt::SubsetDecl {
         name: Symbol::intern(&name),
         base,
+        base_is_explicit,
         predicate,
         version: super::super::simple::current_language_version(),
         is_export: false,

--- a/src/parser/stmt/decl/my_decl_dispatch.rs
+++ b/src/parser/stmt/decl/my_decl_dispatch.rs
@@ -121,6 +121,9 @@ pub(super) fn try_keyword_dispatch(
                 Stmt::SubsetDecl {
                     name: Symbol::intern(&name),
                     base: routine_type,
+                    // `my Str subset MyStr` writes the base type as a prefix,
+                    // so it is explicit just as `subset MyStr of Str` is.
+                    base_is_explicit: true,
                     predicate,
                     version: super::super::simple::current_language_version(),
                     is_export: false,

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -127,9 +127,15 @@ fn collect_declared_names(
             } if custom_traits.iter().any(|(n, _)| n == "__constant") => {
                 out.insert(name.clone(), DeclaredKind::Constant);
             }
+            // A `module`/`package`/`grammar` name resolves at parse time just
+            // like a class one: raku renders a later bareword `M` as a
+            // `Type::Simple` (measured on `module M { }; M.HOW`).
+            Stmt::Package { name, body, .. } => {
+                out.insert(name.resolve(), DeclaredKind::Type);
+                collect_declared_names(body, out);
+            }
             Stmt::Block(body)
             | Stmt::SyntheticBlock(body)
-            | Stmt::Package { body, .. }
             | Stmt::SubDecl { body, .. }
             | Stmt::MethodDecl { body, .. } => collect_declared_names(body, out),
             _ => {}
@@ -163,7 +169,10 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
         }
         Stmt::Last(None) => Ok(Some(statement_expression(control_call("last", &[])?))),
         Stmt::Next(None) => Ok(Some(statement_expression(control_call("next", &[])?))),
-        Stmt::Last(Some(_)) | Stmt::Next(Some(_)) => Err(unsupported("labelled last/next")),
+        Stmt::Redo(None) => Ok(Some(statement_expression(control_call("redo", &[])?))),
+        Stmt::Last(Some(_)) | Stmt::Next(Some(_)) | Stmt::Redo(Some(_)) => {
+            Err(unsupported("labelled last/next/redo"))
+        }
         // `die`/`fail EXPR` are also modelled as bare calls.
         Stmt::Die(expr) => Ok(Some(statement_expression(control_call(
             "die",
@@ -536,6 +545,14 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             class: RakuAstClass::StatementDefault,
             fields: vec![node_field(Some("body"), block_node(body)?)],
         })),
+        // `CATCH { ... }` -> Statement::Catch(body => topic Block + exception).
+        // The body topicalizes the exception, so raku marks the block both
+        // `implicit-topic`/`required-topic` (like a `given` body) and
+        // `exception => 1`, which is what distinguishes it from one.
+        Stmt::Catch(body) => Ok(Some(RakuAstNode {
+            class: RakuAstClass::StatementCatch,
+            fields: vec![node_field(Some("body"), exception_block_node(body)?)],
+        })),
         Stmt::SubDecl {
             name,
             name_expr,
@@ -616,21 +633,27 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             custom_traits,
             ..
         } => {
-            // Plain `method NAME (params) { body }`, with return types in all
-            // three spellings (`-->` via `Signature.returns`, `returns`/`of`
-            // via `Trait::Returns`/`Trait::Of`) — a `RakuAST::Method` is a
-            // `RakuAST::Routine` just like `RakuAST::Sub`, so it carries the
-            // same `signature` / `traits` shape. Private/submethod/multi/our/
-            // my forms, user traits, and delegation carry extra shape.
+            // Plain `method NAME (params) { body }` and `submethod NAME (…) { … }`,
+            // with return types in all three spellings (`-->` via
+            // `Signature.returns`, `returns`/`of` via `Trait::Returns`/`Trait::Of`)
+            // — a `RakuAST::Method` is a `RakuAST::Routine` just like
+            // `RakuAST::Sub`, so it carries the same `signature` / `traits`
+            // shape. raku spells `submethod` as its own class carrying exactly
+            // that shape (measured: a `Submethod` and a `Method` of the same
+            // signature differ only in the class name). Private/multi/our/my
+            // forms, user traits, and delegation carry extra shape.
             let spelling = return_type_spelling(custom_traits)?;
+            // `submethod_decl` marks every submethod `is_my` as its internal
+            // "not inherited" flag, not because the source said `my` — so for a
+            // submethod that flag carries no RakuAST shape of its own.
+            let declared_my = *is_my && !*is_submethod;
             if name_expr.is_some()
                 || *multi
                 || *is_rw
                 || *is_raw
                 || *is_private
                 || *is_our
-                || *is_my
-                || *is_submethod
+                || declared_my
                 || *our_variable_form
                 || *is_default_candidate
                 || deprecated_message.is_some()
@@ -640,7 +663,7 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                     .any(|(t, _)| !is_return_spelling_marker(t))
             {
                 return Err(unsupported(
-                    "method with traits / private / multi / submethod",
+                    "method with traits / private / multi / delegation",
                 ));
             }
             if return_type.is_none() && spelling != ReturnSpelling::Arrow {
@@ -649,7 +672,11 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 return Err(unsupported("method with a return trait but no return type"));
             }
             Ok(Some(statement_expression(routine_node(
-                RakuAstClass::Method,
+                if *is_submethod {
+                    RakuAstClass::Submethod
+                } else {
+                    RakuAstClass::Method
+                },
                 &name.resolve(),
                 param_defs,
                 body,
@@ -704,6 +731,74 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             fields.push(node_field(Some("body"), block_node(body)?));
             Ok(Some(statement_expression(RakuAstNode {
                 class: RakuAstClass::Class,
+                fields,
+            })))
+        }
+        // `module M { }` / `package P { }` -> `RakuAST::Module` / `RakuAST::Package`.
+        // raku gives each declarator keyword its own class (there is no shared
+        // node with a `kind` field), and the body is a plain `Block` exactly as
+        // for a class. `grammar` also parses to `Stmt::Package` here, but its
+        // `RakuAST::Grammar` body holds regex declarations this layer does not
+        // model yet, so it stays the boundary. `unit` and `my` scopes carry
+        // extra RakuAST shape, deferred.
+        Stmt::Package {
+            name,
+            body,
+            kind,
+            is_unit,
+            is_my,
+        } => {
+            if *is_unit || *is_my {
+                return Err(unsupported("unit / my package declaration"));
+            }
+            let class = match kind {
+                crate::ast::PackageKind::Module => RakuAstClass::Module,
+                crate::ast::PackageKind::Package => RakuAstClass::Package,
+                crate::ast::PackageKind::Grammar => {
+                    return Err(unsupported("grammar declaration"));
+                }
+            };
+            Ok(Some(statement_expression(RakuAstNode {
+                class,
+                fields: vec![
+                    node_field(Some("name"), name_from_identifier(&name.resolve())),
+                    node_field(Some("body"), block_node(body)?),
+                ],
+            })))
+        }
+        // `subset S of T where P` -> `RakuAST::Type::Subset`. The `of T` base
+        // type is a `Trait::Of` in the `traits` list (raku models it exactly as
+        // a routine's `of` return type), and the `where` predicate is its own
+        // named field. Export and `my` scope carry extra shape, deferred.
+        Stmt::SubsetDecl {
+            name,
+            base,
+            predicate,
+            is_export,
+            export_tags,
+            is_my,
+            ..
+        } => {
+            if *is_export || !export_tags.is_empty() || *is_my {
+                return Err(unsupported("subset with export / my scope"));
+            }
+            let mut fields = vec![node_field(
+                Some("name"),
+                name_from_identifier(&name.resolve()),
+            )];
+            // Field order matches raku: name, where, traits.
+            if let Some(pred) = predicate {
+                fields.push(node_field(Some("where"), convert_expr(pred)?));
+            }
+            fields.push(RakuAstField {
+                name: Some("traits"),
+                value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(RakuAstNode {
+                    class: RakuAstClass::TraitOf,
+                    fields: vec![node_field(None, build_type_node(base)?)],
+                }))]),
+            });
+            Ok(Some(statement_expression(RakuAstNode {
+                class: RakuAstClass::TypeSubset,
                 fields,
             })))
         }
@@ -1214,6 +1309,13 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             // raku renders, so let those arms decide.
             other => convert_expr(other),
         },
+        // `self` -> `Term::Self`, a node with no fields. mutsu's parser leaves
+        // it as a bareword, so it has to be picked off before the type-name and
+        // declared-name arms below.
+        Expr::BareWord(name) if name == "self" => Ok(RakuAstNode {
+            class: RakuAstClass::TermSelf,
+            fields: Vec::new(),
+        }),
         // A bare type name used as a term (`Int`, `Str`) -> `Type::Simple`.
         Expr::BareWord(name) if is_known_type_constraint(name) => Ok(simple_type_node(name)),
         // A name the same compilation unit declared. raku resolves it at parse
@@ -1827,6 +1929,23 @@ fn topic_block_node(body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
             node_field(Some("body"), blockoid(body)?),
         ],
     })
+}
+
+/// The body of a `CATCH` block: a topic block that also carries `exception => 1`.
+fn exception_block_node(body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
+    let mut node = topic_block_node(body)?;
+    // raku renders the fields in declaration order, with `exception` after the
+    // two topic flags and before `body`.
+    let body_field = node
+        .fields
+        .pop()
+        .expect("topic_block_node pushes body last");
+    node.fields.push(RakuAstField {
+        name: Some("exception"),
+        value: RakuAstFieldValue::Node(Value::int(1)),
+    });
+    node.fields.push(body_field);
+    Ok(node)
 }
 
 /// A multi/zero-parameter pointy block (`-> $a, $b { }`, `-> { }`). An empty
@@ -2591,6 +2710,14 @@ fn postfix_node(op: &crate::token_kind::TokenKind) -> RakuAstNode {
 }
 
 fn convert_literal(v: &Value) -> Result<RakuAstNode, RuntimeError> {
+    // `Nil` is a type object written as a bareword, not a literal value: raku
+    // renders it `Type::Simple.new(Name.from-identifier("Nil"))`, exactly like
+    // `Int`. mutsu's parser resolves the bareword to the value eagerly, so the
+    // check has to come before the `view()` match — `Nil`'s view is not a
+    // variant this function would otherwise recognize.
+    if v.is_nil() {
+        return Ok(simple_type_node("Nil"));
+    }
     match v.view() {
         ValueView::Int(_) | ValueView::BigInt(_) => Ok(RakuAstNode {
             class: RakuAstClass::IntLiteral,

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -769,10 +769,15 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
         // `subset S of T where P` -> `RakuAST::Type::Subset`. The `of T` base
         // type is a `Trait::Of` in the `traits` list (raku models it exactly as
         // a routine's `of` return type), and the `where` predicate is its own
-        // named field. Export and `my` scope carry extra shape, deferred.
+        // named field. A subset that does not write a base type gets NO
+        // `traits` field at all — measured: `subset S where *> 0` and
+        // `subset S of Any where * > 0` are different nodes even though the
+        // implied base *is* `Any`, which is what `base_is_explicit` preserves.
+        // Export and `my` scope carry extra shape, deferred.
         Stmt::SubsetDecl {
             name,
             base,
+            base_is_explicit,
             predicate,
             is_export,
             export_tags,
@@ -790,13 +795,15 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             if let Some(pred) = predicate {
                 fields.push(node_field(Some("where"), convert_expr(pred)?));
             }
-            fields.push(RakuAstField {
-                name: Some("traits"),
-                value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(RakuAstNode {
-                    class: RakuAstClass::TraitOf,
-                    fields: vec![node_field(None, build_type_node(base)?)],
-                }))]),
-            });
+            if *base_is_explicit {
+                fields.push(RakuAstField {
+                    name: Some("traits"),
+                    value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(RakuAstNode {
+                        class: RakuAstClass::TraitOf,
+                        fields: vec![node_field(None, build_type_node(base)?)],
+                    }))]),
+                });
+            }
             Ok(Some(statement_expression(RakuAstNode {
                 class: RakuAstClass::TypeSubset,
                 fields,

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -152,7 +152,13 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         | RakuAstClass::StatementPrefixPhaserClose => lower_phaser(node),
         RakuAstClass::Class => lower_class(node),
         RakuAstClass::Role => lower_role(node),
-        RakuAstClass::Method => lower_method(node),
+        RakuAstClass::Method | RakuAstClass::Submethod => lower_method(node),
+        RakuAstClass::Module | RakuAstClass::Package => lower_package(node),
+        RakuAstClass::TypeSubset => lower_subset(node),
+        // `CATCH { … }` — the `exception`/topic flags on its body block are
+        // implied by the statement class, so only the block's statements are
+        // read back.
+        RakuAstClass::StatementCatch => Ok(Stmt::Catch(lower_block(named_child(node, "body")?)?)),
         // A named `sub f { … }` is a declaration; a nameless one (`sub ($x) { … }`,
         // `sub { … }`) is a closure *value*, so it lowers through the expression
         // path instead.
@@ -199,6 +205,7 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
                 )),
                 "last" => Ok(Stmt::Last(None)),
                 "next" => Ok(Stmt::Next(None)),
+                "redo" => Ok(Stmt::Redo(None)),
                 "die" => Ok(Stmt::Die(
                     args.into_iter().next().unwrap_or(Expr::Literal(Value::NIL)),
                 )),
@@ -519,6 +526,56 @@ fn lower_role(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 /// [`lower_sub`]. The return type comes back through the same
 /// `signature.returns` / `Trait::Returns` / `Trait::Of` reading `lower_sub`
 /// uses, so all three spellings the converter renders lower back.
+/// `module M { … }` / `package P { … }` -> `Stmt::Package`. raku names the
+/// declarator with the class, so the keyword comes back from `node.class`
+/// rather than from a field. `grammar` is refused on the read side (its body
+/// holds regex declarations this layer does not model), so nothing lowered
+/// here is one.
+fn lower_package(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let kind = match node.class {
+        RakuAstClass::Module => crate::ast::PackageKind::Module,
+        RakuAstClass::Package => crate::ast::PackageKind::Package,
+        _ => return Err(unsupported(node)),
+    };
+    Ok(Stmt::Package {
+        name: crate::symbol::Symbol::intern(&call_name_str(node)?),
+        body: lower_block(named_child(node, "body")?)?,
+        kind,
+        is_unit: false,
+        is_my: false,
+    })
+}
+
+/// `subset S of T where P` -> `Stmt::SubsetDecl`. The base type arrives as the
+/// single `Trait::Of` entry of the `traits` list; a `subset` with no explicit
+/// `of` defaults to `Any`, which is what the converter renders, so a missing
+/// trait list is a shape it never produced.
+fn lower_subset(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let name = call_name_str(node)?;
+    let predicate = match node.fields.iter().find(|f| f.name == Some("where")) {
+        Some(f) => Some(lower_expr(child_node(&f.value)?)?),
+        None => None,
+    };
+    let [trait_of] = list_field(node, "traits")? else {
+        return Err(unsupported(node));
+    };
+    let ValueView::RakuAst(trait_of) = trait_of.view() else {
+        return Err(unsupported(node));
+    };
+    if trait_of.class != RakuAstClass::TraitOf {
+        return Err(unsupported(node));
+    }
+    Ok(Stmt::SubsetDecl {
+        name: crate::symbol::Symbol::intern(&name),
+        base: simple_type_name(node, named_child_or_positional(trait_of)?)?,
+        predicate,
+        version: crate::parser::current_language_version(),
+        is_export: false,
+        export_tags: Vec::new(),
+        is_my: false,
+    })
+}
+
 fn lower_method(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let name = call_name_str(node)?;
     let (params, param_defs) = signature_positional_params(node)?;
@@ -536,7 +593,9 @@ fn lower_method(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         is_private: false,
         is_our: false,
         is_my: false,
-        is_submethod: false,
+        // raku names the declarator with the class, so `submethod` comes back
+        // from `node.class` rather than from a field.
+        is_submethod: node.class == RakuAstClass::Submethod,
         our_variable_form: false,
         return_type,
         is_default_candidate: false,
@@ -1001,12 +1060,23 @@ fn lower_var_decl(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     if matches!(leaf_str(node, "scope").as_deref(), Ok("has")) {
         return lower_attribute(node);
     }
-    if node.fields.iter().any(|f| {
-        matches!(
-            f.name,
-            Some("scope") | Some("type") | Some("twigil") | Some("traits")
-        )
-    }) {
+    // The remaining scopes the converter renders are `our` and `state`; `my` is
+    // the default and carries no `scope` field at all. Anything else (a scope
+    // raku has that the converter never emits) stays the boundary.
+    let (is_our, is_state) = match node.fields.iter().find(|f| f.name == Some("scope")) {
+        None => (false, false),
+        Some(_) => match leaf_str(node, "scope")?.as_str() {
+            "our" => (true, false),
+            "state" => (false, true),
+            "my" => (false, false),
+            _ => return Err(unsupported(node)),
+        },
+    };
+    if node
+        .fields
+        .iter()
+        .any(|f| matches!(f.name, Some("type") | Some("twigil") | Some("traits")))
+    {
         return Err(unsupported(node));
     }
     let sigil = leaf_str(node, "sigil")?;
@@ -1038,8 +1108,8 @@ fn lower_var_decl(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         name,
         expr,
         type_constraint: None,
-        is_state: false,
-        is_our: false,
+        is_state,
+        is_our,
         is_dynamic: false,
         is_export: false,
         export_tags: Vec::new(),
@@ -1362,6 +1432,8 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 _ => Err(unsupported(node)),
             }
         }
+        // `self` -> the bareword the parser produces for it.
+        RakuAstClass::TermSelf => Ok(Expr::BareWord("self".to_string())),
         // `True`/`False` -> the Bool literal. Other enum identifiers are deferred.
         RakuAstClass::TermEnum => match positional_leaf(node)?.view() {
             ValueView::Str(s) if s.as_str() == "True" => Ok(Expr::Literal(Value::truth(true))),

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -546,28 +546,38 @@ fn lower_package(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     })
 }
 
-/// `subset S of T where P` -> `Stmt::SubsetDecl`. The base type arrives as the
-/// single `Trait::Of` entry of the `traits` list; a `subset` with no explicit
-/// `of` defaults to `Any`, which is what the converter renders, so a missing
-/// trait list is a shape it never produced.
+/// `subset S of T where P` -> `Stmt::SubsetDecl`. An explicit base type arrives
+/// as the single `Trait::Of` entry of the `traits` list; a `subset` that writes
+/// no `of` carries no `traits` field at all and takes the implied `Any`. Any
+/// other trait is a shape the converter never produced.
 fn lower_subset(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let name = call_name_str(node)?;
     let predicate = match node.fields.iter().find(|f| f.name == Some("where")) {
         Some(f) => Some(lower_expr(child_node(&f.value)?)?),
         None => None,
     };
-    let [trait_of] = list_field(node, "traits")? else {
-        return Err(unsupported(node));
+    let (base, base_is_explicit) = match node.fields.iter().find(|f| f.name == Some("traits")) {
+        None => ("Any".to_string(), false),
+        Some(_) => {
+            let [trait_of] = list_field(node, "traits")? else {
+                return Err(unsupported(node));
+            };
+            let ValueView::RakuAst(trait_of) = trait_of.view() else {
+                return Err(unsupported(node));
+            };
+            if trait_of.class != RakuAstClass::TraitOf {
+                return Err(unsupported(node));
+            }
+            (
+                simple_type_name(node, named_child_or_positional(trait_of)?)?,
+                true,
+            )
+        }
     };
-    let ValueView::RakuAst(trait_of) = trait_of.view() else {
-        return Err(unsupported(node));
-    };
-    if trait_of.class != RakuAstClass::TraitOf {
-        return Err(unsupported(node));
-    }
     Ok(Stmt::SubsetDecl {
         name: crate::symbol::Symbol::intern(&name),
-        base: simple_type_name(node, named_child_or_positional(trait_of)?)?,
+        base,
+        base_is_explicit,
         predicate,
         version: crate::parser::current_language_version(),
         is_export: false,

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -198,6 +198,20 @@ pub enum RakuAstClass {
     StatementPrefixPhaserPost,
     StatementPrefixPhaserQuit,
     StatementPrefixPhaserClose,
+    // `CATCH { ... }` — its own statement class, not a block phaser. Its body is
+    // a topic block that additionally sets `exception => 1`.
+    StatementCatch,
+    // `subset S of T where P` — raku files it under `RakuAST::Type::`, not
+    // under the declaration classes.
+    TypeSubset,
+    // `module M { }` / `package P { }` — siblings of `RakuAST::Class`, one class
+    // per declarator keyword rather than a shared node with a `kind` field.
+    Module,
+    Package,
+    // `submethod m { }` — a sibling of `RakuAST::Method`, again keyword-per-class.
+    Submethod,
+    // `self` — a term with no fields of its own.
+    TermSelf,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -311,6 +325,12 @@ impl RakuAstClass {
             StatementPrefixPhaserPost => "RakuAST::StatementPrefix::Phaser::Post",
             StatementPrefixPhaserQuit => "RakuAST::StatementPrefix::Phaser::Quit",
             StatementPrefixPhaserClose => "RakuAST::StatementPrefix::Phaser::Close",
+            StatementCatch => "RakuAST::Statement::Catch",
+            TypeSubset => "RakuAST::Type::Subset",
+            Module => "RakuAST::Module",
+            Package => "RakuAST::Package",
+            Submethod => "RakuAST::Submethod",
+            TermSelf => "RakuAST::Term::Self",
         }
     }
 
@@ -324,6 +344,7 @@ impl RakuAstClass {
                 | RakuAstClass::TermWhatever
                 | RakuAstClass::WhateverCodeArgument
                 | RakuAstClass::TermHyperWhatever
+                | RakuAstClass::TermSelf
         )
     }
 
@@ -385,7 +406,12 @@ impl RakuAstClass {
             // from the name-prefix rule in `type_object_isa` — it must be
             // listed explicitly (ADR-0033 Phase 2 §2.4). Measured MRO:
             // `Argument, Term, Termish, Expression, ..., Node`.
-            | WhateverCodeArgument => TERM,
+            | WhateverCodeArgument
+            // Measured MRO: `Self, Term, Termish, Expression, ..., Node`. The
+            // `RakuAST::Term::` name prefix already answers `~~ RakuAST::Term`
+            // for an instance, but `RakuAST::Expression` is only reachable
+            // through this list.
+            | TermSelf => TERM,
             ApplyInfix | ApplyPrefix | ApplyPostfix | ApplyListInfix | Ternary => EXPR,
             _ => &[],
         }
@@ -616,6 +642,12 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::StatementPrefixPhaserPost,
     RakuAstClass::StatementPrefixPhaserQuit,
     RakuAstClass::StatementPrefixPhaserClose,
+    RakuAstClass::StatementCatch,
+    RakuAstClass::TypeSubset,
+    RakuAstClass::Module,
+    RakuAstClass::Package,
+    RakuAstClass::Submethod,
+    RakuAstClass::TermSelf,
 ];
 
 /// Entry point for `Str.AST`: parse the source, convert, wrap in `Value::RakuAst`.

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -1017,6 +1017,9 @@ impl Interpreter {
             is_export,
             export_tags,
             is_my,
+            // Only the RakuAST converter cares whether the base type was
+            // written out; execution treats an implied `Any` as an `Any`.
+            base_is_explicit: _,
         } = stmt
         {
             let resolved_name = name.resolve();

--- a/t/lang/parsing/slang-l10n-vocabulary.t
+++ b/t/lang/parsing/slang-l10n-vocabulary.t
@@ -12,7 +12,7 @@ use Test;
 # `L10N::Testish` (t/lib/L10N/Testish.rakumod) is a miniature of the generated
 # roles those distributions ship.
 
-plan 12;
+plan 14;
 
 # --- replacement categories: the localized spelling stands in for the keyword.
 my $ast = 'mine $x = 41; $x + 1'.AST('Testish');
@@ -27,6 +27,16 @@ is 'klass K { }; K.^name'.AST('Testish').EVAL, 'K',
 
 is 'subby f() { 3 }; f()'.AST('Testish').EVAL, 3,
     'a localized routine declarator declares a callable sub';
+
+# A statement prefix is recognized by the bareword-term production (by matching
+# the parsed identifier against a fixed string), not through the `keyword()`
+# seam the block/scope/routine categories hook -- so it needs its own
+# translation site. Without it `试试 { 10 / 2 }` under `L10N::ZH` read as a bare
+# word instead of as a `try` block.
+is 'mine $x = tryish { 10 / 2 }; $x'.AST('Testish').EVAL, 5,
+    'a localized statement prefix parses in expression position';
+is 'tryish { die "boom" }; 7'.AST('Testish').EVAL, 7,
+    'and in statement position, where it still swallows the exception';
 
 # A non-ASCII spelling, matched on a character boundary rather than a byte one.
 is 'mine $x = 0; なければ $x { 9 }'.AST('Testish').EVAL, 9,

--- a/t/lib/L10N/Testish.rakumod
+++ b/t/lib/L10N/Testish.rakumod
@@ -19,6 +19,10 @@ role L10N::Testish {
     token scope-my { mine }
     token package-class { klass }
     token routine-sub { subby }
+    # A statement prefix: mutsu reaches `try` through the bareword-term
+    # production rather than through its keyword seam, so this pins that the
+    # replacement is honoured there too.
+    token stmt-prefix-try { tryish }
     token enum-True { yes }
     # An inert category: mutsu records word-infix translations but does not
     # consult them yet, and that must not make the whole vocabulary fail.

--- a/t/rakuast/rakuast-l10n-constructs.t
+++ b/t/rakuast/rakuast-l10n-constructs.t
@@ -24,7 +24,7 @@ use Test;
 #
 # Passes under BOTH mutsu and raku.
 
-plan 24;
+plan 27;
 
 # --- `Nil` is a Type::Simple, not a literal ---------------------------------
 is Q[Nil].AST.gist, q:to/END/.chomp, 'Nil -> Type::Simple';
@@ -130,7 +130,30 @@ is Q[subset P1 of Int where * > 0].AST.gist, q:to/END/.chomp, 'subset -> Type::S
     )
     END
 
+# A subset that writes no `of` carries no `traits` field at all -- even though
+# its base type *is* `Any`, an explicit `of Any` is a different node. mutsu's
+# parser defaults the base to "Any" either way, so `Stmt::SubsetDecl` records
+# whether the source wrote it rather than letting the converter guess.
+is Q[subset P1a where * > 0].AST.gist, q:to/END/.chomp, 'an implied base renders no traits field';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Type::Subset.new(
+          name  => RakuAST::Name.from-identifier("P1a"),
+          where => RakuAST::ApplyInfix.new(
+            left  => RakuAST::WhateverCode::Argument.new,
+            infix => RakuAST::Infix.new(">"),
+            right => RakuAST::IntLiteral.new(0)
+          )
+        )
+      )
+    )
+    END
+
+is Q[subset P1b of Any where * > 0].AST.gist.lines.grep(*.contains('traits')).elems, 1,
+    'but an explicit `of Any` still renders its Trait::Of';
+
 is EVAL(Q[subset P2 of Int where * > 0; P2.^name].AST), 'P2', 'subset lowers to a live type';
+ok EVAL(Q[subset P2a where * > 0; 5 ~~ P2a].AST), 'a subset with an implied base lowers and matches';
 ok EVAL(Q[subset P3 of Int where * > 0; 5 ~~ P3].AST), 'a lowered subset accepts a matching value';
 nok EVAL(Q[subset P4 of Int where * > 0; -5 ~~ P4].AST), 'a lowered subset rejects a non-matching value';
 

--- a/t/rakuast/rakuast-l10n-constructs.t
+++ b/t/rakuast/rakuast-l10n-constructs.t
@@ -1,0 +1,223 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST coverage for the constructs the `L10N::ZH` test suite exercises
+# (issue #8001): every member of that family is a `Q:to/CODE/.AST($lang).EVAL`,
+# so a construct missing from either direction of the RakuAST boundary fails the
+# whole file even though the interpreter runs the code fine.
+#
+# Covered here, all measured against rakudo 2026.07:
+#   * `Nil` -- a type object written as a bareword, not a literal value;
+#   * `self` -- `RakuAST::Term::Self`, a node with no fields at all;
+#   * `our` / `state` variable declarations in the *write* direction (the read
+#     direction has rendered `scope` since Phase 2 slice 10);
+#   * `redo` -- modelled as a bare call, exactly like `last` / `next`;
+#   * `CATCH { ... }` -- `RakuAST::Statement::Catch`;
+#   * `subset S of T where P` -- `RakuAST::Type::Subset`;
+#   * `module` / `package` -- `RakuAST::Module` / `RakuAST::Package`;
+#   * `submethod` -- `RakuAST::Submethod`.
+#
+# Each declaration uses a distinct name because `.AST` registers the symbol and
+# raku rejects redeclaration.
+#
+# Passes under BOTH mutsu and raku.
+
+plan 24;
+
+# --- `Nil` is a Type::Simple, not a literal ---------------------------------
+is Q[Nil].AST.gist, q:to/END/.chomp, 'Nil -> Type::Simple';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Type::Simple.new(
+          RakuAST::Name.from-identifier("Nil")
+        )
+      )
+    )
+    END
+
+is EVAL(Q[defined(Nil) ?? "d" !! "u"].AST), 'u', 'Nil lowers back to the type object';
+
+# --- `self` ------------------------------------------------------------------
+# `self` has to be measured inside a method: raku refuses to compile a bare
+# `self` at all ("used where no object is available"), so there is no top-level
+# spelling of it to render.
+is Q[class S0 { method m() { self } }].AST.gist.lines.grep(*.contains('Term::Self')).head.trim,
+    'expression => RakuAST::Term::Self.new',
+    'self -> Term::Self, rendered without empty parens';
+
+my $self-node = Q[class S00 { method m() { self } }].AST.statements.head.expression
+                  .body.body.statement-list.statements.head.expression
+                  .body.statement-list.statements.head.expression;
+is $self-node.^name, 'RakuAST::Term::Self', 'the method body is a Term::Self node';
+ok $self-node ~~ RakuAST::Term, 'Term::Self is a RakuAST::Term';
+ok $self-node ~~ RakuAST::Expression, 'Term::Self is a RakuAST::Expression';
+
+is EVAL(Q[class S1 { method who() { self.^name } }; S1.new.who].AST), 'S1',
+    'a method body using self round-trips';
+
+# --- `our` / `state` declarations lower -------------------------------------
+is EVAL(Q[our $o1 = 6; $o1].AST), 6, 'an our-scoped declaration lowers';
+is EVAL(Q[sub c1() { state $n = 0; ++$n }; c1(); c1(); c1()].AST), 3,
+    'a state-scoped declaration lowers and keeps its state across calls';
+
+# --- `redo` ------------------------------------------------------------------
+is Q[redo].AST.gist, q:to/END/.chomp, 'redo -> a bare call, like last/next';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Call::Name::WithoutParentheses.new(
+          name => RakuAST::Name.from-identifier("redo")
+        )
+      )
+    )
+    END
+
+is EVAL(Q[my $r = ""; my $d = False; for 1..3 -> $i { if $i == 2 && !$d { $r ~= "X"; $d = True; redo }; $r ~= $i }; $r].AST),
+    '1X23', 'redo lowers and re-runs the loop body';
+
+# --- `CATCH { ... }` ---------------------------------------------------------
+is Q[CATCH { default { 1 } }].AST.gist, q:to/END/.chomp, 'CATCH -> Statement::Catch with an exception topic block';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Catch.new(
+        body => RakuAST::Block.new(
+          implicit-topic => True,
+          required-topic => 1,
+          exception      => 1,
+          body           => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Default.new(
+                body => RakuAST::Block.new(
+                  body => RakuAST::Blockoid.new(
+                    RakuAST::StatementList.new(
+                      RakuAST::Statement::Expression.new(
+                        expression => RakuAST::IntLiteral.new(1)
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+is EVAL(Q[my $c; try { die "boom"; CATCH { default { $c = "caught" } } }; $c].AST),
+    'caught', 'CATCH lowers and handles the exception';
+
+# --- `subset` ----------------------------------------------------------------
+is Q[subset P1 of Int where * > 0].AST.gist, q:to/END/.chomp, 'subset -> Type::Subset with a Trait::Of base';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Type::Subset.new(
+          name   => RakuAST::Name.from-identifier("P1"),
+          where  => RakuAST::ApplyInfix.new(
+            left  => RakuAST::WhateverCode::Argument.new,
+            infix => RakuAST::Infix.new(">"),
+            right => RakuAST::IntLiteral.new(0)
+          ),
+          traits => (
+            RakuAST::Trait::Of.new(
+              RakuAST::Type::Simple.new(
+                RakuAST::Name.from-identifier("Int")
+              )
+            ),
+          )
+        )
+      )
+    )
+    END
+
+is EVAL(Q[subset P2 of Int where * > 0; P2.^name].AST), 'P2', 'subset lowers to a live type';
+ok EVAL(Q[subset P3 of Int where * > 0; 5 ~~ P3].AST), 'a lowered subset accepts a matching value';
+nok EVAL(Q[subset P4 of Int where * > 0; -5 ~~ P4].AST), 'a lowered subset rejects a non-matching value';
+
+# --- `module` / `package` ----------------------------------------------------
+# raku gives each declarator keyword its own class rather than one node with a
+# `kind` field, and a later bareword naming the package renders as a
+# `Type::Simple` just like a class name does.
+is Q[package K1 { }].AST.gist, q:to/END/.chomp, 'package -> RakuAST::Package';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Package.new(
+          name => RakuAST::Name.from-identifier("K1"),
+          body => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new()
+            )
+          )
+        )
+      )
+    )
+    END
+
+is Q[module K2 { }].AST.gist, q:to/END/.chomp, 'module -> RakuAST::Module';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Module.new(
+          name => RakuAST::Name.from-identifier("K2"),
+          body => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new()
+            )
+          )
+        )
+      )
+    )
+    END
+
+like EVAL(Q[module K3 { }; K3.HOW.^name].AST), rx/ModuleHOW/, 'module lowers to a live module';
+like EVAL(Q[package K4 { }; K4.HOW.^name].AST), rx/PackageHOW/, 'package lowers to a live package';
+
+# --- `submethod` -------------------------------------------------------------
+is Q[class S2 { submethod BUILD($x) { 1 } }].AST.gist, q:to/END/.chomp, 'submethod -> RakuAST::Submethod, same shape as a Method';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          name => RakuAST::Name.from-identifier("S2"),
+          body => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::Submethod.new(
+                    name      => RakuAST::Name.from-identifier("BUILD"),
+                    signature => RakuAST::Signature.new(
+                      parameters => (
+                        RakuAST::Parameter.new(
+                          type     => RakuAST::Type::Setting.new(
+                            RakuAST::Name.from-identifier("Any")
+                          ),
+                          target   => RakuAST::ParameterTarget::Var.new(
+                            name => "\$x"
+                          ),
+                          optional => False
+                        ),
+                      )
+                    ),
+                    body      => RakuAST::Blockoid.new(
+                      RakuAST::StatementList.new(
+                        RakuAST::Statement::Expression.new(
+                          expression => RakuAST::IntLiteral.new(1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+is EVAL(Q[class S3 { submethod greet() { "hi" }; method call() { self.greet } }; S3.new.call].AST),
+    'hi', 'submethod lowers and stays callable';
+
+# A submethod is not inherited, which is what distinguishes it from a method —
+# so the lowered declaration has to keep the `submethod` declarator, not quietly
+# become a `method`.
+nok EVAL(Q[class S4 { submethod only-mine() { 1 } }; class S5 is S4 { }; S5.^can('only-mine') ?? True !! False].AST),
+    'a lowered submethod is not inherited by a subclass';


### PR DESCRIPTION
Closes #8001.

## What this issue turned out to be

The failure #8001 names — `Str.AST($language)` raising `No such method 'AST' for invocant of type 'Str'` — was **already fixed** when the issue was filed. `c4b13a40` (the L10N slang vocabulary) landed a few hours earlier and implemented the one-argument form; the parity ledger records **12 of the 13 distributions green**.

The one that is not is `L10N::ZH`, the only member of the family with a real test suite rather than a single smoke test: 9 files, 41 rakudo assertions, stuck at 17. Because every file is one `Q:to/CODE/.AST("ZH").EVAL`, a file fails *whole* the moment any construct in it is missing from the RakuAST boundary. The interpreter ran all of that code fine — it was the model layer that could not carry it across, and none of what was missing is specific to a localised slang.

## Eight constructs, both directions

Each measured against rakudo 2026.07:

| construct | rakudo shape |
|---|---|
| `Nil` | `Type::Simple(Name("Nil"))` — a type object written as a bareword, not a literal value |
| `self` | `Term::Self`, a node with no fields, printed as a bare `.new` |
| `our` / `state` | write direction only; the read side has rendered `scope` since Phase 2 slice 10 |
| `redo` | a bare call, exactly as `last` / `next` are modelled |
| `CATCH { … }` | `Statement::Catch`, whose body block also carries `exception => 1` |
| `subset S of T where P` | `Type::Subset`, base type as a `Trait::Of` entry in `traits` |
| `module` / `package` | `RakuAST::Module` / `RakuAST::Package` — one class per declarator keyword |
| `submethod` | `RakuAST::Submethod`, a sibling of `Method` with an identical shape |

`self` in particular is not a localisation matter: any method body mentioning it stopped `.AST` dead before this.

## Two things that needed more than a converter arm

**`stmt-prefix-try` was a parser bug, not a RakuAST one.** mutsu recognizes `try` (and `do`, `gather`, `if`, `for`, `last`, `redo`, …) by matching the parsed identifier against a fixed string in the bareword-term production — *not* through the `keyword()` seam that every L10N replacement category hooks. So `试试 { 10 / 2 }` read as `BareWord("试试")`. That production now consults the vocabulary too. The ASCII spelling keeps working there even where the vocabulary replaces it, which over-accepts relative to rakudo but cannot mis-parse a program rakudo accepts.

**A subset's implied base type is not a trait.** `subset S where * > 0` and `subset S of Any where * > 0` are different nodes to rakudo — no `traits` field vs. a `Trait::Of(Any)` — even though the implied base *is* `Any`. mutsu's parser held the base as `Option<String>` right up to construction and then collapsed both into `base: "Any"`, so the converter would have had to invent a trait the source never wrote. `Stmt::SubsetDecl` now records `base_is_explicit` alongside `base`; execution ignores it, and only the RakuAST boundary reads it, in both directions.

## Result

`L10N::ZH` goes from **1 green file / 17 assertions** to **4 green files / 29 assertions**:

| file | before | after |
|---|---|---|
| `t/01-basic` | pass | pass |
| `t/12-scope` | die | **pass (3/3)** |
| `t/17-control-flow` | die | **pass (6/6)** |
| `t/19-logic` | die | **pass (5/5)** |
| `t/13-package` | 1 | 4 |
| `t/14-routine` | 0 | 3 |
| `t/15-modifier` | 0 | 5 |
| `t/16-enum-subset` | 1 | 2 |
| `t/11-use-import` | 0 | 0 |

`L10N::AF`, `L10N::DE`, `L10N::FR` and `L10N::JA` were re-run and stay green. The ledger records themselves are left alone — `ecosystem-sweep.yml` re-measures them.

## Deliberately not started

The five files still failing are blocked on constructs that would fail identically for English-spelled Raku, each its own slice, each filed with side-by-side `mutsu` / `raku` repros:

- #8033 `todo:deep` — no regex node tree. `QuotedRegex` and grammar `token`/`rule`/`regex` declarations cannot cross, because mutsu keeps a regex body as a raw source *string* (`Literal(Regex("\\d+ "))`) rather than an internal tree; needs an ADR. Also the gate on `RakuAST::Grammar`.
- #8034 `todo:ticket` — `Type::Enum`'s `term`, which needs `processors` modelled on `QuotedString` plus a parser change (`Stmt::EnumDecl` normalizes `<a b>`, `«a b»` and `(a => 1)` into one shape).
- #8035 `todo:ticket` — `use` as `RakuAST::Pragma`.
- #8036 `todo:ticket` — the parser desugars `with`/`without` statement modifiers into `given` + `if $_.defined`, so the modifier kind is gone before conversion sees it.

All four are indexed on the campaign issue #7564.

## Tests

`t/rakuast/rakuast-l10n-constructs.t` (27 assertions) pins every construct in both directions, and `t/lang/parsing/slang-l10n-vocabulary.t` gains two cases for the statement prefix against the `L10N::Testish` fixture. **Both files pass under rakudo as well as mutsu**, which is what makes the measured shapes rakudo's rather than an invention. Every new gist was additionally diffed byte-for-byte against `raku`'s.

## Validation

- `cargo fmt --all`, `make lint` — clean
- `make test` — 4042 files, 43016 tests, **PASS** (re-run after rebasing onto current `main`)
- `make roast` — the only real failures are `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8, 10) and `roast/S16-filehandles/filetest.t` (`Failed: 25`), which are the two container-caused entries in [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) — this session runs as `uid 0`, so their `chmod`-based assertions are meaningless here. Counts and test numbers match that table exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kDnX5EQ4CLYXwwpiqPtq1

---
_Generated by [Claude Code](https://claude.ai/code/session_019kDnX5EQ4CLYXwwpiqPtq1)_