### PR TITLE
docs(adr): record what is actually left of #7565, and retire a named blocker

### DIFF
--- a/docs/adr/0092-closure-capture-is-a-chained-tier-not-a-merged-copy.md
+++ b/docs/adr/0092-closure-capture-is-a-chained-tier-not-a-merged-copy.md
@@ -1,0 +1,188 @@
+# ADR-0092: Closure capture should be a chained tier, not a per-call merged copy
+
+- **Status**: Proposed
+- **Date**: 2026-09-12
+- **Related**: [ADR-0018](0018-slot-addressed-lexical-capture-and-env-sync.md)
+  (slot-addressed lexical capture and env sync — the capture's other half),
+  and the env-tier memo shipped for
+  [#7565](https://github.com/tokuhirom/mutsu/issues/7565) (`src/env_tier.rs`),
+  whose thesis — *identity is structural, not positional* — this ADR tests and
+  finds insufficient here
+- **Addresses**: [GitHub issue #7565](https://github.com/tokuhirom/mutsu/issues/7565),
+  item 1 of its remaining list
+
+## 1. Context
+
+Every closure call merges the closure's captured env into the callee frame's
+overlay, one key at a time, in `call_compiled_closure_in_unit`:
+
+```rust
+for (k, v) in data.env.iter() {
+    // ... explicit overwrite cases: ContainerRef cells, `self`,
+    //     a block's topic and `$!` ...
+    self.env_mut().entry_or_insert_sym_with(*k, || v.clone());
+}
+```
+
+`entry_or_insert_sym_with` is *don't overwrite*: it inserts only when the key is
+not visible anywhere in the callee frame's chain. The frame env is a scoped
+child of the caller, so "visible in the chain" means "visible to the caller".
+
+**The merge is, in the ordinary case, a complete no-op.** #8019 measured
+`insert_sym` reached **zero** times on the loop this ticket is about, over 31
+captured keys per call: every captured name is already visible through the
+caller's frame chain, because the capture was filtered out of that very chain
+moments earlier. The whole cost is `contains_key_sym` proving that, 31 times a
+call.
+
+Four slices of #7565 have narrowed what *goes into* the capture (#7707, #7964)
+and what the filter *walks* to build it (#8019, #8060), and one has narrowed
+what the END-phaser refresh does with it (#8042). None of them touched the
+merge, because the fix is its shape rather than its per-key cost.
+
+### 1.1 What it costs, measured
+
+Warm-run callgrind instruction slopes (6 000 → 14 000 iterations,
+`MUTSU_JIT=off MUTSU_GC=off`, release) on #7565's loop, against `main` at
+`1a49a887` with the merge loop gated out:
+
+| | floor (no `use Test`) | `+ use Test` |
+| --- | --- | --- |
+| baseline | 77 395 | 88 183 |
+| merge loop gated out | 73 518 | 83 352 |
+| **saved** | **3 877** | **4 831** |
+
+Two things to read off that table.
+
+**It is the largest remaining item on #7565** — 4 831 against a 10 788-instruction
+`use Test` tax.
+
+**It is mostly a *floor* cost, not a tax.** Only 954 of the 4 831 scales with the
+import list; the rest is paid by any closure call in any program. The capture of
+a closure with **no free variables at all** (`sub ($v) { $v + 1000 }`) is still
+31 entries — the built-in dynamics, `Any`, `?FILE`, the topic — and the merge
+probes every one of them on every call. So this is not a `use Test` problem that
+happens to show up in a benchmark; it is a per-closure-call cost of the
+interpreter, and #7565 is merely where it was measured.
+
+For scale, gating out the *entire* capture machinery (build and merge) on the
+same loop is 13 363 instructions per iteration on the floor — 17% of it.
+
+## 2. Decision (proposed)
+
+Stop merging the capture into the callee overlay key by key. Make it a **tier**
+that the frame's env consults after its parent chain and before `GLOBAL_BASE`:
+
+```
+overlay -> caller chain -> capture -> GLOBAL_BASE
+```
+
+That is the precedence the merge already implements by hand — caller chain
+wins, except for an explicit overwrite list — so the ordinary case needs no
+per-key work at all. The overwrite cases (a captured `ContainerRef` cell, a
+lexical `self`, a non-routine block's topic and `$!`, the authoritative and
+owned capture lists) keep inserting into the overlay, which is above both.
+
+This ADR does not fix the shape of that tier; §3 records three candidate
+mechanisms, two of which are already measured out.
+
+## 3. Mechanisms considered
+
+### 3.1 An identity token, keeping the merge — REJECTED (unsound)
+
+The tempting shortcut is to leave the merge in place and skip it when the caller
+chain is provably the chain the capture was filtered out of. It does not work,
+and the reason is worth recording because the idea recurs:
+
+- **Bare tier addresses are unsound** (ABA: a freed overlay map re-allocated at
+  the same address).
+- **Pinning each tier's `Arc` makes it sound and expensive** — this is
+  `vm_capture_cache`'s mechanism, and holding the creating frame's overlay
+  `Arc` forces `Arc::make_mut` to clone that overlay on the *next* write to it.
+  In this loop that write is the `my &return = ...` that stores the closure
+  itself, so the token would trade a 31-key probe loop for an O(frame overlay)
+  map clone per iteration.
+- **A key-set generation on `Tier`** — the natural extension of `src/env_tier.rs`'s
+  thesis, since the property needed ("every captured name is still visible") is
+  a key-set property that a value write cannot disturb — **fails on
+  supersets**. Storing the closure into the creating scope *adds* a key between
+  capture and call, so exact generation equality never holds on the very
+  workload this is for. Relaxing it to "same lineage, no removals since, at
+  least as many additions" is unsound: two clones of one tier can each take a
+  *different* addition and reach the same counters with different key sets, and
+  a closure captured under one but called under the other would silently lose a
+  captured name. A globally unique add-stamp fixes the collision and destroys
+  the ordering test that the superset case needs.
+
+The general shape of the failure: the merge's precondition is a *superset*
+relation between two key sets, and a memo that is cheap enough to be worth
+having can only certify *equality*.
+
+### 3.2 Append the capture at the chain's tail — REJECTED (fights `scoped_child`)
+
+Chain the capture below the existing tail, so no `Env` field and no lookup
+change are needed: it is just another tier. But `parent` is `Arc<Env>`, so
+appending at the tail means rebuilding every tier above it — O(depth) `Arc::new`
+allocations per closure call. That is the exact cost `Env::scoped_child` was
+tuned to remove ("steady-state recursion therefore allocates nothing here — the
+two `Arc::new`s per call were ~14% of fib with the JIT on"), and it also adds a
+tier per call, so `MAX_OVERLAY_DEPTH`'s O(env) flatten fires twice as often in
+recursion.
+
+### 3.3 A `fallback` tier on the frame env — the candidate
+
+Give `Env` an `Option<Arc<Tier>>` consulted after the chain walk misses and
+before `GLOBAL_BASE`. One `Arc` clone per call, no chain rebuild, no depth
+change.
+
+It needs two things settled, and they are why this is an ADR rather than a perf
+slice:
+
+1. **The lookup split.** `get_sym`/`contains_key_sym` recurse to the chain's
+   tail, which is where `GLOBAL_BASE` is consulted. A fallback on the leaf has
+   to be consulted between those two, so the recursion needs a base-less form
+   with the public entry point wrapping it. These are the hottest functions in
+   the interpreter; the change must be measured, not assumed free.
+
+2. **A real semantic change: capture entries stop being visible to callees.**
+   Today the merge puts them in the frame's *overlay*, so a routine called from
+   the closure body can resolve them by name through the chain. As a fallback
+   tier consulted only at the closure's own level, they cannot. That is
+   arguably the more correct behaviour — the leakage is dynamic scoping where
+   Raku wants lexical — but it is a behaviour change, and `EVAL` (which
+   resolves against the live env chain rather than its own lexical scope) is
+   the consumer most likely to depend on it.
+
+## 4. Consequences
+
+- The merge's explicit overwrite lists stay exactly as they are; only the
+  don't-overwrite default is replaced.
+- The exit writeback is unaffected: it iterates the frame overlay, and capture
+  entries leaving the overlay is what it already tries to filter out by hand
+  ("a captured name, unchanged since capture").
+- `flattened`/`filtered_flat_capture`/`tier_addrs`/`tier_maps` must treat the
+  fallback as an outermost tier, or a closure created *inside* the closure body
+  loses the outer capture.
+- If §3.3's item 2 turns out to be depended on, the fallback can be consulted
+  by the whole chain rather than by the leaf alone, at the cost of carrying it
+  down the recursion.
+
+## 5. What this ADR deliberately does not decide
+
+Whether to do it. The measurement says 4 831 instructions per closure call on
+one loop, most of it floor; that is worth a redesign of this size only if
+§3.3's lookup split measures neutral on the no-closure path. Whoever takes this
+should build §3.3 behind the existing bench harness and measure
+`benchmarks/bench-ctor.raku` and `bench-class.raku` (neither imports anything,
+both create closures inside method frames) before touching semantics.
+
+## 6. Also measured, and relevant to whoever reads this
+
+**#7565's item 2 — the process-global reflective latch on `skip_env_write` — is
+dead.** The ticket body calls it "the worse of the two" costs and #8019 named it
+as the prerequisite for the env-tier memo. Gating `skip_env_write` to ignore
+`opcode::reflective_name_access_possible()` entirely, on the same loop and
+binary as §1.1, is worth **57 instructions per iteration** — 0.5% of the tax,
+inside the noise band this filter is documented to have. The memo it was said to
+block shipped without it (`src/env_tier.rs`). Nobody should spend a large,
+unsound-by-default change on it for this ticket's metric.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -117,3 +117,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0089](0089-role-mixins-own-a-separate-attribute-cell.md) | A role mixin owns an attribute cell separate from its wrapped value | Proposed (revised after design review 2026-09-12) |
 | [0090](0090-has-embedded-cstruct-members.md) | A `HAS` member is laid out by value, and its handle points into the enclosing struct | Accepted (implemented) |
 | [0091](0091-slang-package-declarators.md) | A slang's `package_declarator:sym<...>` candidate is read as a declarator registration, not executed | Accepted (implemented) |
+| [0092](0092-closure-capture-is-a-chained-tier-not-a-merged-copy.md) | Closure capture should be a chained tier, not a per-call merged copy | Proposed |

--- a/news/2026-09/the-reflective-latch-was-not-the-worse-of-the-two.md
+++ b/news/2026-09/the-reflective-latch-was-not-the-worse-of-the-two.md
@@ -1,0 +1,99 @@
+# The reflective latch was not "the worse of the two"
+
+A measurement pass over what is left of [#7565](https://github.com/tokuhirom/mutsu/issues/7565)
+after five slices (#7656, #7707, #7964, #8019, #8042, #8060). It ships no code:
+the two findings are a retired blocker and a redesign that needs a decision,
+recorded as [ADR-0092](../../docs/adr/0092-closure-capture-is-a-chained-tier-not-a-merged-copy.md).
+
+## The method
+
+Everything below is a warm-run callgrind instruction slope between 6 000 and
+14 000 iterations of the ticket's loop, `MUTSU_JIT=off MUTSU_GC=off`, release,
+taken from one build whose gates are all off by default so the variants share a
+binary. "Tax" is the `use Test` line minus the same loop without it.
+
+Baseline on `main` at `1a49a887`: floor 77 195, `+ use Test` 87 787, tax 10 592.
+The gated build reads 77 395 / 88 183 / 10 788 — the gates themselves cost ~200,
+which is why the table below compares within that binary rather than against the
+clean baseline.
+
+| gated out | floor | `+ use Test` | tax |
+| --- | --- | --- | --- |
+| nothing (gated baseline) | 77 395 | 88 183 | 10 788 |
+| the reflective latch on `skip_env_write` | 77 386 | 88 126 | 10 740 |
+| the captured-env merge | 73 518 | 83 352 | 9 834 |
+| the whole capture machinery | 64 032 | 67 811 | 3 779 |
+
+## Finding 1: the latch is dead, and it was named as a prerequisite
+
+#7565's own body calls the process-global reflective latch "the worse of the
+two" costs, on the grounds that one `EVAL` anywhere — including inside a module
+the program never calls into — permanently makes every lexical store mirror
+into the env. #8019's release note went further and named it as the thing
+blocking the per-tier capture memo.
+
+It is worth **57 instructions per iteration**: 0.5% of the tax, inside the drift
+band #7964 documented for this area (four shapes of *identical* logic spanning
+0.8%). And the memo it was said to block shipped in #8060 without it, because
+the address the memo needed was never the right key — a key set is.
+
+That matters beyond the number. A per-chunk `skip_env_write` is not a mechanical
+change: mutsu's `EVAL` resolves against the live env chain rather than its own
+lexical scope, so a callee's `EVAL` reads the caller's mirror and relies on it.
+Someone was going to spend a large, correctness-critical change on this. Nobody
+should, for this ticket's metric.
+
+## Finding 2: the merge is the largest item, and it is a floor cost
+
+Gating out the captured-env merge is 4 831 instructions per iteration with
+`use Test` and 3 877 without — so only **954 of it scales with the import list**.
+The rest is paid by any closure call in any program. The capture of a closure
+with no free variables at all (`sub ($v) { $v + 1000 }`) is still 31 entries —
+the built-in dynamics, `Any`, `?FILE`, the topic — and the merge probes every
+one of them on every call, to insert none of them (#8019 measured `insert_sym`
+reached zero times).
+
+That reframes the item. It is not a `use Test` problem that shows up in a
+benchmark; it is a per-closure-call cost of the interpreter that #7565 happens
+to be where anyone measured. For scale, the whole capture machinery — build and
+merge together — is 13 363 instructions per iteration on the floor, 17% of that
+loop.
+
+## Why no code, and what the ADR settles
+
+Three mechanisms for removing the merge were worked through, and ADR-0092
+records each in full. In short:
+
+- **An identity token that lets the merge be skipped is unsound at any price
+  worth paying.** The merge's precondition is a *superset* relation between two
+  key sets ("every captured name is still visible"), and storing the closure
+  into its own creating scope adds a key between capture and call — so exact
+  equality never holds on this workload, and every cheap relaxation of it
+  collides. Pinning `Arc`s certifies it soundly and costs an O(frame overlay)
+  map clone per iteration, which is more than the merge.
+- **Appending the capture at the chain's tail** needs no new field and no lookup
+  change, but rebuilds every tier above it — reintroducing exactly the two
+  `Arc::new`s per call that `Env::scoped_child` was tuned to remove, and adding
+  a tier per call so `MAX_OVERLAY_DEPTH`'s flatten fires twice as often.
+- **A `fallback` tier on the frame env** is the candidate, and it carries a real
+  semantic change: capture entries stop being visible to *callees* of the
+  closure, because they no longer sit in the frame overlay. That is arguably
+  more correct — the current behaviour is dynamic scoping where Raku wants
+  lexical — but it is a behaviour change with `EVAL` as its most likely
+  dependant, and it is not a call to bake silently into a perf slice.
+
+## What is left on #7565
+
+1. **The no-op capture merge** — ADR-0092. 4 831 instructions per closure call,
+   mostly floor. Largest item, and the only one whose fix is architectural.
+2. **The remaining capture walk** — 43 candidates for 31 kept, at a hash probe
+   per candidate; putting each candidate's resolved key and flags word in the
+   memo beside it is worth roughly 650. Note that 650 is 0.7% of this loop,
+   which is precisely the drift band #7964 measured for codegen shape in this
+   filter, so it is only shippable with an ablation that separates the two.
+3. **The ~20 built-in dynamics** — floor, not tax, and now measurably the same
+   floor the merge pays for. A key-pure filter cannot tell an interpreter's own
+   `init_io_environment` default from a user `my $*OUT = …` redirection, and a
+   thread-bound `start` block needs the latter carried.
+
+Item 2 of the previous list — the reflective latch — is struck, per finding 1.


### PR DESCRIPTION
A measurement pass over what remains of [#7565](https://github.com/tokuhirom/mutsu/issues/7565) after six slices (#7656, #7707, #7964, #8019, #8042, #8060). **It ships no code**: the two findings are a retired blocker and a redesign that needs a decision, and the decision is not mine to bake silently into a perf slice.

Documentation-only, so CI's build jobs report `skipped` by design (`scripts/ci-docs-only.sh`; `--check-inputs` passes).

## The measurement

Warm-run callgrind instruction slopes between 6 000 and 14 000 iterations of the ticket's loop, `MUTSU_JIT=off MUTSU_GC=off`, release, all from one build whose gates are off by default so the variants share a binary. Clean baseline on `main` at `1a49a887` is 77 195 / 87 787 / tax 10 592; the gates themselves cost ~200, which is why the table compares within the gated binary.

| gated out | floor | `+ use Test` | tax |
| --- | --- | --- | --- |
| nothing (gated baseline) | 77 395 | 88 183 | 10 788 |
| the reflective latch on `skip_env_write` | 77 386 | 88 126 | 10 740 |
| the captured-env merge | 73 518 | 83 352 | 9 834 |
| the whole capture machinery | 64 032 | 67 811 | 3 779 |

## Finding 1 — the reflective latch is dead, and it was named as a prerequisite

#7565's body calls the process-global latch **"the worse of the two"** costs, and #8019's note named it as the thing blocking the per-tier capture memo. Gating `skip_env_write` to ignore `opcode::reflective_name_access_possible()` entirely is worth **57 instructions per iteration** — 0.5% of the tax, inside the drift band #7964 documented for this area (four shapes of *identical* logic spanning 0.8%). And the memo it was said to block shipped in #8060 without it, because the address that memo needed was never the right key.

That matters beyond the number. A per-chunk `skip_env_write` is not a mechanical change: mutsu's `EVAL` resolves against the live env chain rather than its own lexical scope, so a callee's `EVAL` reads the caller's mirror and relies on it. Someone was going to spend a large, correctness-critical change on this for half a percent.

## Finding 2 — the merge is the largest item, and it is a *floor* cost

Gating out the captured-env merge is 4 831 instructions per iteration with `use Test` and 3 877 without, so only **954 of it scales with the import list**. The capture of a closure with no free variables at all (`sub ($v) { $v + 1000 }`) is still 31 entries — the built-in dynamics, `Any`, `?FILE`, the topic — and the merge probes every one of them on every call to insert none of them (#8019 measured `insert_sym` reached zero times).

So it is not a `use Test` problem that happens to show up in a benchmark; it is a per-closure-call cost of the interpreter, and #7565 is merely where anyone measured it. For scale, the whole capture machinery — build and merge together — is 13 363 instructions per iteration on the floor, 17% of that loop.

## ADR-0092

Proposes the fix — make the capture a **tier** the frame consults after its parent chain (`overlay -> caller chain -> capture -> GLOBAL_BASE`), which is the precedence the merge already implements by hand — and records three mechanisms, two already measured out:

- **An identity token that lets the merge be skipped is unsound at any price worth paying.** The precondition is a *superset* relation between two key sets ("every captured name is still visible"), and storing the closure into its own creating scope adds a key between capture and call — so exact equality never holds on this workload, and every cheap relaxation collides (two clones of one tier can take different additions and reach the same counters with different key sets). Pinning each tier's `Arc` certifies it soundly and forces an O(frame overlay) map clone on the next write, which in this loop is the `my &return = ...` storing the closure itself.
- **Appending the capture at the chain's tail** needs no new field and no lookup change, but rebuilds every tier above it — reintroducing the two `Arc::new`s per call `Env::scoped_child` was tuned to remove, and adding a tier per call so `MAX_OVERLAY_DEPTH`'s flatten fires twice as often.
- **A `fallback` tier on the frame env** is the candidate. It carries a real semantic change — capture entries stop being visible to *callees* of the closure, because they no longer sit in the frame overlay. Arguably more correct (the current behaviour is dynamic scoping where Raku wants lexical), but a behaviour change with `EVAL` as its most likely dependant.

ADR-0092 deliberately does not decide whether to do it, and says what to measure first (`bench-ctor.raku` / `bench-class.raku`, neither of which imports anything and both of which create closures inside method frames).

## What is left on #7565

1. The no-op capture merge — ADR-0092.
2. The remaining capture walk: 43 candidates for 31 kept, worth roughly 650 — which is 0.7% of this loop, precisely the drift band #7964 measured for codegen shape in this filter, so it is only shippable with an ablation that separates the two.
3. The ~20 built-in dynamics — floor, not tax, and now measurably the same floor the merge pays for.

The previous list's item 2 (the reflective latch) is struck, per finding 1. Leaving #7565 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8)_