### PR TITLE
fix(runtime): shadow imported proto families

### DIFF
--- a/news/2026-09/imported-proto-shadows-outer-sub.md
+++ b/news/2026-09/imported-proto-shadows-outer-sub.md
@@ -1,0 +1,6 @@
+# Imported proto families shadow enclosing routines
+
+mutsu now gives a block-scoped import of a proto/multi routine family the
+same lexical shadowing behavior as Rakudo. Imported candidates no longer merge
+with an enclosing same-named my sub and recurse into it; the enclosing family
+is restored when the import scope exits.

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -307,6 +307,8 @@ impl Compiler {
         // Bake the positional-param → slot map now, while `local_map` still holds
         // exactly the parameter slots (before the body can shadow them). §1.5.
         sub_compiler.record_param_local_slots(params, param_defs);
+        let import_scope_idx = Self::has_use_stmt(body)
+            .then(|| sub_compiler.code.emit(OpCode::ImportScope { body_end: 0 }));
         // Hoist sub declarations within the sub body
         sub_compiler.mark_lexical_body(body);
         sub_compiler.hoist_sub_decls(body, true);
@@ -473,6 +475,9 @@ impl Compiler {
             Self::compile_routine_body_stmts(&mut sub_compiler, body, true);
         } else {
             Self::compile_routine_body_stmts(&mut sub_compiler, body, false);
+        }
+        if let Some(idx) = import_scope_idx {
+            sub_compiler.code.patch_import_scope_end(idx);
         }
 
         let fingerprint = crate::ast::function_body_fingerprint(params, param_defs, body);
@@ -1143,6 +1148,12 @@ impl Compiler {
         } else {
             None
         };
+        // A callable body executes use at runtime in mutsu. Bracket the body
+        // with an import scope so an imported routine family shadows the
+        // enclosing lexical family only for this invocation and is restored on
+        // return or exception.
+        let import_scope_idx = Self::has_use_stmt(body)
+            .then(|| sub_compiler.code.emit(OpCode::ImportScope { body_end: 0 }));
         // Hoist sub declarations within the closure body
         sub_compiler.mark_lexical_body(body);
         sub_compiler.hoist_sub_decls(body, true);
@@ -1541,6 +1552,9 @@ impl Compiler {
         }
         if let Some(idx) = routine_scope_idx {
             sub_compiler.code.patch_routine_scope_end(idx);
+        }
+        if let Some(idx) = import_scope_idx {
+            sub_compiler.code.patch_import_scope_end(idx);
         }
         // Transfer any compiled functions from the closure to the parent while
         // preserving the declaration-plan references into the imported table.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2474,6 +2474,14 @@ pub(crate) enum OpCode {
         body_end: u32,
     },
 
+    /// Bracket a callable body with a lexical import scope. A use inside a
+    /// routine or closure is executed at call time in mutsu, so the registry
+    /// changes must be restored when the body returns, including a non-local
+    /// return or exception.
+    ImportScope {
+        body_end: u32,
+    },
+
     /// Push an anonymous block callframe onto the routine stack. Emitted around a
     /// genuine bare block `{ ... }` that the compiler *inlines* (tail-position
     /// blocks have no `BlockScope`/`TryCatch` boundary to carry the
@@ -8209,6 +8217,14 @@ impl CompiledCode {
         match &mut self.ops[idx] {
             OpCode::RoutineScope { body_end } => *body_end = target,
             _ => panic!("patch_routine_scope_end on non-RoutineScope opcode"),
+        }
+    }
+
+    pub(crate) fn patch_import_scope_end(&mut self, idx: usize) {
+        let target = self.ops.len() as u32;
+        match &mut self.ops[idx] {
+            OpCode::ImportScope { body_end } => *body_end = target,
+            _ => panic!("patch_import_scope_end on non-ImportScope opcode"),
         }
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4248,6 +4248,17 @@ pub(crate) struct ImportScopeSnapshot {
     pub(crate) classes: HashSet<String>,
     pub(crate) proto_subs: HashSet<String>,
     pub(crate) proto_functions: HashSet<Symbol>,
+    /// Function definitions hidden by an imported proto/multi family in this
+    /// scope. Imports merge multi candidates into one package key, so the
+    /// ordinary key snapshot cannot restore an enclosing candidate that the
+    /// import intentionally shadowed.
+    pub(crate) shadowed_functions: HashMap<Symbol, Arc<FunctionDef>>,
+    /// Proto definitions hidden by an imported proto in this scope.
+    pub(crate) shadowed_proto_functions: HashMap<Symbol, Arc<FunctionDef>>,
+    /// Fully-qualified imported proto names already given shadowing semantics
+    /// in this scope. Multiple imports in one scope still merge candidates;
+    /// only the first import hides the enclosing family.
+    pub(crate) shadowed_proto_names: HashSet<String>,
     /// Exact `env` keys `import_module` wrote as an imported alias while
     /// this scope was on top of `import_scope_stack` (e.g. `&ok`, `$CONST`,
     /// or the importing-package-qualified `&GLOBAL::ok` the trait-value

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -52,6 +52,9 @@ impl Interpreter {
                 classes: reg.classes.keys().cloned().collect(),
                 proto_subs: reg.proto_subs_snapshot().iter().cloned().collect(),
                 proto_functions: reg.proto_functions.keys().copied().collect(),
+                shadowed_functions: HashMap::new(),
+                shadowed_proto_functions: HashMap::new(),
+                shadowed_proto_names: HashSet::new(),
                 imported_env_keys: HashSet::new(),
                 newline_mode: self.newline_mode,
                 strict_mode: self.strict_mode,
@@ -83,6 +86,9 @@ impl Interpreter {
                 classes: class_snapshot,
                 proto_subs: proto_sub_snapshot,
                 proto_functions: proto_fn_snapshot,
+                shadowed_functions,
+                shadowed_proto_functions,
+                shadowed_proto_names: _,
                 imported_env_keys,
                 newline_mode,
                 strict_mode,
@@ -118,6 +124,13 @@ impl Interpreter {
                 let ks = key.resolve();
                 ks.contains("::") && !ks.starts_with("GLOBAL::")
             });
+            // An imported proto/multi family has lexical shadowing semantics,
+            // but its candidates share the importing package's flat registry
+            // keys. Restore any enclosing definitions that the first import in
+            // this scope hid before leaving the scope.
+            self.registry_mut()
+                .functions_mut()
+                .extend(shadowed_functions);
             self.module_registered_functions = module_keys;
             // Same exception for classes: a module's own package-qualified
             // classes (`ScanCacheHelper::ScanCacheThing`) persist as long as the
@@ -150,6 +163,9 @@ impl Interpreter {
                 let ks = key.resolve();
                 ks.contains("::") && !ks.starts_with("GLOBAL::")
             });
+            self.registry_mut()
+                .proto_functions_mut()
+                .extend(shadowed_proto_functions);
             // The `env` half of the same distinction: `import_module` writes
             // an imported symbol's aliased name straight into `env` too (a
             // bare `&ok`/`$CONST`, or the `GLOBAL::name`-qualified form under

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -42,6 +42,68 @@ impl Interpreter {
         }
     }
 
+    /// Hide the candidate family already visible at target_single before an
+    /// imported proto is installed. Raku treats the imported proto as a new
+    /// lexical family, while the flat registry otherwise merges its candidates
+    /// with an enclosing my sub and lets the older declaration win. Keep the
+    /// hidden definitions on the import-scope snapshot so the enclosing family
+    /// is restored when the block exits. Further imports in the same scope are
+    /// allowed to merge with the first imported family.
+    fn shadow_imported_proto_family(&mut self, target_single: &str) {
+        let should_shadow = match self.import_scope_stack.last_mut() {
+            Some(snapshot) => snapshot
+                .shadowed_proto_names
+                .insert(target_single.to_string()),
+            None => false,
+        };
+        if !should_shadow {
+            return;
+        }
+        let prefix = format!("{target_single}/");
+        let visible_keys: HashSet<Symbol> = self
+            .import_scope_stack
+            .last()
+            .map(|snapshot| {
+                snapshot
+                    .functions
+                    .iter()
+                    .filter(|key| **key == *target_single || key.resolve().starts_with(&prefix))
+                    .copied()
+                    .collect()
+            })
+            .unwrap_or_default();
+        let keys: Vec<Symbol> = self
+            .registry()
+            .functions
+            .keys()
+            .filter(|key| visible_keys.contains(key))
+            .copied()
+            .collect();
+        let mut shadowed_functions = HashMap::new();
+        for key in keys {
+            if let Some(def) = self.registry_mut().functions_mut().remove(&key) {
+                shadowed_functions.insert(key, def);
+            }
+        }
+        let proto_key = Symbol::intern(target_single);
+        let proto_was_visible = self
+            .import_scope_stack
+            .last()
+            .is_some_and(|snapshot| snapshot.proto_functions.contains(&proto_key));
+        let shadowed_proto = self
+            .registry_mut()
+            .proto_functions_mut()
+            .remove(&proto_key)
+            .filter(|_| proto_was_visible);
+        if let Some(snapshot) = self.import_scope_stack.last_mut() {
+            snapshot.shadowed_functions.extend(shadowed_functions);
+            if let Some(def) = shadowed_proto {
+                snapshot.shadowed_proto_functions.insert(proto_key, def);
+            }
+        }
+        self.fn_resolve_gen += 1;
+    }
+
     pub(crate) fn record_exported_sub_value(&mut self, package: String, name: String, val: Value) {
         crate::runtime::cow_table_mut(&mut self.exported_sub_values)
             .entry(package)
@@ -391,6 +453,18 @@ impl Interpreter {
             let source_prefix = format!("{module}::{name}/");
             let target_single = format!("{target_pkg}::{name}");
             let target_prefix = format!("{target_pkg}::{name}/");
+            let imported_proto = self
+                .registry()
+                .proto_functions
+                .contains_key(&Symbol::intern(&source_single))
+                || (unit_global_subs.contains_key(&name)
+                    && self
+                        .registry()
+                        .proto_functions
+                        .contains_key(&Symbol::intern(&format!("GLOBAL::{name}"))));
+            if imported_proto {
+                self.shadow_imported_proto_family(&target_single);
+            }
 
             let mut function_entries: Vec<(Symbol, Arc<FunctionDef>)> = self
                 .registry()
@@ -458,14 +532,16 @@ impl Interpreter {
                 .proto_functions
                 .iter()
                 .filter_map(|(k, v)| {
-                    if *k == *source_single {
+                    if *k == *source_single
+                        || (unit_global_subs.contains_key(&name)
+                            && *k == Symbol::intern(&format!("GLOBAL::{name}")))
+                    {
                         Some((Symbol::intern(&target_single), v.clone()))
                     } else {
                         None
                     }
                 })
                 .collect();
-            let imported_proto = !proto_entries.is_empty();
             for (k, v) in proto_entries {
                 self.registry_mut().proto_functions_mut().insert(k, v);
             }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -5261,6 +5261,9 @@ impl Interpreter {
             OpCode::RoutineScope { body_end } => {
                 self.exec_routine_scope_op(code, *body_end, ip, compiled_fns)?;
             }
+            OpCode::ImportScope { body_end } => {
+                self.exec_import_scope_op(code, *body_end, ip, compiled_fns)?;
+            }
 
             OpCode::BlockScope {
                 pre_end,

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -417,6 +417,26 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Run [ip+1..body_end) with a lexical import scope saved and restored.
+    /// use is runtime-executed in callable bodies, but its registry effects
+    /// are lexical to that body. Restore the scope on both success and error so
+    /// an escaping return or exception cannot leak imported routines.
+    pub(super) fn exec_import_scope_op(
+        &mut self,
+        code: &CompiledCode,
+        body_end: u32,
+        ip: &mut usize,
+        compiled_fns: &CompiledFns,
+    ) -> Result<(), RuntimeError> {
+        let end = body_end as usize;
+        self.push_import_scope();
+        let result = self.run_range(code, *ip + 1, end, compiled_fns);
+        self.pop_import_scope();
+        result?;
+        *ip = end;
+        Ok(())
+    }
+
     pub(super) fn exec_block_scope_op(
         &mut self,
         code: &CompiledCode,

--- a/t/lib/ImportedProtoShadow.rakumod
+++ b/t/lib/ImportedProtoShadow.rakumod
@@ -1,0 +1,3 @@
+unit module ImportedProtoShadow;
+my proto sub thing(|) is export {*}
+multi sub thing(Str() $s) { "inner3(" ~ $s ~ ")" }

--- a/t/modules/import-export/imported-proto-shadows-outer-sub.t
+++ b/t/modules/import-export/imported-proto-shadows-outer-sub.t
@@ -1,0 +1,17 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+plan 2;
+
+my sub thing(Str() $s) { "outer($s)" }
+
+sub wrapper() {
+    use ImportedProtoShadow;
+    "wrapped:" ~ thing("x");
+}
+
+is wrapper(), 'wrapped:inner3(x)',
+    'an imported proto/multi family shadows an enclosing sub';
+is thing('y'), 'outer(y)',
+    'the enclosing sub remains after the importing routine returns';


### PR DESCRIPTION
Closes #7994

## Summary

- add a VM import-scope opcode for callable bodies containing runtime `use` statements
- hide an enclosing routine family before importing a proto/multi family and restore it when the scope exits
- add a regression test covering the recursion case and post-scope restoration

## Validation

- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast