### PR TITLE
fix(parser): report a parse failure where the parser actually stopped

### DIFF
--- a/news/2026-09/parse-errors-report-the-innermost-position.md
+++ b/news/2026-09/parse-errors-report-the-innermost-position.md
@@ -1,0 +1,90 @@
+# Parse errors report where the parser actually stopped
+
+The ecosystem parity ledger's largest single block was
+[#7988](https://github.com/tokuhirom/mutsu/issues/7988): 99 distributions, 77 of
+them unable to `use` their own modules, clustered together under the family
+`parse-error-expectation-dump` because mutsu described every one of their parse
+failures the same useless way — by dumping the set of things its parser would
+have accepted, at a location that was almost always the first line of the
+module. The ticket called that "99 unknown parse gaps that the ledger cannot
+tell apart" and asked for a method, not a fix.
+
+The method turned out to be one line of position arithmetic.
+
+## The location was thrown away at every nesting level
+
+`stmt_list_with_mode` wraps a failed `statement()` into its own
+`"expected statement at line N (after M stmts): …"` error, and anchored that
+error at `r.len()` — the unconsumed tail at the *start of the statement it had
+been trying to read*. A block body is itself a statement list, so the wrapping
+happens once per nesting level, and each level overwrote the position with its
+own start. The outermost one won.
+
+Concretely: a failure on line 160 of `PrettyDump.rakumod` was reported as
+
+```
+expected statement: expected expected statement: expected expected statement: …
+at lib/PrettyDump.rakumod:1
+------>class PrettyDump {
+```
+
+— the `class` opener on line 1, with an expectation set that varies with parser
+state rather than with the cause. Nothing in that message names a construct, and
+nothing distinguishes it from the other 98 records.
+
+`PError::remaining_len` counts the *unconsumed* tail, so the furthest position
+any alternative reached is the **smallest** one. The statement-list loop now
+keeps `min(inner, own_start)` instead of discarding the inner failure's
+position. The rest of the parser already worked this way —
+`update_best_error` has always scored alternatives by how far they got — so this
+only stops one site from throwing that score away.
+
+The same failure now reads:
+
+```
+at lib/PrettyDump.rakumod:160
+------>        -> :(PrettyDump $pretty, $ds, Int:D :$depth = 0 --> Str) {
+```
+
+which names a construct: a pointy block taking an explicit signature literal.
+
+## What that turned the cluster into
+
+78 of the cluster's distributions were checked out and re-probed with
+`mutsu -I… -e 'use <Module>'`. Before the change, 69 of them failed with a
+location that pointed at a `class`/`sub`/`role` opener; after it, every parse
+failure names the line the parser actually stopped on. Grouped by *construct*
+rather than by message, the ~55 parse failures collapse to roughly forty
+distinct gaps, several of which are shared through a dependency:
+`Math::FractionalPart`'s `die "…":` reaches three distributions,
+`PrettyDump`'s `-> :(…)` three, `Protocol::Postgres`'s `::Enum` type capture
+two, `Net::HTTP`'s `multi method CALL-ME(…)` two, `TOML::NQP`'s leading `&&(`
+two. So #7988 is a queue of small tickets, not a handful of large ones — which
+is the question the ticket asked and could not answer before.
+
+## One of those gaps, fixed with it
+
+`Array::Agnostic`'s `method shape(::?ROLE:D:) { (*,) }` was the first construct
+the new location named, and it exposed a real parser bug with nothing to do
+with roles.
+
+A punctuation-only name in parentheses followed by whitespace was consumed
+*unconditionally* as a call to `prefix:<(…)>`, and the rest of the expression
+demanded as its operand. No declaration was required — the spelling alone was
+taken as proof that such an operator exists. That shadowed Raku's own `(*)`, a
+parenthesised `Whatever`, everywhere a space followed it. The surviving
+spellings explain why this went unnoticed for so long: `(*)` at end of input
+worked (no whitespace), `(* )` and `( *)` worked (the spelling no longer
+matched), and `(*) 1` worked (the "operand" was there) — only `(*)` as a block's
+final statement, or `(*,)`, actually broke.
+
+The site now asks `is_user_declared_prefix_sub` first, exactly as the
+generic user-operator path immediately below it already does; a genuinely
+declared `prefix:<(+-)>` still applies. Three of the sampled distributions
+(`Array::Agnostic`, `List::Agnostic`, `MoarVM::Bytecode`) go from
+`blocked_load` to loading cleanly on this alone.
+
+Pinned by `t/exceptions/parse-error-position-is-innermost.t` (every asserted
+line is the line rakudo reports for the same source) and
+`t/lang/operators/paren-prefix-op-requires-declaration.t` (passes under rakudo
+too).

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -245,6 +245,14 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
                 .chars()
                 .any(|c| matches!(c, '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | '"'))
             && after.chars().next().is_some_and(char::is_whitespace)
+            // The spelling alone does not make this a prefix operator: only a
+            // declaration does. Without this check every punctuation-only
+            // parenthesised term followed by a space was eaten as a call to an
+            // operator nobody declared, so Raku's own `(*)` — a parenthesised
+            // `Whatever` — failed to parse wherever a space followed it
+            // (`method shape() { (*,) }`, issue #7988), and the failure was a
+            // demand for the operand that `prefix:<(*)>` would have taken.
+            && crate::parser::stmt::simple::is_user_declared_prefix_sub(&format!("({})", op))
         {
             let (after, _) = ws(after)?;
             let (after, arg) = prefix_expr(after)?;

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -494,6 +494,15 @@ pub(crate) fn stmt_list_with_mode(
                 let consumed = input.len() - r.len();
                 let line_num = input[..consumed].matches('\n').count() + 1;
                 let context: String = r.chars().take(80).collect();
+                // Keep the *furthest* position any alternative reached, not
+                // this statement's start. `remaining_len` counts the
+                // unconsumed tail, so the deeper failure is the smaller one.
+                // Without this, a failure inside a block body was reported at
+                // the opening line of the enclosing `class`/`sub` — every
+                // nesting level overwrote the position with its own start, so
+                // a 1200-line module reported "at line 1" and named no
+                // construct at all (issue #7988).
+                let deepest = e.remaining_len.map_or(r.len(), |inner| inner.min(r.len()));
                 return Err(PError::raw(
                     format!(
                         "expected statement at line {} (after {} stmts): {} — near: {:?}",
@@ -502,7 +511,7 @@ pub(crate) fn stmt_list_with_mode(
                         e,
                         context
                     ),
-                    Some(r.len()),
+                    Some(deepest),
                 ));
             }
         }

--- a/t/exceptions/parse-error-position-is-innermost.t
+++ b/t/exceptions/parse-error-position-is-innermost.t
@@ -1,0 +1,55 @@
+use Test;
+
+# A parse failure inside a block body must be reported where the parser
+# actually stopped, not where the enclosing declaration opened.
+#
+# The statement-list loop wrapped every failed `statement()` into its own
+# "expected statement at line N" error and anchored that error at the start of
+# the statement it had been trying to read. Because a block body is itself a
+# statement list, every nesting level overwrote the position with its own
+# start, and the outermost one won: a failure anywhere inside `class C { ... }`
+# came out as "at line 1", pointing at the `class` line and naming no
+# construct. Across the ecosystem parity ledger that made 99 distributions
+# indistinguishable from each other (issue #7988) -- every one of them reported
+# the first line of a module and an expectation set that varies with parser
+# state rather than with the cause.
+#
+# `remaining_len` counts the UNCONSUMED tail, so the furthest position reached
+# is the smallest one; the loop now keeps that instead of its own start.
+# Every line asserted below is the line rakudo reports for the same source.
+
+plan 4;
+
+my $nested = q:to/CODE/;
+class C {
+    method a() { 1 }
+    method b() { 2 }
+    method c() { 3 }
+    method d() {
+        my $x = 1 1 1;
+    }
+}
+CODE
+
+try EVAL $nested;
+is $!.^name, 'X::Syntax::Confused', 'an undiagnosed parse failure is still X::Syntax::Confused';
+is $!.line, 6, 'the reported line is the failing routine, not the class opener on line 1';
+
+# The same rule one level deeper: a sub nested inside a sub inside a class.
+my $deeper = q:to/CODE/;
+class D {
+    method outer() {
+        sub inner() {
+            my $y = 2 2 2;
+        }
+    }
+}
+CODE
+
+try EVAL $deeper;
+is $!.line, 4, 'a failure two blocks deep is not attributed to the outermost one';
+
+# A top-level failure keeps reporting its own line -- the change must not push
+# the position past the statement that actually failed.
+try EVAL "my \$a = 1;\nmy \$b = 3 3 3;\n";
+is $!.line, 2, 'a top-level failure still reports its own line';

--- a/t/lang/parsing/paren-prefix-op-requires-declaration.t
+++ b/t/lang/parsing/paren-prefix-op-requires-declaration.t
@@ -1,0 +1,40 @@
+use Test;
+use MONKEY-SEE-NO-EVAL;
+
+# A punctuation-only name in parentheses is only a prefix operator when one has
+# been DECLARED with that name. The parser used to take the spelling alone as
+# proof: any `(<punctuation>)` followed by whitespace was consumed as a call to
+# `prefix:<(...)>` and the rest of the expression was demanded as its operand.
+#
+# That shadowed Raku's own `(*)` -- a parenthesised `Whatever` -- everywhere a
+# space followed it. `(*)` at end of input happened to work (no whitespace),
+# `(* )` and `( *)` worked (the spelling no longer matched), and `(*) 1` worked
+# (the "operand" was there), so the gap only showed up as an unexplained parse
+# failure in real code: `method shape(::?ROLE:D:) { (*,) }` in Array::Agnostic,
+# and the same shape in the distributions surveyed for issue #7988.
+#
+# rakudo parses every line below.
+
+plan 7;
+
+is (*).WHAT.^name, 'Whatever', 'a parenthesised Whatever is a term, not an operator call';
+
+my $spaced = (*) ;
+is $spaced.WHAT.^name, 'Whatever', 'whitespace after it does not make it an operator';
+
+sub returns-whatever-list() { (*,) }
+is returns-whatever-list().elems, 1, '(*,) as a block final statement parses';
+is returns-whatever-list()[0].WHAT.^name, 'Whatever', 'and holds the Whatever itself';
+
+sub returns-whatever() { (*) }
+is returns-whatever().WHAT.^name, 'Whatever', '(*) as a block final statement parses';
+
+# `(**)` is the same shape with HyperWhatever.
+sub returns-hyper() { (**) }
+is returns-hyper().WHAT.^name, 'HyperWhatever', '(**) as a block final statement parses';
+
+# A prefix operator that really is declared still wins over the term reading.
+{
+    sub prefix:<(+-)> ($thing) { "ABOUT$thing" }
+    is EVAL(q[ (+-) "fish" ]), 'ABOUTfish', 'a declared parenthesised prefix operator still applies';
+}


### PR DESCRIPTION
Works [#7988](https://github.com/tokuhirom/mutsu/issues/7988) — the ecosystem parity ledger's largest single block (99 distributions, 77 of them unable to `use` their own modules), clustered together as `parse-error-expectation-dump` only because mutsu described every one of their parse failures the same useless way.

The ticket asked for a method, not a fix. The method turned out to be one line of position arithmetic.

## The location was thrown away at every nesting level

`stmt_list_with_mode` wraps a failed `statement()` into its own `"expected statement at line N (after M stmts): …"` error, and anchored that error at `r.len()` — the unconsumed tail at the **start of the statement it had been trying to read**. A block body is itself a statement list, so the wrapping happens once per nesting level, and each level overwrote the position with its own start. The outermost one won, so a failure anywhere inside a module came out pointing at its first line:

```
expected statement: expected expected statement: expected expected statement: …
at lib/PrettyDump.rakumod:1
------>class PrettyDump {
```

Nothing in that names a construct, and nothing distinguishes it from the other 98 records.

`PError::remaining_len` counts the *unconsumed* tail, so the furthest position any alternative reached is the **smallest** one. The loop now keeps `min(inner, own_start)` instead of discarding the inner failure's position. The rest of the parser already worked this way — `update_best_error` has always scored alternatives by how far they got — so this only stops one site from throwing that score away.

The same failure now reads:

```
at lib/PrettyDump.rakumod:160
------>        -> :(PrettyDump $pretty, $ds, Int:D :$depth = 0 --> Str) {
```

## What that turned the cluster into

78 of the cluster's distributions were checked out and probed with `mutsu -I… -e 'use <Module>'` (a local probe, not a sweep — load-level facts at `7661537f`, not ledger records). 69 failed; after the change every parse failure names the line the parser actually stopped on.

Grouped by **construct** rather than by message, the ~55 parse failures are roughly **forty distinct gaps**, several reaching more than one distribution through a shared dependency:

| construct | file | dists |
|---|---|---|
| `die "…":` (colon after a listop's last argument) | `Math::FractionalPart` | 3 (`Math::FractionalPart`, `Astro::Utils`, `DateTime::Julian`) |
| `-> :(Sig) { … }` (pointy block with a signature literal) | `PrettyDump` | 3 (`PrettyDump`, `Collection`, `RakuConfig`) |
| `method add-enum-type(Str $name, ::Enum --> Promise)` (type capture) | `Protocol::Postgres` | 2 (+`Net::Postgres`) |
| `multi method CALL-ME(Str:D $u, :%header is copy, :$body?, \|c --> Response)` | `Net::HTTP` | 2 (`WebService::Slack::Webhook`, `raku-mailgun`) |
| `&&(` continuing an expression on the next line | `TOML::NQP` | 2 (`TOML`, `Clu`) |
| `submethod BUILD(:ν(:$!nu) = 1) {}` (Unicode named alias onto an attribute) | `Statistics::Distributions` | 2 (+`Math::GameTheory`) |
| `method !private(Str:D $path --> Nil)` | `Selkie` | 2 (+`Selkie::UI`) |
| `⚛=` / `⚛-=` / `+⚛$!x` (atomic ops beyond `--⚛`) | — | 3 (`Async::Workers`, `FFmpegProgressBar`, `Russian`) |

The rest are one apiece. **So #7988 is a queue of small tickets, not a handful of large ones** — which is the question it asked and could not answer before. The full per-distribution survey is posted on the issue; #7988 stays open, since the next sweep will re-cluster these by their new construct-naming messages, which is the right moment to file them individually.

## One of those gaps, fixed with it

`Array::Agnostic`'s `method shape(::?ROLE:D:) { (*,) }` was the first construct the new location named, and the bug had nothing to do with roles.

A punctuation-only name in parentheses followed by whitespace was consumed **unconditionally** as a call to `prefix:<(…)>`, with the rest of the expression demanded as its operand. No declaration was required — the spelling alone was taken as proof that such an operator exists. That shadowed Raku's own `(*)`, a parenthesised `Whatever`, everywhere a space followed it. The surviving spellings explain why it lasted: `(*)` at end of input worked (no whitespace), `(* )` and `( *)` worked (the spelling no longer matched), and `(*) 1` worked (the "operand" was there) — only `(*)` as a block's final statement, or `(*,)`, actually broke.

The site now asks `is_user_declared_prefix_sub` first, exactly as the generic user-operator path immediately below it already does; a genuinely declared `prefix:<(+-)>` still applies. `Array::Agnostic`, `List::Agnostic` and `MoarVM::Bytecode` go `blocked_load` → loading cleanly on this alone, with no other distribution in the sample regressing.

## Tests

- `t/exceptions/parse-error-position-is-innermost.t` — every asserted line is the line rakudo reports for the same source (verified against the oracle).
- `t/lang/parsing/paren-prefix-op-requires-declaration.t` — passes under rakudo too (7/7).

## Verification

- `cargo fmt --all`, `make lint` (all four configurations) — clean.
- `make test` — **4056 files, 43165 tests, all pass.**
- `make roast` — the only failures are the three documented container-only cases from [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md): `roast/6.c/S32-io/file-tests.t` (Failed: 4, tests 6-8/10) and `roast/S16-filehandles/filetest.t` (Failed: 25, tests 57-64/69-72/77-80/101…125), both because this container runs as `uid 0` and root bypasses the permission bits these files assert are `False`; and `roast/S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17") on the sandboxed network. Same files, same test numbers as documented; `id -u` confirms 0.
- `cargo test --lib parser` — 401 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014urvMnrZ9FY7b1aFuV8cjc

---
_Generated by [Claude Code](https://claude.ai/code/session_014urvMnrZ9FY7b1aFuV8cjc)_