### PR TITLE
fix: keep FatRat arithmetic arbitrary precision

### DIFF
--- a/news/2026-09/fatrat-multiplication-keeps-arbitrary-precision.md
+++ b/news/2026-09/fatrat-multiplication-keeps-arbitrary-precision.md
@@ -1,0 +1,10 @@
+# FatRat multiplication keeps arbitrary precision
+
+Multiplying `FatRat` values no longer overflows the machine-sized numerator and
+denominator once their products exceed `i64`. The operation now takes the same
+BigInt-backed rational path as other arbitrary-precision rational operations,
+so it remains exact and preserves the `FatRat` type.
+
+The regression is pinned by `t/types/fatrat-product-overflow.t`.
+
+Closes [#8049](https://github.com/tokuhirom/mutsu/issues/8049).

--- a/src/builtins/arith/rat.rs
+++ b/src/builtins/arith/rat.rs
@@ -50,12 +50,15 @@ pub(crate) fn rat_from_i128_or_num(n: i128, d: i128) -> Value {
     crate::value::make_big_rat_arith(NumBigInt::from(n), NumBigInt::from(d))
 }
 
-/// Check if BigRat arithmetic is needed: at least one operand requires BigInt precision
-/// (BigRat or BigInt) AND at least one operand is rational (Rat/FatRat/BigRat).
-/// Plain Rat-vs-Rat operations use the i128-based overflow-to-Num path instead.
+/// Check if arbitrary-precision rational arithmetic is needed: at least one
+/// operand requires BigInt precision (BigRat, BigInt, or FatRat) AND at least
+/// one operand is rational (Rat/FatRat/BigRat). Plain Rat-vs-Rat operations use
+/// the i128-based overflow-to-Num path instead.
 pub(crate) fn needs_bigrat_path(l: &Value, r: &Value) -> bool {
     let has_big = matches!(l.view(), ValueView::BigRat(_, _) | ValueView::BigInt(_))
         || matches!(r.view(), ValueView::BigRat(_, _) | ValueView::BigInt(_));
+    let has_fat_rat =
+        matches!(l.view(), ValueView::FatRat(_, _)) || matches!(r.view(), ValueView::FatRat(_, _));
     let has_rat = matches!(
         l.view(),
         ValueView::Rat(_, _) | ValueView::FatRat(_, _) | ValueView::BigRat(_, _)
@@ -63,7 +66,7 @@ pub(crate) fn needs_bigrat_path(l: &Value, r: &Value) -> bool {
         r.view(),
         ValueView::Rat(_, _) | ValueView::FatRat(_, _) | ValueView::BigRat(_, _)
     );
-    has_big && has_rat
+    (has_big || has_fat_rat) && has_rat
 }
 
 /// Check if a value should be treated as FatRat for arithmetic.

--- a/t/types/fatrat-product-overflow.t
+++ b/t/types/fatrat-product-overflow.t
@@ -1,0 +1,14 @@
+use Test;
+
+plan 2;
+
+my $r = FatRat.new(1, 3);
+for ^40 {
+    $r = $r * FatRat.new(7, 5);
+}
+
+is $r.Str,
+    '233345.8988636899876685501289392835508332483925',
+    'FatRat multiplication keeps arbitrary precision past i64';
+is $r.^name, 'FatRat',
+    'FatRat multiplication preserves the FatRat type';


### PR DESCRIPTION
## Summary

- Treat `FatRat` operands as requiring arbitrary-precision rational arithmetic.
- Add a regression test for repeated `FatRat` multiplication past `i64`.

## Validation

- `make lint`
- `make test`
- `make roast`

Closes #8049
