### PR TITLE
fix: lower static regex trees to matcher plans

### DIFF
--- a/docs/adr/0088-rakuast-regex-boundary-tree.md
+++ b/docs/adr/0088-rakuast-regex-boundary-tree.md
@@ -1,7 +1,8 @@
 # ADR-0088: RakuAST and execution share a source-level regex tree
 
-- Status: Accepted (static source-tree and RakuAST slices implemented 2026-09-12;
-  dynamic contents and execution-tree migration remain)
+- Status: Accepted (static source-tree, RakuAST, and execution-lowering slices
+  implemented 2026-09-12; dynamic contents and the complete execution-tree
+  migration remain)
 - Date: 2026-09-12
 - Related: [ADR-0011](0011-rakuast-model-layer-and-phasing.md) (the RakuAST
   model layer and its bidirectional conversion),
@@ -338,7 +339,7 @@ from creating a second, divergent regex engine.
 
 ## 7. Implementation status
 
-Implemented for the static slice on 2026-09-12. The parser now retains a
+Implemented for the static source and RakuAST slices on 2026-09-12. The parser now retains a
 `RegexTree` for static regex expressions and declarations, including the
 `match-immediately` bit and boolean adverbs needed by `m:i` / `m:g`. The read
 direction emits `QuotedRegex`, the static `Regex::*` family, declaration nodes,
@@ -346,7 +347,34 @@ and `Grammar`; the write direction lowers those nodes back through the current
 compiler and VM. The focused dual-oracle coverage is in
 `t/rakuast/rakuast-regex.t`.
 
+The static execution bridge was added in the next slice. The runtime parser
+lowers source trees containing literals, quotes, groups, alternation, digit
+classes, and the simple quantifiers directly to `RegexPattern`, carrying the
+`ratchet`, `ignorecase`, and `ignoremark` policies. Sigspace and constructs
+whose meaning depends on captures, interpolation, code, or package state keep
+using the established structural parser. The bridge is intentionally a
+fallback-compatible step: the compiled `Value::Regex` still carries its
+execution spelling, so the parser-bound tree must remain the next migration
+target rather than being rediscovered from normalized declaration text.
+
 The following remain intentionally open: dynamic assertions and interpolation,
-captures and subrules, adverbs with runtime arguments, and migration of the
-matcher's internal `RegexPattern` construction to a full execution lowering
-from `RegexTree`.
+captures and subrules, adverbs with runtime arguments, and replacing the
+string-carried regex value with parser-produced tree provenance throughout the
+remaining matcher entry points.
+
+## 8. Static execution-lowering slice (2026-09-12)
+
+The static subset now has one execution lowering function shared with the
+RakuAST tree. `Interpreter::parse_regex` tries this lowering before the legacy
+structural parser for patterns that contain no runtime interpolation. The
+lowerer emits the existing `RegexPattern` and `RegexAtom` types; it does not
+add a matcher or a VM fallback. Unsupported syntax, sigspace, and any literal
+containing a metacharacter whose escaped/source spelling is not retained fall
+back to the old parser, preserving execution semantics during migration.
+
+The regression pin is `t/regex/regex-tree-static-execution.t`: it exercises
+literal and quantified-class `EVAL` results twice, plus a ratcheted token
+declaration twice, and checks rejection cases. The Rust lowering tests pin the
+plan shape and the fallback boundary. This slice establishes only the static
+plan conversion; captures, subrules, dynamic values, and the parser-produced
+tree transport remain separate slices.

--- a/news/2026-09/rakuast-regex-static-execution.md
+++ b/news/2026-09/rakuast-regex-static-execution.md
@@ -1,0 +1,12 @@
+# Static regex trees lower to the execution matcher
+
+The static `RegexTree` subset used by RakuAST now lowers directly to mutsu's
+existing `RegexPattern` matcher plan for literal sequences, quotes, groups,
+alternation, digit classes, simple quantifiers, and the ratchet/case policies.
+Patterns outside that subset continue through the established structural parser
+until their dynamic semantics can be represented safely.
+
+The Parser -> Compiler -> VM path and existing matcher remain unchanged. The
+parser-produced tree still needs to be transported through regex values before
+the full string-to-plan boundary can be removed; captures, subrules,
+interpolation, and runtime adverb arguments remain open under ADR-0088.

--- a/src/regex_tree.rs
+++ b/src/regex_tree.rs
@@ -83,6 +83,193 @@ impl RegexTree {
     pub(crate) fn to_source(&self) -> String {
         self.body.to_source()
     }
+
+    /// Lower the static source tree into the execution matcher plan.
+    ///
+    /// The runtime parser still owns every construct that needs package state,
+    /// interpolation, or code evaluation.  This deliberately small bridge is
+    /// for the source forms that `parse_static` can prove are structural only;
+    /// returning `None` keeps those forms on the established parser path.
+    pub(crate) fn lower_execution(
+        &self,
+        ratchet: bool,
+        ignore_case: bool,
+        ignore_mark: bool,
+    ) -> Option<crate::runtime::RegexPattern> {
+        fn token(
+            atom: crate::runtime::RegexAtom,
+            quant: crate::runtime::RegexQuant,
+            ratchet: bool,
+        ) -> crate::runtime::RegexToken {
+            crate::runtime::RegexToken {
+                atom,
+                quant,
+                named_capture: None,
+                secondary_named_capture: None,
+                hash_capture: None,
+                force_list_capture: false,
+                ratchet,
+                frugal: false,
+                separator: None,
+                from_runtime_interpolation: false,
+            }
+        }
+
+        fn pattern(
+            tokens: Vec<crate::runtime::RegexToken>,
+            ignore_case: bool,
+            ignore_mark: bool,
+        ) -> crate::runtime::RegexPattern {
+            crate::runtime::RegexPattern {
+                tokens,
+                anchor_start: false,
+                anchor_end: false,
+                ignore_case,
+                ignore_mark,
+            }
+        }
+
+        fn lower_node(
+            node: &RegexNode,
+            ratchet: bool,
+            ignore_case: bool,
+            ignore_mark: bool,
+        ) -> Option<Vec<crate::runtime::RegexToken>> {
+            match node {
+                RegexNode::Literal(text) => {
+                    // These characters are syntax in an unquoted runtime
+                    // pattern. An escaped spelling is intentionally left to
+                    // the established parser because the source tree does
+                    // not yet retain whether a literal character was escaped.
+                    if text.chars().any(|ch| {
+                        matches!(
+                            ch,
+                            '\u{1}'
+                                | '\\'
+                                | '#'
+                                | '&'
+                                | ':'
+                                | ';'
+                                | '='
+                                | '%'
+                                | '~'
+                                | '{'
+                                | '}'
+                                | '.'
+                                | '^'
+                                | '$'
+                                | '<'
+                                | '>'
+                                | '!'
+                                | '\''
+                                | '"'
+                                | '\u{2018}'
+                                | '\u{2019}'
+                                | '\u{201a}'
+                                | '\u{201c}'
+                                | '\u{201d}'
+                                | '\u{201e}'
+                                | '\u{ff62}'
+                                | '\u{ff63}'
+                                | '\u{00ab}'
+                                | '\u{00bb}'
+                        )
+                    }) {
+                        return None;
+                    }
+                    Some(
+                        text.chars()
+                            .map(|ch| {
+                                token(
+                                    crate::runtime::RegexAtom::Literal(ch),
+                                    crate::runtime::RegexQuant::One,
+                                    ratchet,
+                                )
+                            })
+                            .collect(),
+                    )
+                }
+                RegexNode::Quote(text) => Some(
+                    text.chars()
+                        .map(|ch| {
+                            token(
+                                crate::runtime::RegexAtom::Literal(ch),
+                                crate::runtime::RegexQuant::One,
+                                ratchet,
+                            )
+                        })
+                        .collect(),
+                ),
+                RegexNode::CharClassDigit => Some(vec![token(
+                    crate::runtime::RegexAtom::CharClass(crate::runtime::CharClass {
+                        negated: false,
+                        items: vec![crate::runtime::ClassItem::Digit],
+                    }),
+                    crate::runtime::RegexQuant::One,
+                    ratchet,
+                )]),
+                RegexNode::Sequence(nodes) => {
+                    let mut tokens = Vec::new();
+                    for child in nodes {
+                        tokens.extend(lower_node(child, ratchet, ignore_case, ignore_mark)?);
+                    }
+                    Some(tokens)
+                }
+                RegexNode::Alternation(branches) => {
+                    let alternatives = branches
+                        .iter()
+                        .map(|branch| {
+                            lower_node(branch, ratchet, ignore_case, ignore_mark)
+                                .map(|tokens| pattern(tokens, ignore_case, ignore_mark))
+                        })
+                        .collect::<Option<Vec<_>>>()?;
+                    Some(vec![token(
+                        crate::runtime::RegexAtom::Alternation(alternatives),
+                        crate::runtime::RegexQuant::One,
+                        ratchet,
+                    )])
+                }
+                RegexNode::Group(child) => {
+                    let tokens = lower_node(child, ratchet, ignore_case, ignore_mark)?;
+                    Some(vec![token(
+                        crate::runtime::RegexAtom::Group(pattern(tokens, ignore_case, ignore_mark)),
+                        crate::runtime::RegexQuant::One,
+                        ratchet,
+                    )])
+                }
+                RegexNode::Quantified { atom, quantifier } => {
+                    let quant = match quantifier {
+                        RegexQuantifier::ZeroOrMore => crate::runtime::RegexQuant::ZeroOrMore,
+                        RegexQuantifier::OneOrMore => crate::runtime::RegexQuant::OneOrMore,
+                        RegexQuantifier::ZeroOrOne => crate::runtime::RegexQuant::ZeroOrOne,
+                    };
+                    let mut tokens = lower_node(atom, ratchet, ignore_case, ignore_mark)?;
+                    if tokens.len() == 1 {
+                        tokens[0].quant = quant;
+                        return Some(tokens);
+                    }
+                    Some(vec![token(
+                        crate::runtime::RegexAtom::Group(pattern(tokens, ignore_case, ignore_mark)),
+                        quant,
+                        ratchet,
+                    )])
+                }
+                // `WithWhitespace` is a RakuAST semantic wrapper. Written
+                // regex whitespace is insignificant unless the runtime
+                // `:sigspace` policy is active, which this static bridge does
+                // not claim to lower.
+                RegexNode::WithWhitespace(child) => {
+                    lower_node(child, ratchet, ignore_case, ignore_mark)
+                }
+            }
+        }
+
+        Some(pattern(
+            lower_node(&self.body, ratchet, ignore_case, ignore_mark)?,
+            ignore_case,
+            ignore_mark,
+        ))
+    }
 }
 
 impl RegexNode {
@@ -160,10 +347,30 @@ impl Parser {
             }
             let mut atom = self.parse_atom(stops)?;
             if let Some(quantifier) = self.parse_quantifier() {
-                atom = RegexNode::Quantified {
-                    atom: Box::new(atom),
-                    quantifier,
-                };
+                // A quantifier binds to the final atom, not to a run of
+                // adjacent literal characters (`ab+` means `a` then `b+`).
+                // Keep the measured RakuAST shape and let execution lowering
+                // preserve the same boundary.
+                if let RegexNode::Literal(text) = &mut atom
+                    && text.chars().count() > 1
+                {
+                    let last = text.pop().expect("literal has more than one character");
+                    let prefix = std::mem::take(text);
+                    atom = RegexNode::Sequence(vec![
+                        RegexNode::Literal(prefix),
+                        RegexNode::Quantified {
+                            atom: Box::new(RegexNode::Literal(last.to_string())),
+                            quantifier,
+                        },
+                    ]);
+                    // The quantifier has already been attached to the final
+                    // literal in the sequence.
+                } else {
+                    atom = RegexNode::Quantified {
+                        atom: Box::new(atom),
+                        quantifier,
+                    };
+                }
             }
 
             if self.declaration || saw_whitespace && !nodes.is_empty() {
@@ -202,14 +409,11 @@ impl Parser {
                 }
                 Some(RegexNode::Group(Box::new(inner)))
             }
-            '(' => {
-                self.pos += 1;
-                let inner = self.parse_alternation(&[')'])?;
-                if !self.consume_if(')') {
-                    return None;
-                }
-                Some(RegexNode::Group(Box::new(inner)))
-            }
+            // Parentheses are capture groups in regex slang.  Captures need
+            // runtime slot metadata, which this source tree does not retain;
+            // leave them on the established execution parser instead of
+            // silently turning them into a non-capturing `RegexGroup`.
+            '(' => None,
             ')' | ']' if stops.contains(&ch) => None,
             '|' | '+' | '*' | '?' | '.' | '^' | '$' | '<' | '>' => None,
             _ => self.parse_literal(),
@@ -223,11 +427,11 @@ impl Parser {
             self.pos += 1;
             match ch {
                 c if c == quote => return Some(RegexNode::Quote(text)),
-                '\\' => {
-                    let escaped = self.chars.get(self.pos).copied()?;
-                    self.pos += 1;
-                    text.push(escaped);
-                }
+                // Quoted escapes can decode codepoints (`\\x20`) or alter
+                // quoting (`\\"`).  The current Quote node stores only the
+                // decoded-looking text, so it cannot preserve that source
+                // distinction for execution lowering.
+                '\\' => return None,
                 _ => text.push(ch),
             }
         }

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -1,6 +1,58 @@
 use super::regex_parse::*;
 use super::*;
+use crate::regex_tree::RegexTree;
 use ::regex::Regex;
+
+/// Lower the static subset of the shared source tree directly to the matcher
+/// plan.  Prefixes are the execution spelling produced by the existing parser;
+/// anything outside this small flag set stays on `parse_regex_structural`,
+/// because it may carry sigspace, captures, interpolation, or package state.
+fn lower_static_execution_pattern(pattern: &str) -> Option<RegexPattern> {
+    fn strip_flag<'a>(source: &'a str, flag: &str) -> Option<&'a str> {
+        let rest = source.strip_prefix(flag)?;
+        if rest.is_empty()
+            || rest.starts_with(char::is_whitespace)
+            || rest.starts_with(':')
+            || rest.starts_with('/')
+        {
+            Some(rest.trim_start())
+        } else {
+            None
+        }
+    }
+
+    let mut source = pattern.trim_start();
+    let mut ratchet = false;
+    let mut ignore_case = false;
+    let mut ignore_mark = false;
+    loop {
+        if let Some(rest) = strip_flag(source, ":ratchet") {
+            ratchet = true;
+            source = rest;
+        } else if let Some(rest) = strip_flag(source, ":i") {
+            ignore_case = true;
+            source = rest;
+        } else if let Some(rest) = strip_flag(source, ":ignorecase") {
+            ignore_case = true;
+            source = rest;
+        } else if let Some(rest) = strip_flag(source, ":m") {
+            ignore_mark = true;
+            source = rest;
+        } else if let Some(rest) = strip_flag(source, ":ignoremark") {
+            ignore_mark = true;
+            source = rest;
+        } else if source.starts_with(":s") || source.starts_with(":sigspace") {
+            // `WithWhitespace` is a source/model wrapper, but sigspace changes
+            // matching and requires the runtime's WsRule policy.
+            return None;
+        } else {
+            break;
+        }
+    }
+
+    let tree = RegexTree::parse_static(source, false)?;
+    tree.lower_execution(ratchet, ignore_case, ignore_mark)
+}
 
 /// If the iterator is positioned right after a `<` that opens a code
 /// assertion (`<?{ ... }>`, `<!{ ... }>`) or closure interpolation
@@ -1446,8 +1498,8 @@ impl Interpreter {
             }) {
                 return Some(cached);
             }
-            let parsed = self
-                .parse_regex_uncached(pattern, RegexParseMode::Match)
+            let parsed = lower_static_execution_pattern(pattern)
+                .or_else(|| self.parse_regex_uncached(pattern, RegexParseMode::Match))
                 .map(std::sync::Arc::new);
             if let Some(ref p) = parsed {
                 REGEX_PARSE_CACHE.with(|c| {
@@ -1459,5 +1511,47 @@ impl Interpreter {
         }
         self.parse_regex_uncached(pattern, RegexParseMode::Match)
             .map(std::sync::Arc::new)
+    }
+}
+
+#[cfg(test)]
+mod static_execution_tests {
+    use super::*;
+
+    #[test]
+    fn lowers_literal_sequence_without_runtime_reparse() {
+        let pattern = lower_static_execution_pattern("test").expect("static pattern");
+        assert_eq!(pattern.tokens.len(), 4);
+        assert!(
+            pattern
+                .tokens
+                .iter()
+                .all(|token| matches!(token.atom, RegexAtom::Literal(_)))
+        );
+    }
+
+    #[test]
+    fn lowers_flags_and_quantifiers() {
+        let pattern = lower_static_execution_pattern(":ratchet :i \\d+").expect("static pattern");
+        assert!(pattern.ignore_case);
+        assert!(matches!(
+            pattern.tokens.as_slice(),
+            [RegexToken {
+                atom: RegexAtom::CharClass(_),
+                quant: RegexQuant::OneOrMore,
+                ratchet: true,
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn leaves_sigspace_and_unsupported_syntax_on_the_parser_path() {
+        assert!(lower_static_execution_pattern(":s a b").is_none());
+        assert!(lower_static_execution_pattern("a.b").is_none());
+        assert!(lower_static_execution_pattern("[ab]+ %% ','").is_none());
+        assert!(lower_static_execution_pattern("(a)").is_none());
+        assert!(lower_static_execution_pattern(r#""\x20""#).is_none());
+        assert!(lower_static_execution_pattern("\u{1}42\u{1}").is_none());
     }
 }

--- a/t/regex/regex-tree-static-execution.t
+++ b/t/regex/regex-tree-static-execution.t
@@ -1,0 +1,23 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# ADR-0088 issue #8033: static RegexTree nodes lower directly to the matcher
+# plan.  Dynamic regex content remains on the established runtime parser path.
+
+plan 8;
+
+my $literal = EVAL(Q[/test/].AST);
+ok 'test' ~~ $literal, 'a static literal lowered from RakuAST matches';
+ok 'test' ~~ $literal, 'the same lowered literal matches a second time';
+nok 'toast' ~~ $literal, 'the lowered literal still rejects a non-match';
+
+my $digits = EVAL(Q[/\d+/].AST);
+ok '12345' ~~ $digits, 'a quantified character class lowers to the matcher';
+nok 'abc' ~~ $digits, 'the lowered character class rejects letters';
+
+my $grammar = EVAL(Q[grammar GRegexTreeExecution { token digits { \d+ } }].AST);
+ok $grammar.parse('123', :rule<digits>), 'a lowered token declaration matches';
+ok $grammar.parse('456', :rule<digits>), 'a lowered token declaration matches again';
+nok $grammar.parse('abc', :rule<digits>), 'the lowered token rejects a non-match';


### PR DESCRIPTION
## Summary
- lower the static RegexTree subset directly to existing RegexPattern matcher plans
- preserve ratchet, ignorecase, and ignoremark execution flags while conservatively falling back for captures, escapes, interpolation sentinels, sigspace, and unsupported syntax
- fix quantifier binding so the tree keeps the quantified atom boundary
- keep private CStruct attribute lookup compatible with the current sigil-aware local-key metadata
- document the slice in ADR-0088 and add focused TAP/Rust regression coverage plus a news entry

This is one execution-lowering slice of #8033. Captures, subrules, dynamic regex contents, runtime adverb arguments, full regex value provenance, and complete migration remain.

## Validation
- cargo fmt --all
- make lint
- cargo test static_execution --lib
- cargo build --release
- focused grammar, regex, and RakuAST TAP tests: 5 files, 46 tests, Result: PASS
- make test: 4063 files, 43224 tests, Result: PASS
- make roast: 1437 files, 219658 tests, Result: PASS

Part of #8033