### PR TITLE
fix: run a subset's where predicate in its declaration package

### DIFF
--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -104,6 +104,14 @@ pub(crate) struct SubsetDef {
     pub(crate) base: String,
     pub(crate) predicate: Option<Expr>,
     pub(crate) version: String,
+    /// The package the `subset` was declared in (e.g. `"C"` for a `subset`
+    /// inside `class C { ... }`). Raku closes a `where` predicate over its
+    /// declaration scope, so the predicate must be compiled and run as if
+    /// still lexically inside this package — otherwise a class-nested symbol
+    /// the predicate references (a grammar/class declared alongside it) is
+    /// only visible when the predicate happens to run from a method already
+    /// on that class (see #8003).
+    pub(crate) decl_package: String,
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -807,17 +807,18 @@ impl Interpreter {
         // Drop any cached compiled predicate for this name so a redeclaration
         // recompiles against the new predicate (see `subset_predicate_cache`).
         self.subset_predicate_cache.remove(name);
-        let def = SubsetDef {
-            base: base.to_string(),
-            predicate,
-            version: version.to_string(),
-        };
         // A subset defaults to `our` scope: declared inside a package/class/
         // module it is also reachable by its qualified name (`URI::Scheme`),
         // so register that alias too — smartmatch resolves the constraint by
         // the exact name it was referenced with. A `my subset` is lexical and
         // must NOT get the package-qualified alias (S12-subset/type-subset.t).
         let pkg = self.current_package();
+        let def = SubsetDef {
+            base: base.to_string(),
+            predicate,
+            version: version.to_string(),
+            decl_package: pkg.clone(),
+        };
         // The qualified name is the subset's *identity* (raku reports `Foo::RM`
         // from `.^name` and in every type-check message), so the short name is
         // registered as an alias pointing at it — the same shape `class`/`role`

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -964,6 +964,18 @@ impl Interpreter {
             // `where` blocks across `~~` checks. Do NOT snapshot/restore the
             // whole env here (a previous attempt broke that test); the
             // per-name saves below cover only the bind variable.
+            //
+            // Run the predicate as if still lexically inside the package the
+            // `subset` was declared in (Raku closes `where` over the
+            // declaration scope). Without this, a predicate that references a
+            // sibling symbol private to that package (e.g. a `grammar`
+            // nested in the same `class` body) resolves it only when the
+            // ambient dynamic package happens to already be that class —
+            // true inside one of the class's own methods, but NOT while
+            // matching a multi candidate's signature during dispatch, before
+            // any method body has been entered (#8003).
+            let saved_package = self.current_package();
+            self.set_current_package(subset.decl_package.clone());
             let ok = if let Some(pred) = &subset.predicate {
                 // A predicate that takes its candidate value through a single
                 // simple variable is equivalent to running its body with that
@@ -1086,6 +1098,7 @@ impl Interpreter {
             } else {
                 true
             };
+            self.set_current_package(saved_package);
             return ok;
         }
         if let Some((constraint_base, constraint_args)) =

--- a/t/grammar/subset-where-class-scoped-grammar.t
+++ b/t/grammar/subset-where-class-scoped-grammar.t
@@ -1,0 +1,44 @@
+use Test;
+
+# A `subset`'s `where` predicate closes over its DECLARATION scope, not
+# whatever package happens to be dynamically current when the predicate
+# first runs. A subset declared inside a class body, whose predicate refers
+# to a sibling type (here a `grammar`) declared in that same class body,
+# must still resolve that sibling when the predicate runs as part of a
+# `multi method new` candidate's signature check during dispatch -- i.e.
+# BEFORE any method body of the class has been entered and pushed the class
+# onto the method-class stack. Previously the predicate's sibling reference
+# was only visible when it happened to run from inside one of the class's
+# own methods; checked during constructor candidate matching it hit
+# "Undeclared name", every positional `new` candidate silently failed its
+# constraint, and dispatch fell through to the default (named-arguments-only)
+# constructor -- exactly the `Net::Netmask` failure in #8003.
+plan 2;
+
+{
+    class C {
+        grammar IP_Addr {
+            token TOP { ^ <ipv4> $ }
+            token ipv4 { <d8> ** 4 % '.' }
+            token d8 { \d+ }
+        }
+        our subset IPv4 of Str where { IP_Addr.subparse($_, :rule<ipv4>) };
+
+        has $.ip;
+        multi method new(IPv4 $ip) { self.bless(:$ip) }
+    }
+    is C.new("10.0.0.1").ip, "10.0.0.1",
+        'multi method new matches a class-scoped subset whose where predicate calls a sibling grammar';
+}
+
+# The subset's own smartmatch (outside any dispatch) must keep working too.
+{
+    class D {
+        grammar Only5 {
+            token TOP { ^ '5' $ }
+        }
+        our subset Five of Str where { Only5.subparse($_) };
+        method check($s) { so ($s ~~ Five) }
+    }
+    ok D.new.check("5"), 'subset predicate referencing a sibling class-scoped grammar still smartmatches';
+}


### PR DESCRIPTION
## Summary

- A `subset`'s `where` predicate closes over its *declaration* scope in Raku, but mutsu ran it under whatever package happened to be dynamically current at the moment the predicate was first checked (`compile_subset_predicate` cached the first check's context, and nothing set the dynamic `current_package` before evaluating it).
- A subset declared inside a class body, whose predicate references a sibling type declared in that same class body (e.g. a `grammar`), only resolved that sibling when the predicate happened to run from inside one of the class's own methods (the class already on the method-class stack) — **not** when it ran earlier, as part of a `multi method new` candidate's own signature check during dispatch, before any method body of the class had been entered.
- The sibling lookup then failed with "Undeclared name", every positional constructor candidate silently failed its type constraint, and dispatch fell through to the default (named-arguments-only) constructor — exactly the `Net::Netmask` failure described in #8003.
- Fix: store the subset's declaring package (`SubsetDef::decl_package`) at registration time, and temporarily switch `current_package` to it while the predicate runs (mirroring the existing pattern already used for typed-attribute defaults in `attr_build_defaults.rs`), so the predicate resolves class-scoped siblings the same way regardless of where in the dispatch pipeline it is first checked.

## Investigation

Measured against the real `Net::Netmask` distribution named in #8003 (whose `IPv4`/`IPv6` subsets are backed by a `grammar IP_Addr` declared in the same class body):

```
$ mutsu repro.raku   # before
Default constructor for 'Net::Netmask' only takes named arguments

$ mutsu repro.raku   # after
Net::Netmask.new("10.0.0.0/32")   # matches raku
```

While investigating #8003's other 8 listed distributions, two of them (`Version::Raku`, `Version::Nginx`) turned out to share the *symptom* but not the *root cause* — they fail because a user class `is Version` doesn't inherit `Version`'s native positional constructor, unrelated to subsets/grammars entirely. Filed separately as #8070 rather than folded in here.

Net::Netmask itself still has an unrelated, pre-existing bug further down its own constructor chain (a `...` arithmetic sequence producing an empty list for a `/0` CIDR mask), also out of scope for this PR.

## Test plan

- Added `t/grammar/subset-where-class-scoped-grammar.t`, a minimized regression covering both the `multi method new` dispatch case and a plain smartmatch case.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run locally; `make roast`'s only red files are the three environment-only failures documented in `docs/agent-environments.md` (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t` — all match the documented shapes exactly), unrelated to this change.

Closes #8003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_