### PR TITLE
perf(regex): collapse left-recursion bookkeeping into one Symbol-keyed map

### DIFF
--- a/news/2026-09/regex-left-recursion-bookkeeping-one-map.md
+++ b/news/2026-09/regex-left-recursion-bookkeeping-one-map.md
@@ -1,0 +1,87 @@
+# The regex engine's left-recursion bookkeeping stops paying for three String-keyed tables
+
+Every `<subrule>` reference the regex engine resolves registers a
+*left-recursion activation* for the duration of its body walk, so that a
+re-entry of the same rule at the same position reads a growing seed instead of
+recursing forever. Almost no grammar is actually left-recursive — YAMLish is
+not — but every subrule call at every position pays for the bookkeeping anyway.
+
+On a 60-row YAML document that bookkeeping was **4.7% of the whole program**:
+109.4 M instructions for 70,062 activations, about 1,560 instructions each, to
+record three booleans' worth of state.
+
+## What it cost
+
+The state was three thread-local maps — `LR_MEMO` (the seed), `LR_ACTIVE` (is
+it under evaluation), `LR_SEED_READ` (did anything read the seed) — each keyed
+by an owned `(String, usize)` built from the rule name and the number of
+characters remaining. So one call did:
+
+- one `String` allocation to build the key,
+- two more to insert it into `LR_MEMO` and `LR_ACTIVE`,
+- three hash probes to arm the activation and three to tear it down, each
+  hashing the rule-name bytes and confirming the hit with a `memcmp`.
+
+In the callgrind profile that showed up as `lr_begin_activation` (56.4 M) and
+`lr_end_activation` (53.0 M), and underneath them as the largest single caller
+of `HashMap::remove`, a sixth of all `String::clone`s, and a share of the
+allocator traffic that a self-cost profile reads as a diffuse tail.
+
+## What it costs now
+
+One map of one entry struct (`src/runtime/regex/regex_lr_state.rs`):
+
+```rust
+struct LrEntry {
+    seed: Option<Vec<(usize, RegexCaptures)>>,  // Some == under evaluation
+    seed_read: bool,
+}
+```
+
+`seed: Option<_>` subsumes `LR_ACTIVE` (a key is active exactly while it holds a
+seed), so every operation is one `entry()` lookup instead of three, and
+`lr_end_activation` drops the entry once nothing is left to remember — which is
+what keeps the map from accumulating one dead entry per (rule, position).
+
+The key stops being a `String`. The rule name is now an interned `Symbol`, taken
+from the `NamedRegexLookupSpec` that the engine already memoizes per `<subrule>`
+atom text, so it is interned once per distinct atom in the program rather than
+once per call. Hashing it is four bytes instead of the name, comparing it is an
+integer compare instead of a `memcmp`, and cloning the key allocates nothing.
+
+The rule *arguments* stay out of the symbol table on purpose. A parameterized
+call's argument values are part of its rule identity — `multi rule expr($p)`
+calling `<expr($p-1)>` at the same position is ordinary recursion toward a base
+case, not left recursion — but they are runtime data, and interning them would
+grow the (leaked, append-only) symbol table without bound. They live in a
+separate `Option<Box<str>>` field, `None` in the overwhelmingly common case.
+That also makes the key strictly more discriminating than the old one, which
+joined name and arguments into a single NUL-separated string.
+
+While the interned name was there, `resolve_parsed_token_candidates_in_pkg` —
+the memoized subrule resolver, probed once per subrule reference at every
+position — stopped re-interning it to build its own cache key and takes it from
+the caller instead.
+
+## Effect
+
+Instructions retired on the 60-row document (callgrind `Ir`, deterministic and
+load-independent):
+
+| | Ir | vs. baseline |
+| --- | ---: | ---: |
+| before | 2,341,850,737 | |
+| one map, interned key | 2,194,028,605 | -6.31% |
+| + resolver takes the interned name | 2,178,208,714 | **-6.99%** |
+
+`Symbol::intern` goes from 87.3 M (3.73%) to 71.6 M (3.29%) inclusive, and
+`resolve_parsed_token_candidates_in_pkg` from 61.3 M to 45.2 M.
+
+`t/regex/regex-left-recursion-key-identity.t` pins the three ways the key has to
+discriminate (name, arguments, position) and that an activation erases itself
+again; five of its seven rows were verified against `raku`, and the two
+left-recursive ones have no oracle because Rakudo has no growing-seed loop and
+hangs on a left-recursive rule. The unit tests in the new module pin the
+seed-read handover and that a completed round trip leaves the map empty.
+
+Part of [#7576](https://github.com/tokuhirom/mutsu/issues/7576) (round 14).

--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -7,6 +7,7 @@ mod regex_eval_class;
 mod regex_eval_repeat;
 pub(crate) mod regex_helpers;
 mod regex_interpolate;
+mod regex_lr_state;
 mod regex_ltm_rank;
 mod regex_match_atom;
 mod regex_match_atom_simple;

--- a/src/runtime/regex/regex_call_graph.rs
+++ b/src/runtime/regex/regex_call_graph.rs
@@ -221,18 +221,19 @@ impl Interpreter {
         // non-static lives inside a code block, because parse-time interpolation
         // treats those as opaque (`interpolate_bound_regex_scalars`). A body
         // that really does splice a value in is answered `None`.
-        let computed = match self.resolve_parsed_token_candidates_in_pkg(name, pkg) {
-            Some(candidates) => {
-                let raw_empty = candidates.is_empty();
-                self.rule_calls_of(name, pkg, &candidates, raw_empty)
-            }
-            None if self.rule_body_edges_are_generation_stable(name, pkg) => {
-                let spec = Self::parse_named_regex_lookup_spec(name);
-                let (candidates, raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &[]);
-                self.rule_calls_of(name, pkg, &candidates, raw_empty)
-            }
-            None => Err(StreamDecline::CalleeInterpolates),
-        };
+        let computed =
+            match self.resolve_parsed_token_candidates_in_pkg(name, Symbol::intern(name), pkg) {
+                Some(candidates) => {
+                    let raw_empty = candidates.is_empty();
+                    self.rule_calls_of(name, pkg, &candidates, raw_empty)
+                }
+                None if self.rule_body_edges_are_generation_stable(name, pkg) => {
+                    let spec = Self::parse_named_regex_lookup_spec(name);
+                    let (candidates, raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &[]);
+                    self.rule_calls_of(name, pkg, &candidates, raw_empty)
+                }
+                None => Err(StreamDecline::CalleeInterpolates),
+            };
         DIRECT_CALLS.with(|c| {
             let mut c = c.borrow_mut();
             if c.0 != generation {

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -891,6 +891,12 @@ pub(super) struct NamedRegexLookupSpec {
     pub(super) silent: bool,
     pub(super) token_lookup: bool,
     pub(super) lookup_name: String,
+    /// [`Self::lookup_name`] interned. The spec itself is memoized per atom
+    /// text, so this interns once per distinct `<subrule>` atom in the program
+    /// rather than once per call — the left-recursion key is built from it on
+    /// every subrule call at every position
+    /// ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
+    pub(super) lookup_sym: crate::symbol::Symbol,
     pub(super) capture_name: Option<String>,
     pub(super) arg_exprs: Vec<String>,
     /// When true, the alias replaces the original capture name (dot-call alias).

--- a/src/runtime/regex/regex_lr_state.rs
+++ b/src/runtime/regex/regex_lr_state.rs
@@ -1,0 +1,230 @@
+//! Left-recursion bookkeeping for `<subrule>` calls.
+//!
+//! Every `<subrule>` reference registers an *activation* for the duration of
+//! its body walk, so that a re-entry of the same rule at the same position
+//! reads a growing seed instead of recursing forever. The state this needs is
+//! three facts per `(rule, position)` key: whether the key is under
+//! evaluation, the seed it has grown so far, and whether anything actually
+//! read that seed.
+//!
+//! Those three facts used to live in three separate thread-local maps keyed by
+//! an owned `(String, usize)`, so one activation cost three `String` clones and
+//! six hash-map operations, plus the same again to tear it down — measured at
+//! 4.7% of a YAMLish parse for 70k activations, none of which were genuinely
+//! left-recursive ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
+//! One map of one entry struct, keyed by the *interned* rule name, does the
+//! same work in one hash lookup per operation and no allocation at all.
+
+use rustc_hash::FxHashMap as HashMap;
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+
+use crate::runtime::regex_types::RegexCaptures;
+use crate::symbol::Symbol;
+
+/// The left-recursion key a `<subrule>` call at `pos` is evaluated under:
+/// `(written rule name, argument identity, chars remaining)`.
+///
+/// It carries no package, so two grammars that define the same rule name share
+/// it — see `regex_call_graph::subrule_cannot_reenter_itself`.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(super) struct LrKey {
+    /// The written rule name, interned. The set of rule names a program can
+    /// name is bounded by its source text, so putting them in the (leaked,
+    /// append-only) symbol table is bounded too.
+    name: Symbol,
+    /// The formatted argument values, for a parameterized call whose arguments
+    /// are part of its rule identity: `multi rule expr($p)` calling
+    /// `<expr($p-1)>` at the same position is ordinary recursion toward a base
+    /// case, NOT left recursion (99problems-41-to-50.t P47).
+    ///
+    /// Deliberately NOT interned: an argument value is runtime data, and
+    /// interning it would grow the symbol table without bound. `None` — the
+    /// overwhelmingly common case — makes the whole key allocation-free.
+    args: Option<Box<str>>,
+    /// `chars.len() - pos`. Identifies "this rule at this position in the
+    /// subject" regardless of how deeply the `chars` slice has been sliced.
+    remaining: usize,
+}
+
+impl LrKey {
+    pub(super) fn new(name: Symbol, args: Option<Box<str>>, remaining: usize) -> Self {
+        LrKey {
+            name,
+            args,
+            remaining,
+        }
+    }
+}
+
+/// One key's left-recursion state.
+#[derive(Default)]
+struct LrEntry {
+    /// The seed matches grown so far, in HIGHEST PRIORITY FIRST order (as
+    /// returned by `regex_match_ends_from_caps_in_pkg`), with absolute
+    /// positions and no outer wrapping. `Some` exactly while the key is under
+    /// evaluation; an empty vector means "no match yet" (the initial seed).
+    seed: Option<Vec<(usize, RegexCaptures)>>,
+    /// The seed was CONSULTED — read by a recursive re-entry while this key
+    /// was active, i.e. the key is genuinely left-recursive at this position.
+    /// Only those keys need the seed-growing loop's second iteration.
+    ///
+    /// Outlives the activation: `lr_end_activation` hands the flag back to the
+    /// enclosing activation of the same key.
+    seed_read: bool,
+}
+
+impl LrEntry {
+    /// Nothing left to remember — the entry can be dropped, which is what
+    /// keeps the map from accumulating one dead entry per (rule, position).
+    fn is_inert(&self) -> bool {
+        self.seed.is_none() && !self.seed_read
+    }
+}
+
+thread_local! {
+    /// Per-key left-recursion state for the calls currently in flight.
+    ///
+    /// Fx-hashed rather than SipHash-hashed: this map is probed several times
+    /// per `<subrule>` call at every position, and a grammar rule name is not
+    /// adversarial input.
+    static LR_STATE: RefCell<HashMap<LrKey, LrEntry>> = RefCell::new(HashMap::default());
+}
+
+/// `true` when this key is already being evaluated further up the stack, i.e.
+/// entering it again would be a left-recursive re-entry.
+pub(super) fn lr_key_is_active(key: &LrKey) -> bool {
+    LR_STATE.with(|s| s.borrow().get(key).is_some_and(|e| e.seed.is_some()))
+}
+
+/// Mark `key` as under evaluation with an empty seed, returning the enclosing
+/// activation's "seed was consulted" flag for [`lr_end_activation`] to restore.
+pub(super) fn lr_begin_activation(key: &LrKey) -> bool {
+    LR_STATE.with(|s| {
+        let mut s = s.borrow_mut();
+        let entry = s.entry(key.clone()).or_default();
+        entry.seed = Some(Vec::new());
+        std::mem::take(&mut entry.seed_read)
+    })
+}
+
+/// Undo [`lr_begin_activation`], reporting whether anything re-entered `key`
+/// and read its seed while it was active.
+pub(super) fn lr_end_activation(key: &LrKey, outer_seed_read: bool) -> bool {
+    LR_STATE.with(|s| {
+        let mut s = s.borrow_mut();
+        match s.entry(key.clone()) {
+            Entry::Occupied(mut occupied) => {
+                let entry = occupied.get_mut();
+                entry.seed = None;
+                let consulted = entry.seed_read;
+                entry.seed_read = outer_seed_read;
+                if entry.is_inert() {
+                    occupied.remove();
+                }
+                consulted
+            }
+            Entry::Vacant(vacant) => {
+                if outer_seed_read {
+                    vacant.insert(LrEntry {
+                        seed: None,
+                        seed_read: true,
+                    });
+                }
+                false
+            }
+        }
+    })
+}
+
+/// Read the seed grown so far for an active `key`, recording that it was
+/// consulted (which is what makes this key genuinely left-recursive).
+pub(super) fn lr_read_seed(key: &LrKey) -> Vec<(usize, RegexCaptures)> {
+    LR_STATE.with(|s| {
+        let mut s = s.borrow_mut();
+        let entry = s.entry(key.clone()).or_default();
+        entry.seed_read = true;
+        entry.seed.clone().unwrap_or_default()
+    })
+}
+
+/// Has anything read `key`'s seed?
+pub(super) fn lr_seed_was_consulted(key: &LrKey) -> bool {
+    LR_STATE.with(|s| s.borrow().get(key).is_some_and(|e| e.seed_read))
+}
+
+/// Replace the seed of the activation that owns `key` (one iteration of the
+/// growing-seed loop).
+pub(super) fn lr_store_seed(key: &LrKey, seed: Vec<(usize, RegexCaptures)>) {
+    LR_STATE.with(|s| {
+        s.borrow_mut().entry(key.clone()).or_default().seed = Some(seed);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(name: &str, remaining: usize) -> LrKey {
+        LrKey::new(Symbol::intern(name), None, remaining)
+    }
+
+    #[test]
+    fn activation_round_trip_leaves_no_entry() {
+        let k = key("lr_round_trip", 7);
+        assert!(!lr_key_is_active(&k));
+        let outer = lr_begin_activation(&k);
+        assert!(!outer);
+        assert!(lr_key_is_active(&k));
+        assert!(!lr_end_activation(&k, outer));
+        assert!(!lr_key_is_active(&k));
+        LR_STATE.with(|s| assert!(!s.borrow().contains_key(&k)));
+    }
+
+    #[test]
+    fn seed_read_is_reported_once_and_handed_back_to_the_enclosing_activation() {
+        let k = key("lr_seed_read", 3);
+        // Outer activation, re-entered and consulted.
+        let outer = lr_begin_activation(&k);
+        assert!(lr_read_seed(&k).is_empty());
+        assert!(lr_seed_was_consulted(&k));
+        // A nested activation of the same key starts un-consulted, and hands
+        // the outer flag back on the way out.
+        let inner = lr_begin_activation(&k);
+        assert!(
+            inner,
+            "the outer activation's consulted flag is handed over"
+        );
+        assert!(!lr_seed_was_consulted(&k));
+        assert!(!lr_end_activation(&k, inner));
+        assert!(lr_seed_was_consulted(&k));
+        assert!(lr_end_activation(&k, outer));
+        LR_STATE.with(|s| assert!(!s.borrow().contains_key(&k)));
+    }
+
+    #[test]
+    fn stored_seed_is_returned_to_a_re_entry() {
+        let k = key("lr_stored_seed", 5);
+        let outer = lr_begin_activation(&k);
+        lr_store_seed(&k, vec![(9, RegexCaptures::default())]);
+        let seed = lr_read_seed(&k);
+        assert_eq!(seed.len(), 1);
+        assert_eq!(seed[0].0, 9);
+        lr_end_activation(&k, outer);
+        // The seed dies with the activation.
+        assert!(lr_read_seed(&k).is_empty());
+        lr_end_activation(&k, false);
+        LR_STATE.with(|s| assert!(!s.borrow().contains_key(&k)));
+    }
+
+    #[test]
+    fn arguments_are_part_of_the_key() {
+        let name = Symbol::intern("lr_args");
+        let bare = LrKey::new(name, None, 4);
+        let with_args = LrKey::new(name, Some("\u{0}1".into()), 4);
+        let outer = lr_begin_activation(&bare);
+        assert!(lr_key_is_active(&bare));
+        assert!(!lr_key_is_active(&with_args));
+        lr_end_activation(&bare, outer);
+    }
+}

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -1,82 +1,17 @@
-use std::cell::RefCell;
-// The left-recursion bookkeeping tables below are probed several times per
-// `<subrule>` call at every position, so they are Fx-hashed rather than
-// SipHash-hashed — a grammar rule name is not adversarial input, and the
-// hashing showed up as a measurable share of a YAML-parse profile
-// (<https://github.com/tokuhirom/mutsu/issues/7576>).
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-
 use super::super::*;
 use super::regex_helpers::{
     LTM_DECLARATIVE_MODE, LTM_PREFIX_TERMINATED, NamedRegexLookupSpec, alternation_capture_slots,
     merge_regex_captures,
 };
+use super::regex_lr_state::{
+    LrKey, lr_begin_activation, lr_end_activation, lr_read_seed, lr_seed_was_consulted,
+    lr_store_seed,
+};
 use super::regex_ltm_rank::{LtmAtomMode, ltm_atom_mode};
-
-thread_local! {
-    /// Memoization cache for left-recursive named regex calls.
-    /// Key: (rule_name, remaining_chars_count) where remaining = chars.len() - pos.
-    /// This uniquely identifies "matching rule at this position in the string"
-    /// regardless of how deeply the chars slice has been sliced.
-    /// Value: current seed matches (in HIGHEST PRIORITY FIRST order, as returned by
-    /// regex_match_ends_from_caps_in_pkg). Empty vec means "no match yet" (initial seed).
-    #[allow(clippy::type_complexity)]
-    static LR_MEMO: RefCell<HashMap<(String, usize), Vec<(usize, RegexCaptures)>>>
-        = RefCell::new(HashMap::default());
-
-    /// Set of (rule_name, remaining_chars_count) pairs currently being evaluated.
-    /// When a recursive call sees its key here, it returns the current seed.
-    static LR_ACTIVE: RefCell<HashMap<(String, usize), ()>>
-        = RefCell::new(HashMap::default());
-
-    /// Keys whose seed was actually CONSULTED (read by a recursive re-entry)
-    /// while they were active — i.e. the keys that are genuinely
-    /// left-recursive at this position. Only those need the seed-growing
-    /// loop's second iteration; see the `seed_was_consulted` check below.
-    static LR_SEED_READ: RefCell<HashSet<(String, usize)>>
-        = RefCell::new(HashSet::default());
-}
 
 /// ADR-0022 §4.4(a): one `|` branch's rank key (prefix_len, litlen) paired
 /// with its PLURAL ends (highest-priority-first).
 type RankedAlternationBranch = ((usize, usize), Vec<(usize, RegexCaptures)>);
-
-/// The left-recursion key a `<subrule>` call at `pos` is evaluated under:
-/// `(written rule name, chars remaining)`. It carries no package, so two
-/// grammars that define the same rule name share it — see
-/// `regex_call_graph::subrule_cannot_reenter_itself`.
-pub(super) type LrKey = (String, usize);
-
-/// `true` when this key is already being evaluated further up the stack, i.e.
-/// entering it again would be a left-recursive re-entry.
-pub(super) fn lr_key_is_active(key: &LrKey) -> bool {
-    LR_ACTIVE.with(|a| a.borrow().contains_key(key))
-}
-
-/// Mark `key` as under evaluation with an empty seed, returning the enclosing
-/// activation's "seed was consulted" flag for [`lr_end_activation`] to restore.
-pub(super) fn lr_begin_activation(key: &LrKey) -> bool {
-    LR_MEMO.with(|m| m.borrow_mut().insert(key.clone(), Vec::new()));
-    LR_ACTIVE.with(|a| a.borrow_mut().insert(key.clone(), ()));
-    LR_SEED_READ.with(|s| s.borrow_mut().remove(key))
-}
-
-/// Undo [`lr_begin_activation`], reporting whether anything re-entered `key`
-/// and read its seed while it was active.
-pub(super) fn lr_end_activation(key: &LrKey, outer_seed_read: bool) -> bool {
-    LR_ACTIVE.with(|a| a.borrow_mut().remove(key));
-    LR_MEMO.with(|m| m.borrow_mut().remove(key));
-    LR_SEED_READ.with(|s| {
-        let mut s = s.borrow_mut();
-        let consulted = s.contains(key);
-        if outer_seed_read {
-            s.insert(key.clone());
-        } else {
-            s.remove(key);
-        }
-        consulted
-    })
-}
 
 impl Interpreter {
     /// An alternation alternative that is a lone plain `{ … }` code block
@@ -636,29 +571,25 @@ impl Interpreter {
                 // identity: `multi rule expr($p)` calling `<expr($p-1)>` at the same
                 // position is ordinary recursion toward a base case, NOT left
                 // recursion (99problems-41-to-50.t P47).
-                let lr_name = if arg_values.is_empty() {
-                    spec.lookup_name.clone()
-                } else {
-                    let mut n = spec.lookup_name.clone();
+                let lr_args = (!arg_values.is_empty()).then(|| {
+                    let mut n = String::new();
                     for v in &arg_values {
                         n.push('\u{0}');
                         n.push_str(&Self::format_named_regex_arg_value(v));
                     }
-                    n
-                };
-                let lr_key = (lr_name, chars.len() - pos);
+                    n.into_boxed_str()
+                });
+                let lr_key = LrKey::new(spec.lookup_sym, lr_args, chars.len() - pos);
 
                 // Check if this call is currently active (left recursion detected).
-                let is_active = LR_ACTIVE.with(|a| a.borrow().contains_key(&lr_key));
+                let is_active = super::regex_lr_state::lr_key_is_active(&lr_key);
                 if is_active {
                     // Genuine left recursion: this key's evaluation depends on
-                    // its own seed, so the owner must keep growing it.
-                    LR_SEED_READ.with(|s| s.borrow_mut().insert(lr_key.clone()));
-                    // Return the current seed for this (name, position).
+                    // its own seed, so the owner must keep growing it. Reading
+                    // the seed is what records that.
                     // The seed is stored in HIGHEST FIRST order (raw inner
                     // matches, absolute positions).
-                    let seed =
-                        LR_MEMO.with(|m| m.borrow().get(&lr_key).cloned().unwrap_or_default());
+                    let seed = lr_read_seed(&lr_key);
                     // Wrap seed into outer captures. build_named_candidates_from_inner
                     // returns items in the same order as input (HIGHEST FIRST).
                     // Caller expects LOWEST FIRST, so reverse.
@@ -676,13 +607,11 @@ impl Interpreter {
                 // When is_active branch reads the seed, it passes them to
                 // build_named_candidates_from_inner which adds the outer wrapping.
                 //
-                // Initialize with empty seed (= no match yet).
-                LR_MEMO.with(|m| m.borrow_mut().insert(lr_key.clone(), Vec::new()));
-                LR_ACTIVE.with(|a| a.borrow_mut().insert(lr_key.clone(), ()));
-                // This key starts out un-consulted for THIS activation; a stale
-                // entry from an earlier activation at the same key must not be
-                // read as "left-recursive" here.
-                let outer_seed_read = LR_SEED_READ.with(|s| s.borrow_mut().remove(&lr_key));
+                // Initialize with empty seed (= no match yet). This key starts
+                // out un-consulted for THIS activation; a stale entry from an
+                // earlier activation at the same key must not be read as
+                // "left-recursive" here.
+                let outer_seed_read = lr_begin_activation(&lr_key);
 
                 // best_inner_max: max inner_end seen so far (None = nothing matched yet).
                 let mut best_inner_max: Option<usize> = None;
@@ -830,7 +759,7 @@ impl Interpreter {
                     // identical set — and since every nested subrule did the same,
                     // that redundant second pass compounded to 2^depth over a
                     // precedence-climbing grammar (99problems-41-to-50.t P47).
-                    let seed_was_consulted = LR_SEED_READ.with(|s| s.borrow().contains(&lr_key));
+                    let seed_was_consulted = lr_seed_was_consulted(&lr_key);
                     if !seed_was_consulted {
                         best_raw = deduped_raw;
                         break;
@@ -862,26 +791,17 @@ impl Interpreter {
                         // Seed grew: store the raw matches (HIGHEST FIRST) as the seed.
                         best_inner_max = new_max;
                         best_raw = deduped_raw.clone();
-                        LR_MEMO.with(|m| m.borrow_mut().insert(lr_key.clone(), deduped_raw));
+                        lr_store_seed(&lr_key, deduped_raw);
                     } else {
                         // No growth: done.
                         break;
                     }
                 }
 
-                // Clean up active/memo state.
-                LR_ACTIVE.with(|a| a.borrow_mut().remove(&lr_key));
-                LR_MEMO.with(|m| m.borrow_mut().remove(&lr_key));
-                // Restore the enclosing activation's consulted flag: an inner
-                // activation of the same key must not mask the outer one's.
-                LR_SEED_READ.with(|s| {
-                    let mut s = s.borrow_mut();
-                    if outer_seed_read {
-                        s.insert(lr_key.clone());
-                    } else {
-                        s.remove(&lr_key);
-                    }
-                });
+                // Clean up this activation, restoring the enclosing one's
+                // consulted flag: an inner activation of the same key must not
+                // mask the outer one's.
+                lr_end_activation(&lr_key, outer_seed_read);
 
                 // Wrap best_raw into outer captures and return.
                 // best_raw is HIGHEST FIRST; build_named_candidates_from_inner returns in

--- a/src/runtime/regex/regex_match_lazy_subrule.rs
+++ b/src/runtime/regex/regex_match_lazy_subrule.rs
@@ -79,8 +79,8 @@ impl Interpreter {
             return decline(reason);
         }
         let spec = Self::parse_named_regex_lookup_spec(name);
-        let lr_key = (spec.lookup_name.clone(), chars.len() - pos);
-        if super::regex_match_atom::lr_key_is_active(&lr_key) {
+        let lr_key = super::regex_lr_state::LrKey::new(spec.lookup_sym, None, chars.len() - pos);
+        if super::regex_lr_state::lr_key_is_active(&lr_key) {
             return decline(StreamDecline::LrKeyActive);
         }
         // Same resolution the eager arm performs (memoized for a static body,
@@ -99,7 +99,7 @@ impl Interpreter {
         let parsed = std::sync::Arc::clone(parsed);
         let sub_pkg = sub_pkg.clone();
 
-        let outer_seed_read = super::regex_match_atom::lr_begin_activation(&lr_key);
+        let outer_seed_read = super::regex_lr_state::lr_begin_activation(&lr_key);
         // Ends are deduplicated the way the eager arm does it: the first (=
         // highest-priority) path to reach an end wins, later ones are dropped.
         let mut seen_ends: Vec<usize> = Vec::new();
@@ -136,9 +136,9 @@ impl Interpreter {
                 // body walk; the code-block re-entry the activation exists to
                 // catch happens inside the body, which is still covered.
                 *seed_consulted_in_cont |=
-                    super::regex_match_atom::lr_end_activation(&lr_key, outer_seed_read);
+                    super::regex_lr_state::lr_end_activation(&lr_key, outer_seed_read);
                 let stop = on(interp, store, end, delta);
-                super::regex_match_atom::lr_begin_activation(&lr_key);
+                super::regex_lr_state::lr_begin_activation(&lr_key);
                 if stop {
                     *unwind = true;
                     return true;
@@ -158,7 +158,7 @@ impl Interpreter {
                 &mut MatchSink::Cont(&mut cont),
             );
         }
-        let seed_consulted = super::regex_match_atom::lr_end_activation(&lr_key, outer_seed_read)
+        let seed_consulted = super::regex_lr_state::lr_end_activation(&lr_key, outer_seed_read)
             || seed_consulted_in_cont;
         if seed_consulted && !unwind {
             // A `{ ... }` block re-entered this key after all, so the single

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -607,10 +607,12 @@ impl Interpreter {
         }
 
         let (lookup_name, arg_exprs) = Self::parse_regex_lookup_target(raw);
+        let lookup_sym = crate::symbol::Symbol::intern(&lookup_name);
         NamedRegexLookupSpec {
             silent,
             token_lookup,
             lookup_name,
+            lookup_sym,
             capture_name,
             arg_exprs,
             alias_replaces_original,

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -95,14 +95,23 @@ impl Interpreter {
     /// (pkg, name). Returns `None` when any candidate's pattern is non-static
     /// (its parse depends on runtime variable interpolation) or fails to
     /// parse — callers fall back to the uncached per-call path.
+    ///
+    /// `name_sym` is `name` interned. Callers that already hold it (every
+    /// `<subrule>` reference does — the memoized [`NamedRegexLookupSpec`]
+    /// carries it) pass it in rather than re-interning: this function is
+    /// probed once per subrule reference at every position, and interning is a
+    /// thread-local hash-map probe of the string, not a free operation
+    /// ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
     pub(super) fn resolve_parsed_token_candidates_in_pkg(
         &mut self,
         name: &str,
+        name_sym: Symbol,
         pkg: &str,
     ) -> Option<std::sync::Arc<Vec<ParsedTokenCandidate>>> {
+        debug_assert_eq!(name_sym, Symbol::intern(name));
         let tok_gen =
             crate::runtime::regex_parse::TOKEN_DEFS_GEN.load(std::sync::atomic::Ordering::Relaxed);
-        let cache_key = (Symbol::intern(pkg), Symbol::intern(name));
+        let cache_key = (Symbol::intern(pkg), name_sym);
         if let Some(hit) = PARSED_TOKEN_CANDIDATES.with(|c| {
             c.borrow()
                 .get(&cache_key)
@@ -173,7 +182,8 @@ impl Interpreter {
         arg_values: &[Value],
     ) -> (std::sync::Arc<Vec<ParsedTokenCandidate>>, bool) {
         if arg_values.is_empty()
-            && let Some(hit) = self.resolve_parsed_token_candidates_in_pkg(&spec.lookup_name, pkg)
+            && let Some(hit) =
+                self.resolve_parsed_token_candidates_in_pkg(&spec.lookup_name, spec.lookup_sym, pkg)
         {
             let raw_empty = hit.is_empty();
             return (hit, raw_empty);

--- a/t/regex/regex-left-recursion-key-identity.t
+++ b/t/regex/regex-left-recursion-key-identity.t
@@ -1,0 +1,75 @@
+use v6;
+use Test;
+
+# The regex engine's left-recursion bookkeeping is keyed by
+# `(rule name, argument identity, characters remaining)`. Round 14 of #7576
+# replaced three `String`-keyed thread-local tables with a single map whose key
+# holds the *interned* rule name and the argument identity in separate fields,
+# instead of joining them into one string with a NUL separator; an activation
+# now also has to erase itself from that one map on the way out.
+#
+# These rows pin the three ways the key has to discriminate, plus the teardown:
+# a key that conflated two calls would make the second read the first's empty
+# seed and fail, and a retained entry would do the same to a later call at the
+# same position.
+#
+# The left-recursive rows have no `raku` oracle -- Rakudo has no growing-seed
+# loop and hangs on a left-recursive rule (same caveat as
+# `t/regex/regex-lazy-candidate-enumeration.t`'s E3d). Every other row matches
+# raku.
+
+plan 7;
+
+# The seed-growing loop itself: `expr` re-enters itself at the same position.
+grammar LeftRec {
+    token TOP  { <expr> }
+    token expr { <expr> '+' <term> | <term> }
+    token term { \d+ }
+}
+is ~(LeftRec.parse('1+2+3') // ''), '1+2+3', 'a left-recursive rule grows its seed';
+is ~(LeftRec.parse('7') // ''), '7', 'and still matches its base case';
+
+# Name discrimination: `item` and `item-list` are distinct keys at the same
+# position, even though one name is a prefix of the other.
+grammar PrefixNames {
+    token TOP       { <item-list> }
+    token item-list { <item>+ % ',' }
+    token item      { \w+ }
+}
+is ~(PrefixNames.parse('a,b,c') // ''), 'a,b,c',
+    'rule names that share a prefix are separate activations';
+
+# Argument discrimination: `<depth($n-1)>` at the same position is ordinary
+# recursion toward a base case, not left recursion, so it must not read the
+# outer call's seed.
+grammar Parameterized {
+    rule TOP { <depth(3)> }
+    multi rule depth(0)  { \d+ }
+    multi rule depth($n) { <depth($n-1)> }
+}
+ok Parameterized.parse('42').defined,
+    'the same rule at the same position with a different argument is not left recursion';
+
+# Teardown: two sibling calls to the same rule at the same zero-width position.
+# The second one must not find the first one's activation still registered.
+grammar Siblings {
+    token gap { \s* }
+    token TOP { 'a' <.gap> <.gap> 'b' }
+}
+ok Siblings.parse('ab').defined, 'an activation is erased when its call returns';
+
+# ... and the same rule reached again at a *later* position, after the first
+# activation at an earlier one has ended.
+grammar Repeated {
+    token word { \w+ }
+    token TOP  { <word> ' ' <word> }
+}
+is ~(Repeated.parse('one two') // ''), 'one two',
+    'the same rule at two positions keeps two independent keys';
+
+# The key carries no package, so two grammars that define the same rule name
+# share it -- which is sound only because an activation never outlives its call.
+grammar SameNameA { token TOP { <part> }; token part { 'x' } }
+grammar SameNameB { token TOP { <part> }; token part { 'y' } }
+ok SameNameA.parse('x').defined && SameNameB.parse('y').defined,
+    'a rule name shared by two grammars resolves per grammar';


### PR DESCRIPTION
Round 14 of #7576.

## The finding

Every `<subrule>` reference the regex engine resolves registers a *left-recursion activation* for the duration of its body walk, so a re-entry of the same rule at the same position reads a growing seed instead of recursing forever. Almost no grammar is actually left-recursive — YAMLish is not — but every subrule call at every position paid for the bookkeeping anyway.

On a 60-row YAML document that was **4.7% of the whole program**: 109.4 M instructions for 70,062 activations, about 1,560 each, to record three booleans' worth of state.

The state lived in three thread-local maps (`LR_MEMO`, `LR_ACTIVE`, `LR_SEED_READ`), each keyed by an owned `(String, usize)` built from the rule name and the characters remaining. Arming one activation cost three `String` allocations and three hash probes; tearing it down cost three more — each hashing the rule-name bytes and confirming the hit with a `memcmp`. Underneath `lr_begin_activation` (56.4 M) and `lr_end_activation` (53.0 M) that showed up as the largest single caller of `HashMap::remove`, a sixth of every `String::clone` in the program, and a share of the allocator traffic a self-cost profile reads as a diffuse tail.

## The change

**One map of one entry struct** (`src/runtime/regex/regex_lr_state.rs`), where `seed: Option<_>` subsumes `LR_ACTIVE` — a key is active exactly while it holds a seed — so every operation is one `entry()` lookup instead of three, and the entry is dropped once nothing is left to remember (which is what keeps the map from accumulating one dead entry per (rule, position)).

**The key stops being a `String`.** The rule name is an interned `Symbol`, taken from the `NamedRegexLookupSpec` the engine already memoizes per `<subrule>` atom text, so it is interned once per distinct atom in the program rather than once per call. Hashing it is four bytes instead of the name, comparing it is an integer compare, and cloning the key allocates nothing.

The rule **arguments** stay out of the symbol table on purpose. They are part of a parameterized call's rule identity — `multi rule expr($p)` calling `<expr($p-1)>` at the same position is ordinary recursion toward a base case, not left recursion — but they are runtime data, and interning them would grow the leaked, append-only symbol table without bound. They live in a separate `Option<Box<str>>`, `None` in the common case. That also makes the key strictly more discriminating than the old one, which joined name and arguments into a single NUL-separated string.

With the interned name available, `resolve_parsed_token_candidates_in_pkg` — the memoized subrule resolver, probed once per subrule reference at every position — takes it from the caller instead of re-interning it to build its own cache key.

## Effect

Instructions retired on the 60-row document (callgrind `Ir`, deterministic and load-independent, as in rounds 10–13):

| | Ir | vs. baseline |
| --- | ---: | ---: |
| before | 2,341,850,737 | |
| one map, interned key | 2,194,028,605 | -6.31% |
| + resolver takes the interned name | 2,178,208,714 | **-6.99%** |

`Symbol::intern` inclusive goes 87.3 M (3.73%) → 71.6 M (3.29%); `resolve_parsed_token_candidates_in_pkg` 61.3 M → 45.2 M.

## Method note

Round 12's lesson was "a profile's flat tail regenerates itself; re-run the caller attribution after every round rather than carrying the previous round's *what is left* forward as a conclusion." Round 14 is that lesson paying out: round 13 handed off "the profile is flat, allocator ~19% / `memcpy` 7.1% / `LocalKey::with` 5.8%, nothing above 1.9%", and a fresh `callgrind_annotate --tree=caller` put 4.7% of it in two bookkeeping functions that had never appeared in any previous round's summary. They were invisible for the usual reason — their cost sat in `malloc`, `String::clone` and `HashMap::remove`, not under their own names.

One measurement trap worth recording for whoever profiles this next: **warm the module precompilation cache before taking a profile.** The first run of a freshly built binary re-parses `YAMLish` from source, which adds ~190 M Ir of parser work under `parse_module_source` and made this change look like a 1.9% *regression* until the run was repeated.

## Tests

`t/regex/regex-left-recursion-key-identity.t` (new) pins the three ways the key has to discriminate — name, arguments, position — and that an activation erases itself again; five of its seven rows were verified against `raku`, and the two left-recursive ones have no oracle because Rakudo has no growing-seed loop and hangs on a left-recursive rule (the same caveat `t/regex/regex-lazy-candidate-enumeration.t` records for its E3d row). The unit tests in the new module pin the seed-read handover and that a completed round trip leaves the map empty.

`cargo fmt --all`, `make lint`, `make test` (4054 files, 43152 tests) and `make roast` (1437 files, 219635 tests) all run locally on the rebased branch. The only roast failures are the three this container is documented to produce — `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` (`uid 0` makes their `chmod` assertions meaningless) — per [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md).

## What is left on #7576

The ticket stays open. The next item with a named mechanism is the one round 13 handed off, now with a measured shape: `RegexCaptures` is **336 bytes** and is constructed, moved and dropped per candidate — `memcpy` is 7.10% of the reduced total and its callers are exactly the `RegexCaptures`-carrying paths (`regex_match_atom_all_with_capture_*`, `build_named_candidates_from_inner`, `regex_walk_ends_in_pkg`, `walk_tokens`), with `RegexCaptures::clone` at 2.69% and `drop_in_place<RegexCaptures>` at 2.86%. The fix is the ADR-0016-P2 split applied one level up: move the cold fields (`regex_vars`, `capture_alias_map`, `hash_captures`, `positional_slots`, `sym`, `action_name`, `target`, `outer_backref`) behind one boxed rare-payload, so an empty delta stays a handful of words. Secondary: `arm_inline_vars_seed` / `take_inline_regex_vars_seed` clone the whole `:my` variable map per inline sub-pattern (1.5%), which an `Option<Arc<RegexVarMap>>` would turn into a refcount bump, and `resolve_parsed_token_candidates_in_pkg` still interns its *package* name on every probe (~0.7%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_