### PR TITLE
fix(oo): register exported role-body subsets at declaration; resolve relative param types

### DIFF
--- a/news/2026-09/role-body-exported-subsets-and-relative-qualified-param-types.md
+++ b/news/2026-09/role-body-exported-subsets-and-relative-qualified-param-types.md
@@ -1,0 +1,104 @@
+# Two false `Invalid typename ... in parameter declaration` rejections in role bodies
+
+The ecosystem parity ledger grouped 21 distributions under one failure line,
+`Invalid typename '<X>' in parameter declaration.`
+([#7993](https://github.com/tokuhirom/mutsu/issues/7993)), across 14 different
+typenames. The ticket's own guess was that the names pointed at several
+unrelated resolution paths and the first job was to find out how many gaps they
+really were. Minimising one case from each group found **four** distinct root
+causes hiding behind the single message. Two of them are fixed here.
+
+## 1. An exported `subset` declared in a role body was invisible until composition
+
+`PDF::COS` hands its types out from inside a role body:
+
+```raku
+role PDF::COS {
+    my subset IndRef of Pair is export(:IndRef) where {.key eq 'ind-ref'};
+    ...
+}
+```
+
+and `PDF::COS::Tie` imports it and names it in a signature:
+
+```raku
+role PDF::COS::Tie {
+    use PDF::COS :IndRef;
+    multi method deref(IndRef $ind-ref!) { ... }
+}
+```
+
+mutsu defers a role body wholesale to *composition* — correct for the body's
+runtime statements (rakudo runs a role body once per composition, not at the
+declaration), but wrong for a **declaration**. Rakudo installs a `my subset` in
+the role body's pad, and its `is export` entry in the module's export table, when
+the role is compiled. Deferring it meant `use PDF::COS :IndRef` imported nothing:
+the type was not registered, `IndRef` decayed to a bareword `Str`, and every type
+check against it silently failed.
+
+That was the quiet half. The loud half was the ledger's message. `PDF::COS::Tie`'s
+signature is validated when a class composes the role, in a scope where `IndRef`
+is not lexically visible. The validator has an escape hatch for exactly this —
+"a module this body `use`s has not been loaded yet, so defer" — but by the time
+`PDF::COS::Array` composes the role, `PDF::COS` *is* loaded (it is `use`d two
+lines earlier), the hatch no longer applies, and the unregistered `IndRef` was
+reported as a bogus typename.
+
+`register_role_body_exported_subsets` now registers an `is export`ed `subset`
+declared directly in a role body at role-declaration time as well as at
+composition. Role-private subsets are left alone: they are already accepted in
+their own body via `RoleDeclCx::body_declared_types` and have no cross-module
+consumer to serve. A subset whose base type is one of the role's own type
+parameters (`role R[::T] { my subset S of T … }`) is skipped too — its base is
+not known until the role is parameterised, so composition stays the only correct
+point for it.
+
+Six PDF-family distributions (`PDF`, `PDF::Class`, `PDF::Content`,
+`PDF::Font::Loader`, `FDF`, `Pod::To::PDF::Lite`) are this shape — a third of
+the cluster. They now get past the typename error to their next, unrelated
+blocker. (`LibXML`'s `NCName` failure looks similar but is not this: its
+`LibXML::Types` declares the subsets at module scope, and the failure does not
+reproduce outside the sweep's dependency closure. It needs a re-measure.)
+
+## 2. A role method parameter naming a sibling type relatively
+
+`SQL::Abstract` is a `unit class`, so its nested `class Column::List` registers
+as `SQL::Abstract::Column::List` — but every signature in the file spells it with
+the relative `Column::List`:
+
+```raku
+unit class SQL::Abstract;
+class Column::List does Value::List { ... }
+role Distinction {
+    multi method COERCE(Column::List(Any) $columns) { ... }
+}
+```
+
+The role-method validator already walks the enclosing packages to resolve a
+sibling type, but it did so only for a constraint with no `::` in it, and it
+prefixed the *raw* constraint rather than the undecorated base name. So a
+relatively-qualified name never reached the walk at all, and a decorated one
+(`Column::List(Any)`, `Foo::Bar:D`) could not have matched even if it had. The
+walk now uses the stripped base name and is no longer gated on the constraint
+being unqualified. A genuinely undeclared qualified name still reports
+`X::Parameter::InvalidType`.
+
+## The two gaps this did not fix
+
+Recorded as their own tickets, since they turned out to be unrelated machinery:
+
+- **A `my`-scoped declaration with a compound name does not install into the
+  named package.** `TAP.rakumod` declares `role Entry` and then
+  `my role Entry::Handler`; rakudo installs `Handler` into the `Entry` package,
+  so `TAP::Entry::Handler` resolves. mutsu does not, and rejects the later
+  `my class State does TAP::Entry::Handler`. Affects `TAP`, `App::Mi6`,
+  `Mi6::Helper`.
+- **`class Foo does SomeRole` where the role's nested class inherits `Attribute`.**
+  With gap 1 fixed, the PDF family's next error is
+  `'PDF::COS::Tie::COSAttr::CosOfAttr' cannot inherit from 'Attribute' because it
+  is unknown` — a missing MOP type, nothing to do with typename resolution.
+
+The remaining names in the cluster (`GType`, `Sizing`, `EncodeBuffer`,
+`NcplaneHandle`, `Enumeration`, `Event:D`, `License::Software::Year`) sit behind
+distribution dependencies that are not resolvable outside the sweep, or behind
+earlier parse failures; they are left on #7993 for the next pass.

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -437,4 +437,74 @@ impl Interpreter {
         }
         Ok(())
     }
+
+    /// Register every `is export`ed `subset` declared directly in a role body
+    /// at ROLE-DECLARATION time, in addition to the composition-time run.
+    ///
+    /// A role body's statements are deferred to composition (see
+    /// `exec_register_role_op`'s comment on why), but a `subset` is a
+    /// *declaration*, and rakudo installs it — and its `is export` entry — when
+    /// the role is compiled, not when some class finally composes it. Deferring
+    /// it wholesale meant a module that hands its types out from a role body
+    /// exported nothing until an unrelated class composed the role:
+    ///
+    /// ```raku
+    /// # Types.rakumod
+    /// role Types { my subset IndRef of Pair is export(:IndRef) where {.key eq 'ind-ref'} }
+    /// # consumer
+    /// use Types :IndRef;   # imported nothing; `IndRef` fell back to a bareword Str
+    /// ```
+    ///
+    /// `PDF::COS` is exactly this shape, and `PDF::COS::Tie`'s
+    /// `multi method deref(IndRef $ind-ref!)` then failed role-composition
+    /// validation with `Invalid typename 'IndRef' in parameter declaration.` —
+    /// six PDF-family distributions ([#7993]).
+    ///
+    /// [#7993]: https://github.com/tokuhirom/mutsu/issues/7993
+    ///
+    /// Only `is export` subsets are registered here. A role-private one is
+    /// already accepted in its own body via `RoleDeclCx::body_declared_types`
+    /// and has no cross-module consumer to serve, so registering it early would
+    /// widen its visibility for no gain. A subset whose base type is one of the
+    /// role's own type parameters (`role R[::T] { my subset S of T … }`) is
+    /// skipped too: its base is not known until the role is parameterised, so
+    /// composition remains the only point where it can be registered correctly.
+    pub(crate) fn register_role_body_exported_subsets(
+        &mut self,
+        role_name: &str,
+        deferred_body_ops: &[crate::opcode::DeferredBodyOp],
+        type_params: &[String],
+    ) {
+        for op in deferred_body_ops {
+            let Stmt::SubsetDecl {
+                name,
+                base,
+                predicate,
+                version,
+                is_export: true,
+                export_tags,
+                is_my,
+                ..
+            } = &op.raw
+            else {
+                continue;
+            };
+            if type_params.iter().any(|tp| tp == base) {
+                continue;
+            }
+            let resolved_name = name.resolve();
+            crate::value::note_user_declared_type_name(&resolved_name);
+            self.register_subset_decl(&resolved_name, base, predicate.as_ref(), version, *is_my);
+            if self.suppress_exports {
+                continue;
+            }
+            let (export_pkg, export_short) = match resolved_name.rsplit_once("::") {
+                Some((pkg, short)) => (pkg.to_string(), short.to_string()),
+                // A role body's own package IS the role, so an unqualified
+                // subset exports from the role's name (`use PDF::COS :IndRef`).
+                None => (role_name.to_string(), resolved_name.clone()),
+            };
+            self.register_exported_var(export_pkg, export_short, export_tags.clone());
+        }
+    }
 }

--- a/src/runtime/registration_role_method.rs
+++ b/src/runtime/registration_role_method.rs
@@ -106,10 +106,23 @@ impl Interpreter {
                     // runs; accept its name here.
                     || cx.body_declared_types.contains(tc_base)
                     || self.is_resolvable_type(tc)
-                    || (!tc.contains("::")
-                        && enclosing_prefixes
-                            .iter()
-                            .any(|pfx| self.is_resolvable_type(&format!("{pfx}::{tc}"))))
+                    // Qualify with each enclosing package. `tc_base`, not
+                    // `tc`: a decorated constraint (`Column::List(Any)`,
+                    // `Event:D`) never matches a registered name verbatim,
+                    // so prefixing the undecorated form is the only spelling
+                    // that can resolve. And a RELATIVELY qualified name is
+                    // exactly what needs prefixing: `unit class SQL::Abstract`
+                    // registers its nested `class Column::List` as
+                    // `SQL::Abstract::Column::List`, while
+                    // `role Distinction { multi method COERCE(Column::List(Any) $c) }`
+                    // in the same file names it by the relative `Column::List`
+                    // ([#7993]). Gating this walk on an unqualified `tc` left
+                    // every such sibling unresolvable.
+                    //
+                    // [#7993]: https://github.com/tokuhirom/mutsu/issues/7993
+                    || enclosing_prefixes
+                        .iter()
+                        .any(|pfx| self.is_resolvable_type(&format!("{pfx}::{tc_base}")))
                     // Last resort: any registered type known by this
                     // short name. A compound role name in a `unit
                     // package` (`my role Packet::Empty`) leaves the

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -865,6 +865,17 @@ impl Interpreter {
             // in this scope (which may be stored under a mangled name), matching
             // the class-parent remapping in `exec_register_class_op`.
             self.remap_role_parents_via_env(&qualified_name);
+            // An `is export`ed `subset` declared directly in the role body is
+            // a COMPILE-TIME declaration in rakudo, not a composition-time side
+            // effect: `role PDF::COS { my subset IndRef of Pair is export(:IndRef)
+            // … }` makes `IndRef` importable the moment `PDF::COS` is loaded,
+            // long before any class composes the role. Register it here as well
+            // as at composition — see `register_role_body_exported_subsets`.
+            self.register_role_body_exported_subsets(
+                &qualified_name,
+                deferred_body_ops,
+                type_params,
+            );
             // A role declared in a CLASS body (`unit class UA; role Connection
             // { … }`) is scoped to that class, like a nested `my class`. Record
             // the short name so `resolve_suppressed_type` resolves it through the

--- a/t/lib/RoleBodySubsetConsumer.rakumod
+++ b/t/lib/RoleBodySubsetConsumer.rakumod
@@ -1,0 +1,11 @@
+use v6;
+
+# The `PDF::COS::Tie` shape: a role whose body imports a type from another
+# module and names it in a method signature. The signature is validated when
+# a class composes this role, in a scope where `IndRef` is not lexically
+# visible, so the import has to have registered the type globally by then.
+role RoleBodySubsetConsumer {
+    use RoleBodySubsetProvider :IndRef;
+
+    method deref(IndRef $ind-ref) { $ind-ref.value }
+}

--- a/t/lib/RoleBodySubsetProvider.rakumod
+++ b/t/lib/RoleBodySubsetProvider.rakumod
@@ -1,0 +1,11 @@
+use v6;
+
+# The `PDF::COS` shape: a module whose types are declared inside a ROLE body
+# and handed out with `is export(:tag)`. Consumers `use` the tag long before
+# any class composes the role, so the subset has to be installed (and
+# exported) when the role is declared, not at composition time.
+role RoleBodySubsetProvider {
+    my subset IndRef of Pair is export(:IndRef) where { .key eq 'ind-ref' };
+
+    method provider-marker() { 'provider' }
+}

--- a/t/modules/import-export/role-body-exported-subset.t
+++ b/t/modules/import-export/role-body-exported-subset.t
@@ -1,0 +1,39 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# A `subset` declared `is export` inside a ROLE body is a compile-time
+# declaration, not a composition-time side effect: `use`ing the module makes
+# the type importable immediately, even though no class has composed the role.
+#
+# mutsu used to defer the whole role body to composition, so the subset was
+# never registered at load time. Two failures followed, both measured across
+# the zef corpus by https://github.com/tokuhirom/mutsu/issues/7993:
+#
+#   * `use Provider :IndRef` imported nothing, so `IndRef` in the consumer
+#     decayed to a bareword `Str` and every type check against it failed;
+#   * a role that named the imported type in a method signature
+#     (`PDF::COS::Tie`'s `multi method deref(IndRef $ind-ref!)`) failed
+#     role-composition validation with
+#     "Invalid typename 'IndRef' in parameter declaration."
+#
+# The import order below matters: loading the provider FIRST is what made the
+# second failure reproduce, because the consumer's "a body-`use`d module has
+# not been loaded yet, defer the check" escape hatch no longer applied.
+use RoleBodySubsetProvider :IndRef;
+use RoleBodySubsetConsumer;
+
+plan 5;
+
+ok IndRef ~~ Any, 'the exported subset imports as a type, not a bareword Str';
+ok ('ind-ref' => [1, 0]) ~~ IndRef, 'its where-clause accepts a matching Pair';
+nok ('other' => [1, 0]) ~~ IndRef, 'its where-clause rejects a non-matching Pair';
+
+my $obj;
+lives-ok {
+    class RoleBodySubsetClass does RoleBodySubsetConsumer { }
+    $obj = RoleBodySubsetClass.new;
+}, 'a class composes the consumer role without X::Parameter::InvalidType';
+
+is $obj.deref('ind-ref' => 42), 42,
+    'the composed method accepts a value matching the imported subset';

--- a/t/oo/role/role-method-param-enclosing-qualified-type.t
+++ b/t/oo/role/role-method-param-enclosing-qualified-type.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# A role method's parameter type may name a sibling type by the name it is
+# written with in the source, which is RELATIVE to the enclosing package:
+# `unit class SA` registers a nested `class Column::List` as
+# `SA::Column::List`, but every signature in the file spells it
+# `Column::List`.
+#
+# mutsu validates a role method's parameter types when the role is composed,
+# and qualified the name with each enclosing package only for an UNQUALIFIED
+# constraint, with the undecorated base name never substituted. So a
+# relatively-qualified name — with or without a coercion/definedness
+# decoration — was rejected as
+# "Invalid typename 'Column::List(Any)' in parameter declaration."
+# `SQL::Abstract`'s `role Distinction` is exactly this shape; measured by
+# https://github.com/tokuhirom/mutsu/issues/7993.
+
+plan 4;
+
+class SA {
+    class Column::List {
+        has $.elems;
+        method COERCE($x) { self.new(:elems($x)) }
+    }
+
+    role Distinction {
+        method plain(Column::List $c) { 'plain:' ~ $c.elems }
+        method coerced(Column::List(Any) $c) { 'coerced:' ~ $c.elems }
+        method definite(Column::List:D $c) { 'definite:' ~ $c.elems }
+    }
+
+    class Distinction::Columns does Distinction { }
+}
+
+my $obj = SA::Distinction::Columns.new;
+
+is $obj.plain(SA::Column::List.new(:elems('a'))), 'plain:a',
+    'a relatively-qualified sibling type resolves in a role method signature';
+is $obj.coerced('b'), 'coerced:b',
+    'the same name decorated as a coercion type resolves too';
+is $obj.definite(SA::Column::List.new(:elems('c'))), 'definite:c',
+    'the same name with a :D smiley resolves too';
+
+throws-like { EVAL 'role RNope { method f(No::Such::Type $x) { } }; class CNope does RNope { }' },
+    X::Parameter::InvalidType,
+    'a genuinely undeclared qualified name is still rejected';


### PR DESCRIPTION
Triages the `invalid-typename` ecosystem cluster ([#7993](https://github.com/tokuhirom/mutsu/issues/7993) — 21 distributions, 14 distinct typenames, one failure line) and fixes two of the four root causes it turned out to be hiding.

The ticket asked first for a decision on how many gaps the 14 names actually are. Minimising one case from each of the four groups it named: **they do not collapse** — four unrelated resolution paths produce the same message. Two are fixed here; two are filed separately.

## 1. An exported `subset` declared in a role body was invisible until composition

`PDF::COS` hands its types out from inside a role body, and `PDF::COS::Tie` imports one and names it in a signature:

```raku
role PDF::COS {
    my subset IndRef of Pair is export(:IndRef) where {.key eq 'ind-ref'};
}
role PDF::COS::Tie {
    use PDF::COS :IndRef;
    multi method deref(IndRef $ind-ref!) { ... }
}
```

mutsu defers a role body wholesale to *composition*. That is right for the body's runtime statements — rakudo runs a role body once per composition, not at the declaration — but a `subset` is a **declaration**: rakudo installs it, and its `is export` entry, when the role is compiled.

Deferring it had a quiet half and a loud half. Quiet: `use PDF::COS :IndRef` imported nothing, so `IndRef` decayed to a bareword `Str` and every type check against it silently failed. Loud: `PDF::COS::Tie`'s signature is validated when a class composes the role, in a scope where `IndRef` is not lexically visible; the validator's "a module this body `use`s has not been loaded yet, so defer" escape hatch no longer applies once the composing unit has already `use`d the provider, so the unregistered name was reported as bogus.

`register_role_body_exported_subsets` now registers such a subset at role-declaration time as well as at composition. Role-private subsets are untouched (already accepted via `RoleDeclCx::body_declared_types`, and no cross-module consumer to serve); a subset whose base is one of the role's own type parameters (`role R[::T] { my subset S of T … }`) is skipped, since its base is unknown until the role is parameterised.

## 2. A role method parameter naming a sibling type relatively

```raku
unit class SA;
class Column::List { }
role Distinction { method f(Column::List $c) { } }   # Invalid typename 'Column::List'
```

`unit class SA` registers the nested class as `SA::Column::List`, but every signature in the file spells it relatively. The role-method validator already walks the enclosing packages, but only for a constraint with no `::` in it, and it prefixed the *raw* constraint rather than the undecorated base — so a relatively-qualified name never reached the walk, and a decorated one (`Column::List(Any)`, `Foo:D`) could not have matched anyway. `SQL::Abstract`'s `role Distinction` is exactly this shape.

The walk now uses the stripped base name and is no longer gated on the constraint being unqualified. A genuinely undeclared qualified name still reports `X::Parameter::InvalidType` (pinned in the new test).

## Effect on the cluster

Six PDF-family distributions (`PDF`, `PDF::Class`, `PDF::Content`, `PDF::Font::Loader`, `FDF`, `Pod::To::PDF::Lite`) and `SQL::Abstract` get past the typename error to their next, unrelated blocker. That is a third of the cluster.

Filed as their own tickets, since they are different machinery:

- [#8061](https://github.com/tokuhirom/mutsu/issues/8061) — `my role A::B` does not install `B` into package `A` (`TAP`, `App::Mi6`, `Mi6::Helper`).
- [#8062](https://github.com/tokuhirom/mutsu/issues/8062) — `class Foo is Attribute` is unknown; the PDF family's next error once gap 1 is fixed.

#7993 stays open as the cluster's home: eight of the names (`GType`, `Sizing`, `EncodeBuffer`, `NcplaneHandle`, `Enumeration`, `Net::BGP::Error:D`, `Event:D`, `License::Software::Year`) could not be reproduced outside the sweep's dependency closure and want one re-measure rather than more guessing. The full triage is written up in [a comment on the issue](https://github.com/tokuhirom/mutsu/issues/7993#issuecomment-5643572000).

## Tests

- `t/modules/import-export/role-body-exported-subset.t` (+ two `t/lib` fixtures) — the exported role-body subset imports as a type, keeps its `where` clause, and composes without `X::Parameter::InvalidType`. The import order in it matters and is commented: loading the provider *first* is what made the loud half reproduce.
- `t/oo/role/role-method-param-enclosing-qualified-type.t` — a relatively-qualified sibling type in a role method signature, plain / coercion / `:D`, plus a guard that an undeclared qualified name is still rejected.

Both pass under `raku` as well.

## Verification

- `cargo fmt --all`, `make lint` (all four configurations) — clean.
- `make test` — **PASS**, 4056 files / 43163 tests.
- `make roast` — the only red files are the three documented container-only failures, at their documented shapes (`docs/agent-environments.md`): `6.c/S32-io/file-tests.t` `Failed: 4` (tests 6-8, 10) and `S16-filehandles/filetest.t` `Failed: 25`, both because this container runs as `uid 0` and root bypasses permission bits; `S32-io/IO-Socket-Async.t` exit 124 "planned 40 ran 17" from the network sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK)_