### PR TITLE
fix(parser,collections): a nullary term keyword is not a listop head, and QuantHash coercions fold through a role mixin

### DIFF
--- a/ecosystem/dists/H/Hash--Restricted~9935eb4e.json
+++ b/ecosystem/dists/H/Hash--Restricted~9935eb4e.json
@@ -11,11 +11,11 @@
     {
       "cmp": "regression",
       "mutsu": {
-        "first_failure": "Unknown prefix operator: (-)",
+        "first_failure": "Not allowed to access non-existing <a>",
         "nok": 0,
-        "ok": 1,
+        "ok": 4,
         "plan": 32,
-        "secs": 0.18,
+        "secs": 0.13,
         "skip": 0,
         "todo": 0,
         "verdict": "die"
@@ -25,7 +25,7 @@
         "nok": 0,
         "ok": 32,
         "plan": 32,
-        "secs": 1.99,
+        "secs": 1.71,
         "skip": 0,
         "todo": 0,
         "verdict": "pass"
@@ -37,10 +37,10 @@
   },
   "measured": {
     "attempts": 3,
-    "date": "2026-09-11",
-    "harness": 1,
-    "host": "gha-ubuntu24-4c",
-    "mutsu_commit": "7807eb5",
+    "date": "2026-09-12",
+    "harness": 2,
+    "host": "linux-x86_64",
+    "mutsu_commit": "f4b55d71",
     "mutsu_version": "0.23.0",
     "raku_backend": "moar 2026.07",
     "raku_version": "2026.07",
@@ -55,7 +55,7 @@
   "totals": {
     "baseline_assertions": 32,
     "baseline_files": 1,
-    "mutsu_assertions": 1,
+    "mutsu_assertions": 4,
     "parity_files": 0,
     "regressed_files": 1
   },

--- a/news/2026-09/term-keyword-and-mixin-quanthash-coercion.md
+++ b/news/2026-09/term-keyword-and-mixin-quanthash-coercion.md
@@ -1,0 +1,66 @@
+# `self (-) %allowed` parses, and a role-mixed hash coerces to a Set by its keys
+
+Working `Hash::Restricted` 0.0.9 (`ecosystem/dists/H/Hash--Restricted~9935eb4e.json`, `red`, dying
+at its first assertion with `Unknown prefix operator: (-)`) turned up two general interpreter gaps.
+Neither is about restricted hashes.
+
+## A nullary term keyword is not a listop head
+
+`self`, `now`, `time`, `pi`, `Any`, `Mu` and the rest of the nullary term keywords are *terms* in
+rakudo — `term:sym<self>` and friends — so what follows one of them is an **operator** position.
+mutsu's no-paren listop branch in `src/parser/primary/ident/identifier_call.rs` did not know that: it
+accepts any identifier followed by whitespace and a term start as a call, and `(` is a term start. So
+`self (-) %allowed` compiled to `self((-) %allowed)` and died at runtime with `Unknown prefix
+operator: (-)`, and outside a module the same source got the compile-time `Undeclared routine: self`
+instead. `Mu` took the same path.
+
+The branch now refuses a term keyword as a listop head unless a routine of that name is actually
+declared or imported, which is the rule the rest of that branch already follows. `self (-) $set` is
+set-difference, and `self (1, 2)` is the "two terms in a row" error rakudo reports rather than a
+call.
+
+`now` and `time` had a second, narrower version of the same bug in
+`src/parser/primary/ident/term_literals.rs`: both correctly reject the call form `now(...)` as
+rakudo's `Undeclared routine`, but they tested for the paren *after* `trim_start()`, so
+`now (-) $set` was rejected too. Only an adjacent paren is the call form; after whitespace the
+parenthesis belongs to the operator position.
+
+## QuantHash coercions fold through a role mixin
+
+A role mixin **wraps** a value without replacing it: rakudo's `%h does R` is a `Hash+{R}`, still a
+Hash, and `@a but R` is still an Array. Every QuantHash coercion in mutsu matched on
+`value.view()` without stripping `ValueView::Mixin`, so a mixin fell through to the "unknown scalar"
+arm and contributed **the whole hash as one element**: `%m.Set` answered
+`Set.new({:a(42), :b(0)})`, `%m (-) $set` cancelled nothing, `%m (.) $bag` was empty, and
+`'a' (elem) %m` was False.
+
+`runtime::utils::quanthash_operand` (descalarize + strip the mixin) and its mixin-only half
+`strip_quanthash_mixin` (for nested element positions, where stripping the `Scalar` container would
+change the flattening rule) are now applied at every coercion entry point: `coerce_to_set`,
+`coerce_value_to_quanthash`, `to_bag_map`, `to_mix_map`, `set_type_level`, `builtins`' `to_set` /
+`to_bag` / `to_mix`, the VM's `value_to_set_keys` / `value_to_bag_counts` / `value_to_mix_weights` /
+`set_contains` / `coerce_to_bag` / `coerce_to_mix` / `set_type_level_full`, and
+`ops_set`'s four `apply_set_*` entry points. `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash`
+and `(-)`/`(|)`/`(&)`/`(^)`/`(+)`/`(.)`/`(elem)` all agree with rakudo on a mixin now.
+
+Only a **role** mixin is folded through. An allomorph is a `Mixin` too — `<1>` is
+`Mixin(Int(1), {Str => "1"})` — and its whole point is to be a distinct element from the value it
+wraps, so `(1, "1", 1.0, <1>).Set` has four elements. The discriminator is the `__mutsu_role__<name>`
+marker, the same one `dispatch_mixin_method_call`'s `.clone` arm already uses. The nested-element
+form splits one step further: a role-mixed **aggregate** element flattens its contents in list
+context (`(1, %h).Set` is `Set(1, "a")`), while a role-mixed **scalar** element keeps its own
+identity (`(5, 5 but R).Set` has two elements, keyed `Int` and `Int+{R}`).
+
+Pinned by `t/lang/term-keyword-not-listop-head.t` and
+`t/collections/set-bag-mix/quanthash-folding-of-wrapped-values.t`, whose last five assertions are
+exactly the identity cases above.
+
+## What is left of the distribution
+
+`Hash::Restricted`'s suite goes from 1 to 4 of 32 assertions. Assertion 5 onwards needs
+[#8026](https://github.com/tokuhirom/mutsu/issues/8026): a role mixed into a non-`Instance` value has
+no store for its own attributes, so the `%!allowed` key set the module's `STORE` computes is
+discarded before `AT-KEY` can read it. Since ADR-0019 Phase 3 Stage 2c every `$!attr` access inside a
+compiled method is cell-direct, and `self_instance_attrs` has no cell to offer for a `Mixin` over a
+Hash — giving it one is a change to the `Value::Mixin` representation, so it is filed rather than
+fixed here.

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -32,6 +32,13 @@ pub(crate) fn to_set(target: Value, what: &str) -> Result<Value, RuntimeError> {
     if Interpreter::is_lazy_for_coerce(&target) {
         return Err(RuntimeError::cannot_lazy_what(what));
     }
+    // A role mixin WRAPS the value without replacing it: rakudo's `%h does R` is
+    // a `Hash+{R}`, still a Hash, so the coercion folds the inner value's
+    // elements rather than taking the whole mixin as one element.
+    if let ValueView::Mixin(inner, _) = target.view() {
+        let inner = inner.as_ref().clone();
+        return to_set(inner, what);
+    }
     let mut elems = HashSet::new();
     let mut original_keys: HashMap<String, Value> = HashMap::new();
     // `flatten` is true when this item sits in a list-context-flattening
@@ -45,6 +52,7 @@ pub(crate) fn to_set(target: Value, what: &str) -> Result<Value, RuntimeError> {
         item: &Value,
         flatten: bool,
     ) {
+        let item = crate::runtime::utils::strip_quanthash_mixin_elem(item);
         match item.view() {
             ValueView::Pair(k, v) => {
                 if v.truthy() {
@@ -223,6 +231,13 @@ pub(crate) fn to_bag(target: Value, what: &str) -> Result<Value, RuntimeError> {
     if Interpreter::is_lazy_for_coerce(&target) {
         return Err(RuntimeError::cannot_lazy_what(what));
     }
+    // A role mixin WRAPS the value without replacing it: rakudo's `%h does R` is
+    // a `Hash+{R}`, still a Hash, so the coercion folds the inner value's
+    // elements rather than taking the whole mixin as one element.
+    if let ValueView::Mixin(inner, _) = target.view() {
+        let inner = inner.as_ref().clone();
+        return to_bag(inner, what);
+    }
     let mut counts: HashMap<String, BigInt> = HashMap::new();
     let mut original_keys: HashMap<String, Value> = HashMap::new();
 
@@ -231,6 +246,7 @@ pub(crate) fn to_bag(target: Value, what: &str) -> Result<Value, RuntimeError> {
         original_keys: &mut HashMap<String, Value>,
         item: &Value,
     ) -> Result<(), RuntimeError> {
+        let item = crate::runtime::utils::strip_quanthash_mixin_elem(item);
         match item.view() {
             ValueView::Pair(k, v) => {
                 let weight = pair_weight(v)?;
@@ -543,6 +559,7 @@ fn mix_add_item_with_keys(
     item: &Value,
     flatten: bool,
 ) -> Result<(), RuntimeError> {
+    let item = crate::runtime::utils::strip_quanthash_mixin_elem(item);
     match item.view() {
         ValueView::Pair(k, v) => {
             mix_accum(weights, str_elem_key(k), mix_pair_weight_value(v)?)?;
@@ -629,6 +646,13 @@ pub(crate) fn to_mix(target: Value, what: &str) -> Result<Value, RuntimeError> {
                 .collect::<crate::value::AttrMap>(),
         )));
         return Err(err);
+    }
+    // A role mixin WRAPS the value without replacing it: rakudo's `%h does R` is
+    // a `Hash+{R}`, still a Hash, so the coercion folds the inner value's
+    // elements rather than taking the whole mixin as one element.
+    if let ValueView::Mixin(inner, _) = target.view() {
+        let inner = inner.as_ref().clone();
+        return to_mix(inner, what);
     }
     // Weights are folded as exact `Value`s (so `0.1 + 0.02` stays `0.12`) and
     // lowered to the stored `f64` representation only at the return boundary.

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1865,8 +1865,21 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         name.as_str(),
         "method" | "submethod" | "multi" | "proto" | "macro" | "regex" | "token" | "rule"
     );
+    // A nullary term keyword (`self`, `Mu`, `now`, `time`, ...) is a complete
+    // term, so it is never a listop head: rakudo's `term:sym<self>` leaves what
+    // follows to the OPERATOR position, which is why `self (-) %allowed` is
+    // set-difference (Hash::Restricted's `STORE` method) and `now (1)` is "two
+    // terms in a row" rather than a call with a parenthesized argument list.
+    // Without this, the `next == '('` term-start test below read the `(-)` as
+    // `self((-) %allowed)` and died with "Unknown prefix operator: (-)".
+    // A user-declared or imported routine of the same name wins, as it does
+    // everywhere else in this branch.
+    let is_nullary_term_keyword = crate::parser::primary::ident::predicates::is_term_keyword(&name)
+        && !crate::parser::stmt::simple::is_user_declared_sub(&name)
+        && !crate::parser::stmt::simple::is_imported_function(&name);
     if !is_keyword(&name)
         && !is_declarator_head
+        && !is_nullary_term_keyword
         // An infix word (`before`, `eq`, `and`, ...) is refused as a listop
         // head UNLESS a `sub` of that exact name is declared and in scope —
         // this is term position (a fresh term is being parsed), so a

--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -61,17 +61,14 @@ pub(crate) fn starts_with_quote_construct(input: &str) -> bool {
     }
 }
 
-/// Check if input starts with a term keyword (like `i`, `e`, `pi`, etc.)
-/// that can appear as a listop argument without parentheses.
-pub(crate) fn starts_with_term_keyword(input: &str) -> bool {
-    let first = input.chars().next().unwrap_or('\0');
-    if first == '\u{03C0}' || first == '\u{03C4}' || first == '\u{1D452}' {
-        return true;
-    }
-    let word_end = input
-        .find(|c: char| !c.is_alphanumeric() && c != '_')
-        .unwrap_or(input.len());
-    let word = &input[..word_end];
+/// Is `word` a nullary term keyword — a word that is a complete term on its
+/// own, so it can neither take listop arguments nor be called?
+///
+/// These are rakudo's `term:sym<...>` tokens (`self`, `now`, `time`, `pi`, ...).
+/// Because they are terms, what follows them is an *operator* position: rakudo
+/// parses `self (-) %allowed` as set-difference and rejects `now (1)` as "two
+/// terms in a row" rather than reading the parentheses as an argument list.
+pub(crate) fn is_term_keyword(word: &str) -> bool {
     matches!(
         word,
         "i" | "e"
@@ -89,6 +86,19 @@ pub(crate) fn starts_with_term_keyword(input: &str) -> bool {
             | "time"
             | "rand"
     )
+}
+
+/// Check if input starts with a term keyword (like `i`, `e`, `pi`, etc.)
+/// that can appear as a listop argument without parentheses.
+pub(crate) fn starts_with_term_keyword(input: &str) -> bool {
+    let first = input.chars().next().unwrap_or('\0');
+    if first == '\u{03C0}' || first == '\u{03C4}' || first == '\u{1D452}' {
+        return true;
+    }
+    let word_end = input
+        .find(|c: char| !c.is_alphanumeric() && c != '_')
+        .unwrap_or(input.len());
+    is_term_keyword(&input[..word_end])
 }
 
 /// Check if a name is a Raku keyword (not a function call).

--- a/src/parser/primary/ident/term_literals.rs
+++ b/src/parser/primary/ident/term_literals.rs
@@ -466,8 +466,12 @@ pub(crate) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
     {
         let after = input[3..].trim_start();
         // `now` is a term, not a routine: the call form `now(...)` is a
-        // compile-time "Undeclared routine" in rakudo.
-        if after.starts_with('(') && !crate::parser::stmt::simple::is_user_declared_sub("now") {
+        // compile-time "Undeclared routine" in rakudo. Only an *adjacent* paren
+        // is that call form — after whitespace the parenthesis belongs to the
+        // operator position (`now (-) $set` is set-difference, `now (1)` is
+        // rakudo's "two terms in a row"), so it must not be claimed here.
+        if input[3..].starts_with('(') && !crate::parser::stmt::simple::is_user_declared_sub("now")
+        {
             return Err(PError::fatal_at(
                 format!(
                     "X::Undeclared::Symbols: Undeclared routine:\n    now used at line {}",
@@ -514,8 +518,12 @@ pub(crate) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
     {
         let after = input[4..].trim_start();
         // `time` is a term, not a routine: the call form `time(...)` is a
-        // compile-time "Undeclared routine" in rakudo.
-        if after.starts_with('(') && !crate::parser::stmt::simple::is_user_declared_sub("time") {
+        // compile-time "Undeclared routine" in rakudo. Only an *adjacent* paren
+        // is that call form — after whitespace the parenthesis belongs to the
+        // operator position (`time (-) $set` is set-difference, `time (1)` is
+        // rakudo's "two terms in a row"), so it must not be claimed here.
+        if input[4..].starts_with('(') && !crate::parser::stmt::simple::is_user_declared_sub("time")
+        {
             return Err(PError::fatal_at(
                 format!(
                     "X::Undeclared::Symbols: Undeclared routine:\n    time used at line {}",

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -380,6 +380,10 @@ impl Interpreter {
                 // `push @.order, ...`) are visible after the call returns. This
                 // updates every binding in scope that holds the same instance
                 // (including the one wrapped inside this Mixin).
+                //
+                // A role's OWN attributes on a mixin over a non-Instance value
+                // (`%h does R`) have no store to come back to at all — see
+                // tokuhirom/mutsu#8026.
                 if let Some(cell) = &inner_cell {
                     cell.commit_attrs(updated);
                 }

--- a/src/runtime/ops_set.rs
+++ b/src/runtime/ops_set.rs
@@ -147,6 +147,11 @@ impl Interpreter {
     }
 
     pub(crate) fn apply_set_union(left: &Value, right: &Value) -> Result<Value, RuntimeError> {
+        // A role mixin wraps the operand without replacing it (rakudo's
+        // `%h does R` is a `Hash+{R}`, still a Hash), so fold the value
+        // underneath it.
+        let left = crate::runtime::utils::strip_quanthash_mixin(left);
+        let right = crate::runtime::utils::strip_quanthash_mixin(right);
         if matches!(left.view(), ValueView::Instance { class_name, .. } if class_name == "Failure")
             || matches!(right.view(), ValueView::Instance { class_name, .. } if class_name == "Failure")
         {
@@ -202,6 +207,11 @@ impl Interpreter {
     }
 
     pub(crate) fn apply_set_equality(left: &Value, right: &Value) -> Result<bool, RuntimeError> {
+        // A role mixin wraps the operand without replacing it (rakudo's
+        // `%h does R` is a `Hash+{R}`, still a Hash), so fold the value
+        // underneath it.
+        let left = crate::runtime::utils::strip_quanthash_mixin(left);
+        let right = crate::runtime::utils::strip_quanthash_mixin(right);
         if matches!(left.view(), ValueView::Mix(_, _))
             || matches!(right.view(), ValueView::Mix(_, _))
         {
@@ -487,14 +497,11 @@ impl Interpreter {
     }
 
     pub(crate) fn apply_set_multiply(left: &Value, right: &Value) -> Result<Value, RuntimeError> {
-        let left = match left.view() {
-            ValueView::Scalar(inner) => inner,
-            _ => left,
-        };
-        let right = match right.view() {
-            ValueView::Scalar(inner) => inner,
-            _ => right,
-        };
+        // A role mixin wraps the operand without replacing it (rakudo's
+        // `%h does R` is a `Hash+{R}`, still a Hash) and a `Scalar` container is
+        // transparent to a set operator, so fold the value underneath both.
+        let left = crate::runtime::utils::quanthash_operand(left);
+        let right = crate::runtime::utils::quanthash_operand(right);
         if matches!(left.view(), ValueView::Instance { class_name, .. } if class_name == "Failure")
             || matches!(right.view(), ValueView::Instance { class_name, .. } if class_name == "Failure")
         {
@@ -734,14 +741,11 @@ impl Interpreter {
     }
 
     pub(crate) fn apply_set_addition(left: &Value, right: &Value) -> Result<Value, RuntimeError> {
-        let left = match left.view() {
-            ValueView::Scalar(inner) => inner,
-            _ => left,
-        };
-        let right = match right.view() {
-            ValueView::Scalar(inner) => inner,
-            _ => right,
-        };
+        // A role mixin wraps the operand without replacing it (rakudo's
+        // `%h does R` is a `Hash+{R}`, still a Hash) and a `Scalar` container is
+        // transparent to a set operator, so fold the value underneath both.
+        let left = crate::runtime::utils::quanthash_operand(left);
+        let right = crate::runtime::utils::quanthash_operand(right);
         if matches!(left.view(), ValueView::Instance { class_name, .. } if class_name == "Failure")
             || matches!(right.view(), ValueView::Instance { class_name, .. } if class_name == "Failure")
         {

--- a/src/runtime/utils/set_coerce.rs
+++ b/src/runtime/utils/set_coerce.rs
@@ -31,6 +31,70 @@ pub(crate) fn quanthash_operand_list(v: &Value) -> Vec<Value> {
     }
 }
 
+/// The value a QuantHash coercion should actually fold: the operand with its
+/// `Scalar` container and any role mixin stripped.
+///
+/// A mixin WRAPS a value without replacing it — rakudo's `%h does R` is a
+/// `Hash+{R}`, still a Hash, and `@a but R` is still an Array — so `.Set` /
+/// `.Bag` / `.Mix` and every set operator must fold the inner value's elements.
+/// Without the strip a mixin fell through to the "unknown scalar" arm and
+/// contributed the WHOLE hash as one element, which is why `self (-) %allowed`
+/// inside a role's `STORE` never cancelled anything (Hash::Restricted).
+pub(crate) fn quanthash_operand(val: &Value) -> &Value {
+    strip_quanthash_mixin(val.descalarize())
+}
+
+/// The mixin-only half of [`quanthash_operand`], for positions where stripping
+/// the `Scalar` container would change the flattening rule (an itemized
+/// `$(...)` element is taken whole) but the mixin wrapper must still be seen
+/// through.
+///
+/// Only a ROLE mixin is stripped. An **allomorph** is a `Mixin` too (`<1>` is
+/// `Mixin(Int(1), {Str => "1"})`, see
+/// `parser::primary::container::allomorph::make_allomorphic_value`) and its
+/// whole point is to be a distinct element from the value it wraps:
+/// `(1, "1", 1.0, <1>).Set` has four elements. A role mixin carries a
+/// `__mutsu_role__<name>` marker, which is what tells the two apart — the same
+/// discriminator `dispatch_mixin_method_call`'s `.clone` arm uses.
+pub(crate) fn strip_quanthash_mixin(val: &Value) -> &Value {
+    let mut val = val;
+    while let ValueView::Mixin(inner, mixins) = val.view() {
+        if !mixins.keys().any(|k| k.starts_with("__mutsu_role__")) {
+            break;
+        }
+        val = inner.as_ref().descalarize();
+    }
+    val
+}
+
+/// The nested-element form of [`strip_quanthash_mixin`].
+///
+/// A role-mixed AGGREGATE flattens its contents in list context, exactly as the
+/// bare aggregate would (`(1, %h).Set` is `Set(1, "a")` in rakudo for a
+/// `%h does R` holding `a => 1`). A role-mixed SCALAR keeps its own identity
+/// instead: `(5, 5 but R).Set` has two elements, keyed `Int` and `Int+{R}`. So
+/// the strip applies only when what it uncovers is something the surrounding
+/// flattening arms would spill anyway.
+pub(crate) fn strip_quanthash_mixin_elem(val: &Value) -> &Value {
+    let stripped = strip_quanthash_mixin(val);
+    if std::ptr::eq(stripped, val) {
+        return val;
+    }
+    let spills = matches!(
+        stripped.view(),
+        ValueView::Hash(_)
+            | ValueView::Array(_, _)
+            | ValueView::Seq(_)
+            | ValueView::Slip(_)
+            | ValueView::Set(_, _)
+            | ValueView::Bag(_, _)
+            | ValueView::Mix(_, _)
+            | ValueView::Pair(_, _)
+            | ValueView::ValuePair(_, _)
+    ) || stripped.is_range();
+    if spills { stripped } else { val }
+}
+
 pub(crate) fn coerce_to_set(
     val: &Value,
     originals: &mut HashMap<String, Value>,
@@ -41,6 +105,7 @@ pub(crate) fn coerce_to_set(
         value: &Value,
     ) {
         let pair_selected = |weight: &Value| weight.truthy() || weight.is_nil();
+        let value = strip_quanthash_mixin_elem(value);
         match value.view() {
             ValueView::Set(items, _) => {
                 extend_quanthash_originals(originals, &items.original_keys);
@@ -103,7 +168,7 @@ pub(crate) fn coerce_to_set(
         }
     }
 
-    let val = val.descalarize();
+    let val = quanthash_operand(val);
     match val.view() {
         ValueView::Set(s, _) => {
             extend_quanthash_originals(originals, &s.original_keys);
@@ -166,7 +231,7 @@ pub(crate) fn coerce_to_set(
 /// - Pair with falsy value → empty Set
 /// - Other scalars → Set with one element
 pub(crate) fn coerce_value_to_quanthash(val: &Value) -> Value {
-    let val = val.descalarize();
+    let val = quanthash_operand(val);
     match val.view() {
         ValueView::Set(_, _) | ValueView::Bag(_, _) | ValueView::Mix(_, _) => val.clone(),
         ValueView::Hash(h) => {
@@ -277,7 +342,7 @@ pub(crate) fn coerce_value_to_quanthash(val: &Value) -> Value {
 
 /// Determine the promotion level for set operations: 0=Set, 1=Bag, 2=Mix
 pub(crate) fn set_type_level(v: &Value) -> u8 {
-    match v.view() {
+    match strip_quanthash_mixin(v).view() {
         ValueView::Mix(_, _) => 2,
         ValueView::Bag(_, _) => 1,
         _ => 0,
@@ -289,6 +354,7 @@ pub(crate) fn to_mix_map(
     v: &Value,
     originals: &mut HashMap<String, Value>,
 ) -> HashMap<String, f64> {
+    let v = strip_quanthash_mixin(v);
     match v.view() {
         ValueView::Mix(m, _) => {
             extend_quanthash_originals(originals, &m.original_keys);
@@ -391,6 +457,7 @@ pub(crate) fn to_bag_map(
     v: &Value,
     originals: &mut HashMap<String, Value>,
 ) -> HashMap<String, BigInt> {
+    let v = strip_quanthash_mixin(v);
     match v.view() {
         ValueView::Bag(b, _) => {
             extend_quanthash_originals(originals, &b.original_keys);

--- a/src/vm/vm_set_arith_ops.rs
+++ b/src/vm/vm_set_arith_ops.rs
@@ -10,7 +10,7 @@ impl Interpreter {
     /// Determine the set type level, including Package type objects.
     /// 0 = Set/SetHash, 1 = Bag/BagHash, 2 = Mix/MixHash
     fn set_type_level_full(val: &Value) -> u8 {
-        match val.view() {
+        match crate::runtime::utils::strip_quanthash_mixin(val).view() {
             ValueView::Mix(_, _) => 2,
             ValueView::Bag(_, _) => 1,
             ValueView::Package(sym) => {
@@ -187,6 +187,9 @@ impl Interpreter {
         originals: &mut HashMap<String, Value>,
     ) -> HashMap<String, NumBigInt> {
         use crate::runtime::utils::{extend_quanthash_originals, str_elem_key};
+        // A role mixin wraps the operand without replacing it (`%h does R` is a
+        // `Hash+{R}`, still a Hash), so fold the value underneath it.
+        let val = crate::runtime::utils::strip_quanthash_mixin(val);
         match val.view() {
             // A Bag/Set/Mix subclass instance (`class Foo is Bag`) carries its real
             // quantified collection in `__baggy_data__`; unwrap it so a set/baggy op
@@ -263,6 +266,9 @@ impl Interpreter {
     /// Coerce a value to a Mix (HashMap<String, f64>)
     fn coerce_to_mix(val: &Value, originals: &mut HashMap<String, Value>) -> HashMap<String, f64> {
         use crate::runtime::utils::{extend_quanthash_originals, str_elem_key};
+        // A role mixin wraps the operand without replacing it (`%h does R` is a
+        // `Hash+{R}`, still a Hash), so fold the value underneath it.
+        let val = crate::runtime::utils::strip_quanthash_mixin(val);
         match val.view() {
             ValueView::Instance { attributes, .. } if attributes.contains_key("__baggy_data__") => {
                 match attributes.as_map().get("__baggy_data__") {

--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -158,6 +158,14 @@ impl Interpreter {
         } else {
             container.clone()
         };
+        // A role mixin wraps the container without replacing it, so `%h does R`
+        // is a `Hash+{R}` whose membership test is still over the hash's keys.
+        // Gated on the tag probe so the common non-mixin container pays nothing.
+        let container = if container.is_mixin_value() {
+            crate::runtime::utils::strip_quanthash_mixin(&container).clone()
+        } else {
+            container
+        };
         // Set/Bag/Mix stores are `.WHICH`-keyed: membership is element
         // identity (`===`), so `<1> ∈ (1,).Set` is False (IntStr vs Int)
         // and `"1" ∈ (1,).Set` is False (Str vs Int) — matching Rakudo.
@@ -261,6 +269,7 @@ impl Interpreter {
             record_quanthash_original, str_elem_key,
         };
         let pair_selected = |weight: &Value| weight.truthy() || weight.is_nil();
+        let value = crate::runtime::utils::strip_quanthash_mixin_elem(value);
         match value.view() {
             ValueView::Set(items, _) => {
                 extend_quanthash_originals(originals, &items.original_keys);
@@ -338,6 +347,10 @@ impl Interpreter {
         if Self::is_lazy_union_input(value) {
             return Err(Self::lazy_list_error());
         }
+        // A role mixin wraps the operand without replacing it (rakudo's
+        // `%h does R` is a `Hash+{R}`, still a Hash), so fold the value
+        // underneath it.
+        let value = crate::runtime::utils::strip_quanthash_mixin(value);
         match value.view() {
             ValueView::Set(s, _) => {
                 extend_quanthash_originals(originals, &s.original_keys);
@@ -404,6 +417,10 @@ impl Interpreter {
         if Self::is_lazy_union_input(value) {
             return Err(Self::lazy_list_error());
         }
+        // A role mixin wraps the operand without replacing it (rakudo's
+        // `%h does R` is a `Hash+{R}`, still a Hash), so fold the value
+        // underneath it.
+        let value = crate::runtime::utils::strip_quanthash_mixin(value);
         match value.view() {
             ValueView::Bag(b, _) => {
                 extend_quanthash_originals(originals, &b.original_keys);
@@ -439,6 +456,10 @@ impl Interpreter {
         if Self::is_lazy_union_input(value) {
             return Err(Self::lazy_list_error());
         }
+        // A role mixin wraps the operand without replacing it (rakudo's
+        // `%h does R` is a `Hash+{R}`, still a Hash), so fold the value
+        // underneath it.
+        let value = crate::runtime::utils::strip_quanthash_mixin(value);
         match value.view() {
             ValueView::Mix(m, _) => {
                 extend_quanthash_originals(originals, &m.original_keys);

--- a/t/collections/set-bag-mix/quanthash-folding-of-wrapped-values.t
+++ b/t/collections/set-bag-mix/quanthash-folding-of-wrapped-values.t
@@ -1,0 +1,63 @@
+# A role mixin WRAPS a value without replacing it: rakudo's `%h does R` is a
+# `Hash+{R}`, still a Hash, and `@a but R` is still an Array. So `.Set`/`.Bag`/
+# `.Mix` (and their mutable variants) and every set operator must fold the inner
+# value's ELEMENTS. mutsu used to fall through to the "unknown scalar" arm for a
+# mixin and contribute the whole hash as ONE element, so `%h (-) %allowed` never
+# cancelled anything and `%h.Set` answered `Set.new({:a(42), :b(0)})`.
+#
+# From Hash::Restricted 0.0.9, whose restricting roles do `self (-) %allowed`
+# inside their own `STORE` with `self` a role-mixed hash.
+
+use Test;
+
+plan 23;
+
+role Tagged { method tagged() { True } }
+
+my %m does Tagged = a => 42, b => 0;
+my @l does Tagged = 1, 2, 2;
+
+# --- coercion methods on a mixin --------------------------------------------
+# `b => 0` is a falsy value, so a Setty coercion drops it; a Baggy one keeps
+# the value as the weight.
+is-deeply %m.Set, set('a'), 'Hash+{R}.Set folds the hash keys (falsy value dropped)';
+is-deeply %m.Bag, ('a' => 42).Bag, 'Hash+{R}.Bag uses the hash values as weights';
+is-deeply %m.Mix, ('a' => 42).Mix, 'Hash+{R}.Mix uses the hash values as weights';
+is %m.SetHash.elems, 1, 'Hash+{R}.SetHash folds the hash keys';
+is %m.BagHash<a>, 42, 'Hash+{R}.BagHash keeps the weight';
+is %m.MixHash<a>, 42, 'Hash+{R}.MixHash keeps the weight';
+
+is-deeply @l.Set, set(1, 2), 'Array+{R}.Set folds the elements';
+is-deeply @l.Bag, bag(1, 2, 2), 'Array+{R}.Bag counts the elements';
+
+# --- set operators over a mixin ---------------------------------------------
+is-deeply %m (-) set('a'), set(), 'Hash+{R} (-) $set cancels the shared key';
+is-deeply %m (-) set('z'), set('a'), 'Hash+{R} (-) $set keeps an unmatched key';
+is-deeply %m (|) set('z'), set('a', 'z'), 'Hash+{R} (|) $set unions the keys';
+is-deeply %m (&) set('a'), set('a'), 'Hash+{R} (&) $set intersects the keys';
+is-deeply %m (^) set('z'), set('a', 'z'), 'Hash+{R} (^) $set is the symmetric difference';
+is-deeply @l (|) set('z'), set(1, 2, 'z'), 'Array+{R} (|) $set unions the elements';
+ok 'a' (elem) %m, 'Hash+{R} is a membership container over its keys';
+
+# Baggy arithmetic reads the hash values as weights, so `(+)` adds them and
+# `(.)` multiplies -- both are 1-weighted against a plain `bag('a')`.
+is (%m (+) bag('a'))<a>, 43, 'Hash+{R} (+) $bag adds the weights';
+is (%m (.) bag('a'))<a>, 42, 'Hash+{R} (.) $bag multiplies the weights';
+is (%m (&) set('a')).elems, 1, 'Hash+{R} (&) $set keeps exactly the shared key';
+
+# --- what must NOT be unwrapped --------------------------------------------
+# An allomorph is a mixin too (`<1>` wraps `Int(1)` with a `Str` override), and
+# its whole point is to be a DISTINCT element from the value it wraps. Only a
+# role mixin may be folded through.
+is (1, "1", 1.0, <1>).Set.elems, 4,
+  'an allomorph stays a distinct Set element from the value it wraps';
+is (<1>,).Set.keys[0].Str, '1', 'the allomorph element survives the coercion';
+is (<1> (|) set('z')).elems, 2, 'an allomorph operand is one element, not its inner value';
+
+# A role-mixed SCALAR element keeps its own identity, but a role-mixed
+# AGGREGATE element flattens in list context exactly as the bare one would.
+my $scalar-mixin = 5 but Tagged;
+is (5, $scalar-mixin).Set.elems, 2,
+  'a role-mixed scalar element is distinct from the value it wraps';
+is-deeply (1, %m).Set, set(1, 'a'),
+  'a role-mixed hash element flattens its keys in list context';

--- a/t/lang/term-keyword-not-listop-head.t
+++ b/t/lang/term-keyword-not-listop-head.t
@@ -1,0 +1,38 @@
+# A nullary term keyword (`self`, `now`, `time`, `pi`, ...) is a complete term,
+# so what follows it is an OPERATOR position -- rakudo's `term:sym<self>` never
+# takes a parenthesized argument list. mutsu used to read the `(` after one as
+# the start of a no-paren listop call's first argument, so the set-difference
+# infix `(-)` became `self((-) %allowed)` and died with
+# "Unknown prefix operator: (-)".
+#
+# From Hash::Restricted 0.0.9 (`t/01-basic.rakutest`), whose restricting roles
+# compare the hash against the allowed key set with `self (-) %allowed` inside
+# their own `STORE`.
+
+use Test;
+
+plan 8;
+
+my $allowed = set('a');
+
+# The construct the distribution actually uses, inside a method.
+class SetDiffProbe {
+    method diff-from-self() { self (-) $allowed }
+}
+ok SetDiffProbe.new.diff-from-self ~~ Set,
+  'self (-) $set parses as set-difference inside a method';
+
+# Each of these is a term in rakudo, so the `(-)` after it is the infix.
+ok (Any (-) $allowed) ~~ Set, 'Any (-) $set is set-difference';
+ok (now (-) $allowed) ~~ Set, 'now (-) $set is set-difference';
+ok (time (-) $allowed) ~~ Set, 'time (-) $set is set-difference';
+ok (pi (-) $allowed) ~~ Set, 'pi (-) $set is set-difference';
+
+# The other bracketed set infixes go the same way.
+is (pi (|) $allowed).elems, 2, 'pi (|) $set is set-union';
+# `$allowed` holds "a" and `pi` is not a member, so the intersection is empty.
+is (pi (&) $allowed).elems, 0, 'pi (&) $set is set-intersection';
+
+# A term keyword with an ADJACENT paren is still rakudo's "Undeclared routine":
+# only the spaced form is an operator position, so the call form stays rejected.
+eval-dies-ok 'now(1)', 'now(...) is not a call';


### PR DESCRIPTION
## Distribution

`Hash::Restricted` 0.0.9 (`ecosystem/dists/H/Hash--Restricted~9935eb4e.json`), `axis: pure`,
`status: red` — `t/01-basic.rakutest` died at its **first** assertion with
`Unknown prefix operator: (-)`.

Baseline files: 1 of 1 under rakudo (32/32 assertions). Before → after under mutsu:
**1 → 4 of 32 assertions**, and the file's first failure moves from a parse-level death to the one
remaining root cause. The record stays `red`; the residue is [#8026](https://github.com/tokuhirom/mutsu/issues/8026).

Neither fix is about restricted hashes — both are general interpreter gaps the distribution happened
to expose.

## What was fixed

### 1. A nullary term keyword is not a listop head

`self`, `now`, `time`, `pi`, `Any` and `Mu` are *terms* in rakudo (`term:sym<self>` and friends), so
what follows one of them is an **operator** position. mutsu's no-paren listop branch in
`src/parser/primary/ident/identifier_call.rs` accepts any identifier followed by whitespace and a
term start as a call, and `(` is a term start — so

```raku
if self (-) %allowed -> $extra { ... }     # Hash::Restricted's STORE
```

compiled to `self((-) %allowed)` and died at runtime on the nonexistent prefix operator `(-)`.
Outside a module the same source got the compile-time `Undeclared routine: self` instead. `Mu` took
the same path.

The branch now refuses a term keyword as a listop head unless a routine of that name is actually
declared or imported — the rule the rest of that branch already follows for infix words. `self (1, 2)`
stays the "two terms in a row" error rakudo reports rather than becoming a call.

`now` and `time` carried a narrower version of the same bug in
`src/parser/primary/ident/term_literals.rs`: both correctly reject the call form `now(...)` as
rakudo's `Undeclared routine`, but they tested for the paren **after** `trim_start()`, so
`now (-) $set` was rejected too. Only an adjacent paren is the call form; after whitespace the
parenthesis belongs to the operator position.

### 2. QuantHash coercions fold through a role mixin

A mixin **wraps** a value without replacing it: rakudo's `%h does R` is a `Hash+{R}`, still a Hash,
and `@a but R` is still an Array. Every QuantHash coercion matched on `value.view()` without
stripping `ValueView::Mixin`, so a mixin fell through to the "unknown scalar" arm and contributed
**the whole hash as one element**:

| | mutsu (before) | rakudo |
|---|---|---|
| `%m.Set` | `Set.new({:a(42), :b(0)})` | `Set.new("a")` |
| `%m (-) set('a')` | `Set.new({:a(42), :b(0)})` | `set()` |
| `%m (.) bag('a')` | `bag()` | `("a"=>42).Bag` |
| `'a' (elem) %m` | `False` | `True` |

`runtime::utils::quanthash_operand` (descalarize + strip the mixin) and its mixin-only half
`strip_quanthash_mixin` are now applied at every coercion entry point: `coerce_to_set`,
`coerce_value_to_quanthash`, `to_bag_map`, `to_mix_map`, `set_type_level`, `builtins`' `to_set` /
`to_bag` / `to_mix`, the VM's `value_to_set_keys` / `value_to_bag_counts` / `value_to_mix_weights` /
`set_contains` / `coerce_to_bag` / `coerce_to_mix` / `set_type_level_full`, and `ops_set`'s four
`apply_set_*` entry points. `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash` and
`(-)`/`(|)`/`(&)`/`(^)`/`(+)`/`(.)`/`(elem)` now all agree with rakudo on a mixin.

**Only a ROLE mixin is folded through.** An allomorph is a `Mixin` too — `<1>` is
`Mixin(Int(1), {Str => "1"})` — and its whole point is to be a distinct element from the value it
wraps, so `(1, "1", 1.0, <1>).Set` must have four elements. The discriminator is the
`__mutsu_role__<name>` marker, the same one `dispatch_mixin_method_call`'s `.clone` arm already uses.
(An ungated strip regressed `t/collections/set-bag-mix/set-bag-mix-which-keys.t` to 3 elements; the
gate is pinned by three new assertions.)

In **nested element** position it splits one step further, matching rakudo: a role-mixed *aggregate*
element flattens its contents in list context (`(1, %h).Set` is `Set(1, "a")`), while a role-mixed
*scalar* element keeps its own identity (`(5, 5 but R).Set` has two elements, keyed `Int` and
`Int+{R}`).

The strips added where no stripping happened before are deliberately **mixin-only**, so this change
is exactly the mixin gap and does not quietly alter how a `Scalar`-contained operand is treated on
those paths.

## Tests

- `t/lang/term-keyword-not-listop-head.t` (8 assertions)
- `t/collections/set-bag-mix/quanthash-folding-of-wrapped-values.t` (23 assertions; the last five are
  the allomorph / scalar-vs-aggregate identity rules)

Both pass verbatim under `raku` 2026.07 as well as mutsu.

## Still red, and why

`t/01-basic.rakutest` assertions 5-32 need
[#8026](https://github.com/tokuhirom/mutsu/issues/8026) (`todo:deep`): a role mixed into a
non-`Instance` value has no store for its own attributes. `Hash::Restricted`'s `restrict-current`
role keeps the permitted key set in `has %!allowed`, fills it from its own `STORE`, and reads it back
from `AT-KEY` — but since ADR-0019 Phase 3 Stage 2c every `$!attr` access inside a compiled method is
cell-direct, and `self_instance_attrs` has no cell to offer for a `Mixin` over a Hash. The write is
discarded, so `AT-KEY` sees an empty set and rejects every key. Giving a mixin a real attribute cell
is a change to the `Value::Mixin` representation touching GC tracing, every `self_instance_attrs`
consumer and the role-vs-class commit split, so it is filed rather than forced in here. The issue
carries the reduction, the `rust-gdb` evidence, and the three distinct sub-gaps.

No neighbour record shares either root cause: `Unknown prefix operator: (` appears in no other
ledger record, and the one other record whose first failure is an `Undeclared routine`
(`DirHandle` 0.0.9) turned out to be `MY::<...>:exists` pseudo-package lookup, verified unrelated.

## Verification

- `cargo fmt --all` clean
- `make lint` green — all four configurations (default clippy, `jit` off, wasm32 lib, rustdoc)
- `make test` — **4035 files, 42952 tests, all pass**
- `make roast` — 1437 files, 219635 tests; the only failures are the three documented
  environment-only files, by name and shape: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`),
  `roast/S16-filehandles/filetest.t` (`Failed: 25`) — both `uid 0` — and
  `roast/S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17) — sandboxed network. See
  `docs/agent-environments.md`.
- Ledger re-measured with `--only` on the release binary; `ecosystem/index-snapshot.json` left
  unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA2JwYAbA7FL9TozmgQwQF


---
_Generated by [Claude Code](https://claude.ai/code/session_01SA2JwYAbA7FL9TozmgQwQF)_