### PR TITLE
fix(nativecall): expose the TEST library helper

### DIFF
--- a/news/2026-09/nativecall-test-tag.md
+++ b/news/2026-09/nativecall-test-tag.md
@@ -1,0 +1,6 @@
+# NativeCall exposes its TEST library helper
+
+mutsu now supports NativeCall's :TEST export tag and provides the
+guess_library_name helper with its string, versioned, list, callable, and
+path forms. Unknown NativeCall export tags continue to raise
+X::Import::NoSuchTag.

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -86,7 +86,7 @@ class GLOBAL::NativeCall::CStr {
 }
 "#;
 
-/// NativeCall's five exported helper routines, each with the name that gates
+/// NativeCall's six exported helper routines, each with the name that gates
 /// its injection.
 ///
 /// **None of these is a Raku builtin.** Rakudo exports them from
@@ -98,8 +98,8 @@ class GLOBAL::NativeCall::CStr {
 /// pass or wrap. The marshalling stays in Rust behind a `__mutsu_`-prefixed
 /// primitive that is not part of the user-visible surface.
 ///
-/// Injected per entry, so a program that declares its own `sub refresh` keeps
-/// the other four (see `inject_nativecall_subs_prelude`).
+/// Injected per entry, so a program that declares its own sub refresh keeps
+/// the other five (see inject_nativecall_subs_prelude).
 ///
 /// None is `is export`, even though Rakudo declares them `is export(:DEFAULT)`:
 /// a prelude is spliced into the *host* compunit, so an `is export` here would
@@ -172,6 +172,30 @@ our sub explicitly-manage(Str $str, :$encoding = 'utf8') {
         "refresh",
         r#"
 our sub refresh($obj) { 1 }
+"#,
+    ),
+    (
+        "guess_library_name",
+        r#"
+our proto guess_library_name(|) { * }
+multi guess_library_name(IO::Path $lib) {
+    guess_library_name($lib.absolute.Str)
+}
+multi guess_library_name(Callable $lib) {
+    guess_library_name($lib())
+}
+multi guess_library_name(List $lib) {
+    guess_library_name($lib[0], $lib[1])
+}
+multi guess_library_name(Str $libname, $apiversion = '') {
+    $libname.DEFINITE
+        ?? $libname ~~ /[\.<.alpha>+ | \.so [\.<.digit>+]+ ] $/
+            ?? $libname
+            !! $*VM.platform-library-name(
+                $libname.IO, :version($apiversion || Version)
+            ).Str
+        !! ''
+}
 "#,
     ),
 ];

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -72,11 +72,11 @@ impl Interpreter {
         *stmts = combined;
     }
 
-    /// Prepend NativeCall's exported helper routines — `cglobal`, `nativecast`,
-    /// `nativesizeof`, `explicitly-manage`, `refresh` — to a program that uses
-    /// NativeCall and calls them.
+    /// Prepend NativeCall's exported helper routines — cglobal, nativecast,
+    /// nativesizeof, explicitly-manage, refresh, guess_library_name — to a
+    /// program that uses NativeCall and calls them.
     ///
-    /// None of the five is a Raku builtin: Rakudo exports them from
+    /// None of the six is a Raku builtin: Rakudo exports them from
     /// `NativeCall.rakumod`, and mutsu's working agreement puts a routine in the
     /// builtin set only if `Language/perl-func.rakudoc` lists it. Injecting them
     /// as ordinary `our sub`s is what makes them importable rather than ambient,
@@ -95,6 +95,7 @@ impl Interpreter {
         if !source.contains("NativeCall") {
             return;
         }
+        let test_tag_requested = source.contains("use NativeCall :TEST");
         use std::sync::OnceLock;
         static SUB_STMTS: OnceLock<Vec<Vec<Stmt>>> = OnceLock::new();
         let parsed = SUB_STMTS.get_or_init(|| {
@@ -111,7 +112,10 @@ impl Interpreter {
         });
         let mut prelude: Vec<Stmt> = Vec::new();
         for ((name, _), decl) in NATIVECALL_SUB_PRELUDES.iter().zip(parsed) {
-            if source.contains(name) && !Self::declares_toplevel_sub(stmts, name) {
+            if source.contains(name)
+                && (*name != "guess_library_name" || test_tag_requested)
+                && !Self::declares_toplevel_sub(stmts, name)
+            {
                 prelude.extend(decl.iter().cloned());
             }
         }

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -241,8 +241,8 @@ impl Interpreter {
     /// the re-export silently did nothing.
     ///
     /// The list is Rakudo's `NativeCall.rakumod` / `NativeCall::Types` export
-    /// set: the trait that makes a sub native, the four helper routines, and the
-    /// C type objects.
+    /// set: the trait that makes a sub native, the five DEFAULT helper
+    /// routines, the TEST-only library-name helper, and the C type objects.
     ///
     /// A module loaded from source populates `exported_subs` as its `is export`
     /// declarations are registered, and `package_stash_value` builds
@@ -278,13 +278,12 @@ impl Interpreter {
         for name in SUBS {
             self.register_exported_sub("NativeCall".to_string(), name.to_string(), Vec::new());
         }
-        // `guess_library_name` is a routine, but it is spelled `&…` by consumers
-        // and lives with the types in Rakudo's export map; registering it in both
-        // sets keeps either spelling resolvable.
+        // guess_library_name is a TEST-only routine in Rakudo. It is kept out
+        // of DEFAULT so use NativeCall :TEST is the import that exposes it.
         self.register_exported_sub(
             "NativeCall".to_string(),
             "guess_library_name".to_string(),
-            Vec::new(),
+            vec!["TEST".to_string()],
         );
         for name in TYPES {
             self.register_exported_var("NativeCall".to_string(), name.to_string(), Vec::new());

--- a/t/nativecall/nativecall-test-tag.t
+++ b/t/nativecall/nativecall-test-tag.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+plan 9;
+
+use NativeCall :TEST;
+
+is guess_library_name('libm.so.6', v1), 'libm.so.6',
+    'the TEST export accepts the Str plus Version form';
+is guess_library_name(('libm.so.6', v1)), 'libm.so.6',
+    'the TEST export accepts the ABI-version List form';
+is guess_library_name(-> { 'libm.so.6' }), 'libm.so.6',
+    'the TEST export accepts a Callable library name';
+like guess_library_name('libm.so.6'.IO), /'libm.so.6'$/,
+    'the TEST export accepts an IO::Path library name';
+is guess_library_name(Str), '',
+    'an undefined Str type object has no library name';
+like guess_library_name('m', v1), /'libm.so.' || '.dylib' || '.dll'/,
+    'a library stem is decorated for the current platform';
+throws-like {
+    EVAL 'use NativeCall :NOSUCHTAG; 1';
+}, X::Import::NoSuchTag, 'unknown NativeCall tags are still rejected';
+my $proc = run($*EXECUTABLE, '-e', 'use NativeCall; say guess_library_name("m")',
+    :out, :err);
+$proc.out.slurp(:close);
+my $err = $proc.err.slurp(:close);
+nok $proc.so, 'guess_library_name is not exposed by the DEFAULT tag';
+like $err, /guess_library_name/, 'the missing TEST import is reported';


### PR DESCRIPTION
Closes #7997

Implement NativeCall's :TEST export tag and expose guess_library_name with the string, versioned, list, callable, and IO::Path forms used by ecosystem distributions. Keep the helper out of the DEFAULT export and preserve X::Import::NoSuchTag for unknown tags.

Validation:
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast