### PR TITLE
fix: give role mixins a live attribute cell

### DIFF
--- a/docs/adr/0089-role-mixins-own-a-separate-attribute-cell.md
+++ b/docs/adr/0089-role-mixins-own-a-separate-attribute-cell.md
@@ -1,6 +1,6 @@
 # ADR-0089: A role mixin owns an attribute cell separate from its wrapped value
 
-- **Status**: Proposed (revised after design review on 2026-09-12)
+- **Status**: Accepted and implemented (2026-09-12)
 - **Date**: 2026-09-12
 - **Related**: [ADR-0013](0013-container-interior-mutability-cellvalue.md) (one
   authoritative interior-mutable cell),

--- a/news/2026-09/mixin-role-attribute-cell.md
+++ b/news/2026-09/mixin-role-attribute-cell.md
@@ -1,0 +1,7 @@
+# Role mixins keep live attributes on non-instance values
+
+Role attributes mixed onto hashes, arrays, native scalars, and wrapped
+instances now use a shared live cell owned by the mixin. Compiled method
+writes persist across calls, remain visible through public accessors, stay
+separate from same-named class or other-role attributes, and are copied by
+Raku `.clone` into independent role state.

--- a/src/builtins/arith/range.rs
+++ b/src/builtins/arith/range.rs
@@ -207,7 +207,7 @@ where
         ValueView::Mixin(inner, mixins) if inner.is_range() => {
             let inner_val = (**inner).clone();
             let mix_clone = (**mixins).clone();
-            Some(op(inner_val, right).map(|r| Value::mixin(r, mix_clone)))
+            Some(op(inner_val, right).map(|r| Value::mixin_with_state(r, mix_clone)))
         }
         _ => None,
     }
@@ -221,7 +221,7 @@ where
     match left.view() {
         ValueView::Mixin(inner, mixins) if inner.is_range() => {
             let result = op((**inner).clone(), right);
-            Some(Value::mixin(result, (**mixins).clone()))
+            Some(Value::mixin_with_state(result, (**mixins).clone()))
         }
         _ => None,
     }

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -717,7 +717,20 @@ pub(crate) fn native_method_0arg(
                 Some(Err(e)) => return Some(Err(e)),
                 None => inner.as_ref().clone(),
             };
-            return Some(Ok(Value::mixin(inner_clone, mixins.as_ref().clone())));
+            return Some(Ok(Value::mixin_with_state(
+                inner_clone,
+                mixins.as_ref().clone(),
+            )));
+        }
+        // Role mixins need the interpreter-backed clone path below so their
+        // private role cell is deep-copied. Delegating this one method to the
+        // native inner value would silently drop the wrapper.
+        if method == "clone"
+            && mixins
+                .keys()
+                .any(|k| k.starts_with("__mutsu_role__") || k.starts_with("__mutsu_attr__"))
+        {
+            return None;
         }
         // Check for mixin key matching the method name (e.g. "Array", "List", "Int", etc.)
         // This handles `True but [1, 2]` where `.Array` should return the mixed-in array.

--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -50,7 +50,10 @@ impl Interpreter {
         // Handle Mixin targets (e.g. `&b does R` followed by `push &b.s, val`).
         if let ValueView::Mixin(inner, mixins) = target.view() {
             let attr_key = format!("__mutsu_attr__{}", attr_name);
-            if let Some(current) = mixins.get(&attr_key).cloned() {
+            if let Some(current) = mixins
+                .role_attribute_by_name(&attr_name)
+                .or_else(|| mixins.get(&attr_key).cloned())
+            {
                 let old_array_arc = match current.view() {
                     ValueView::Array(arc, ..) => Some(arc.clone()),
                     _ => None,

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -512,7 +512,9 @@ impl Interpreter {
         args: Vec<Value>,
         invocant: Option<Value>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
-        let cell = invocant.as_ref().and_then(Self::self_instance_attrs);
+        let cell = invocant
+            .as_ref()
+            .and_then(|value| self.method_attr_cell(value, owner_class));
         // Non-instance invocant (no live cell): keep the entry snapshot as the
         // unadjusted fallback map, mirroring the pre-Option return contract.
         let fallback = if cell.is_none() {

--- a/src/runtime/json.rs
+++ b/src/runtime/json.rs
@@ -157,11 +157,11 @@ fn jsonify(val: &Value, opts: &ToJsonOpts, level: usize, out: &mut String) {
             // string. A bare-role pun keeps its attrs in the mixin map.
             if mixins.contains_key("__mutsu_role__Rational")
                 && let (Some(n), Some(d)) = (
-                    mixins.get("__mutsu_attr__numerator"),
-                    mixins.get("__mutsu_attr__denominator"),
+                    mixins.role_attribute("Rational", "numerator"),
+                    mixins.role_attribute("Rational", "denominator"),
                 )
             {
-                jsonify(&rational_as_rat(n, d), opts, level, out);
+                jsonify(&rational_as_rat(&n, &d), opts, level, out);
             } else {
                 jsonify(inner, opts, level, out);
             }

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -4458,7 +4458,10 @@ impl Interpreter {
         if let ValueView::Mixin(inner, mixins) = target.view() {
             if args.is_empty() {
                 let attr_key = format!("__mutsu_attr__{}", method);
-                if let Some(value) = mixins.get(&attr_key) {
+                if let Some(value) = mixins
+                    .role_attribute_by_name(method)
+                    .or_else(|| mixins.get(&attr_key).cloned())
+                {
                     return Ok(value.clone());
                 }
             }

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -102,6 +102,57 @@ impl Interpreter {
             .any(|role_name| self.role_has_method(role_name, method_name))
     }
 
+    /// Commit the merged attribute snapshot returned by a role method to the
+    /// two stores it may contain. The method frame deliberately presents one
+    /// flat namespace to the Raku body, but a role's attributes belong to the
+    /// Mixin-owned cell while attributes inherited from the wrapped instance
+    /// belong to that instance's cell. Committing the merged snapshot to one
+    /// cell would leak class attributes into the role cell (and would replace
+    /// owner-qualified role keys with bare names).
+    pub(crate) fn commit_mixin_role_method_attrs(
+        &self,
+        mixins: &crate::value::MixinOverrides,
+        role_name: &str,
+        role: &RoleDef,
+        inner_cell: Option<&crate::gc::Gc<crate::value::InstanceAttrs>>,
+        updated: AttrMap,
+    ) {
+        let role_attr_names: Vec<Symbol> = role
+            .attributes
+            .iter()
+            .map(|attr| Symbol::intern(&attr.name))
+            .collect();
+        for attr in &role.attributes {
+            if let Some(value) = updated.get(Symbol::intern(&attr.name)) {
+                mixins.set_role_attribute(role_name, &attr.name, value.clone());
+            }
+        }
+        let Some(inner_cell) = inner_cell else {
+            return;
+        };
+
+        // `run_resolved_method_compiled_or_treewalk` returns only attributes
+        // whose frame slots were dirty, rather than a complete copy of the
+        // input map. Start with the live inner snapshot so an otherwise
+        // untouched class attribute cannot disappear on a role call.
+        let mut inner_updated = inner_cell.to_map();
+        for (key, value) in &updated {
+            if !role_attr_names.contains(key) {
+                inner_updated.insert(*key, value.clone());
+            }
+        }
+        // A role attribute can shadow a same-named class attribute in the
+        // merged frame. Preserve the class cell's current value, including a
+        // mutation made by nextsame/callsame, instead of writing the role value
+        // into the class-owned cell.
+        for key in &role_attr_names {
+            if let Some(value) = inner_cell.as_map().get(*key) {
+                inner_updated.insert(*key, value.clone());
+            }
+        }
+        inner_cell.commit_attrs(inner_updated);
+    }
+
     /// Dispatch method calls on Mixin targets.
     /// Returns Some(result) if the method was handled, None if not.
     pub(crate) fn dispatch_mixin_method_call(
@@ -114,14 +165,13 @@ impl Interpreter {
             return None;
         };
 
-        // `.clone` on a role mixin. A punned role's attributes live in
-        // `__mutsu_attr__*` mixin markers, not the inner instance's attr map (see
-        // `dispatch_new` — a bare-role `.new` returns `Mixin(empty-instance,
-        // {__mutsu_attr__x: ...})`). The generic instance clone unwraps to the
-        // inner value and drops every marker, so the clone lost all attributes
-        // (`Zef::Client.fetch`'s `$candi.clone(:$dist)` then had no `.as`). Clone
-        // the mixin instead: recursively clone the inner value, copy every marker,
-        // and apply each `:attr(val)` override to its `__mutsu_attr__` marker.
+        // `.clone` on a role mixin. A punned role's `__mutsu_attr__*` entries are
+        // construction seeds for the Mixin-owned role cell, not the live state.
+        // The generic instance clone unwraps to the inner value and drops the
+        // role composition, so the clone lost all attributes (`Zef::Client.fetch`'s
+        // `$candi.clone(:$dist)` then had no `.as`). Clone the mixin instead:
+        // recursively clone the inner value, deep-copy the role cell, copy every
+        // marker, and apply each `:attr(val)` override to the new role cell.
         // Restricted to role mixins (a `__mutsu_role__`/`__mutsu_attr__` marker is
         // present) so allomorph / non-role `but` mixins keep their existing path.
         if method == "clone"
@@ -130,15 +180,14 @@ impl Interpreter {
                 .any(|k| k.starts_with("__mutsu_role__") || k.starts_with("__mutsu_attr__"))
         {
             let inner_owned = inner.as_ref().clone();
-            let mut new_mixins: HashMap<String, Value> = mixins.as_ref().clone();
+            let mut new_mixins = mixins.as_ref().clone();
             // An override names either a role attribute (a `__mutsu_attr__`
             // marker) or an attribute of the inner class. Apply the former to the
             // marker; forward the rest to the inner clone so `$w.clone(:id(99))`
             // on a `Widget but Named` still overrides Widget's own `$.id`.
-            // A punned role's attributes also live in the inner instance's own
-            // cell (that is what `$!attr` reads), so an override that lands on a
-            // marker must reach the cell too — otherwise the accessor, which
-            // prefers the cell, keeps serving the pre-clone value.
+            // An override that lands on a role marker must reach the deep-copied
+            // role cell too — otherwise the accessor would keep serving the
+            // pre-clone value from that cell.
             let inner_attrs = Self::self_instance_attrs(inner);
             let mut inner_args: Vec<Value> = Vec::new();
             for arg in &args {
@@ -147,9 +196,13 @@ impl Interpreter {
                         new_mixins.entry(format!("__mutsu_attr__{}", key))
                 {
                     e.insert(val.clone());
+                    let attr = Symbol::intern(key);
+                    if new_mixins.set_role_attribute_by_name(key, val.clone()) {
+                        continue;
+                    }
                     let in_cell = inner_attrs
                         .as_ref()
-                        .is_some_and(|c| c.as_map().contains_key(Symbol::intern(key)));
+                        .is_some_and(|c| c.as_map().contains_key(attr));
                     if !in_cell {
                         continue;
                     }
@@ -160,7 +213,7 @@ impl Interpreter {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };
-            return Some(Ok(Value::mixin(inner_clone, new_mixins)));
+            return Some(Ok(Value::mixin_with_state(inner_clone, new_mixins)));
         }
 
         if method == "of"
@@ -201,13 +254,33 @@ impl Interpreter {
                             })
                         });
                 if is_public {
-                    // The marker is only the construction-time seed. If the
-                    // wrapped instance carries the attribute, that cell is the
-                    // store of record — a `$!foo = ...` inside a role method
-                    // writes there, and the accessor must not serve the stale
-                    // seed afterwards.
+                    // Role attributes live in the Mixin-owned cell. The
+                    // wrapped instance is only the fallback for an attribute
+                    // belonging to the wrapped class with the same public
+                    // spelling.
+                    let attr = Symbol::intern(method);
+                    let role_live = mixins
+                        .keys()
+                        .filter_map(|key| key.strip_prefix("__mutsu_role__"))
+                        .filter_map(|role_name| {
+                            self.registry()
+                                .roles
+                                .get(role_name)
+                                .cloned()
+                                .map(|role| (role_name.to_string(), role))
+                        })
+                        .find_map(|(role_name, role)| {
+                            role.attributes
+                                .iter()
+                                .any(|attr| attr.name == method && attr.is_public)
+                                .then(|| mixins.role_attribute(&role_name, method))
+                                .flatten()
+                        });
+                    if let Some(live) = role_live {
+                        return Some(Ok(live));
+                    }
                     if let Some(cell) = Self::self_instance_attrs(inner)
-                        && let Some(live) = cell.as_map().get(Symbol::intern(method))
+                        && let Some(live) = cell.as_map().get(attr)
                     {
                         return Some(Ok(live.clone()));
                     }
@@ -303,6 +376,11 @@ impl Interpreter {
                     }
                     _ => (None, AttrMap::new()),
                 };
+                for attr in &role.attributes {
+                    if let Some(value) = mixins.role_attribute(&role_name, &attr.name) {
+                        method_attrs.insert(attr.name.clone(), value);
+                    }
+                }
                 for (key, value) in mixins.iter() {
                     if let Some(attr) = key.strip_prefix("__mutsu_attr__") {
                         let sym = Symbol::intern(attr);
@@ -375,16 +453,19 @@ impl Interpreter {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
-                // Propagate attribute mutations made by the role method back to
-                // the inner instance, so that changes to class attributes (e.g.
-                // `push @.order, ...`) are visible after the call returns. This
-                // updates every binding in scope that holds the same instance
-                // (including the one wrapped inside this Mixin).
-                //
-                // A role's OWN attributes on a mixin over a non-Instance value
-                // (`%h does R`) have no store to come back to at all — see
-                // tokuhirom/mutsu#8026.
-                if let Some(cell) = &inner_cell {
+                // Propagate attribute mutations made by the role method to the
+                // owner-selected store. Role attributes go to the Mixin-owned
+                // cell; class attributes go to the wrapped instance cell. This
+                // updates every binding in scope that holds the same store.
+                if self.is_role(&role_name) {
+                    self.commit_mixin_role_method_attrs(
+                        mixins,
+                        &role_name,
+                        &role,
+                        inner_cell.as_ref(),
+                        updated,
+                    );
+                } else if let Some(cell) = &inner_cell {
                     cell.commit_attrs(updated);
                 }
                 return Some(Ok(result));

--- a/src/runtime/methods_mixin_what_cache.rs
+++ b/src/runtime/methods_mixin_what_cache.rs
@@ -51,7 +51,7 @@ impl Interpreter {
             .mixin_what_cache
             .entry(key)
             .or_insert_with(|| {
-                crate::gc::Gc::new(crate::value::types::filter_composition_markers(mixins))
+                crate::gc::Gc::new(crate::value::types::filter_composition_markers(mixins).into())
             })
             .clone()
     }
@@ -96,7 +96,7 @@ impl Interpreter {
         role_name: &str,
     ) -> Result<Value, RuntimeError> {
         self.ensure_role_punned_to_class(role_name)?;
-        let mut mixins: crate::value::MixinOverrides = HashMap::new();
+        let mut mixins: crate::value::MixinOverrides = HashMap::new().into();
         mixins.insert(format!("__mutsu_role__{role_name}"), Value::TRUE);
         // Mirrors `mark_punned_role_instance`'s own role-id lookup so a
         // punned instance's `.WHAT` and `^pun`'s return value key to the

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -1,40 +1,11 @@
 use super::*;
-use crate::symbol::Symbol;
-
 impl Interpreter {
-    /// Mirror an accessor write to a role-mixin attribute into the wrapped
-    /// instance's own cell.
-    ///
-    /// The `__mutsu_attr__` mixin entries are construction-time seeds; the cell
-    /// is the store of record, because that is what a private access (`$!attr`)
-    /// inside a role method reads and writes. A write that only updated the
-    /// mixin map would be invisible to `$!attr`, and the next accessor read —
-    /// which prefers the cell — would serve the stale seed.
-    fn sync_mixin_attr_to_instance(inner: &Value, attr: &str, value: &Value) {
-        let Some(cell) = Self::self_instance_attrs(inner) else {
-            return;
-        };
-        let sym = Symbol::intern(attr);
-        // Only mirror an attribute the instance already carries: a `but Role`
-        // mixin over an unrelated object must not gain attributes it never had.
-        if !cell.as_map().contains_key(sym) {
-            return;
-        }
-        let mut map = cell.to_map();
-        map.insert(attr, value.clone());
-        cell.commit_attrs(map);
-    }
-
     /// Whether the role attribute backing a mixin override key
     /// (`__mutsu_attr__{method}`) is declared `is rw`. Scans the mixin's
     /// `__mutsu_role__*` entries for a role that declares the attribute; an
     /// ad-hoc mixin with no declaring role stays writable (matching the
     /// lenient ad-hoc branch of the Instance mixin path).
-    fn mixin_attr_is_rw(
-        &self,
-        mixins: &std::collections::HashMap<String, Value>,
-        method: &str,
-    ) -> bool {
+    fn mixin_attr_is_rw(&self, mixins: &crate::value::MixinOverrides, method: &str) -> bool {
         let mut found_attr = false;
         for role_name in mixins
             .keys()
@@ -53,6 +24,20 @@ impl Interpreter {
             }
         }
         !found_attr
+    }
+
+    fn mixin_has_public_attr(&self, mixins: &crate::value::MixinOverrides, method: &str) -> bool {
+        mixins
+            .keys()
+            .filter_map(|key| key.strip_prefix("__mutsu_role__"))
+            .any(|role_name| {
+                let base = role_name.split('[').next().unwrap_or(role_name);
+                [role_name, base].iter().any(|candidate| {
+                    self.collect_role_attributes_for_class(candidate)
+                        .iter()
+                        .any(|attr| attr.name == method && attr.is_public)
+                })
+            })
     }
 
     /// `Pair.freeze`: decontainerize the pair's value (severing any
@@ -961,7 +946,7 @@ impl Interpreter {
                     }
                     let mut updated = (**mixins).clone();
                     updated.insert(mixin_attr_key, value.clone());
-                    Self::sync_mixin_attr_to_instance(minner, method, &value);
+                    updated.set_role_attribute_by_name(method, value.clone());
                     *cell.lock().unwrap() =
                         Value::mixin_parts(minner.clone(), crate::gc::Gc::new(updated));
                     return Ok(value);
@@ -979,56 +964,37 @@ impl Interpreter {
 
         // Handle Mixin-wrapped instances (e.g. from role punning) by updating
         // the mixin attribute entry directly.
-        if let ValueView::Mixin(inner, mixins) = target.view()
-            && let ValueView::Instance { class_name, .. } = inner.as_ref().view()
-        {
+        if let ValueView::Mixin(inner, mixins) = target.view() {
             let mixin_attr_key = format!("__mutsu_attr__{}", method);
-            // Check if the role attribute is public and rw before allowing assignment
-            let cn = class_name.resolve();
-            let role_attrs = self.collect_role_attributes_for_class(&cn);
-            for attr in &role_attrs {
-                if attr.name == method && attr.is_public {
-                    if !attr.is_rw && attr.sigil != '@' && attr.sigil != '%' {
-                        return Err(RuntimeError::new(format!(
-                            "X::Assignment::RO: method '{}' is not rw",
-                            method
-                        )));
-                    }
-                    let mut updated_mixins = (**mixins).clone();
-                    updated_mixins.insert(
-                        if mixins.contains_key(&mixin_attr_key) {
-                            mixin_attr_key
-                        } else {
-                            format!("__mutsu_attr__{}", method)
-                        },
-                        value.clone(),
-                    );
-                    Self::sync_mixin_attr_to_instance(inner, method, &value);
-                    let new_mixin =
-                        Value::mixin_parts(inner.clone(), crate::gc::Gc::new(updated_mixins));
-                    if let Some(var_name) = target_var {
-                        self.env
-                            .insert_through(var_name.to_string(), new_mixin.clone());
-                    }
-                    // Inside a trait_mod the rebuilt Mixin must also refresh the
-                    // writeback capture (same convention as DoesVar): the value
-                    // DoesVar captured predates this assignment and would hand
-                    // the trait's caller a mixin missing it (JSON::Name's
-                    // `$a.json-name = $json-name` right after `$a does ...`).
-                    if self.trait_mod_writeback_key.is_some()
-                        && self.trait_mod_writeback_value.is_some()
-                    {
-                        self.trait_mod_writeback_value = Some(new_mixin);
-                    }
-                    return Ok(value);
+            if mixins.contains_key(&mixin_attr_key) && self.mixin_has_public_attr(mixins, method) {
+                if !self.mixin_attr_is_rw(mixins, method) {
+                    return Err(RuntimeError::new(format!(
+                        "X::Assignment::RO: method '{}' is not rw",
+                        method
+                    )));
                 }
+                let mut updated_mixins = (**mixins).clone();
+                updated_mixins.insert(mixin_attr_key, value.clone());
+                updated_mixins.set_role_attribute_by_name(method, value.clone());
+                let new_mixin =
+                    Value::mixin_parts(inner.clone(), crate::gc::Gc::new(updated_mixins));
+                if let Some(var_name) = target_var {
+                    self.env
+                        .insert_through(var_name.to_string(), new_mixin.clone());
+                }
+                if self.trait_mod_writeback_key.is_some()
+                    && self.trait_mod_writeback_value.is_some()
+                {
+                    self.trait_mod_writeback_value = Some(new_mixin);
+                }
+                return Ok(value);
             }
             // If we have the mixin key but didn't find a matching role attribute,
             // still allow the update (e.g. for ad-hoc mixins)
             if mixins.contains_key(&mixin_attr_key) {
                 let mut updated_mixins = (**mixins).clone();
                 updated_mixins.insert(mixin_attr_key, value.clone());
-                Self::sync_mixin_attr_to_instance(inner, method, &value);
+                updated_mixins.set_role_attribute_by_name(method, value.clone());
                 let new_mixin =
                     Value::mixin_parts(inner.clone(), crate::gc::Gc::new(updated_mixins));
                 if let Some(var_name) = target_var {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -630,14 +630,14 @@ impl Interpreter {
                 crate::value::ValueView::Mixin(inner, existing) => {
                     (inner.as_ref().clone(), (**existing).clone())
                 }
-                _ => (base.clone(), HashMap::new()),
+                _ => (base.clone(), HashMap::new().into()),
             };
             for map in &override_maps {
                 for (k, v) in map {
                     mixins.insert(k.clone(), v.clone());
                 }
             }
-            attrs.insert(attr_name, Value::mixin(inner, mixins));
+            attrs.insert(attr_name, Value::mixin_with_state(inner, mixins));
         }
     }
 

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -778,9 +778,16 @@ impl Interpreter {
                     } else {
                         AttrMap::new()
                     };
+                for attr in &role.attributes {
+                    if let Some(value) = mixins.role_attribute(qualifier, &attr.name) {
+                        role_attrs.insert(attr.name.clone(), value);
+                    }
+                }
                 for (key, value) in mixins.iter() {
                     if let Some(attr) = key.strip_prefix("__mutsu_attr__") {
-                        role_attrs.insert(attr.to_string(), value.clone());
+                        role_attrs
+                            .entry(attr.to_string())
+                            .or_insert_with(|| value.clone());
                     }
                 }
                 let mut saved: Vec<(String, Option<Value>)> = Vec::new();
@@ -804,7 +811,21 @@ impl Interpreter {
                         self.env.remove(&name);
                     }
                 }
-                return Some(res.map(|(result, _updated)| result));
+                return Some(res.map(|(result, updated)| {
+                    if mixins.contains_key(&format!("__mutsu_role__{qualifier}")) {
+                        let inner_cell = Self::self_instance_attrs(inner.as_ref());
+                        self.commit_mixin_role_method_attrs(
+                            mixins,
+                            qualifier,
+                            &role,
+                            inner_cell.as_ref(),
+                            updated,
+                        );
+                    } else if let Some(cell) = self.method_attr_cell(target, qualifier) {
+                        cell.commit_attrs(updated);
+                    }
+                    result
+                }));
             }
         }
 
@@ -861,7 +882,12 @@ impl Interpreter {
                     args,
                     Some(target.clone()),
                 );
-                return Some(res.map(|(result, _updated)| result));
+                return Some(res.map(|(result, updated)| {
+                    if let Some(cell) = self.method_attr_cell(target, qualifier) {
+                        cell.commit_attrs(updated);
+                    }
+                    result
+                }));
             }
             // Last resort: qualifier is a native builtin ancestor of the mixin's
             // inner instance (e.g. `self.IO::Path::slurp` where `self` is a

--- a/src/runtime/promise_broken_gist.rs
+++ b/src/runtime/promise_broken_gist.rs
@@ -59,7 +59,7 @@ impl Interpreter {
         Some(if remaining.is_empty() {
             inner
         } else {
-            Value::mixin(inner, remaining)
+            Value::mixin_with_state(inner, remaining)
         })
     }
 

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -64,7 +64,7 @@ impl Interpreter {
         }
         let (inner, mut mixins) = match sub_val.view() {
             ValueView::Mixin(inner, existing) => (inner.as_ref().clone(), (**existing).clone()),
-            _ => (sub_val, HashMap::new()),
+            _ => (sub_val, HashMap::new().into()),
         };
         for role_name in &roles {
             mixins.insert(format!("__mutsu_role__{role_name}"), Value::TRUE);
@@ -86,12 +86,12 @@ impl Interpreter {
                 );
             }
         }
-        Value::mixin(inner, mixins)
+        Value::mixin_with_state(inner, mixins)
     }
 
     pub(crate) fn role_def_for_mixin_role(
         &self,
-        mixins: &std::collections::HashMap<String, Value>,
+        mixins: &crate::value::MixinOverrides,
         role_name: &str,
     ) -> Option<RoleDef> {
         let role_id = mixins
@@ -214,7 +214,7 @@ impl Interpreter {
 
     pub(crate) fn delegated_role_attr_key_from_mixins(
         &self,
-        mixins: &std::collections::HashMap<String, Value>,
+        mixins: &crate::value::MixinOverrides,
         method_name: &str,
     ) -> Option<String> {
         for role_name in mixins
@@ -238,6 +238,45 @@ impl Interpreter {
                     let attr_name = attr_var_name.trim_start_matches(['.', '!']);
                     return Some(format!("__mutsu_attr__{attr_name}"));
                 }
+            }
+        }
+        None
+    }
+
+    /// Return the live role attribute used by a `handles` delegation method.
+    /// The `__mutsu_attr__*` entry is only a construction seed; reads must use
+    /// the owner-qualified role cell so a delegated container mutation remains
+    /// visible through every alias of the Mixin.
+    pub(crate) fn delegated_role_attr_value_from_mixins(
+        &self,
+        mixins: &crate::value::MixinOverrides,
+        method_name: &str,
+    ) -> Option<Value> {
+        for role_name in mixins
+            .keys()
+            .filter_map(|key| key.strip_prefix("__mutsu_role__"))
+        {
+            let Some(role) = self.role_def_for_mixin_role(mixins, role_name) else {
+                continue;
+            };
+            let Some(method_defs) = role.methods.get(method_name) else {
+                continue;
+            };
+            for method_def in method_defs {
+                let Some((attr_var_name, target_method)) = &method_def.delegation else {
+                    continue;
+                };
+                if attr_var_name.starts_with('&') || target_method != method_name {
+                    continue;
+                }
+                let attr_name = attr_var_name.trim_start_matches(['.', '!']);
+                let marker = format!("__mutsu_attr__{attr_name}");
+                if !mixins.contains_key(&marker) {
+                    continue;
+                }
+                return mixins
+                    .role_attribute(role_name, attr_name)
+                    .or_else(|| mixins.get(&marker).cloned());
             }
         }
         None
@@ -361,7 +400,7 @@ impl Interpreter {
                 .entry(format!("__mutsu_role_group__{name}"))
                 .or_insert_with(|| Value::int(group));
         }
-        Value::mixin(inner.as_ref().clone(), mixins)
+        Value::mixin_with_state(inner.as_ref().clone(), mixins)
     }
 
     /// Open an application group that the next runs of
@@ -703,7 +742,7 @@ impl Interpreter {
         let (inner, mut mixins) = if let ValueView::Mixin(inner, existing) = left.view() {
             (inner.as_ref().clone(), (**existing).clone())
         } else {
-            (left, HashMap::new())
+            (left, HashMap::new().into())
         };
         mixins.insert(format!("__mutsu_role__{}", role_name), Value::TRUE);
         // A monotonic application-order stamp: Rakudo resolves a method-name
@@ -870,7 +909,7 @@ impl Interpreter {
             );
         }
 
-        Ok(Value::mixin(inner, mixins))
+        Ok(Value::mixin_with_state(inner, mixins))
     }
 
     /// Call BUILD and TWEAK submethods from a role after mixin composition.
@@ -937,7 +976,10 @@ impl Interpreter {
         if let ValueView::Mixin(_, mixins) = target.view() {
             for (attr_name, sigil) in &attr_names {
                 let key = format!("__mutsu_attr__{}", attr_name);
-                if let Some(val) = mixins.get(&key) {
+                if let Some(val) = mixins
+                    .role_attribute(role_name, attr_name)
+                    .or_else(|| mixins.get(&key).cloned())
+                {
                     self.env
                         .insert(attr_env_key(*sigil, attr_name), val.clone());
                 }
@@ -975,12 +1017,11 @@ impl Interpreter {
         // Execute the body directly in current scope so closure variable
         // mutations propagate to the outer scope. `$!attr` reads/writes
         // inside the compiled body resolve to `GetLocal`/`SetLocal` ops on a
-        // slot named `"!attr"` (ADR-0019 D8-3): `self_instance_attrs` finds
-        // no cell for a Mixin over a non-Instance `self` (the scenario here
-        // — `does`/`but` on a plain value) and its cell-mirror is a silent
-        // no-op both ways, so the locals<->env bridge that `run_nested`
-        // performs at entry/exit is what actually threads the seeded
-        // `env["!attr"]` values through. Run D8-1's precompiled chunk when
+        // slot named `"!attr"` (ADR-0019 D8-3). For a Mixin over a non-Instance
+        // value, the role-owned attribute cell is the authoritative storage;
+        // the locals<->env bridge that `run_nested` performs at entry/exit is
+        // retained for the role-body execution path and copied back to that
+        // cell below. Run D8-1's precompiled chunk when
         // available instead of re-parsing/re-compiling `def.body` on every
         // composition; a method not yet compiled (e.g. installed via a
         // meta-programming hook) falls back to the raw-AST carrier.
@@ -997,6 +1038,7 @@ impl Interpreter {
             for (attr_name, sigil) in &attr_names {
                 let env_key = attr_env_key(*sigil, attr_name);
                 if let Some(val) = self.env.get(&env_key) {
+                    mixins.set_role_attribute(role_name, attr_name, val.clone());
                     mixins.insert(format!("__mutsu_attr__{}", attr_name), val.clone());
                 }
             }
@@ -1004,7 +1046,7 @@ impl Interpreter {
             for (attr_name, sigil) in &attr_names {
                 self.env.remove(&attr_env_key(*sigil, attr_name));
             }
-            Value::mixin((**inner).clone(), mixins)
+            Value::mixin_with_state((**inner).clone(), mixins)
         } else {
             target
         };

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -68,11 +68,245 @@ pub(crate) fn seq_consumed_error_for(type_name: &str) -> RuntimeError {
 /// Shared mutable attribute storage for Proxy subclasses.
 pub(crate) type ProxySubclassAttrs = Arc<Mutex<HashMap<String, Value>>>;
 
-/// The overrides map of a [`ValueRepr::Mixin`]: a type or role name (or one of
-/// the `__mutsu_*__` marker keys) to the value that overrides it. Lives behind
-/// a `Gc` so `^set_name`'s in-place write is sound and so the collector can
-/// trace through it — see the variant's doc comment.
-pub(crate) type MixinOverrides = HashMap<String, Value>;
+/// The mutable state attached to a [`ValueRepr::Mixin`].
+///
+/// `overrides` is composition metadata: type/method overrides and the
+/// `__mutsu_*__` markers used by the existing mixin machinery. `attributes` is
+/// a separate, private cell for attributes declared by roles in this
+/// composition. Keeping the cell behind the same GC node preserves the
+/// NaN-box payload shape while making aliases of one mixin share role state.
+///
+/// The two fields deliberately do not implement `Deref` to one another. A
+/// caller must choose whether it is inspecting composition metadata or live
+/// role state. `Clone` is the composition-copy operation: it copies the marker
+/// map and deep-copies the role cell. Ordinary `Value` cloning only clones the
+/// containing `Gc<MixinOverrides>`, and therefore aliases both fields.
+#[derive(Debug)]
+pub(crate) struct MixinOverrides {
+    overrides: HashMap<String, Value>,
+    attributes: Gc<InstanceAttrs>,
+}
+
+impl MixinOverrides {
+    pub(crate) fn new(overrides: HashMap<String, Value>) -> Self {
+        let state = Self::with_attributes(overrides, AttrMap::new());
+        state.seed_missing_attributes();
+        state
+    }
+
+    pub(crate) fn with_attributes(overrides: HashMap<String, Value>, attributes: AttrMap) -> Self {
+        Self {
+            overrides,
+            attributes: Gc::new(InstanceAttrs::role_storage(attributes)),
+        }
+    }
+
+    /// The composition/override map. This is the only map used for type
+    /// identity, method overrides, and marker inspection.
+    pub(crate) fn overrides(&self) -> &HashMap<String, Value> {
+        &self.overrides
+    }
+
+    pub(crate) fn overrides_mut(&mut self) -> &mut HashMap<String, Value> {
+        &mut self.overrides
+    }
+
+    pub(crate) fn attributes(&self) -> &Gc<InstanceAttrs> {
+        &self.attributes
+    }
+
+    /// Seed newly composed role attributes into the live role cell without
+    /// overwriting a value that an earlier method call already established.
+    pub(crate) fn seed_missing_attributes(&self) {
+        let role_names: Vec<String> = self
+            .overrides
+            .keys()
+            .filter_map(|key| key.strip_prefix("__mutsu_role__"))
+            .map(str::to_string)
+            .collect();
+        for (key, value) in &self.overrides {
+            let Some(name) = key.strip_prefix("__mutsu_attr__") else {
+                continue;
+            };
+            if role_names.is_empty() {
+                // Compatibility for ad-hoc/legacy values that have an
+                // attribute marker but no role declaration marker.
+                self.attributes
+                    .insert_if_absent(Symbol::intern(name), value.clone());
+            } else {
+                for role_name in &role_names {
+                    self.attributes
+                        .insert_if_absent(self.role_attribute_key(role_name, name), value.clone());
+                }
+            }
+        }
+    }
+
+    fn role_identity(&self, owner: &str) -> String {
+        self.get(&format!("__mutsu_role_id__{owner}"))
+            .and_then(|value| match value.view() {
+                ValueView::Int(id) if id > 0 => Some(id.to_string()),
+                _ => None,
+            })
+            .unwrap_or_else(|| owner.to_string())
+    }
+
+    pub(crate) fn role_attribute_key(&self, owner: &str, name: &str) -> Symbol {
+        Symbol::intern(&format!(
+            "__mutsu_role_attr__\0{}\0{name}",
+            self.role_identity(owner)
+        ))
+    }
+
+    pub(crate) fn role_attribute(&self, owner: &str, name: &str) -> Option<Value> {
+        let key = self.role_attribute_key(owner, name);
+        let map = self.attributes.as_map();
+        map.get(key)
+            .or_else(|| map.get(Symbol::intern(name)))
+            .cloned()
+    }
+
+    pub(crate) fn set_role_attribute_by_name(&self, name: &str, value: Value) -> bool {
+        let keys: Vec<Symbol> = self
+            .attributes
+            .as_map()
+            .keys()
+            .copied()
+            .filter(|key| key.as_str() == name || key.as_str().ends_with(&format!("\0{name}")))
+            .collect();
+        if keys.is_empty() {
+            return false;
+        }
+        for key in keys {
+            self.attributes.store_through_container(key, value.clone());
+        }
+        true
+    }
+
+    /// Update one role's live attribute, preferring its owner-qualified cell
+    /// entry and falling back to the legacy bare entry for pre-cell values.
+    pub(crate) fn set_role_attribute(&self, owner: &str, name: &str, value: Value) -> bool {
+        let key = {
+            let map = self.attributes.as_map();
+            let qualified = self.role_attribute_key(owner, name);
+            if map.contains_key(qualified) {
+                Some(qualified)
+            } else {
+                let bare = Symbol::intern(name);
+                map.contains_key(bare).then_some(bare)
+            }
+        };
+        if let Some(key) = key {
+            self.attributes.store_through_container(key, value);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn role_attribute_by_name(&self, name: &str) -> Option<Value> {
+        let suffix = format!("\0{name}");
+        self.attributes
+            .as_map()
+            .iter()
+            .find(|(key, _)| key.as_str() == name || key.as_str().ends_with(&suffix))
+            .map(|(_, value)| value.clone())
+    }
+
+    // Map-shaped accessors keep the representation migration local while
+    // callers are moved to the explicit `overrides()` API. They are not a
+    // Deref implementation: taking a clone of this state always has the
+    // intentionally different deep-copy semantics documented above.
+    pub(crate) fn get<Q>(&self, key: &Q) -> Option<&Value>
+    where
+        String: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.overrides.get(key)
+    }
+
+    pub(crate) fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut Value>
+    where
+        String: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.overrides.get_mut(key)
+    }
+
+    pub(crate) fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        String: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.overrides.contains_key(key)
+    }
+
+    pub(crate) fn insert(&mut self, key: String, value: Value) -> Option<Value> {
+        self.overrides.insert(key, value)
+    }
+
+    pub(crate) fn entry(
+        &mut self,
+        key: String,
+    ) -> std::collections::hash_map::Entry<'_, String, Value> {
+        self.overrides.entry(key)
+    }
+
+    pub(crate) fn iter(&self) -> std::collections::hash_map::Iter<'_, String, Value> {
+        self.overrides.iter()
+    }
+
+    pub(crate) fn iter_mut(&mut self) -> std::collections::hash_map::IterMut<'_, String, Value> {
+        self.overrides.iter_mut()
+    }
+
+    pub(crate) fn keys(&self) -> std::collections::hash_map::Keys<'_, String, Value> {
+        self.overrides.keys()
+    }
+
+    pub(crate) fn values(&self) -> std::collections::hash_map::Values<'_, String, Value> {
+        self.overrides.values()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.overrides.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.overrides.is_empty()
+    }
+
+    pub(crate) fn remove<Q>(&mut self, key: &Q) -> Option<Value>
+    where
+        String: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.overrides.remove(key)
+    }
+}
+
+impl From<HashMap<String, Value>> for MixinOverrides {
+    fn from(overrides: HashMap<String, Value>) -> Self {
+        Self::new(overrides)
+    }
+}
+
+impl Clone for MixinOverrides {
+    fn clone(&self) -> Self {
+        Self {
+            overrides: self.overrides.clone(),
+            attributes: Gc::new((*self.attributes).clone()),
+        }
+    }
+}
+
+impl PartialEq for MixinOverrides {
+    fn eq(&self, other: &Self) -> bool {
+        // Mutable role state is not composition metadata. Equality and type
+        // identity retain their pre-cell semantics.
+        self.overrides == other.overrides
+    }
+}
 
 /// How the bytes of one element read back out of a [`BufData`] node.
 ///

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -344,7 +344,7 @@ fn shared_multifield_box_decodes_by_clone_unique_by_move() {
     // Shared word: both clones decode to the same field pointers.
     let b = NanBox::from_repr(ValueRepr::Mixin(
         inner.clone(),
-        crate::gc::Gc::new(HashMap::new()),
+        crate::gc::Gc::new(HashMap::new().into()),
     ));
     let b2 = b.clone();
     let (r1, r2) = (b.into_repr(), b2.into_repr());
@@ -513,7 +513,7 @@ fn every_variant_roundtrips_losslessly() {
         ValueRepr::HyperWhatever,
         ValueRepr::Mixin(
             Arc::new(Value::int(1)),
-            crate::gc::Gc::new(HashMap::from([("Bool".to_string(), Value::truth(true))])),
+            crate::gc::Gc::new(HashMap::from([("Bool".to_string(), Value::truth(true))]).into()),
         ),
         ValueRepr::Capture {
             positional: Box::new(vec![Value::int(1)]),

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -110,6 +110,14 @@ enum SerValue {
         sig_info: Option<crate::value::signature::SigInfo>,
     },
     Mixin(Box<SerValue>, HashMap<String, SerValue>),
+    /// Current role-cell state for a Mixin. The two-field `Mixin` variant is
+    /// retained so pre-cell serialized values continue to decode as seed-only
+    /// compositions.
+    MixinWithAttributes {
+        inner: Box<SerValue>,
+        overrides: HashMap<String, SerValue>,
+        attributes: HashMap<String, SerValue>,
+    },
     Capture {
         positional: Vec<SerValue>,
         named: HashMap<String, SerValue>,
@@ -123,6 +131,8 @@ enum SerValue {
         type_args: Vec<SerValue>,
     },
     Scalar(Box<SerValue>),
+    ContainerRef(Box<SerValue>),
+    ContainerView(Box<SerValue>),
     Nil,
     Whatever,
     HyperWhatever,
@@ -310,10 +320,17 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
                 .iter()
                 .map(|(k, v)| value_to_ser(v).map(|sv| (k.clone(), sv)))
                 .collect();
-            Ok(SerValue::Mixin(
-                Box::new(value_to_ser(inner)?),
-                ser_overrides?,
-            ))
+            let ser_attributes: Result<HashMap<_, _>, _> = overrides
+                .attributes()
+                .as_map()
+                .iter()
+                .map(|(k, v)| value_to_ser(v).map(|sv| (k.resolve(), sv)))
+                .collect();
+            Ok(SerValue::MixinWithAttributes {
+                inner: Box::new(value_to_ser(inner)?),
+                overrides: ser_overrides?,
+                attributes: ser_attributes?,
+            })
         }
         ValueView::Capture { positional, named } => {
             let ser_pos: Result<Vec<_>, _> = positional.iter().map(value_to_ser).collect();
@@ -341,6 +358,18 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
             })
         }
         ValueView::Scalar(inner) => Ok(SerValue::Scalar(Box::new(value_to_ser(inner)?))),
+        ValueView::ContainerRef(cell) => {
+            let value = cell
+                .lock()
+                .map_err(|_| "cannot lock ContainerRef for serialization".to_string())?;
+            Ok(SerValue::ContainerRef(Box::new(value_to_ser(&value)?)))
+        }
+        ValueView::ContainerView(cell) => {
+            let value = cell
+                .lock()
+                .map_err(|_| "cannot lock ContainerView for serialization".to_string())?;
+            Ok(SerValue::ContainerView(Box::new(value_to_ser(&value)?)))
+        }
         ValueView::Nil => Ok(SerValue::Nil),
         ValueView::Whatever => Ok(SerValue::Whatever),
         ValueView::HyperWhatever => Ok(SerValue::HyperWhatever),
@@ -354,9 +383,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
         | ValueView::CustomType { .. }
         | ValueView::CustomTypeInstance(_)
         | ValueView::LazyThunk(_)
-        | ValueView::HashEntryRef { .. }
-        | ValueView::ContainerRef(_)
-        | ValueView::ContainerView(_) => Err(format!(
+        | ValueView::HashEntryRef { .. } => Err(format!(
             "cannot serialize Value variant: {}",
             super::what_type_name(v)
         )),
@@ -534,13 +561,31 @@ fn ser_to_value(sv: SerValue) -> Value {
         }),
         SerValue::Mixin(inner, overrides) => Value::Mixin(
             Arc::new(ser_to_value(*inner)),
-            crate::gc::Gc::new(
+            crate::gc::Gc::new(crate::value::MixinOverrides::from(
                 overrides
                     .into_iter()
                     .map(|(k, v)| (k, ser_to_value(v)))
-                    .collect(),
-            ),
+                    .collect::<HashMap<_, _>>(),
+            )),
         ),
+        SerValue::MixinWithAttributes {
+            inner,
+            overrides,
+            attributes,
+        } => {
+            let overrides = overrides
+                .into_iter()
+                .map(|(k, v)| (k, ser_to_value(v)))
+                .collect::<HashMap<_, _>>();
+            let attributes = attributes
+                .into_iter()
+                .map(|(k, v)| (Symbol::intern(&k), ser_to_value(v)))
+                .collect();
+            Value::mixin_with_state(
+                ser_to_value(*inner),
+                crate::value::MixinOverrides::with_attributes(overrides, attributes),
+            )
+        }
         SerValue::Capture { positional, named } => Value::capture(
             positional.into_iter().map(ser_to_value).collect(),
             named
@@ -557,6 +602,12 @@ fn ser_to_value(sv: SerValue) -> Value {
             type_args: type_args.into_iter().map(ser_to_value).collect(),
         }),
         SerValue::Scalar(inner) => Value::Scalar(Box::new(ser_to_value(*inner))),
+        SerValue::ContainerRef(inner) => Value::container_ref(crate::gc::Gc::new(
+            crate::value::ContainerCell::new(ser_to_value(*inner)),
+        )),
+        SerValue::ContainerView(inner) => Value::container_view(crate::gc::Gc::new(
+            crate::value::ContainerCell::new(ser_to_value(*inner)),
+        )),
         SerValue::Nil => Value::Nil,
         SerValue::Whatever => Value::Whatever,
         SerValue::HyperWhatever => Value::HyperWhatever,
@@ -574,5 +625,54 @@ impl<'de> Deserialize<'de> for Value {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let sv = SerValue::deserialize(deserializer)?;
         Ok(ser_to_value(sv))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mixin_serialization_preserves_live_role_cell_and_promoted_value() {
+        let mut overrides = HashMap::new();
+        overrides.insert("__mutsu_role__R".to_string(), Value::TRUE);
+        overrides.insert("__mutsu_attr__n".to_string(), Value::int(1));
+        let value = Value::mixin(Value::int(0), overrides);
+        let ValueView::Mixin(_, state) = value.view() else {
+            panic!("expected a mixin");
+        };
+        let key = state.role_attribute_key("R", "n");
+        state
+            .attributes()
+            .store_through_container(key, Value::int(2));
+        let promoted = state.attributes().promote_attr_to_container(key);
+        if let ValueView::ContainerRef(cell) = promoted.view() {
+            *cell.lock().unwrap() = Value::int(3);
+        } else {
+            panic!("expected a promoted role attribute");
+        }
+
+        let encoded = serde_json::to_string(&value).expect("serialize mixin");
+        let restored: Value = serde_json::from_str(&encoded).expect("deserialize mixin");
+        let ValueView::Mixin(_, restored_state) = restored.view() else {
+            panic!("expected a restored mixin");
+        };
+        let restored_value = restored_state
+            .role_attribute("R", "n")
+            .expect("restored role attribute");
+        assert_eq!(restored_value.deref_container(), Value::int(3));
+        assert!(matches!(restored_value.view(), ValueView::ContainerRef(_)));
+    }
+
+    #[test]
+    fn legacy_seed_only_mixin_serialization_still_decodes() {
+        let mut overrides = HashMap::new();
+        overrides.insert("__mutsu_role__R".to_string(), SerValue::Bool(true));
+        overrides.insert("__mutsu_attr__n".to_string(), SerValue::Int(7));
+        let restored = ser_to_value(SerValue::Mixin(Box::new(SerValue::Int(0)), overrides));
+        let ValueView::Mixin(_, state) = restored.view() else {
+            panic!("expected a restored legacy mixin");
+        };
+        assert_eq!(state.role_attribute("R", "n"), Some(Value::int(7)));
     }
 }

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -24,7 +24,7 @@ pub(crate) const ANON_ROLE_MARKER_PREFIX: &str = "__mutsu_anon_role__";
 
 /// The anonymous roles recorded in `mixins`, as `(group, seq, display name)`.
 fn anon_role_entries(
-    mixins: &std::collections::HashMap<String, Value>,
+    mixins: &crate::value::MixinOverrides,
 ) -> impl Iterator<Item = (i64, i64, String)> + '_ {
     mixins
         .keys()
@@ -192,9 +192,7 @@ pub(crate) fn what_type_name(val: &Value) -> String {
 /// double underscore distinguishes them from the bookkeeping keys
 /// `__mutsu_role_id__` / `__mutsu_role_typeargs__` / `__mutsu_role_param__`).
 /// Returns e.g. `Foo::Bar` for `5 but Foo::Bar` so `.^name` reads `Int+{Foo::Bar}`.
-pub(crate) fn role_mixin_suffix(
-    mixins: &std::collections::HashMap<String, Value>,
-) -> Option<String> {
+pub(crate) fn role_mixin_suffix(mixins: &MixinOverrides) -> Option<String> {
     role_mixin_suffix_excluding(mixins, "")
 }
 
@@ -212,10 +210,7 @@ pub(crate) fn role_mixin_suffix(
 /// name equals it, for the punning case
 /// ([`role_mixin_suffix_excluding`]'s argument of the same name); pass `""`
 /// to exclude nothing.
-pub(crate) fn mixin_roles_applied_last_first(
-    mixins: &std::collections::HashMap<String, Value>,
-    base: &str,
-) -> Vec<String> {
+pub(crate) fn mixin_roles_applied_last_first(mixins: &MixinOverrides, base: &str) -> Vec<String> {
     let mut entries: Vec<(i64, String)> = mixins
         .keys()
         .filter_map(|k| k.strip_prefix("__mutsu_role__"))
@@ -244,10 +239,7 @@ pub(crate) fn mixin_roles_applied_last_first(
 /// [`role_mixin_suffix`], but skipping the role whose name equals `base` — the
 /// role-punning case, where `R.new` builds `Mixin(Instance{R}, __mutsu_role__R)`
 /// and raku reports plain `R` rather than `R+{R}`. Pass `""` to exclude nothing.
-pub(crate) fn role_mixin_suffix_excluding(
-    mixins: &std::collections::HashMap<String, Value>,
-    base: &str,
-) -> Option<String> {
+pub(crate) fn role_mixin_suffix_excluding(mixins: &MixinOverrides, base: &str) -> Option<String> {
     // APPLICATION order, not alphabetical: raku gives each composition its own
     // bracket and shows them in the order they were applied, which is the
     // property that distinguishes `(1 but A) but B` (`Int+{A}+{B}`) from
@@ -311,7 +303,7 @@ pub(crate) fn role_mixin_suffix_excluding(
 /// group of its own -- the pre-stamp behaviour and the right answer for every
 /// single-role application.
 fn role_application_group(
-    mixins: &std::collections::HashMap<String, Value>,
+    mixins: &crate::value::MixinOverrides,
     role_name: &str,
     fallback: i64,
 ) -> i64 {
@@ -328,7 +320,7 @@ fn role_application_group(
 /// composition time (`__mutsu_role_seq__{name}`), or `i64::MIN` when the marker
 /// is absent (a value built before the stamp existed, or by a path that does
 /// not record one) so such entries sort first and stay deterministic.
-fn role_application_seq(mixins: &std::collections::HashMap<String, Value>, role_name: &str) -> i64 {
+fn role_application_seq(mixins: &crate::value::MixinOverrides, role_name: &str) -> i64 {
     mixins
         .get(&format!("__mutsu_role_seq__{role_name}"))
         .and_then(|v| match v.view() {
@@ -353,10 +345,7 @@ fn role_application_seq(mixins: &std::collections::HashMap<String, Value>, role_
 /// * A parameterised role keeps its type arguments in the name
 ///   (`Int+{G[Int]}`, `Hash+{Associative[Int,Int]}`), read back from the
 ///   `__mutsu_role_typeargs__{name}` marker recorded alongside the role marker.
-fn role_mixin_suffix_entry(
-    mixins: &std::collections::HashMap<String, Value>,
-    role_name: &str,
-) -> String {
+fn role_mixin_suffix_entry(mixins: &crate::value::MixinOverrides, role_name: &str) -> String {
     let display = crate::value::user_facing_type_name(role_name).into_owned();
     // An already-parameterised spelling (a role registered under a bracketed
     // name) must not get a second `[...]` appended.
@@ -399,10 +388,7 @@ fn role_mixin_suffix_entry(
 /// by typeargs), and every other non-composition key this flat map can
 /// carry (`__mutsu_var_target`, `__mutsu_how_target`, `__mutsu_topic_ro__`,
 /// the allomorph `"Str"` key, `__mutsu_language_revision`, ...).
-pub(crate) fn mixin_composition_key(
-    base_type_name: &str,
-    mixins: &std::collections::HashMap<String, Value>,
-) -> String {
+pub(crate) fn mixin_composition_key(base_type_name: &str, mixins: &MixinOverrides) -> String {
     let mut parts: Vec<(i64, i64, String)> = mixins
         .keys()
         .filter_map(|k| k.strip_prefix("__mutsu_role__"))
@@ -496,7 +482,7 @@ pub(crate) fn mixin_composition_key(
 /// (`<42> === IntStr.new(42, "forty-two")` is `False`) and
 /// [`VALUE_MIXIN_MARKER`]'s fresh anonymous name per `but <non-role>`
 /// application (`(1 but "x") === (1 but "x")` is `False`).
-pub(crate) fn mixin_identity_key(mixins: &std::collections::HashMap<String, Value>) -> String {
+pub(crate) fn mixin_identity_key(mixins: &MixinOverrides) -> String {
     // Roles in application order (`__mutsu_role_seq__` ascending, name as the
     // tie-break for a marker that carries no stamp), each with the same
     // (name, role_id, typeargs) triple `mixin_composition_key` uses.
@@ -597,7 +583,7 @@ pub(crate) fn mixin_identity_key(mixins: &std::collections::HashMap<String, Valu
 /// `__mutsu_type_name__` (the mutable `.^set_name` target — written later,
 /// in place, onto the cache entry itself), and any other bookkeeping key.
 pub(crate) fn filter_composition_markers(
-    mixins: &std::collections::HashMap<String, Value>,
+    mixins: &MixinOverrides,
 ) -> std::collections::HashMap<String, Value> {
     mixins
         .iter()
@@ -627,10 +613,7 @@ pub(crate) fn filter_composition_markers(
 
 /// Return the allomorphic type name for a Mixin value, if it is allomorphic.
 /// An allomorphic Mixin has a "Str" key and a numeric inner value.
-pub(crate) fn allomorph_type_name(
-    inner: &Value,
-    mixins: &std::collections::HashMap<String, Value>,
-) -> Option<String> {
+pub(crate) fn allomorph_type_name(inner: &Value, mixins: &MixinOverrides) -> Option<String> {
     if !mixins.contains_key("Str") {
         return None;
     }

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -512,13 +512,15 @@ impl Trace for BufData {
 /// however many mixin values share the map.
 impl Trace for MixinOverrides {
     fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
-        for v in self.values() {
+        for v in self.overrides().values() {
             v.gc_trace(visit);
         }
+        visit(&self.attributes().erased());
     }
 
     fn drop_gc_edges(&mut self) {
-        self.clear();
+        self.overrides_mut().clear();
+        self.attributes().clear_gc_edges();
     }
 }
 
@@ -1015,7 +1017,39 @@ mod tests {
             panic!("not a Mixin");
         };
         map.trace(&mut |_| nested += 1);
-        assert_eq!(nested, 1, "the overrides node traces its own Value edges");
+        assert_eq!(
+            nested, 2,
+            "the overrides node traces its own Value edges and role cell"
+        );
+    }
+
+    #[test]
+    fn mixin_role_cell_aliases_value_clones_but_deep_clone_detaches() {
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert("__mutsu_role__R".to_string(), Value::Bool(true));
+        overrides.insert("__mutsu_attr__n".to_string(), Value::Int(1));
+        let value = Value::mixin(Value::Int(0), overrides);
+        let alias = value.clone();
+
+        let ValueView::Mixin(_, state) = value.view() else {
+            panic!("not a Mixin");
+        };
+        let key = state.role_attribute_key("R", "n");
+        state
+            .attributes()
+            .store_through_container(key, Value::Int(2));
+
+        let ValueView::Mixin(_, alias_state) = alias.view() else {
+            panic!("alias is not a Mixin");
+        };
+        assert_eq!(alias_state.role_attribute("R", "n"), Some(Value::Int(2)));
+
+        let detached = crate::gc::Gc::new((**state).clone());
+        detached
+            .attributes()
+            .store_through_container(key, Value::Int(3));
+        assert_eq!(state.role_attribute("R", "n"), Some(Value::Int(2)));
+        assert_eq!(detached.role_attribute("R", "n"), Some(Value::Int(3)));
     }
 
     #[test]

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -97,6 +97,13 @@ impl Clone for InstanceAttrs {
 }
 
 impl InstanceAttrs {
+    /// Build a private attribute store for a role mixin. It reuses the
+    /// interior-mutability and GC tracing machinery of ordinary instances but
+    /// is not a Raku object: it has no user identity or DESTROY lifecycle.
+    pub(crate) fn role_storage(attributes: AttrMap) -> Self {
+        Self::new(Symbol::intern("Any"), attributes, 0, false)
+    }
+
     pub(crate) fn new(
         class_name: Symbol,
         attributes: AttrMap,

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -81,6 +81,11 @@ impl Value {
         })
     }
     pub fn mixin(inner: Value, overrides: HashMap<String, Value>) -> Self {
+        Self::mixin_with_state(inner, overrides.into())
+    }
+
+    pub(crate) fn mixin_with_state(inner: Value, overrides: crate::value::MixinOverrides) -> Self {
+        overrides.seed_missing_attributes();
         Value::Mixin(Arc::new(inner), crate::gc::Gc::new(overrides))
     }
     pub fn generic_range(start: Value, end: Value, excl_start: bool, excl_end: bool) -> Self {

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -961,7 +961,7 @@ impl Interpreter {
             // against the live cell + local/env writes before the env is torn
             // down. The cell-direct reads + per-op mirrors make the cell the
             // single source; the legacy attribute writeback is gone.
-            reconciled_attrs = self.reconcile_attrs(&base, cc, &method_def.params);
+            reconciled_attrs = self.reconcile_attrs(&base, owner_class, cc, &method_def.params);
 
             let method_var_bindings = self.take_var_bindings();
             let mut restored_bindings = saved_var_bindings;
@@ -988,7 +988,7 @@ impl Interpreter {
 
             // Phase 3 Stage 2: reconcile all attributes against the live cell +
             // local/env writes before the env is merged away.
-            reconciled_attrs = self.reconcile_attrs(&base, cc, &method_def.params);
+            reconciled_attrs = self.reconcile_attrs(&base, owner_class, cc, &method_def.params);
             // Callee-frame key predicate for the merge (formerly a per-call
             // materialized HashSet<String>): the method's params and locals,
             // the frame fixtures, the attribute twigil forms and sigilless
@@ -1244,15 +1244,11 @@ impl Interpreter {
     fn reconcile_attrs(
         &self,
         base: &Value,
+        owner_class: &str,
         code: &CompiledCode,
         params: &[String],
     ) -> Option<AttrMap> {
-        let ValueView::Instance {
-            attributes: cell, ..
-        } = base.view()
-        else {
-            return None;
-        };
+        let cell = self.method_attr_cell(base, owner_class)?;
         // Cheap pre-check: a `:=` attr override can only be observed as a
         // ContainerRef value in THIS frame's locals or env overlay (the bind
         // op writes it there). No ContainerRef anywhere -> skip the per-attr
@@ -1489,10 +1485,12 @@ impl Interpreter {
     ) -> Result<(Value, Option<AttrMap>), RuntimeError> {
         crate::alloc_scope!("mfast");
         crate::alloc_scope_named!(_sc_pro, "mfast:prologue");
-        let attrs_cell = match base.view() {
-            ValueView::Instance { attributes, .. } => Some(attributes.clone()),
-            _ => None,
-        };
+        let attrs_cell = self.method_attr_cell(&base, owner_class);
+        let fallback_attrs_cell = self.method_attr_cells(&base, owner_class).1.filter(|cell| {
+            attrs_cell.as_ref().is_some_and(|primary| {
+                crate::gc::Gc::as_ptr(primary) != crate::gc::Gc::as_ptr(cell)
+            })
+        });
         // RAII (`MarkContextGuard`,
         // `todo/deep/mark-context-flags-leak-across-live-call-boundary.md`):
         // isolate the "mark context" one-shot flag family (bind_context et
@@ -1869,8 +1867,32 @@ impl Interpreter {
 
         {
             let attrs_guard = attrs_cell.as_ref().map(|c| c.as_map());
+            let fallback_attrs_guard = fallback_attrs_cell.as_ref().map(|c| c.as_map());
+            let role_state = if self.is_role(owner_class) {
+                match base.view() {
+                    ValueView::Mixin(_, mixins)
+                        if mixins.contains_key(&format!("__mutsu_role__{owner_class}")) =>
+                    {
+                        Some(mixins.clone())
+                    }
+                    _ => None,
+                }
+            } else {
+                None
+            };
             let attr_get = |key: &str| -> Option<Value> {
-                attrs_guard.as_ref().and_then(|g| g.get(key).cloned())
+                let bare = key.rsplit('\0').next().unwrap_or(key);
+                let role_key = role_state
+                    .as_ref()
+                    .map(|state| state.role_attribute_key(owner_class, bare));
+                role_key
+                    .and_then(|key| attrs_guard.as_ref().and_then(|g| g.get(key).cloned()))
+                    .or_else(|| attrs_guard.as_ref().and_then(|g| g.get(key).cloned()))
+                    .or_else(|| {
+                        fallback_attrs_guard
+                            .as_ref()
+                            .and_then(|g| g.get(key).cloned())
+                    })
             };
             for (i, local_name) in cc.locals.iter().enumerate() {
                 self.locals[i] = match local_name.as_str() {
@@ -2136,7 +2158,7 @@ impl Interpreter {
         });
         // Phase 3 Stage 2: reconcile all attributes against the live cell +
         // local/env writes before the env is torn down.
-        let reconciled = self.reconcile_attrs(&base, cc, &method_def.params);
+        let reconciled = self.reconcile_attrs(&base, owner_class, cc, &method_def.params);
 
         let method_var_bindings = self.take_var_bindings();
         let mut restored_bindings = saved_var_bindings;

--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -185,7 +185,7 @@ impl Interpreter {
     fn apply_single_mixin(left: Value, mixin_type: String, right: Value) -> Value {
         let mut mixins = match left.view() {
             ValueView::Mixin(_, existing_mixins) => (**existing_mixins).clone(),
-            _ => std::collections::HashMap::new(),
+            _ => std::collections::HashMap::new().into(),
         };
         mixins.insert(mixin_type, right);
         let anon = crate::parser::next_anon_role_name();
@@ -211,8 +211,8 @@ impl Interpreter {
         mixins.insert(format!("__mutsu_role_seq__{anon}"), Value::int(seq));
         mixins.insert(format!("__mutsu_role_group__{anon}"), Value::int(seq));
         match left.view() {
-            ValueView::Mixin(inner, _) => Value::mixin(inner.as_ref().clone(), mixins),
-            _ => Value::mixin(left, mixins),
+            ValueView::Mixin(inner, _) => Value::mixin_with_state(inner.as_ref().clone(), mixins),
+            _ => Value::mixin_with_state(left, mixins),
         }
     }
 

--- a/src/vm/vm_var_assign_computed_attr.rs
+++ b/src/vm/vm_var_assign_computed_attr.rs
@@ -197,6 +197,79 @@ impl Interpreter {
         None
     }
 
+    /// Return the attribute stores visible to a method, in lookup order. A
+    /// role method on a Mixin owns the Mixin's role cell; attributes not found
+    /// there fall through to the wrapped instance cell. Methods owned by the
+    /// wrapped class see the ordinary instance cell only.
+    pub(crate) fn method_attr_cells(
+        &self,
+        val: &Value,
+        owner: &str,
+    ) -> (
+        Option<crate::gc::Gc<crate::value::InstanceAttrs>>,
+        Option<crate::gc::Gc<crate::value::InstanceAttrs>>,
+    ) {
+        let inner = Self::self_instance_attrs(val);
+        if !self.is_role(owner) {
+            return (None, inner);
+        }
+        let mut current = val.clone();
+        for _ in 0..8 {
+            match current.view() {
+                ValueView::Mixin(inner_value, mixins) => {
+                    let marker = format!("__mutsu_role__{owner}");
+                    if mixins.contains_key(&marker) {
+                        return (Some(mixins.attributes().clone()), inner);
+                    }
+                    current = inner_value.as_ref().clone();
+                }
+                ValueView::ContainerRef(_) => {
+                    current = current.deref_container();
+                }
+                _ => break,
+            }
+        }
+        (None, inner)
+    }
+
+    /// Select the primary live attribute cell for a resolved method owner.
+    /// Per-key reads and writes additionally fall through from a role cell to
+    /// the wrapped instance cell.
+    pub(crate) fn method_attr_cell(
+        &self,
+        val: &Value,
+        owner: &str,
+    ) -> Option<crate::gc::Gc<crate::value::InstanceAttrs>> {
+        let (role, inner) = self.method_attr_cells(val, owner);
+        role.or(inner)
+    }
+
+    pub(crate) fn method_role_attr_key(
+        &self,
+        val: &Value,
+        owner: &str,
+        bare: crate::symbol::Symbol,
+    ) -> Option<crate::symbol::Symbol> {
+        if !self.is_role(owner) {
+            return None;
+        }
+        let mut current = val.clone();
+        for _ in 0..8 {
+            match current.view() {
+                ValueView::Mixin(inner_value, mixins) => {
+                    let marker = format!("__mutsu_role__{owner}");
+                    if mixins.contains_key(&marker) {
+                        return Some(mixins.role_attribute_key(owner, bare.as_str()));
+                    }
+                    current = inner_value.as_ref().clone();
+                }
+                ValueView::ContainerRef(_) => current = current.deref_container(),
+                _ => return None,
+            }
+        }
+        None
+    }
+
     /// Read a scalar attribute straight from `self`'s shared cell. `Some` only
     /// when `name` is a scalar attr-twigil, `self` is a concrete instance (or a
     /// Mixin wrapping one), and the attribute exists in the cell.
@@ -234,23 +307,24 @@ impl Interpreter {
         bare: crate::symbol::Symbol,
         is_private: bool,
     ) -> Option<Value> {
-        if let Some(self_val) = self.get_env_self()
-            && let Some(attributes) = Self::self_instance_attrs(&self_val)
-        {
-            let map = attributes.as_map();
-            if let Some(key) = self.attr_key_in_map(bare, is_private, &map) {
-                // An attribute slot promoted to a shared `ContainerRef` cell
-                // (`promote_attr_to_container`, reached by a `:=` bind to the
-                // accessor, ADR-0067's E6 producer, or an `is rw` method whose
-                // tail is the bare attribute) is a *container*: reading `$!x`
-                // yields what it holds, exactly as the accessor read does. The
-                // undereferenced cell was indistinguishable from a defined
-                // value, so `with $!x { ... }` entered on an attribute holding
-                // a type object and the topic was the cell rather than the
-                // object (URI's `multi method authority(--> Authority) is rw`
-                // promoted the slot; `with $!authority` then took the wrong
-                // branch and died assigning through the topic).
-                return map.get(key).map(|v| v.deref_container());
+        if let Some(self_val) = self.get_env_self() {
+            let owner = self.method_class_stack_top_str().unwrap_or("");
+            let (role_cell, inner_cell) = self.method_attr_cells(&self_val, owner);
+            if let Some(attributes) = role_cell {
+                let map = attributes.as_map();
+                let key = self
+                    .method_role_attr_key(&self_val, owner, bare)
+                    .filter(|key| map.contains_key(*key))
+                    .or_else(|| self.attr_key_in_map(bare, is_private, &map));
+                if let Some(key) = key {
+                    return map.get(key).map(|v| v.deref_container());
+                }
+            }
+            if let Some(attributes) = inner_cell {
+                let map = attributes.as_map();
+                if let Some(key) = self.attr_key_in_map(bare, is_private, &map) {
+                    return map.get(key).map(|v| v.deref_container());
+                }
             }
         }
         self.read_class_level_attr_cell(bare, is_private)
@@ -404,24 +478,32 @@ impl Interpreter {
     /// Mixin). No-op when `self` is not a concrete instance or the attribute does
     /// not exist on it.
     fn write_attr_cell_by_key(&self, bare: crate::symbol::Symbol, is_private: bool, val: Value) {
-        if let Some(self_val) = self.get_env_self()
-            && let Some(attributes) = Self::self_instance_attrs(&self_val)
-        {
-            let key = {
-                let map = attributes.as_map();
-                self.attr_key_in_map(bare, is_private, &map)
-            };
-            if let Some(key) = key {
-                self.record_build_attr_write(&attributes, key);
-                // Write *through* a promoted `ContainerRef` slot rather than
-                // replacing it: the cell is the attribute's Scalar, so
-                // `$!x = v` must be visible to every alias handed out of it
-                // (a `:=`-bound name, an `is rw` method result, an `is rw`
-                // argument). Replacing the slot would disconnect all of them at
-                // the first internal write. See the matching deref in
-                // `read_attr_cell_by_key`.
-                attributes.store_through_container(key, val);
-                return;
+        if let Some(self_val) = self.get_env_self() {
+            let owner = self.method_class_stack_top_str().unwrap_or("");
+            let (role_cell, inner_cell) = self.method_attr_cells(&self_val, owner);
+            if let Some(attributes) = role_cell {
+                let key = {
+                    let map = attributes.as_map();
+                    self.method_role_attr_key(&self_val, owner, bare)
+                        .filter(|key| map.contains_key(*key))
+                        .or_else(|| self.attr_key_in_map(bare, is_private, &map))
+                };
+                if let Some(key) = key {
+                    self.record_build_attr_write(&attributes, key);
+                    attributes.store_through_container(key, val.clone());
+                    return;
+                }
+            }
+            if let Some(attributes) = inner_cell {
+                let key = {
+                    let map = attributes.as_map();
+                    self.attr_key_in_map(bare, is_private, &map)
+                };
+                if let Some(key) = key {
+                    self.record_build_attr_write(&attributes, key);
+                    attributes.store_through_container(key, val);
+                    return;
+                }
             }
         }
         // Class-level attribute fallback: see `read_class_level_attr_cell`'s

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -74,7 +74,7 @@ impl Interpreter {
 
     pub(super) fn delegated_mixin_attr_key(
         &self,
-        mixins: &std::collections::HashMap<String, Value>,
+        mixins: &crate::value::MixinOverrides,
         method_name: &str,
     ) -> Option<String> {
         self.delegated_role_attr_key_from_mixins(mixins, method_name)
@@ -83,15 +83,15 @@ impl Interpreter {
     /// Element-assign into a punned role object (`$obj{k} = v` / `$obj[i] = v`)
     /// by mutating the container attribute its role delegates the subscript to.
     ///
-    /// The wrapped instance's shared attribute cell is the store of record for a
-    /// punned role's attributes (every sigil is seeded into it), so the mutated
-    /// container is written there: that is what the delegation forwarder reads,
-    /// and it reaches every alias — including an object held in an attribute or a
-    /// collection element, which the caller-side env writeback never could.
+    /// The Mixin-owned role cell is the store of record for role attributes
+    /// (every sigil is seeded into it), so the mutated container is written
+    /// there: that is what the delegation forwarder reads, and it reaches every
+    /// alias — including an object held in an attribute or a collection element,
+    /// which the caller-side env writeback never could.
     ///
-    /// Returns the rebuilt `Mixin` when the assignment applied (the caller stores
-    /// it back if the object lives in a plain lexical), `None` when `target` is
-    /// not a role mixin or no delegated container accepted the index.
+    /// Returns the same `Mixin` when the assignment applied, preserving aliases;
+    /// returns `None` when `target` is not a role mixin or no delegated container
+    /// accepted the index.
     pub(crate) fn assign_role_mixin_element(
         &mut self,
         target: &Value,
@@ -137,18 +137,24 @@ impl Interpreter {
             inner.hash_assign_at(&key, Self::itemize_value(val.clone()));
             return Ok(Some(target.clone()));
         }
-        // Refresh each `__mutsu_attr__` marker from the cell before mutating, so
-        // an element write made directly inside a role method (`%!h<k> = 1`,
-        // which goes to the cell) is not overwritten by a stale marker.
-        let inst_attrs = Self::self_instance_attrs(&inner);
-        if let Some(attrs) = &inst_attrs {
-            let map = attrs.as_map();
-            for (key, attr_value) in updated_mixins.iter_mut() {
-                if let Some(bare) = key.strip_prefix("__mutsu_attr__")
-                    && let Some(cur) = map.get(Symbol::intern(bare))
-                {
-                    *attr_value = cur.clone();
-                }
+        // Refresh each marker from the live role cell before mutating, so an
+        // element write made directly inside a role method (`%!h<k> = 1`) is
+        // not overwritten by a stale construction seed.
+        let role_attribute_values: Vec<(String, Value)> = updated_mixins
+            .iter()
+            .filter_map(|(key, _)| {
+                key.strip_prefix("__mutsu_attr__").and_then(|bare| {
+                    updated_mixins
+                        .role_attribute_by_name(bare)
+                        .map(|v| (bare.to_string(), v))
+                })
+            })
+            .collect();
+        for (key, attr_value) in updated_mixins.iter_mut() {
+            if let Some(bare) = key.strip_prefix("__mutsu_attr__")
+                && let Some((_, cur)) = role_attribute_values.iter().find(|(name, _)| name == bare)
+            {
+                *attr_value = cur.clone();
             }
         }
         // Which delegation applies is decided by the *delegate container*, not by
@@ -226,16 +232,22 @@ impl Interpreter {
         let Some(assigned_key) = assigned_key else {
             return Ok(None);
         };
-        if let Some(attrs) = &inst_attrs
-            && let Some(bare) = assigned_key.strip_prefix("__mutsu_attr__")
+        if let Some(bare) = assigned_key.strip_prefix("__mutsu_attr__")
             && let Some(new_value) = updated_mixins.get(&assigned_key)
         {
-            attrs.insert(Symbol::intern(bare), new_value.clone());
+            // `updated_mixins` is a deep composition copy, so its role cell is
+            // detached from the Mixin held by an attribute, a lexical alias, or
+            // a collection element. Publish the changed delegate into the
+            // original live cell instead. The marker map remains a
+            // construction-time seed; the next delegated write refreshes its
+            // working copy from this cell before applying another change.
+            mixins.set_role_attribute_by_name(bare, new_value.clone());
         }
-        Ok(Some(Value::mixin_parts(
-            inner,
-            crate::gc::Gc::new(updated_mixins),
-        )))
+        // Role-cell mutation is already visible through every alias of this
+        // Mixin. Returning the original value is important for a plain lexical:
+        // replacing it with the deep-copied `updated_mixins` would silently
+        // detach aliases that still point at the old role cell.
+        Ok(Some(Value::mixin_parts(inner, mixins)))
     }
 
     pub(crate) fn assign_mixin_container_slot(

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -328,7 +328,7 @@ impl Interpreter {
         if let Some(overrides) = mixin_overrides
             && let Some(mutated) = self.env().get(&var_name).cloned()
         {
-            let rewrapped = Value::mixin(mutated, overrides);
+            let rewrapped = Value::mixin_with_state(mutated, overrides);
             self.env_mut().insert(var_name.clone(), rewrapped.clone());
             self.write_local_slot_or_name(code, slot, &var_name, rewrapped);
         }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1868,8 +1868,8 @@ impl Interpreter {
             }
             (ValueView::Mixin(inner, _), ValueView::Int(i)) => {
                 if let ValueView::Mixin(_, mixins) = target.view()
-                    && let Some(attr_key) = self.delegated_mixin_attr_key(mixins, "AT-POS")
-                    && let Some(attr_value) = mixins.get(&attr_key).cloned()
+                    && let Some(attr_value) =
+                        self.delegated_role_attr_value_from_mixins(mixins, "AT-POS")
                 {
                     self.stack.push(attr_value);
                     self.stack.push(Value::int(i));
@@ -1937,8 +1937,7 @@ impl Interpreter {
                 let mut results = Vec::with_capacity(keys.len());
                 let delegated_attr: Option<Value> =
                     if let ValueView::Mixin(_, mixins) = target.view() {
-                        self.delegated_mixin_attr_key(mixins, "AT-POS")
-                            .and_then(|attr_key| mixins.get(&attr_key).cloned())
+                        self.delegated_role_attr_value_from_mixins(mixins, "AT-POS")
                     } else {
                         None
                     };

--- a/t/oo/role/mixin-role-attribute-cell.t
+++ b/t/oo/role/mixin-role-attribute-cell.t
@@ -1,0 +1,101 @@
+use Test;
+
+# A role mixed onto a non-Instance value owns a live attribute cell. Its
+# construction markers are seeds only: repeated compiled method calls must see
+# the previous call's scalar, array, and hash writes.
+
+role Counter {
+    has $!n = 0;
+    method bump() { $!n = $!n + 1 }
+    method n() { $!n }
+}
+
+sub check-counter($value, $name) {
+    $value.bump;
+    $value.bump;
+    is $value.n, 2, "$name role attribute persists across calls";
+}
+
+check-counter({} but Counter, 'Hash');
+check-counter([] but Counter, 'Array');
+check-counter(0 but Counter, 'native scalar');
+
+class Plain { }
+check-counter(Plain.new but Counter, 'Instance mixin');
+
+role Aggregate {
+    has @.items;
+    has %.counts;
+    method add($value) {
+        @!items.push($value);
+        %.counts{$value} = %.counts{$value} + 1;
+    }
+}
+my $aggregate = [] but Aggregate;
+$aggregate.add('a');
+$aggregate.add('a');
+$aggregate.add('b');
+is-deeply $aggregate.items, ['a', 'a', 'b'], 'role array attribute retains aggregate writes';
+is $aggregate.counts<a>, 2, 'role hash attribute retains repeated writes';
+is $aggregate.counts<b>, 1, 'role hash attribute retains a second key';
+
+class HasCount {
+    has $!n = 10;
+    method bump() { $!n = $!n + 1 }
+    method n() { $!n }
+}
+role HasCountRole {
+    has $!n = 0;
+    method role-bump() { $!n = $!n + 1 }
+    method role-n() { $!n }
+    method bump() { $!n = $!n + 1; nextsame }
+}
+my $separate = HasCount.new but HasCountRole;
+$separate.role-bump;
+$separate.role-bump;
+$separate.bump;
+is $separate.role-n, 3, 'role and class same-named attributes are independent';
+is $separate.n, 11, 'nextsame writes the wrapped class attribute';
+
+role First {
+    has $!x = 1;
+    method first() { $!x = $!x + 1; $!x }
+}
+role Second {
+    has $!x = 10;
+    method second() { $!x = $!x + 1; $!x }
+}
+my $same-named = 0 but First but Second;
+is $same-named.first, 2, 'first role has an owner-qualified attribute cell';
+is $same-named.second, 11, 'second role has an owner-qualified attribute cell';
+is $same-named.first, 3, 'first same-named role state persists';
+is $same-named.second, 12, 'second same-named role state persists';
+
+role PublicCounter {
+    has $.value is rw = 3;
+    method set() { $!value = 7 }
+}
+my $public = 0 but PublicCounter;
+$public.set;
+is $public.value, 7, 'public role accessor reads the live role cell';
+$public.value = 9;
+is $public.value, 9, 'public role accessor assignment updates the live role cell';
+
+my $qualified = 0 but Counter;
+$qualified.Counter::bump;
+$qualified.Counter::bump;
+is $qualified.Counter::n, 2, 'qualified role dispatch keeps the role attribute cell';
+
+role CloneCounter {
+    has $!n = 0;
+    method bump() { ++$!n }
+    method n() { $!n }
+}
+my $original = 0 but CloneCounter;
+$original.bump;
+my $copy = $original.clone;
+$original.bump;
+is $original.n, 2, 'original mixin keeps its role state after clone';
+is $copy.n, 1, 'Raku clone gets an independent role attribute cell';
+
+done-testing;


### PR DESCRIPTION
Closes #8026

Summary:
- Give every role mixin a GC-traced live attribute cell separate from the wrapped value.
- Route role/class attribute dispatch, delegated containers, clone, serialization, and qualified calls through the correct owner.
- Keep construction markers as seeds and add regressions for scalar, aggregate, alias, clone, and identity behavior.

Tests:
- cargo fmt --all -- --check
- make lint
- make test
- make roast
