### PR TITLE
perf(regex): memoize sub-pattern parses on the interpolated pattern text

### DIFF
--- a/news/2026-09/subpattern-parses-are-memoized-on-interpolated-text.md
+++ b/news/2026-09/subpattern-parses-are-memoized-on-interpolated-text.md
@@ -1,0 +1,118 @@
+# Sub-pattern parses are memoized, keyed on interpolated text
+
+`Interpreter::parse_regex` memoizes a compiled `RegexPattern` per
+`(package, pattern)` under the grammar-token registry generation. The parser is
+recursive, though, and its *inner* entry point was not covered: a group, a
+lookaround body, an alternation branch, a conjunction part and a `%`-separator
+atom each re-enter the parser through `parse_regex_with_mode`, which was a bare
+passthrough to `parse_regex_uncached` with no memo of its own. So the outer
+pattern was cached while everything inside it was re-parsed on every parse of
+the outer pattern.
+
+A `rust-gdb` hit-count sweep over one 60-row variant of
+`benchmarks/bench-yaml-parse.raku` measured the result: **10,958 parses of only
+255 distinct patterns**, `<.space>` alone 1,005 times, for **597 M of the run's
+5.18 Bn instructions (11.5%)** — the site round 12 of
+[#7576](https://github.com/tokuhirom/mutsu/issues/7576) handed off.
+
+## Keying on the source text is worth a third of the available win
+
+The obvious memo — the same key `parse_regex` uses, guarded by
+`regex_pattern_is_static` — was implemented first and measured **-2.7%**. Then
+the same gdb sweep on that build showed why: 4,994 of the parses still missed,
+and the missed patterns were dominated by YAMLish rules like
+
+```
+[ <properties> <.space>+ ]?  $<value> = [ … ]
+[ $<content>= [ <.after .> ] ]
+$<kind>=<[\|\>]> $<chomp>=<[+-]>?
+```
+
+`regex_pattern_is_static` counts `$<name>` as interpolation. It is
+conservative by design — a false "dynamic" costs a cache miss, never
+correctness — but `$<name>` *names a capture*, it does not read a variable, and
+these are exactly the workhorse rules of a grammar.
+
+## The purity boundary is after interpolation, not before
+
+`Match` mode substitutes `$`/`@`/`%` variable values into the pattern text
+first, and the structural parse that follows is a function of the resulting
+string plus the token registry. So the memo key is the **interpolated** text,
+and the static-pattern predicate drops out of the picture entirely:
+`parse_regex_uncached` now interpolates, probes, and on a miss calls the
+extracted `parse_regex_structural`, which is the old body minus its
+interpolation step.
+
+That also caches patterns that genuinely do interpolate, whenever the result
+repeats — a grammar that splices an indent string re-parses once per *distinct*
+indent instead of once per call.
+
+## The exclusions have to come from the parser, not from reading it
+
+`Validate` mode is excluded outright: a structurally-questionable pattern pushes
+non-fatal diagnostics onto `REGEX_SORROWS` on its way to a *successful* parse
+and `validate_regex_structurally` drains them, so a cache hit would report none
+the second time. It has nothing to gain either — validation runs once per regex
+literal at compile time, 20 times over the whole profiled document.
+
+The `Match`-mode exclusions were harder, and the first attempt got them wrong.
+Interpolation is not quite the whole of the impurity: a handful of parse steps
+read state the key does not carry. `<$var>` and `<@var>` *assertion* forms take
+the variable's value at parse time and recompile it as a regex (unlike a bare
+`$var`, which interpolation substitutes into the text first, so the key already
+reflects it), and `<~~>` reads `PARSING_TOP_LEVEL_SOURCE`. The first version of
+this memo derived its exclusion list by reading the parser, caught `<~~>`,
+missed the sigil-assertion forms, and made `roast/S05-metasyntax/litvar.t` reuse
+the tree parsed for `$var = '$i'` when matching `$var = '<$i>'` — two
+consecutive matches of the identical source pattern `/<$var>/`, one of which
+must die.
+
+A list of pattern syntaxes maintained next to the parser cannot stay correct as
+the parser grows, so the exclusions are raised **at the reads themselves**:
+`Interpreter::note_regex_parse_ambient_read` sets a
+`PARSE_CONSULTED_AMBIENT_STATE` flag, `parse_regex_uncached` runs each parse
+with the flag cleared, refuses to store a parse that raised it, and ORs it into
+the enclosing parse so a pattern containing an impure sub-pattern is not stored
+either. Adding a new parse-time read of interpreter state means calling that
+one function; forgetting to update a syntax list is no longer possible.
+
+Unlike source text, interpolated text is not bounded by the program — a regex
+that splices a loop counter mints a fresh key every iteration — so each
+`(package, mode)` bucket is capped at `SUBPATTERN_PARSE_CACHE_MAX` entries and
+cleared on reaching it. Dropping a memo costs re-parses and nothing else.
+
+A hit clones the stored tree rather than handing out the `Arc`, because every
+caller moves the `RegexPattern` into a `RegexAtom`. The clone is a memory copy
+of one sub-tree; the parse it replaces re-scans the source, re-resolves grammar
+tokens against the registry, and re-runs LTM expansion over it.
+
+## Effect
+
+60-row document, `valgrind --tool=callgrind` (deterministic and
+load-independent, per the method note rounds 10-12 added to the ticket):
+
+| | instructions | `parse_regex` inclusive | structural parses |
+| --- | ---: | ---: | ---: |
+| before | 5,176,849,912 | 597,362,519 (11.54%) | 10,958 |
+| source-keyed | 5,038,201,950 | 460,379,018 (9.14%) | 4,994 |
+| interpolated-keyed | 4,673,371,023 | 82,442,085 (1.76%) | 269 |
+| | **-9.7%** | **-86%** | **-98%** |
+
+269 structural parses over 247 distinct patterns is within rounding of optimal:
+one parse per distinct pattern, plus the dozen `<$var>`/`<~~>` parses the
+ambient-read flag correctly refuses to store.
+
+`t/regex/regex-subpattern-parse-memo.t` pins the key's three axes and both
+exclusion mechanisms: a variable whose value changes between calls (including
+inside a nested group), a `$<name>` capture form repeated across matches, the
+`<$var>` assertion form under two different values of the same pattern text,
+`<@var>`, two grammars whose `TOP` bodies are character-for-character identical
+but whose `<+digit +thing>` folds must resolve in their own package, a grammar
+declared after an earlier parse, and `<~~>` recursion. All eighteen assertions
+were verified against rakudo v2026.07.
+
+One thing the test deliberately does *not* pin: a `<@var>` regex literal
+evaluated before the array is reassigned later in the same scope already sees
+the later value, on `main` with this change both applied and stashed. That is a
+separate pre-existing bug, filed as
+[#8040](https://github.com/tokuhirom/mutsu/issues/8040).

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -40,6 +40,63 @@ thread_local! {
     pub(crate) static REGEX_PARSE_CACHE: RefCell<HashMap<String, (u64, std::sync::Arc<RegexPattern>)>> =
         RefCell::new(HashMap::new());
 
+    /// Memoization cache for *sub-pattern* parses — every `parse_regex_uncached`
+    /// entry, not just the outermost one [`REGEX_PARSE_CACHE`] covers.
+    ///
+    /// The parser is recursive: a group, a lookaround body, an alternation
+    /// branch, a conjunction part and a `%`-separator atom each re-enter
+    /// `parse_regex_uncached` through `parse_regex_with_mode`, which was a bare
+    /// passthrough with no memo of its own. So the *outer* pattern was cached
+    /// while everything inside it was re-parsed on every outer parse. A
+    /// `rust-gdb` hit-count sweep over one 60-row
+    /// `benchmarks/bench-yaml-parse.raku` document counted **10,958 parses of
+    /// only 255 distinct patterns** — `<.space>` alone 1,005 times — for 11.6%
+    /// of the whole program ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
+    ///
+    /// Two levels of key, so a probe allocates nothing: the outer key is
+    /// `(current package, mode)`, both `Copy`, and the inner map is probed with
+    /// the pattern as a borrowed `&str`. Entries record the `TOKEN_DEFS_GEN`
+    /// they were parsed under, exactly like [`REGEX_PARSE_CACHE`].
+    ///
+    /// Keyed on the pattern text *after* variable interpolation, because that
+    /// is where purity begins: `Match` mode substitutes `$`/`@`/`%` variable
+    /// values into the pattern first, and the structural parse that follows is
+    /// a function of the resulting string plus the token registry. Keying on
+    /// the source text instead would have to refuse everything
+    /// [`regex_pattern_is_static`] calls dynamic, which on the profiled
+    /// document is most of the repeated patterns — that predicate
+    /// conservatively counts `$<name>` *capture* forms (`$<value> = [ … ]`) as
+    /// interpolation even though they name a capture rather than read a
+    /// variable.
+    ///
+    /// Only `Match` mode is stored. A `Validate`-mode parse pushes non-fatal
+    /// diagnostics onto [`REGEX_SORROWS`] on its way to a successful parse and
+    /// [`validate_regex_structurally`] drains them, so a cache hit
+    /// would report none the second time — and validation runs once per regex
+    /// literal at compile time, so there is nothing to gain either.
+    ///
+    /// One `Match`-mode shape is still excluded: text containing `~~`. `<~~>` bakes
+    /// the *enclosing* regex's source into `RegexAtom::RecurseSelf`, read from
+    /// [`PARSING_TOP_LEVEL_SOURCE`], so the same sub-pattern text can parse to
+    /// different trees under different outer patterns. `RecurseSelf` is
+    /// produced only where the text handed to *this* parse literally spells
+    /// `<~~>`, so testing that text is sufficient.
+    ///
+    /// A failed parse is never stored: failure reports through the
+    /// [`PENDING_REGEX_ERROR`] side channel, which a cache hit would not
+    /// reproduce.
+    ///
+    /// Bounded by [`SUBPATTERN_PARSE_CACHE_MAX`] per bucket — see the note at
+    /// the insert site for why interpolated text, unlike source text, is not
+    /// bounded by the program.
+    #[allow(clippy::type_complexity)]
+    pub(crate) static REGEX_SUBPATTERN_PARSE_CACHE: RefCell<
+        rustc_hash::FxHashMap<
+            (Symbol, RegexParseMode),
+            rustc_hash::FxHashMap<String, (u64, std::sync::Arc<RegexPattern>)>,
+        >,
+    > = RefCell::new(rustc_hash::FxHashMap::default());
+
     /// Memoization cache for the *main-slang* code strings evaluated during
     /// regex matching: `{ … }` side-effect blocks, `<?{ … }>`/`<!{ … }>`
     /// assertions, `<{ … }>` closure interpolations, `** {code}` quantifier
@@ -53,6 +110,28 @@ thread_local! {
     /// them, the same discipline as `REGEX_PARSE_CACHE`'s `TOKEN_DEFS_GEN`.
     pub(crate) static REGEX_CODE_PARSE_CACHE: RefCell<HashMap<String, CachedCodeParse>> =
         RefCell::new(HashMap::new());
+
+    /// Set by any point in the structural parse that consults interpreter or
+    /// ambient state the [`REGEX_SUBPATTERN_PARSE_CACHE`] key does not capture:
+    /// the `<$var>` / `<@var>` assertion forms, which read the variable's value
+    /// at PARSE time (unlike a bare `$var`, which
+    /// `Interpreter::interpolate_regex_scalars` substitutes into the text
+    /// first, so the key already reflects it), and `<~~>`, which reads
+    /// [`PARSING_TOP_LEVEL_SOURCE`].
+    ///
+    /// `Interpreter::parse_regex_uncached` refuses to store a parse that raised
+    /// this, and propagates it to the enclosing parse so an outer pattern
+    /// containing such a sub-pattern is not stored either.
+    ///
+    /// This is a flag raised at the reads themselves rather than a list of
+    /// pattern syntaxes tested up front, because the list cannot be kept
+    /// correct as the parser grows: the first version of this memo derived the
+    /// exclusions from reading the code, missed the `<$var>` form, and made
+    /// `roast/S05-metasyntax/litvar.t` reuse the tree of `$var = '$i'` for
+    /// `$var = '<$i>'`. Anything that reads such state must raise this;
+    /// `Interpreter::note_regex_parse_ambient_read` is the single way to do it.
+    pub(crate) static PARSE_CONSULTED_AMBIENT_STATE: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
 
     /// The source text of the regex currently being parsed at TOP level, so a
     /// `<~~>` found at any nesting depth inside it can record what "recurse into
@@ -316,6 +395,13 @@ mod static_pattern_tests {
     }
 }
 
+/// Per-bucket entry cap for [`REGEX_SUBPATTERN_PARSE_CACHE`]. Reaching it
+/// clears the bucket: the memo is an optimization, so dropping it costs
+/// re-parses and nothing else, and a bound is needed because its keys are
+/// interpolated pattern text — a regex that splices a loop counter mints a
+/// fresh one on every iteration.
+pub(crate) const SUBPATTERN_PARSE_CACHE_MAX: usize = 4096;
+
 /// Parsing mode for the shared regex grammar parser (`parse_regex_uncached`).
 ///
 /// The structural parser is the single source of truth for Raku regex grammar.
@@ -330,7 +416,7 @@ mod static_pattern_tests {
 ///   variable references as opaque, syntactically-valid atoms. Every structural
 ///   and grammar syntax check still fires, so this replaces the former standalone
 ///   `regex_validate` module.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub(crate) enum RegexParseMode {
     Match,
     Validate,

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -364,6 +364,15 @@ impl Interpreter {
         !self.current_package().is_empty() && self.resolve_token_defs(name).is_some()
     }
 
+    /// Raise [`PARSE_CONSULTED_AMBIENT_STATE`]
+    /// for the parse in progress. Call this from any point in the structural
+    /// parse that reads interpreter or ambient state, so
+    /// [`Interpreter::parse_regex_uncached`] does not memoize a tree that is
+    /// not a function of its key.
+    pub(super) fn note_regex_parse_ambient_read() {
+        crate::runtime::regex_parse::PARSE_CONSULTED_AMBIENT_STATE.with(|f| f.set(true));
+    }
+
     /// Build the alternation atom for a `<@var>` array-variable subrule: look up
     /// the array variable named by `env_key` (including its `@` sigil) and
     /// compile each element as a regex pattern, collapsing to a character class
@@ -371,6 +380,9 @@ impl Interpreter {
     /// is empty / unset. Shared by `<@var>` and its `<?@var>` / `<!@var>`
     /// lookahead forms.
     fn array_var_alternation_atom(&self, env_key: &str, mode: RegexParseMode) -> Option<RegexAtom> {
+        // Reads the array's VALUE at parse time; the tree is not a function of
+        // the pattern text alone.
+        Self::note_regex_parse_ambient_read();
         let value = self.env.get(env_key).cloned().unwrap_or(Value::NIL);
         let elements = match value.view() {
             ValueView::Array(arr, _) => arr.as_ref().clone(),
@@ -631,9 +643,118 @@ impl Interpreter {
             })
     }
 
+    /// Parse `pattern`, memoizing the structural parse in
+    /// [`REGEX_SUBPATTERN_PARSE_CACHE`].
+    ///
+    /// This wraps EVERY entry into the recursive-descent parser, not just the
+    /// outermost one [`REGEX_PARSE_CACHE`]
+    /// covers: the parser re-enters itself through
+    /// [`Interpreter::parse_regex_with_mode`] for groups, lookaround bodies,
+    /// alternation branches, conjunction parts and `%`-separator atoms, and
+    /// that path had no memo of its own, so the inside of a cached outer
+    /// pattern was re-parsed on every outer parse.
+    ///
+    /// The memo key is the **interpolated** text, not the source pattern,
+    /// because that is where purity mostly begins: `Match` mode substitutes
+    /// `$`/`@`/`%` variable values into the pattern first, and what follows is
+    /// a function of the resulting string plus the grammar-token registry
+    /// (pinned by `TOKEN_DEFS_GEN`). Keying on the source text instead would
+    /// have to refuse every pattern `regex_pattern_is_static` calls dynamic —
+    /// which on the profiled document is most of the repeated ones, since that
+    /// predicate conservatively counts `$<name>` *capture* forms
+    /// (`$<value> = [ … ]`) as interpolation. Measured: source-keyed -2.7%,
+    /// interpolated-keyed -9.0%.
+    ///
+    /// "Mostly", because a few parse steps read state the key does not carry —
+    /// the `<$var>` / `<@var>` assertion forms take the variable's value at
+    /// parse time, and `<~~>` reads the enclosing regex's source. Those raise
+    /// [`PARSE_CONSULTED_AMBIENT_STATE`]
+    /// at the read itself and their parse is not stored; the flag propagates
+    /// outward, so an enclosing pattern is not stored either.
+    ///
+    /// A hit clones the stored tree rather than handing out the `Arc`, because
+    /// every caller moves the `RegexPattern` into a `RegexAtom`. The clone is a
+    /// memory copy of one sub-tree; the parse it replaces re-scans the source,
+    /// re-resolves grammar tokens against the registry, and re-runs LTM
+    /// expansion over it.
     pub(super) fn parse_regex_uncached(
         &self,
         pattern: &str,
+        mode: RegexParseMode,
+    ) -> Option<RegexPattern> {
+        // `Match` mode interpolates `$`/`@`/`%` variable values into the pattern
+        // before structural parsing. `Validate` mode (parse-time dry run) has no
+        // variable values available, so it skips interpolation and treats sigil
+        // references as opaque atoms further down.
+        let interpolated = if mode == RegexParseMode::Match {
+            match self.interpolate_regex_scalars(pattern) {
+                Ok(s) => s,
+                Err(e) => {
+                    PENDING_REGEX_ERROR.with(|err| {
+                        *err.borrow_mut() = Some(e);
+                    });
+                    return None;
+                }
+            }
+        } else {
+            pattern.to_string()
+        };
+        // `Validate` mode is not memoized: a structurally-questionable pattern
+        // pushes non-fatal diagnostics onto `REGEX_SORROWS` on its way to a
+        // successful parse, and `validate_regex_structurally` drains them — a
+        // cache hit would report none the second time. It also has nothing to
+        // gain: validation runs once per regex literal at compile time (20
+        // times over the whole profiled document, against 10,958 match-mode
+        // parses).
+        if mode != RegexParseMode::Match {
+            return self.parse_regex_structural(&interpolated, mode);
+        }
+        let tok_gen =
+            crate::runtime::regex_parse::TOKEN_DEFS_GEN.load(std::sync::atomic::Ordering::Relaxed);
+        let bucket = (self.current_package_sym(), mode);
+        if let Some(hit) = crate::runtime::regex_parse::REGEX_SUBPATTERN_PARSE_CACHE.with(|c| {
+            c.borrow()
+                .get(&bucket)
+                .and_then(|m| m.get(interpolated.as_str()))
+                .filter(|(entry_gen, _)| *entry_gen == tok_gen)
+                .map(|(_, p)| std::sync::Arc::clone(p))
+        }) {
+            return Some((*hit).clone());
+        }
+        // Run the parse with a cleared ambient-read flag so it reports only its
+        // OWN reads, then restore the enclosing parse's flag — OR-ing this
+        // parse's result in, since a pattern containing an impure sub-pattern is
+        // itself impure. The borrow above is dropped first: the parse recurses
+        // back into this function for its own sub-patterns.
+        let ambient = &crate::runtime::regex_parse::PARSE_CONSULTED_AMBIENT_STATE;
+        let outer_read = ambient.with(|f| f.replace(false));
+        let parsed = self.parse_regex_structural(&interpolated, mode);
+        let this_read = ambient.with(|f| f.replace(outer_read || f.get()));
+        let stored = std::sync::Arc::new(parsed?);
+        if !this_read {
+            crate::runtime::regex_parse::REGEX_SUBPATTERN_PARSE_CACHE.with(|c| {
+                let mut cache = c.borrow_mut();
+                let bucket_map = cache.entry(bucket).or_default();
+                // Interpolated text is unbounded in a way source text is not: a
+                // pattern that splices a loop counter produces a fresh key every
+                // iteration. Keep the memo bounded rather than let it grow with
+                // the program's data; dropping it only costs re-parses.
+                if bucket_map.len() >= crate::runtime::regex_parse::SUBPATTERN_PARSE_CACHE_MAX {
+                    bucket_map.clear();
+                }
+                bucket_map.insert(interpolated, (tok_gen, std::sync::Arc::clone(&stored)));
+            });
+        }
+        Some((*stored).clone())
+    }
+
+    /// The structural parse proper: everything after variable interpolation.
+    /// Pure in `interpolated` given the grammar-token registry and (for a
+    /// `<~~>`-bearing pattern) `PARSING_TOP_LEVEL_SOURCE` — which is what lets
+    /// [`Interpreter::parse_regex_uncached`] memoize around it.
+    fn parse_regex_structural(
+        &self,
+        interpolated: &str,
         mode: RegexParseMode,
     ) -> Option<RegexPattern> {
         fn token_is_ws_like(token: &RegexToken) -> bool {
@@ -652,30 +773,13 @@ impl Interpreter {
             }
         }
 
-        // `Match` mode interpolates `$`/`@`/`%` variable values into the pattern
-        // before structural parsing. `Validate` mode (parse-time dry run) has no
-        // variable values available, so it skips interpolation and treats sigil
-        // references as opaque atoms further down.
-        let interpolated = if mode == RegexParseMode::Match {
-            match self.interpolate_regex_scalars(pattern) {
-                Ok(s) => s,
-                Err(e) => {
-                    PENDING_REGEX_ERROR.with(|err| {
-                        *err.borrow_mut() = Some(e);
-                    });
-                    return None;
-                }
-            }
-        } else {
-            pattern.to_string()
-        };
         // Remember what `<~~>` would recurse into. The text recorded is the
         // *interpolated* one (leading `:i`/`:s`/… adverb prefixes included), so
         // re-parsing it at match time reproduces exactly this tree. Only the
         // OUTERMOST parse installs a value; sub-pattern parses (groups,
         // lookaround bodies, alternation branches) re-enter here and inherit it.
         let _top_level_source =
-            crate::runtime::regex_parse::TopLevelSourceScope::enter(&interpolated);
+            crate::runtime::regex_parse::TopLevelSourceScope::enter(interpolated);
         let mut source = interpolated.trim_start();
         let mut ignore_case = false;
         let mut ignore_mark = false;
@@ -2993,6 +3097,10 @@ impl Interpreter {
                                     // scalar into a shared `ContainerRef` cell (bug 1 of
                                     // `todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md`),
                                     // which must be dereferenced before it is stringified.
+                                    // Reads the scalar's VALUE at parse time (and
+                                    // recompiles it as a regex), so the tree is not a
+                                    // function of the pattern text alone.
+                                    Self::note_regex_parse_ambient_read();
                                     let value = match self
                                         .env
                                         .get(var_name)
@@ -3275,6 +3383,9 @@ impl Interpreter {
                                     // `<~~N>` — recursing into a numbered capture — is
                                     // "not yet implemented" in Rakudo too, so it keeps
                                     // falling through to the generic subrule path.
+                                    // Reads the ENCLOSING regex's source, which the
+                                    // memo key (this pattern's own text) does not carry.
+                                    Self::note_regex_parse_ambient_read();
                                     match crate::runtime::regex_parse::TopLevelSourceScope::current(
                                     ) {
                                         Some(src) => RegexAtom::RecurseSelf(Box::from(&*src)),

--- a/t/regex/regex-subpattern-parse-memo.t
+++ b/t/regex/regex-subpattern-parse-memo.t
@@ -1,0 +1,103 @@
+use Test;
+
+plan 18;
+
+# The regex parser is recursive: a group, a lookaround body, an alternation
+# branch, a conjunction part and a `%`-separator atom each re-enter the parse
+# entry point for their own text. That entry point memoizes now, so the inside
+# of a pattern is parsed once instead of once per parse of the enclosing
+# pattern (10,958 parses of 247 distinct patterns down to 257 on a 60-row
+# `benchmarks/bench-yaml-parse.raku` document, issue #7576).
+#
+# The key is the pattern text *after* `$`/`@`/`%` interpolation, which is where
+# the parse actually becomes a function of its input, plus the current package
+# and the grammar-token registry generation. These tests drive each of those
+# three axes, and the one pattern shape deliberately left out of the memo.
+# Every expectation here was verified against rakudo v2026.07.
+
+# --- the interpolated text is the key, not the source text ------------------
+# The same source pattern with a different variable value must parse to a
+# different tree, including when the variable sits inside a nested group (a
+# separate, recursive parse of its own).
+{
+    my $x = 'ab';
+    ok 'zabz' ~~ / z [ $x ] z /, 'interpolated group matches its first value';
+    $x = 'cd';
+    ok 'zcdz' ~~ / z [ $x ] z /, 'interpolated group follows the new value';
+    nok 'zabz' ~~ / z [ $x ] z /, 'the old value is not still cached';
+}
+
+# A `$<name>` capture form is *not* a variable read, so the interpolated text
+# is stable and these do share a memo entry. Repeating the same capturing
+# sub-pattern must still capture per-match, not replay the first match.
+{
+    my @got;
+    for 'k1: v1', 'k2: v2' -> $line {
+        $line ~~ / $<key> = [ \w+ ] ':' \s* $<val> = [ \w+ ] /;
+        @got.push: "$<key>=$<val>";
+    }
+    is @got[0], 'k1=v1', 'a repeated capture sub-pattern captures the first match';
+    is @got[1], 'k2=v2', 'and the second, rather than replaying the first';
+}
+
+# --- a parse step that reads runtime state is never stored --------------------
+# `<$var>` takes the variable's VALUE at parse time and recompiles it as a
+# regex, so the same pattern text means different things under different
+# values. (Unlike a bare `$var`, which is substituted into the text first, so
+# the memo key already reflects it.) This is the shape that caught the first
+# version of this memo, which derived its exclusions from reading the parser
+# instead of from the parser reporting its own reads:
+# `roast/S05-metasyntax/litvar.t`, where `$var = '$i'` and `$var = '<$i>'` are
+# two consecutive matches of the identical source pattern `/<$var>/`.
+{
+    my $one = 'aa';
+    my $var = '$one';
+    my $two = 'bb';
+    ok 'aa' ~~ / ^ <$var> $ /, 'a <$var> assertion compiles the current value';
+    $var = '$two';
+    ok 'bb' ~~ / ^ <$var> $ /, 'and follows a new value under the same pattern text';
+    nok 'aa' ~~ / ^ <$var> $ /, 'rather than reusing the first parse';
+}
+
+# `<@var>` reads the array's elements at parse time, the same way. (The
+# matching "follows a reassignment" case is NOT pinned here: a `<@var>` regex
+# literal evaluated before the array is reassigned later in the same scope
+# already sees the later value on `main`, independently of this memo — see
+# issue #8040.)
+{
+    my @alts = <cat dog>;
+    ok 'cat' ~~ / ^ <@alts> $ /, 'a <@var> assertion matches an element';
+    nok 'emu' ~~ / ^ <@alts> $ /, 'and only an element';
+}
+
+# --- the current package is part of the key ---------------------------------
+# `<+digit +thing>` folds `thing`'s body into the character class at parse
+# time, so two grammars whose TOP bodies are character-for-character identical
+# must still get different trees.
+{
+    grammar MemoA { token TOP { <+digit +thing>+ }; token thing { <[x]> } }
+    grammar MemoB { token TOP { <+digit +thing>+ }; token thing { <[y]> } }
+    ok  MemoA.parse('1x2'), 'a folded token body resolves in its own grammar';
+    nok MemoA.parse('1y2'), 'and not against the other grammar of the same body text';
+    ok  MemoB.parse('1y2'), 'the identical body text folds the other grammar"s token';
+    nok MemoB.parse('1x2'), 'without inheriting the first grammar"s fold';
+}
+
+# --- a token (re)definition invalidates entries ------------------------------
+# The memo records the token-registry generation it was built under, so a
+# pattern parsed before a token exists must not keep its pre-definition tree.
+{
+    ok 'q' ~~ / <[q]> /, 'a plain class matches before the grammar is declared';
+    grammar MemoC { token TOP { <+alpha +punct>+ } }
+    ok MemoC.parse('ab,cd'), 'a grammar declared later still parses';
+}
+
+# --- the shape deliberately left out of the memo -----------------------------
+# `<~~>` records the *enclosing* regex's source, so the same sub-pattern text
+# can mean different things under different outer patterns. Such patterns skip
+# the memo entirely; this checks recursion still works.
+{
+    my regex balanced { '(' [ <-[()]> | <~~> ]* ')' };
+    ok  '(a(b)c)' ~~ /^ <balanced> $/, '<~~> recursion matches a nested pair';
+    nok '(a(b c)'  ~~ /^ <balanced> $/, '<~~> recursion rejects an unbalanced one';
+}


### PR DESCRIPTION
Round 13 of #7576, picking up the site round 12 handed off.

`parse_regex` memoizes a compiled `RegexPattern` per `(package, pattern)` under the token-registry generation — but the parser is *recursive*, and its inner entry point was not covered. A group, a lookaround body, an alternation branch, a conjunction part and a `%`-separator atom each re-enter through `parse_regex_with_mode`, a bare passthrough with no memo of its own. So the outer pattern was cached while everything inside it was re-parsed on every outer parse.

A `rust-gdb` hit-count sweep over a 60-row variant of `benchmarks/bench-yaml-parse.raku`: **10,958 parses of only 255 distinct patterns**, `<.space>` alone 1,005 times, for **597 M of the run's 5.18 Bn instructions (11.5%)**.

## Keying on the source text is worth a third of the win

The obvious memo — the same key `parse_regex` uses, guarded by `regex_pattern_is_static` — was implemented first and measured **-2.7%**. The same gdb sweep showed why: 4,994 parses still missed, dominated by YAMLish rules like

```
[ <properties> <.space>+ ]?  $<value> = [ … ]
[ $<content>= [ <.after .> ] ]
$<kind>=<[\|\>]> $<chomp>=<[+-]>?
```

`regex_pattern_is_static` counts `$<name>` as interpolation — conservative by design, but `$<name>` *names a capture*, it does not read a variable, and these are the workhorse rules of a grammar.

## The purity boundary is after interpolation

`Match` mode substitutes `$`/`@`/`%` values into the pattern text first, so the memo key is the **interpolated** text: `parse_regex_uncached` interpolates, probes, and on a miss calls the extracted `parse_regex_structural` (the old body minus its interpolation step). That also caches patterns that genuinely interpolate, whenever the result repeats — a grammar splicing an indent string re-parses once per *distinct* indent.

## The exclusions come from the parser, not from reading it

`Validate` mode is excluded outright: a questionable pattern pushes non-fatal diagnostics onto `REGEX_SORROWS` on its way to a *successful* parse and `validate_regex_structurally` drains them, so a hit would report none the second time. It runs 20 times over the whole document, against 10,958 match-mode parses.

The `Match`-mode exclusions were harder, **and the first attempt got them wrong.** A few parse steps read state the key does not carry: `<$var>` / `<@var>` assertion forms take the variable's *value* at parse time and recompile it as a regex, and `<~~>` reads `PARSING_TOP_LEVEL_SOURCE`. The first version derived its exclusion list by reading the parser, caught `<~~>`, missed the sigil-assertion forms, and made `roast/S05-metasyntax/litvar.t` reuse the tree parsed for `$var = '$i'` when matching `$var = '<$i>'` — two consecutive matches of the identical source pattern `/<$var>/`, one of which must die. (Caught by the pre-publication `make roast`, before this PR existed.)

A syntax list maintained next to the parser cannot stay correct as the parser grows, so the exclusions are raised **at the reads themselves**: `note_regex_parse_ambient_read` sets a `PARSE_CONSULTED_AMBIENT_STATE` flag, `parse_regex_uncached` runs each parse with it cleared, refuses to store one that raised it, and ORs it into the enclosing parse so a pattern containing an impure sub-pattern is not stored either. Adding a new parse-time read of interpreter state means calling that one function.

Interpolated text is not bounded by the program the way source text is (a regex splicing a loop counter mints a fresh key every iteration), so each `(package, mode)` bucket is capped at `SUBPATTERN_PARSE_CACHE_MAX` and cleared on reaching it. A hit clones the stored tree because every caller moves the `RegexPattern` into a `RegexAtom`.

## Effect

60-row document, `valgrind --tool=callgrind` (deterministic, load-independent):

| | instructions | `parse_regex` inclusive | structural parses |
| --- | ---: | ---: | ---: |
| before | 5,176,849,912 | 597,362,519 (11.54%) | 10,958 |
| source-keyed | 5,038,201,950 | 460,379,018 (9.14%) | 4,994 |
| interpolated-keyed | 4,673,371,023 | 82,442,085 (1.76%) | 269 |
| | **-9.7%** | **-86%** | **-98%** |

269 structural parses over 247 distinct patterns is within rounding of optimal — one parse per distinct pattern, plus the dozen `<$var>`/`<~~>` parses the flag correctly refuses to store.

## Testing

- `t/regex/regex-subpattern-parse-memo.t` (new, 18 assertions, **all verified against rakudo v2026.07**): a variable whose value changes between calls (including inside a nested group), a `$<name>` capture form repeated across matches, the `<$var>` assertion form under two values of the same pattern text, `<@var>`, two grammars whose `TOP` bodies are character-for-character identical but whose `<+digit +thing>` folds must resolve in their own package, a grammar declared after an earlier parse, and `<~~>` recursion.
- `cargo fmt --all`, `make lint` — green.
- `make test` — green (4035 files, 42945 tests).
- `make roast` — the only failures are the two documented container-only ones (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`; this container runs as `uid 0`). `litvar.t` passes.

## Found on the way

A `<@var>` regex literal evaluated *before* the array is reassigned later in the same scope already sees the later value — on `main`, with this change both applied and stashed. Filed as #8040; the test's `<@var>` case is deliberately limited to the shape that works, with a pointer to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_