### PR TITLE
perf(env): give each env tier a key-set memo so capture skips what it cannot keep

### DIFF
--- a/news/2026-09/env-tiers-carry-a-key-set-memo-so-capture-skips-what-it-cannot-keep.md
+++ b/news/2026-09/env-tiers-carry-a-key-set-memo-so-capture-skips-what-it-cannot-keep.md
@@ -1,0 +1,133 @@
+# Env tiers carry a key-set memo, so closure capture skips what it can never keep
+
+`use Test` taxes every hot loop in the file that loads it ([#7565]). Four rounds
+have taken that tax apart; what was left at the top of the list was the walk
+itself. `Env::filtered_flat` visits every name visible from the creating scope
+on **every closure creation**, and after a bare `use Test` a closure created
+inside a sub visits 96 keys to keep 31. Of the 65 it rejects, 49 are
+`__mutsu_callable_id::<pkg>::<name>` routine-registration markers — one per
+routine the import made visible — and the rest are attribute-twigil
+materializations and `__mutsu_type::` metadata whose subject is one of those.
+
+That is the ticket's thesis in miniature: the importing scope's ordinary code
+gets slower in proportion to how much the module exports, and the mechanism is a
+per-creation walk over names no closure can name.
+
+## Why the obvious memo could not be built before
+
+Every earlier attempt keyed the memo on the tier's **address** and failed the
+same way. An address memo has to hold the tier's `Arc` to stop the allocator
+recycling the address under it, and holding it forces `Arc::make_mut` to clone
+the map on the next ordinary value write — so in a loop that writes a mainline
+lexical the memo is invalidated before it is ever read. #7707 measured a
+whole-chain version of this at +18%; #8019's note recorded the per-tier version
+as unreachable for the same reason, and named the process-global
+`skip_env_write` latch as the thing that would have to be fixed first.
+
+It does not, because the address was never the right key. The rejects are a pure
+function of the tier's **key set**, and a value write does not change that. So
+the memo belongs on the tier, not beside it: identity becomes structural rather
+than positional, and a copy-on-write clone carries the memo across, because a
+clone has exactly the key set the original had.
+
+## The change
+
+`Env::inner` is now an `Arc<Tier>` (`src/env_tier.rs`) rather than an
+`Arc<SymMap>`. A `Tier` is the overlay map — **private**, with every mutator
+living on `Tier` — plus the indexes derived from its key set. Making the map
+unreachable is the point: a key-set memo is only safe if nothing can add a key
+behind its back, and this turns that from a review obligation into a
+compile-time one. Mutators that can only *remove* a key leave the indexes alone,
+because they are supersets by contract and the reader looks each key up.
+
+The one index so far is `capture_candidates`: the tier's keys that a capture
+could keep, i.e. everything `env_tier::capture_never_keeps` does not reject.
+`Env::filtered_flat_capture` walks it instead of the map when it is much shorter
+(below two thirds), and walks the map otherwise. A tier narrower than 32 keys
+never builds the memo at all — a call frame's own overlay is a handful of
+entries *and* is allocated fresh per call, so it would rebuild the list on every
+capture and never read it twice.
+
+A tier is memoized only on the **second** capture that walks it, which is the
+same "wait for a repeat" discipline `vm_capture_cache` arms its own memo with. A
+tier can be both wide and allocated fresh per call — a method frame that flattens
+its chain gets one — and a capture inside it would build a list, read it once and
+drop it. That is a pure loss, and it was **2.4% of `benchmarks/bench-ctor.raku`**
+before the second-ask gate went in.
+
+Three things were built, measured and thrown away on the way, all worth recording:
+
+- **Hoisting the key-only half of the filter out into the walk is a
+  regression.** It looks like the natural shape — the tier already knows that
+  verdict, so why ask again — and it cost **+880 instructions per closure
+  creation on an import-free program**, more than the memo saves on one that
+  imports. Both halves of the filter open by loading the key's memoized flags
+  word, and splitting them made every walked key pay that load twice. `keep` is
+  therefore the whole filter in both arms; the memo's copy of the verdict is
+  used only to decide *which keys to visit*, never to skip work inside the
+  filter.
+- **Sharing the loop body between the two arms through a closure is a
+  regression too**, for the plainer reason that a capturing `FnMut` there is not
+  inlined. The arms spell their body out.
+- **Walking the candidate list unconditionally is a regression** on a tier where
+  almost everything is a candidate: the list costs a hash probe per key where
+  the map costs an iterator step. Hence the two-thirds threshold, and the
+  32-key floor below which no memo is built at all.
+
+`Env::filtered_flat` also stopped taking `&dyn Fn` and is monomorphized on its
+predicate, which is where a little of the gain below comes from.
+
+## Measured
+
+Warm-run callgrind instruction slopes between 6 000 and 14 000 iterations,
+`MUTSU_JIT=off MUTSU_GC=off`, release, against `main` at `23c7c216` built with
+the same procedure. "Tax" is the `use Test` line minus its floor — the thing
+this ticket is about.
+
+| | base | after | |
+| --- | --- | --- | --- |
+| leaf loop, no `use Test` (the floor) | 76 344 | 76 777 | |
+| leaf loop `+ use Test` | 88 237 | 87 323 | -1.0% |
+| **its tax** | **11 893** | **10 546** | **-11.3%** |
+| calling loop, no `use Test` | 83 007 | 83 659 | |
+| calling loop `+ use Test` | 97 622 | 96 686 | -1.0% |
+| **its tax** | **14 615** | **13 027** | **-10.9%** |
+
+On the ticket's own loop the memo takes the mainline tier's walk from 92 keys to
+43, and the whole capture from 96 visited keys to 47.
+
+The floor lines are up 0.4-0.8%, which needs saying plainly: it is at the edge of
+the drift band this particular filter is documented to sit in — #7964 built four
+shapes of *identical* logic and measured them spanning 0.8% — and two whole
+programs measured end to end say the same thing, so I read it as codegen shape
+rather than added work:
+
+| whole program, instructions | base | after | |
+| --- | --- | --- | --- |
+| `benchmarks/bench-ctor.raku` | 1 401 425 034 | 1 398 995 804 | -0.2% |
+| `benchmarks/bench-class.raku` | 1 171 088 568 | 1 173 525 194 | +0.2% |
+
+Neither imports anything, and both create closures inside method frames — the
+shape the second-ask gate exists for. Numbers here are local; anything that ends
+up in PERFORMANCE.md or PLAN.md has to come from the bench CI.
+
+## What is left
+
+Unchanged from #8042's note, with the walk item re-measured:
+
+1. **The no-op capture merge** — the capture-as-a-fallback-tier design change,
+   still architectural and still the biggest single item. `Tier` does not help
+   it: the obstacle there is an identity token for the caller chain, and that is
+   an address question, not a key-set one.
+2. **`skip_env_write`'s process-global latch**, with the `EVAL`-scope question
+   from #8019's note. It no longer gates anything on this list — the memo it was
+   said to block is shipped — but it is still a per-store cost.
+3. **The remaining walk.** 43 candidates for 31 kept, at a hash probe per
+   candidate. The next step that looks worth having is putting each candidate's
+   *resolved key and flags word* in the memo beside it, so the filter does not
+   reload them — roughly 650 instructions per creation on this loop. It needs a
+   second predicate for the candidate arm; the shared tail is
+   `capture_never_keeps_resolved`, so the two cannot drift.
+4. **The ~20 built-in dynamics** — floor, not tax.
+
+[#7565]: https://github.com/tokuhirom/mutsu/issues/7565

--- a/src/env.rs
+++ b/src/env.rs
@@ -13,7 +13,11 @@ use crate::value::Value;
 /// cost dominated method/variable-heavy benchmarks (perf: ~7% of self time in
 /// `SipHasher::write`/`hash_one`). Iteration order is unspecified either way, so
 /// no env-iteration consumer (`iter`/`keys`/`values`/pseudo-stash) is affected.
-pub(crate) type SymMap = rustc_hash::FxHashMap<Symbol, Value>;
+///
+/// An env *tier* is this map plus the indexes derived from its key set; see
+/// [`crate::env_tier::Tier`], which owns the map and is what `Env::inner`
+/// actually holds.
+pub(crate) use crate::env_tier::{CaptureWalk, SymMap, Tier};
 
 /// Process-wide immutable "base" tier of the environment.
 ///
@@ -443,7 +447,7 @@ pub(crate) fn note_env_key(key: &str) {
 /// environment, so it is invisible to `iter`/`keys`/`values`/`len`/`remove`.
 #[derive(Clone)]
 pub struct Env {
-    inner: Arc<SymMap>,
+    inner: Arc<Tier>,
     /// Optional read-through "parent" tier: the enclosing call frame's whole env
     /// (itself possibly scoped, forming a *chain*). When present (a *scoped* env),
     /// name lookups fall through overlay -> parent-chain -> [`GLOBAL_BASE`], but
@@ -538,15 +542,15 @@ const MAX_OVERLAY_DEPTH: u16 = 16;
 /// copy-on-write, no behavioral difference. `Env::ptr_eq` consumers are
 /// unaffected: two envs sharing this map are both empty, and any write
 /// un-shares the writer before it can be observed.
-fn empty_overlay() -> Arc<SymMap> {
+fn empty_overlay() -> Arc<Tier> {
     empty_overlay_ref().clone()
 }
 
 /// Borrowed access to the shared empty overlay singleton, for identity checks
 /// that must not pay the `Arc` refcount round-trip a `clone` would cost.
-fn empty_overlay_ref() -> &'static Arc<SymMap> {
-    static EMPTY: std::sync::OnceLock<Arc<SymMap>> = std::sync::OnceLock::new();
-    EMPTY.get_or_init(|| Arc::new(SymMap::default()))
+fn empty_overlay_ref() -> &'static Arc<Tier> {
+    static EMPTY: std::sync::OnceLock<Arc<Tier>> = std::sync::OnceLock::new();
+    EMPTY.get_or_init(|| Arc::new(Tier::default()))
 }
 
 /// The interned `"?FILE"` key. Interning it once keeps the maintenance hook in
@@ -569,7 +573,7 @@ fn file_sym_of(v: &Value) -> Option<Symbol> {
 impl Env {
     pub(crate) fn new() -> Self {
         Self {
-            inner: Arc::new(SymMap::default()),
+            inner: Arc::new(Tier::default()),
             parent: None,
             tombstones: None,
             depth: 0,
@@ -953,7 +957,7 @@ impl Env {
                     tiers.push(cur);
                     cur = parent;
                 }
-                let mut merged: SymMap = (*cur.inner).clone();
+                let mut merged: SymMap = (**cur.inner).clone();
                 for tier in tiers.into_iter().rev() {
                     // An overlay that never received a write (and holds no
                     // tombstone) is invisible to lookups.
@@ -967,7 +971,7 @@ impl Env {
                     }
                 }
                 Self {
-                    inner: Arc::new(merged),
+                    inner: Arc::new(Tier::new(merged)),
                     parent: None,
                     tombstones: None,
                     depth: 0,
@@ -994,19 +998,21 @@ impl Env {
     /// lambda creation inside method frames (`todo/deep/closure-env-capture-cost.md`).
     /// The base tier (`GLOBAL_BASE`) is — as in `flattened()` — never
     /// materialized; it stays reachable through the flat env's tail lookup.
-    pub(crate) fn filtered_flat(&self, keep: &dyn Fn(Symbol, &Value) -> bool) -> Env {
+    pub(crate) fn filtered_flat<F: Fn(Symbol, &Value) -> bool>(&self, keep: &F) -> Env {
         /// `outermost` is true for the base of the chain -- the tier processed
         /// first, while `out` still holds nothing. A rejected or tombstoned key
         /// there cannot be shadowing an outer tier's kept entry (there is no
         /// outer tier, and a map yields each of its own keys once), so the
         /// suppressing `out.remove` is a guaranteed miss: a hash and a probe per
         /// rejected key, on the widest tier of the chain. A closure created in a
-        /// sub after a bare `use Test` walks 95 visible keys and keeps 31, and
-        /// all 62 of its removes landed on that one tier (#7565).
-        fn collect(
+        /// sub after a bare `use Test` walked 95 visible keys and kept 31, and
+        /// all 62 of its removes landed on that one tier (#7565); that capture
+        /// now goes through [`Env::filtered_flat_capture`], but the shape of
+        /// the saving is the same for any other wide chain this walks.
+        fn collect<F: Fn(Symbol, &Value) -> bool>(
             env: &Env,
             out: &mut SymMap,
-            keep: &dyn Fn(Symbol, &Value) -> bool,
+            keep: &F,
             outermost: bool,
         ) {
             let outermost = match &env.parent {
@@ -1054,7 +1060,111 @@ impl Env {
         // `keep` may have rejected `?FILE`, so re-derive rather than inherit.
         let file_sym = out.get(&file_key()).and_then(file_sym_of);
         Self {
-            inner: Arc::new(out),
+            inner: Arc::new(Tier::new(out)),
+            parent: None,
+            tombstones: None,
+            depth: 0,
+            file_sym,
+            frame_writes: None,
+            code_entries: None,
+        }
+    }
+
+    /// [`Self::filtered_flat`] specialized for the closure capture: the keys no
+    /// capture can ever keep are skipped **without being visited**, by walking
+    /// each tier's [`Tier::capture_candidates`] memo instead of its whole map.
+    ///
+    /// `keep` therefore only has to decide the part of the capture filter that
+    /// depends on which closure is being created; the key-only part lives in
+    /// [`crate::env_tier::capture_never_keeps`], which is what the memo caches.
+    ///
+    /// Skipping a non-candidate outright — rather than rejecting it and then
+    /// suppressing an outer tier's entry with `out.remove`, as
+    /// [`Self::filtered_flat`] must — is sound precisely because that verdict is
+    /// a pure function of the key: a key rejected on one tier was rejected on
+    /// every tier, so it was never inserted into `out` and there is nothing to
+    /// suppress. The candidate list is a *superset* (a removal does not prune
+    /// it), so each key is looked up rather than assumed present.
+    ///
+    /// After a bare `use Test` this is the difference between visiting 96 keys
+    /// and visiting 47 for the same 31-entry result, on every closure creation
+    /// in the importing file (#7565).
+    pub(crate) fn filtered_flat_capture<F: Fn(Symbol, &Value) -> bool>(&self, keep: &F) -> Env {
+        fn collect<F: Fn(Symbol, &Value) -> bool>(
+            env: &Env,
+            out: &mut SymMap,
+            keep: &F,
+            outermost: bool,
+        ) {
+            let outermost = match &env.parent {
+                Some(parent) => {
+                    collect(parent, out, keep, outermost);
+                    false
+                }
+                None => outermost,
+            };
+            if let Some(tomb) = &env.tombstones
+                && !outermost
+            {
+                for k in tomb {
+                    out.remove(k);
+                }
+            }
+            // The body is spelled out per arm rather than shared through a
+            // closure: a capturing `FnMut` here is not inlined, and that cost
+            // more per key than skipping the rejected ones saved (#7565).
+            //
+            // `keep` is the WHOLE filter in both arms, never-keeps included.
+            // Hoisting the key-only half out of it and testing it separately
+            // here looks like an obvious saving and is not: both halves start
+            // by loading the key's memoized flags word, so splitting them made
+            // every walked key pay that load twice — measured at +880
+            // instructions per closure creation on an import-free program,
+            // which is more than the memo saves on one that imports (#7565).
+            match env.inner.capture_walk() {
+                CaptureWalk::Entries => {
+                    for (k, v) in env.inner.iter() {
+                        if keep(*k, v) {
+                            out.insert(*k, v.clone());
+                        } else if !outermost {
+                            out.remove(k);
+                        }
+                    }
+                }
+                CaptureWalk::Candidates(keys) => {
+                    for &k in keys {
+                        // Superset index: the key may have been removed since
+                        // the memo was built.
+                        let Some(v) = env.inner.get(&k) else {
+                            continue;
+                        };
+                        if keep(k, v) {
+                            out.insert(k, v.clone());
+                        } else if !outermost {
+                            out.remove(&k);
+                        }
+                    }
+                }
+            }
+        }
+        // Pre-size from the candidate counts rather than the whole chain's key
+        // count: the rejected families are exactly what makes the two diverge
+        // (36 against 96 after a bare `use Test`), and over-reserving cost a
+        // 2 KiB allocation and its zeroing per closure creation.
+        let mut cap = 0usize;
+        {
+            let mut cur = Some(self);
+            while let Some(env) = cur {
+                cap += env.inner.capture_upper_bound();
+                cur = env.parent.as_deref();
+            }
+        }
+        let mut out = SymMap::with_capacity_and_hasher(cap, Default::default());
+        collect(self, &mut out, keep, true);
+        // `keep` may have rejected `?FILE`, so re-derive rather than inherit.
+        let file_sym = out.get(&file_key()).and_then(file_sym_of);
+        Self {
+            inner: Arc::new(Tier::new(out)),
             parent: None,
             tombstones: None,
             depth: 0,
@@ -1175,7 +1285,7 @@ impl Env {
     /// O(env_size) deep copy whenever the env is shared (the real dual-store
     /// cost; see docs/vm-dual-store.md and `vm_stats::record_env_deep_copy`).
     #[inline]
-    fn cow_mut(&mut self) -> &mut SymMap {
+    fn cow_mut(&mut self) -> &mut Tier {
         if crate::vm::vm_stats::enabled() && Arc::strong_count(&self.inner) > 1 {
             crate::vm::vm_stats::record_env_deep_copy(self.inner.len());
         }
@@ -1537,7 +1647,7 @@ impl Env {
     #[allow(dead_code)]
     pub(crate) fn inner_mut(&mut self) -> &mut SymMap {
         self.code_entries = None;
-        self.cow_mut()
+        self.cow_mut().map_mut()
     }
 
     /// Direct read access to the inner HashMap (this env's OWN tier only — it
@@ -1580,7 +1690,7 @@ impl Env {
     /// be freed and re-allocated at one of them) AND forces copy-on-write on
     /// the next by-name write to any tier, so an address match proves the
     /// visible contents are byte-for-byte the ones that were there before.
-    pub(crate) fn tier_maps(&self) -> Vec<Arc<SymMap>> {
+    pub(crate) fn tier_maps(&self) -> Vec<Arc<Tier>> {
         let mut maps = Vec::new();
         let mut cur = self;
         loop {
@@ -1610,7 +1720,7 @@ pub(crate) struct TierAddrs {
 impl TierAddrs {
     /// True when `maps` (an owning [`Env::tier_maps`] snapshot) is exactly the
     /// chain these addresses describe.
-    pub(crate) fn matches(&self, maps: &[Arc<SymMap>]) -> bool {
+    pub(crate) fn matches(&self, maps: &[Arc<Tier>]) -> bool {
         maps.len() == self.len
             && maps
                 .iter()
@@ -1633,7 +1743,7 @@ impl From<HashMap<String, Value>> for Env {
             .collect();
         let file_sym = sym_map.get(&file_key()).and_then(file_sym_of);
         Self {
-            inner: Arc::new(sym_map),
+            inner: Arc::new(Tier::new(sym_map)),
             parent: None,
             tombstones: None,
             depth: 0,
@@ -1649,7 +1759,7 @@ impl From<HashMap<Symbol, Value>> for Env {
         let map: SymMap = map.into_iter().collect();
         let file_sym = map.get(&file_key()).and_then(file_sym_of);
         Self {
-            inner: Arc::new(map),
+            inner: Arc::new(Tier::new(map)),
             parent: None,
             tombstones: None,
             depth: 0,
@@ -1682,6 +1792,7 @@ impl IntoIterator for Env {
     fn into_iter(self) -> Self::IntoIter {
         Arc::try_unwrap(self.inner)
             .unwrap_or_else(|arc| (*arc).clone())
+            .into_map()
             .into_iter()
     }
 }

--- a/src/env_tier.rs
+++ b/src/env_tier.rs
@@ -1,0 +1,411 @@
+//! One env tier: a frame's overlay map, plus the indexes that are a pure
+//! function of its **key set** and so may outlive any number of value writes.
+//!
+//! The map is private and every mutator lives here, which is the whole point:
+//! a memo derived from the key set is only safe if no code path can add a key
+//! behind its back, and making [`Tier::map`] unreachable is what turns that
+//! from a review obligation into a compile-time one. A mutator that can only
+//! REMOVE a key leaves the indexes alone: they are supersets by contract, and
+//! their readers look each named key up rather than assume it is present.
+//!
+//! # Why a key-set-scoped memo at all
+//!
+//! Closure capture (`Interpreter::capture_closure_env` -> [`Env::filtered_flat_capture`])
+//! walks every name visible from the creating scope and keeps a handful. After a
+//! bare `use Test` a closure created inside a sub visits 96 keys to keep 31, and
+//! 49 of the 65 rejects are decided by the key alone: `__mutsu_callable_id::`
+//! routine-registration markers, one per routine the import made visible, plus
+//! attribute-twigil materializations. That is the cost #7565 is about — the
+//! importing scope's ordinary code gets slower in proportion to how much the
+//! module exports — and it is paid on *every* closure creation.
+//!
+//! Those rejects cannot be memoized against the tier's *address*: an armed
+//! address memo has to hold the tier's `Arc` to stop the allocator recycling it,
+//! and holding it forces `Arc::make_mut` to clone the map on the next ordinary
+//! value write, so in a loop that writes a mainline lexical the memo never
+//! survives to be read (measured, #7565 and #8019). Hanging the memo off the
+//! tier itself has neither problem: identity is structural rather than
+//! positional, and a copy-on-write clone carries the memo across because a
+//! clone has exactly the key set the original had.
+//!
+//! [`Env`]: crate::env::Env
+//! [`Env::filtered_flat_capture`]: crate::env::Env::filtered_flat_capture
+
+use std::ops::Deref;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::symbol::{Symbol, flags};
+use crate::value::Value;
+
+/// A single env tier's overlay storage.
+// Keyed by interned `Symbol`; `FxHashMap` (non-cryptographic hash over the
+// small integer key), not the default `SipHash` — this is the map every env
+// lookup probes.
+pub(crate) type SymMap = rustc_hash::FxHashMap<Symbol, Value>;
+
+/// One env tier: the overlay map plus its key-set-derived indexes.
+///
+/// `Clone` carries the indexes over deliberately — a clone has the original's
+/// key set, which is exactly what they describe. That is what makes them
+/// survive `Arc::make_mut`'s copy-on-write.
+#[derive(Default)]
+pub(crate) struct Tier {
+    map: SymMap,
+    /// Memo of [`Self::capture_candidates`]. Empty until something asks;
+    /// reset by every mutation that can ADD a key (see
+    /// [`Self::invalidate_key_set`]).
+    ///
+    /// A *superset* index, never a subset — a removal deliberately leaves it
+    /// alone, so a named key may no longer be in the map and the reader looks
+    /// each one up rather than trusting it to be present. It must never MISS a
+    /// present key, or a closure would silently capture one name fewer than it
+    /// should; that is what the private `map` guarantees.
+    ///
+    /// Boxed: a `Tier` is allocated per copy-on-write clone of any frame
+    /// overlay, so the memo costs those allocations one pointer rather than the
+    /// index inline.
+    capture_candidates: OnceLock<Box<CandidateIndex>>,
+    /// Whether a capture has already walked this tier — see
+    /// [`Tier::capture_walk`], which builds the memo only on the SECOND ask.
+    capture_asked: AtomicBool,
+}
+
+impl Clone for Tier {
+    fn clone(&self) -> Self {
+        Self {
+            map: self.map.clone(),
+            capture_candidates: self.capture_candidates.clone(),
+            capture_asked: AtomicBool::new(self.capture_asked.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+/// The candidate list, with the map length it was built at. The length is a
+/// debug-only staleness net: an addition invalidates the memo, so a longer map
+/// than the one it was built from means a mutator bypassed
+/// [`Tier::invalidate_key_set`].
+#[derive(Clone)]
+struct CandidateIndex {
+    keys: Box<[Symbol]>,
+    built_at_len: usize,
+}
+
+/// How [`Env::filtered_flat_capture`] should enumerate one tier — see
+/// [`Tier::capture_walk`].
+///
+/// [`Env::filtered_flat_capture`]: crate::env::Env::filtered_flat_capture
+pub(crate) enum CaptureWalk<'a> {
+    /// Iterate the tier's whole map and let the filter reject what it rejects.
+    Entries,
+    /// Iterate these keys and look each one up, skipping the rest of the map
+    /// unvisited. Worth its hash probe per key only when the list is much
+    /// shorter than the map — the `use Test` case, where it is 43 keys against
+    /// 92 (#7565).
+    Candidates(&'a [Symbol]),
+}
+
+/// True when no closure capture can ever keep `key`, decided by the key alone —
+/// the part of the capture filter that does not depend on which closure is
+/// being created, factored out so a tier can memoize it once per key set.
+///
+/// * Attribute-twigil keys (`!x`, `@!x`, `%.x`, ...) are per-frame
+///   materializations of `self`'s attributes, not lexicals: the closure must
+///   read them through its captured `self` at RUN time, or a creation-time
+///   snapshot goes stale the moment the instance mutates.
+/// * `__mutsu_callable_id::<pkg>::<name>` is a routine-registration marker, one
+///   per named routine visible in the creating scope, and nothing a closure
+///   body can name. Every consumer reads it from the LIVE env at call time; the
+///   single case that cannot (an escaping closure whose `use`-inside-`EVAL`
+///   scope has been popped) is re-added by name in `capture_bare_callees`.
+/// * `__mutsu_callable_type` is closure-IDENTITY metadata (the WhateverCode
+///   marker), installed on the genuine closure's own env after capture. An
+///   ordinary inner block that inherited it would be mis-detected as a
+///   WhateverCode.
+///
+/// `__mutsu_type::<name>` is *shadow metadata*: it says what `<name>` is
+/// constrained to and nothing can observe it except through `<name>` itself, so
+/// it is decided on its subject's terms rather than its own (#7964).
+#[inline]
+pub(crate) fn capture_never_keeps(key: Symbol) -> bool {
+    let mut k = key;
+    let mut f = k.flags();
+    if f & flags::TYPE_META != 0 {
+        // `None` cannot happen (the flag is a pure string property of the
+        // prefix), but keeping the key is the conservative answer.
+        let Some(subject) = k.type_meta_subject() else {
+            return false;
+        };
+        k = subject;
+        f = subject.flags();
+    }
+    capture_never_keeps_resolved(k, f)
+}
+
+/// [`capture_never_keeps`] for a caller that has already resolved the key
+/// through its `__mutsu_type::` wrapper and loaded its flags word — the closure
+/// capture filter, which needs both anyway. Sharing this tail is what keeps the
+/// two askers from drifting apart; drift here would mean a tier skipping a key
+/// the filter would have kept, i.e. a silently incomplete closure capture.
+#[inline]
+pub(crate) fn capture_never_keeps_resolved(key: Symbol, flags: u16) -> bool {
+    const DROP: u16 = flags::ATTR_TWIGIL_ENV_KEY | flags::CALLABLE_ID_META;
+    flags & DROP != 0 || key == crate::symbol::well_known::callable_type()
+}
+
+/// Smallest tier the candidate memo is built for — see [`Tier::capture_walk`].
+const CANDIDATE_MEMO_MIN_KEYS: usize = 32;
+
+impl Tier {
+    /// Wrap an already-built map. Every whole-map rebuild goes through here, so
+    /// the indexes start empty exactly as they must.
+    pub(crate) fn new(map: SymMap) -> Self {
+        Self {
+            map,
+            capture_candidates: OnceLock::new(),
+            capture_asked: AtomicBool::new(false),
+        }
+    }
+
+    /// This tier's keys that a closure capture could keep — everything
+    /// [`capture_never_keeps`] does not reject. Computed on first ask and held
+    /// until the key set changes.
+    pub(crate) fn capture_candidates(&self) -> &[Symbol] {
+        if let Some(idx) = self.capture_candidates.get() {
+            debug_assert!(
+                idx.built_at_len >= self.map.len(),
+                "capture-candidate memo missed a key added since it was built",
+            );
+            return &idx.keys;
+        }
+        // Pre-sized: the list is at most the map's key count, and growing a
+        // `Vec` through its doubling ladder for a wide tier was a measurable
+        // share of the build (`realloc` on `benchmarks/bench-ctor.raku`).
+        let mut keys = Vec::with_capacity(self.map.len());
+        keys.extend(
+            self.map
+                .keys()
+                .copied()
+                .filter(|k| !capture_never_keeps(*k)),
+        );
+        let keys = keys.into_boxed_slice();
+        let built_at_len = self.map.len();
+        &self
+            .capture_candidates
+            .get_or_init(|| Box::new(CandidateIndex { keys, built_at_len }))
+            .keys
+    }
+
+    /// How a closure capture should enumerate this tier.
+    ///
+    /// Walking the by-key candidate list costs a hash probe per key, which only
+    /// pays when the list is much shorter than the map. Everything else walks
+    /// the map exactly as it did before the memo existed — the filter still
+    /// rejects the never-keeps, it just does not get to skip them — so a
+    /// program with no wide import list pays nothing for this.
+    pub(crate) fn capture_walk(&self) -> CaptureWalk<'_> {
+        // Below this, building the memo cannot pay for itself. The tiers that
+        // matter are the wide ones a whole file's names live in; a call frame's
+        // own overlay is a handful of entries AND is allocated fresh per call,
+        // so it would rebuild the list — a `Vec` collect and its allocation —
+        // on every single capture and never read it twice (measured: ~400
+        // instructions per closure creation for a 4-entry frame tier, #7565).
+        if self.map.len() < CANDIDATE_MEMO_MIN_KEYS {
+            return CaptureWalk::Entries;
+        }
+        // Build on the SECOND ask, never the first — the same "wait for a
+        // repeat" discipline `vm_capture_cache` arms its memo with, and for the
+        // same reason. A tier can be both wide and allocated fresh per call: a
+        // method frame that flattens its chain gets one, and a capture inside
+        // it would build a list, read it once and drop it. That is a pure loss,
+        // and it was 2.4% of `benchmarks/bench-ctor.raku` (#7565). A tier worth
+        // memoizing is by definition one a second capture comes back to.
+        if self.capture_candidates.get().is_none()
+            && !self.capture_asked.swap(true, Ordering::Relaxed)
+        {
+            return CaptureWalk::Entries;
+        }
+        let candidates = self.capture_candidates();
+        // Break-even is around two thirds: skipping a key saves an iterator
+        // step and a filter call, and costs a hash probe on each key that is
+        // kept. (The index is a superset, so after removals it can be as long
+        // as -- or longer than -- the map; that lands on `Entries`, which is
+        // right.)
+        if candidates.len() * 3 >= self.map.len() * 2 {
+            return CaptureWalk::Entries;
+        }
+        CaptureWalk::Candidates(candidates)
+    }
+
+    /// Upper bound on how many of this tier's entries a capture can keep, for
+    /// pre-sizing the result map. Reads the memo if it is already there and
+    /// never builds it — building is [`Self::capture_walk`]'s decision, and
+    /// this runs before it.
+    pub(crate) fn capture_upper_bound(&self) -> usize {
+        match self.capture_candidates.get() {
+            Some(idx) => idx.keys.len().min(self.map.len()),
+            None => self.map.len(),
+        }
+    }
+
+    /// Drop every key-set-derived index. Called by each mutator that can ADD a
+    /// key; a mutator that can only REMOVE one leaves them alone, because they
+    /// are supersets by contract.
+    #[inline(always)]
+    fn invalidate_key_set(&mut self) {
+        // `take` needs no atomic: it has `&mut self`, so the initialized bit is
+        // a plain read. It is reached only from a mutator that really did add a
+        // key, which on the hot insert path is the rare case.
+        self.capture_candidates.take();
+    }
+
+    #[inline]
+    pub(crate) fn insert(&mut self, key: Symbol, value: Value) -> Option<Value> {
+        let prev = self.map.insert(key, value);
+        if prev.is_none() {
+            self.invalidate_key_set();
+        }
+        prev
+    }
+
+    /// A removal cannot invalidate a superset index — see
+    /// [`Self::capture_candidates`].
+    #[inline]
+    pub(crate) fn remove(&mut self, key: &Symbol) -> Option<Value> {
+        self.map.remove(key)
+    }
+
+    /// Value-only: the key must already be present, so the key set is unchanged.
+    #[inline]
+    pub(crate) fn get_mut(&mut self, key: &Symbol) -> Option<&mut Value> {
+        self.map.get_mut(key)
+    }
+
+    #[inline]
+    pub(crate) fn values_mut(
+        &mut self,
+    ) -> std::collections::hash_map::ValuesMut<'_, Symbol, Value> {
+        self.map.values_mut()
+    }
+
+    /// Filtering can only remove keys — superset indexes survive it.
+    #[inline]
+    pub(crate) fn retain(&mut self, f: impl FnMut(&Symbol, &mut Value) -> bool) {
+        self.map.retain(f);
+    }
+
+    #[inline]
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.map.reserve(additional);
+    }
+
+    /// Raw mutable access, for the bulk paths that add keys without naming
+    /// them. Drops the indexes up front, since it cannot report what it did.
+    #[inline]
+    pub(crate) fn map_mut(&mut self) -> &mut SymMap {
+        self.invalidate_key_set();
+        &mut self.map
+    }
+
+    /// Unwrap the tier back into its map (`Env::into_iter`).
+    pub(crate) fn into_map(self) -> SymMap {
+        self.map
+    }
+}
+
+impl Deref for Tier {
+    type Target = SymMap;
+
+    #[inline(always)]
+    fn deref(&self) -> &SymMap {
+        &self.map
+    }
+}
+
+impl std::fmt::Debug for Tier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.map.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(name: &str) -> Symbol {
+        Symbol::intern(name)
+    }
+
+    fn candidates_are_exact(tier: &Tier) -> bool {
+        let mut want: Vec<Symbol> = tier
+            .keys()
+            .copied()
+            .filter(|k| !capture_never_keeps(*k))
+            .collect();
+        let mut got: Vec<Symbol> = tier
+            .capture_candidates()
+            .iter()
+            .copied()
+            .filter(|k| tier.contains_key(k))
+            .collect();
+        want.sort_by_key(|k| k.id());
+        got.sort_by_key(|k| k.id());
+        want == got
+    }
+
+    #[test]
+    fn candidate_memo_drops_the_never_captured_families() {
+        let mut tier = Tier::default();
+        tier.insert(s("$x"), Value::int(1));
+        tier.insert(s("__mutsu_callable_id::GLOBAL::ok"), Value::int(2));
+        tier.insert(s("@!attr"), Value::int(3));
+        tier.insert(s("__mutsu_callable_type"), Value::int(4));
+        let got: Vec<Symbol> = tier.capture_candidates().to_vec();
+        assert_eq!(got, vec![s("$x")]);
+    }
+
+    #[test]
+    fn a_value_overwrite_keeps_the_memo_and_a_new_key_rebuilds_it() {
+        let mut tier = Tier::default();
+        tier.insert(s("$x"), Value::int(1));
+        let before = tier.capture_candidates().as_ptr();
+        // Value-only write: the key set is unchanged, so the memo must survive
+        // -- this is the whole point of the index (#7565).
+        tier.insert(s("$x"), Value::int(2));
+        assert_eq!(tier.capture_candidates().as_ptr(), before);
+        tier.insert(s("$y"), Value::int(3));
+        assert!(candidates_are_exact(&tier));
+        assert_eq!(tier.capture_candidates().len(), 2);
+    }
+
+    #[test]
+    fn a_clone_carries_the_memo_because_it_has_the_same_keys() {
+        let mut tier = Tier::default();
+        tier.insert(s("$x"), Value::int(1));
+        let _ = tier.capture_candidates();
+        let copy = tier.clone();
+        assert_eq!(copy.capture_candidates(), &[s("$x")]);
+        assert!(candidates_are_exact(&copy));
+    }
+
+    #[test]
+    fn a_removal_leaves_a_superset_the_reader_must_re_probe() {
+        let mut tier = Tier::default();
+        tier.insert(s("$x"), Value::int(1));
+        tier.insert(s("$y"), Value::int(2));
+        let _ = tier.capture_candidates();
+        tier.remove(&s("$y"));
+        assert_eq!(tier.capture_candidates().len(), 2);
+        assert!(candidates_are_exact(&tier));
+    }
+
+    #[test]
+    fn map_mut_drops_the_memo_because_it_can_add_a_key() {
+        let mut tier = Tier::default();
+        tier.insert(s("$x"), Value::int(1));
+        let _ = tier.capture_candidates();
+        tier.map_mut().insert(s("$z"), Value::int(9));
+        assert!(candidates_are_exact(&tier));
+        assert_eq!(tier.capture_candidates().len(), 2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod compiler;
 pub mod crash_report;
 pub mod doc_mode;
 pub(crate) mod env;
+pub(crate) mod env_tier;
 pub mod error_render;
 pub(crate) mod gc;
 mod interpreter;

--- a/src/vm/vm_capture_cache.rs
+++ b/src/vm/vm_capture_cache.rs
@@ -49,7 +49,7 @@
 
 use std::sync::Arc;
 
-use crate::env::{Env, SymMap, TierAddrs};
+use crate::env::{Env, Tier, TierAddrs};
 use crate::opcode::CompiledCode;
 
 /// Consecutive wasted arms (armed, then replaced without a single hit) after
@@ -66,7 +66,7 @@ const ARM_RETRY_EVERY: u32 = 512;
 struct ArmedCapture {
     /// Every tier's overlay map, leaf first — see the module docs for why these
     /// are held rather than merely addressed.
-    tiers: Vec<Arc<SymMap>>,
+    tiers: Vec<Arc<Tier>>,
     /// The closure chunk whose free-var / own-local sets shaped the filter.
     /// Held so `Arc::ptr_eq` against a later chunk cannot be fooled by a
     /// recycled allocation.
@@ -135,7 +135,7 @@ impl CaptureCache {
         &mut self,
         addrs: Option<TierAddrs>,
         code: &Arc<CompiledCode>,
-        tiers: Option<Vec<Arc<SymMap>>>,
+        tiers: Option<Vec<Arc<Tier>>>,
         captured: &Env,
     ) {
         self.last = addrs.map(|addrs| (addrs, Arc::as_ptr(code) as usize));

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1060,15 +1060,12 @@ impl Interpreter {
         // the caller on return (`* ~~ /<$r>/` invoked inside a grep-in-`for`).
         let own_locals = cc.capture_local_set();
         // Keep only the upvalue set, shadow-meta, and system names, walking the
-        // env tiers directly (`filtered_flat`) — flattening first (`clone_env`)
-        // deep-cloned the entire parent-chain map per lambda creation. The
-        // filter is key-pure, so the tier walk's shadow/tombstone handling is
-        // exactly the flattened view. `__mutsu_callable_type` is
-        // closure-identity metadata (the WhateverCode marker), (re)installed on
-        // the genuine closure's own env after capture — never inherit it, or an
-        // ordinary inner block would be mis-detected as a WhateverCode (see the
-        // by-name path above).
-        let callable_type_sym = crate::symbol::well_known::callable_type();
+        // env tiers directly (`filtered_flat_capture`) — flattening first
+        // (`clone_env`) deep-cloned the entire parent-chain map per lambda
+        // creation. The filter is key-pure, so the tier walk's shadow/tombstone
+        // handling is exactly the flattened view, and the half of it that reads
+        // nothing but the key is memoized per tier
+        // (`env_tier::capture_never_keeps`) rather than re-asked per creation.
         // The filter below reads only the KEY, so its result is a pure function
         // of the visible env contents and of `cc` — which is what lets a
         // repeated creation of the same closure literal from an unchanged scope
@@ -1081,7 +1078,7 @@ impl Interpreter {
             self.finish_closure_capture(code, cc, &mut env);
             return env;
         }
-        let mut env = self.env().filtered_flat(&|k, _v| {
+        let mut env = self.env().filtered_flat_capture(&|k, _v| {
             // One memoized flags word answers the string questions this filter
             // asks per key (see `symbol::flags`), instead of resolving the
             // symbol and re-scanning its bytes.
@@ -1100,7 +1097,7 @@ impl Interpreter {
             // lexical anywhere in the creating scope: 11 of the ~35 entries a
             // closure captured after a bare `use Test`, which scale with the
             // importer's scope exactly like the `__mutsu_callable_id::` markers
-            // below (#7565).
+            // do (#7565).
             //
             // Deciding it by its subject rather than by "is it a free
             // variable" is what keeps a typed *dynamic* (`my Int $*x`) — a
@@ -1115,30 +1112,15 @@ impl Interpreter {
                 k = subject;
                 flags = subject.flags();
             }
-            // Two unconditional rejects, fused into one mask test because both
-            // are pure string properties of the key and neither needs a set
-            // probe. Most of what this filter walks is answered here:
-            //
-            // * Attribute-twigil keys (`!x`, `@!x`, `%.x`, …) are per-frame
-            //   materializations of `self`'s attributes, not lexicals: the
-            //   closure must read them through its captured `self` at RUN time.
-            //   A creation-time snapshot goes stale the moment the instance
-            //   mutates — a `start` block reading `@!before` inside
-            //   Cro::CompositeConnector.connect saw an empty pre-mutation copy.
-            // * `__mutsu_callable_id::<pkg>::<name>` is a routine-registration
-            //   marker, one per named routine visible in the creating scope —
-            //   after a bare `use Test` that is 49 of the 95 keys this filter
-            //   walks, none of which any closure body can name. Every consumer
-            //   reads it from the LIVE env at call time, where it is still
-            //   visible through the frame chain; the single case that is not (an
-            //   escaping closure whose `use`-inside-`EVAL` scope has been
-            //   popped) is pinned by name in `capture_bare_callees`.
-            const DROP: u16 =
-                crate::symbol::flags::ATTR_TWIGIL_ENV_KEY | crate::symbol::flags::CALLABLE_ID_META;
-            if flags & DROP != 0 {
-                return false;
-            }
-            if k == callable_type_sym {
+            // The unconditional, key-only rejects — see
+            // `env_tier::capture_never_keeps`, which is the same verdict, asked
+            // once per key SET rather than once per closure creation so that
+            // `filtered_flat_capture` can skip these keys without visiting
+            // them. It stays spelled out here as well, and this is deliberate:
+            // both halves of the filter open by loading the key's flags word,
+            // so a version that tested the memoized half separately paid that
+            // load twice per key (#7565).
+            if crate::env_tier::capture_never_keeps_resolved(k, flags) {
                 return false;
             }
             // A plain user lexical is inherited only as an upvalue, so the

--- a/t/routines/closure/closure-capture-tier-key-memo.t
+++ b/t/routines/closure/closure-capture-tier-key-memo.t
@@ -1,0 +1,71 @@
+use Test;
+
+# Each env tier memoizes the subset of its keys a closure capture could ever
+# keep, so a wide scope's never-captured metadata (routine-registration markers,
+# attribute-twigil materializations) is skipped without being visited
+# (`src/env_tier.rs`, #7565). The memo is keyed to the tier's KEY SET: a value
+# write must not disturb it and a new key must rebuild it.
+#
+# The padding below is what makes this file test the memoized path at all — the
+# memo is only built for a tier wide enough to pay for it, so a scope with a
+# handful of names would exercise the plain walk instead and prove nothing.
+
+plan 14;
+
+my $Pad01 = 1; my $Pad02 = 2; my $Pad03 = 3; my $Pad04 = 4; my $Pad05 = 5;
+my $Pad06 = 6; my $Pad07 = 7; my $Pad08 = 8; my $Pad09 = 9; my $Pad10 = 10;
+my $Pad11 = 11; my $Pad12 = 12; my $Pad13 = 13; my $Pad14 = 14; my $Pad15 = 15;
+my $Pad16 = 16; my $Pad17 = 17; my $Pad18 = 18; my $Pad19 = 19; my $Pad20 = 20;
+sub pad-a() { 'a' }; sub pad-b() { 'b' }; sub pad-c() { 'c' }; sub pad-d() { 'd' }
+sub pad-e() { 'e' }; sub pad-f() { 'f' }; sub pad-g() { 'g' }; sub pad-h() { 'h' }
+sub pad-i() { 'i' }; sub pad-j() { 'j' }; sub pad-k() { 'k' }; sub pad-l() { 'l' }
+
+# --- The wide scope's names are still all visible from a capture -------------
+is { $Pad07 }(), 7, 'an uppercase-initial lexical is captured from a wide scope';
+is { Int }().gist, '(Int)', 'a type name resolves inside a closure in a wide scope';
+is { pad-c() }(), 'c', 'an enclosing named sub is callable from the closure';
+
+my $*WIDE = 'dyn';
+is { $*WIDE }(), 'dyn', 'a dynamic is captured from a wide scope';
+
+# --- Repeated creation from the same wide scope ------------------------------
+# The memo lives on the tier, so every one of these creations reads the same
+# candidate list. Each closure must still capture its own free variable.
+sub make($n) { return { $n * 3 } }
+is (1 .. 5).map({ make($_).() }).join(','), '3,6,9,12,15',
+    'each closure created from the wide scope keeps its own free variable';
+
+# --- A VALUE write must not disturb the memo ---------------------------------
+$Pad07 = 70;
+is { $Pad07 }(), 70, 'a value write to a wide-scope name is seen by a later capture';
+is make(2).(), 6, 'and the repeated-creation path is unaffected by it';
+
+# --- A NEW key must rebuild it ------------------------------------------------
+# `$Late` is declared after the memo above was built. A capture that missed it
+# would leave the closure unable to see the name at all.
+my $Late = 'late';
+is { $Late }(), 'late', 'a name declared after the memo was built is still captured';
+sub late-sub() { 'late-sub' }
+is { late-sub() }(), 'late-sub', 'so is a routine declared after it';
+
+# --- Shadow metadata still follows its subject --------------------------------
+my Int $Typed = 3;
+is { $Typed }(), 3, 'a typed wide-scope lexical is captured';
+dies-ok { my $w = { $Typed = 'str' }; $w() },
+    'and its type constraint is captured with it';
+
+my Int $*TypedDyn = 4;
+is { $*TypedDyn }(), 4, 'a typed dynamic is captured';
+dies-ok { my $w = { $*TypedDyn = 'str' }; $w() },
+    'and so is its constraint (it is a system name, never a free variable)';
+
+# --- `self` reaches through a capture made in a wide method scope --------------
+class Wide {
+    has $.v;
+    method wrapped() {
+        my $q01 = 1; my $q02 = 2; my $q03 = 3; my $q04 = 4; my $q05 = 5;
+        my $q06 = 6; my $q07 = 7; my $q08 = 8; my $q09 = 9; my $q10 = 10;
+        return { self.v + $q07 }
+    }
+}
+is Wide.new(v => 5).wrapped().(), 12, 'self and a method local both reach the closure';


### PR DESCRIPTION
`Env::filtered_flat` visits every name visible from the creating scope on **every
closure creation**. After a bare `use Test` a closure created inside a sub visits
96 keys to keep 31, and 49 of the 65 rejects are
`__mutsu_callable_id::<pkg>::<name>` routine-registration markers — one per
routine the import made visible, none of which any closure body can name. That is
#7565's thesis in miniature: the importing scope's ordinary code gets slower in
proportion to how much the module exports.

## Why the obvious memo could not be built before

Every earlier attempt keyed on the tier's **address** and failed the same way: an
address memo must hold the tier's `Arc` to stop the allocator recycling it, and
holding it forces `Arc::make_mut` to clone the map on the next ordinary value
write — so in a loop that writes a mainline lexical the memo is invalidated
before it is ever read. #7707 measured a whole-chain version at +18%; #8019
recorded the per-tier version as unreachable and named the process-global
`skip_env_write` latch as the prerequisite.

It is not a prerequisite, because the address was never the right key. The
verdict is a pure function of the tier's **key set**, which a value write does
not change. So the memo belongs *on* the tier: identity becomes structural rather
than positional, and a copy-on-write clone carries it across, because a clone has
exactly the key set the original had.

## The change

`Env::inner` is now `Arc<Tier>` (`src/env_tier.rs`): the overlay map — **private**,
with every mutator on `Tier` — plus the indexes derived from its key set. Making
the map unreachable is the point; a key-set memo is only safe if nothing can add
a key behind its back, and this makes that a compile-time property rather than a
review obligation. Mutators that can only *remove* a key leave the indexes alone,
because they are supersets by contract and readers re-probe each key.

`Env::filtered_flat_capture` walks the candidate list when it is much shorter than
the map (below two thirds) and walks the map otherwise. Two guards keep the memo
from costing a program that cannot use it: a tier under 32 keys never builds one,
and a tier builds one only on the **second** capture that walks it — the same
"wait for a repeat" discipline `vm_capture_cache` arms with. A tier can be both
wide and allocated fresh per call (a method frame that flattens its chain), where
a list built, read once and dropped is pure loss; that was **2.4% of
`benchmarks/bench-ctor.raku`** before the second-ask gate.

`Env::filtered_flat` is also monomorphized on its predicate rather than taking
`&dyn Fn`.

## Measured

Warm-run callgrind instruction slopes (6 000 → 14 000 iterations, `MUTSU_JIT=off
MUTSU_GC=off`, release), against `main` at `23c7c216` built the same way. "Tax" is
the `use Test` line minus its floor.

| | base | after | |
| --- | --- | --- | --- |
| leaf loop, no `use Test` (the floor) | 76 344 | 76 777 | |
| leaf loop `+ use Test` | 88 237 | 87 323 | -1.0% |
| **its tax** | **11 893** | **10 546** | **-11.3%** |
| calling loop, no `use Test` | 83 007 | 83 659 | |
| calling loop `+ use Test` | 97 622 | 96 686 | -1.0% |
| **its tax** | **14 615** | **13 027** | **-10.9%** |

On the ticket's loop the memo takes the mainline tier's walk from 92 keys to 43,
and the whole capture from 96 visited keys to 47.

The floor lines are up 0.4-0.8%, which is worth stating plainly: it sits at the
edge of the drift band this filter is documented to have (#7964 built four shapes
of *identical* logic and measured them spanning 0.8%). Two whole programs read as
neutral, which is why I take it for codegen shape rather than added work:

| whole program, instructions | base | after | |
| --- | --- | --- | --- |
| `benchmarks/bench-ctor.raku` | 1 401 425 034 | 1 398 995 804 | -0.2% |
| `benchmarks/bench-class.raku` | 1 171 088 568 | 1 173 525 194 | +0.2% |

Neither imports anything and both create closures inside method frames — the
shape the second-ask gate exists for. These are local numbers; anything destined
for PERFORMANCE.md or PLAN.md has to come from the bench CI.

## Measured and NOT shipped — do not redo blind

All three are recorded in comments at the site:

- **Hoisting the key-only half of the filter out into the walk is a regression**:
  +880 instructions per closure creation on an import-free program, more than the
  memo saves on one that imports. Both halves open by loading the key's memoized
  flags word, and splitting them pays that load twice. `keep` is therefore the
  whole filter in both arms; the memo decides only *which keys to visit*.
- **Sharing the loop body between the two arms through a closure is a regression
  too** — a capturing `FnMut` there is not inlined.
- **Walking the candidate list unconditionally loses** on a tier where almost
  everything is a candidate: the list costs a hash probe per key where the map
  costs an iterator step. Hence the two-thirds threshold.

## Tests

`t/routines/closure/closure-capture-tier-key-memo.t` (14 assertions, verified
against rakudo) pins the mechanism's semantics in a scope wide enough to reach
the memoized path: everything a wide scope's capture must still see, that a value
write does not disturb the memo, that a name declared *after* it was built is
still captured, and that `__mutsu_type::` shadow metadata still follows its
subject (including the typed-dynamic case, which is a system name and never a
free variable). `src/env_tier.rs` carries unit tests for the invalidation
contract itself — value overwrite keeps the memo, a new key rebuilds it, a clone
carries it, a removal leaves a superset, and `map_mut` drops it.

`make test` PASS (4043 files, 43007 tests), `make lint` clean, `make roast` with
only the three container-only failures `docs/agent-environments.md` documents
(the two `uid 0` `chmod` tests and the sandboxed-network socket test, with the
exact failure counts it lists).

## Related

Leaves #7565 open — the tax is reduced, not gone. The remaining list is in the
news entry; the largest item is still the no-op capture merge, which `Tier` does
not help (its obstacle is an identity token for the caller chain, an address
question rather than a key-set one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8)_