### PR TITLE
fix(signature): give a type capture its own ParamDef field so `::T Foo:D:` parses and `T` binds

### DIFF
--- a/news/2026-09/type-capture-is-its-own-field-on-paramdef.md
+++ b/news/2026-09/type-capture-is-its-own-field-on-paramdef.md
@@ -1,0 +1,78 @@
+# A type capture is its own field on `ParamDef`, so `::T Foo:D:` parses and `T` binds
+
+`method merge(::T CRDT:D: $other --> T)` — a type capture on the invocant *followed by* a nominal
+invocant type — did not parse at all, and the two spellings that did parse mis-bound the captured
+name. All three problems were one representation bug: `ParamDef` carried a parameter's type as a
+single `Option<String>`, and a capture was encoded *inside* that string as `"::T"`. There was no room
+in it for both `::T` and `CRDT:D`.
+
+```
+$ mutsu -e 'class Foo { method m(::T Foo:D: $x --> T) { $x } }; say "ok"'       # before
+===SORRY!=== Error while compiling -e
+Confused. expected statement: ...
+$ mutsu -e 'class Foo { method m(::T: $x --> T) { $x } }; say Foo.new.m(Foo.new).WHAT'
+Type check failed for return value; expected T but got Any (Foo())
+```
+
+`ParamDef` now has a `type_capture: Option<String>` of its own, holding the bare captured name with
+no `::` prefix and no smiley; `type_constraint` is only ever the nominal half. One accessor,
+`ParamDef::captured_type_name()`, is what every binding, dispatch, role and RakuAST site asks —
+roughly twenty of them used to re-derive the capture by stripping `"::"` off the constraint string,
+which is exactly why a parameter could never hold both facts. The parser builds the pair at one
+choke point: the capture branch consumes `::T` and then parses whatever follows as an ordinary
+parameter, hanging the capture off the result, so defaults, traits, `where` clauses and
+sub-signatures all keep it for free. An invocant capture is split off before the invocant marker is
+read (`split_invocant_type_capture`), so `::T CRDT:D:` becomes one invocant parameter carrying both
+`type_capture: Some("T")` and `type_constraint: Some("CRDT:D")` — the capture binds *and* the
+nominal type is enforced, where the old code had them as mutually exclusive arms of one `if`/`else`
+chain.
+
+Three further defects fell out of the same change.
+
+**The capture-bound marker collided with a parameter name.** `bind_type_capture` recorded "a capture
+named `T` is bound" under the env key `__type_capture__T` — which is also the synthetic *parameter
+name* a bare `::T` / `::T:` capture carries. So the binder's own "bind the parameter under its name"
+step overwrote the marker with the argument value, `has_type_capture_binding("T")` then said no, and
+every later resolution of `T` fell back to the literal name. That is why `--> T` reported "expected
+T". The marker key is now `__mutsu_type_capture_bound__<name>`, which no parameter name can reach.
+
+**A method resolved its `--> T` return constraint after its own env was gone.** The sub paths
+resolve the return spec before popping the call frame; both method paths did it after restoring the
+caller's env, so a capture bound by the method's own signature was no longer visible. Both now
+resolve it while the callee env is still live.
+
+**A `::T` capture on a method silently took the read-only fast path.** The fast path has no
+capture-binding step; it used to be kept out by accident, because the capture lived in
+`type_constraint` and either the invocant-constraint gate or the fast path's own nominal type check
+(which `"::T"` could never satisfy) bounced the call. With the capture in a field of its own the
+gate has to name it, so `has_type_capture` joins the fast-path conditions. Before this,
+`class Foo { method m(::T $x) { say T } }` failed outright — the capture was type-checked against
+the literal string `::T`.
+
+**A role body that does not parse is now a parse error.** `role_decl` fell back to
+`consume_raw_braced_body` on a non-fatal block failure, which discarded the entire body and produced
+a role with no methods. `role R { method m(::T R:D: $x) { 1 } }` therefore compiled silently and the
+call site died with "No such method 'm'", with nothing pointing at the signature that had failed to
+parse. Roles now parse their body exactly as classes do.
+
+Signature introspection follows the field. `SigParam` grew the same `type_capture`, so
+`Parameter.type_captures` reads it there rather than by slicing a `"::T"` constraint string,
+`.type` stays `Any` for a capture-only parameter, and `.gist` renders the capture ahead of the
+nominal-type slot the way Rakudo does — two spaces and all (`(::T  $x)`), with a bare `::T`
+parameter showing as the anonymous `$` instead of leaking its synthetic
+`$__type_capture__T` name.
+
+Several fast paths had been excluding captures *by accident*, because `"::T"` was a constraint string
+that no fast type check could satisfy. With the capture in a field of its own they had to be told:
+the method fast path (above), and the sub light / positional-light paths in `vm_call_eligibility.rs`.
+Getting that wrong was visible immediately — `sub f(::T $x) { my T $y = 4.2 }` reported "Type 'T' is
+not declared", because the light path bound the argument without ever binding the capture.
+
+The `::T:D` spelling is no longer read as a capture *named* `T:D`. Rakudo reports such a parameter's
+`.type` as `Any` and enforces nothing — `sub f(::T:U $x) { }; f(42)` runs there — so the smiley is
+consumed and discarded and the capture is named `T`, which is what `::GrammarType:U :$schema`
+(YAMLish) has always meant.
+
+Pinned by `t/routines/signature/invocant-type-capture-param.t`. Closes #7984. One adjacent pre-existing
+divergence surfaced while writing that test and is tracked separately: a capture-constrained
+parameter's binding failure is catchable by `try` but does not reach `dies-ok`'s handler (#8064).

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -76,6 +76,16 @@ pub(crate) struct ParamDef {
     #[allow(dead_code)]
     pub(crate) sigilless: bool,
     pub(crate) type_constraint: Option<String>,
+    /// The name a `::T` type capture binds, with NO `::` prefix and no type
+    /// smiley — `None` on a parameter that captures nothing.
+    ///
+    /// This is deliberately a field of its own rather than a `"::T"` spelling
+    /// inside [`ParamDef::type_constraint`]: a parameter can carry a capture
+    /// *and* a nominal type at the same time (`method m(::T Foo:D: $x)`, #7984),
+    /// which a single `Option<String>` cannot express. `type_constraint` is
+    /// therefore only ever the nominal half.
+    #[serde(default)]
+    pub(crate) type_capture: Option<String>,
     pub(crate) literal_value: Option<Value>,
     #[allow(dead_code)]
     pub(crate) sub_signature: Option<Vec<ParamDef>>,
@@ -154,6 +164,29 @@ impl ParamDef {
     /// invocant's env key, and it declares no lexical (ADR-0061).
     pub(crate) fn declares_self_lexical(&self) -> bool {
         self.name == "self" && !self.traits.iter().any(|t| t == IMPLICIT_INVOCANT_TRAIT)
+    }
+
+    /// The name a `::T` type capture on this parameter binds, if any.
+    ///
+    /// The single oracle for "does this parameter capture a type, and under what
+    /// name". Prefer it over reading [`ParamDef::type_constraint`] and stripping
+    /// a `::` prefix: that spelling cannot hold a capture and a nominal type at
+    /// once, which is exactly what `method m(::T Foo:D: $x)` needs (#7984).
+    ///
+    /// The fallback covers the two constraint spellings the parser still keeps
+    /// in `type_constraint` with their `::` prefix intact, because dispatch also
+    /// consumes them as nominal constraints: the pseudo-types `::?CLASS` /
+    /// `::?ROLE` (with an optional smiley) and the indirect form `::(expr)`.
+    /// Those are not ident captures, and their long-standing behavior — binding
+    /// a capture under the post-`::` spelling, which makes the constraint a
+    /// no-op type check — is preserved verbatim.
+    pub(crate) fn captured_type_name(&self) -> Option<&str> {
+        if let Some(name) = self.type_capture.as_deref() {
+            return Some(name);
+        }
+        self.type_constraint
+            .as_deref()
+            .and_then(|tc| tc.strip_prefix("::"))
     }
 
     /// True when this parameter is a capture that carries a subsignature, i.e.
@@ -3443,6 +3476,7 @@ pub(crate) fn make_anon_sub(stmts: Vec<Stmt>) -> Expr {
             let param_defs = legacy_params
                 .iter()
                 .map(|name| ParamDef {
+                    type_capture: None,
                     name: name.clone(),
                     default: None,
                     multi_invocant: true,
@@ -3492,6 +3526,7 @@ pub(crate) fn make_anon_sub(stmts: Vec<Stmt>) -> Expr {
                     // Named placeholders use `:` twigil: $:f, @:f, %:f
                     let is_named = name.contains(':');
                     ParamDef {
+                        type_capture: None,
                         name: name.clone(),
                         default: None,
                         multi_invocant: true,

--- a/src/ast/fingerprint_tests.rs
+++ b/src/ast/fingerprint_tests.rs
@@ -16,6 +16,7 @@ fn say(text: &str) -> Stmt {
 
 fn param(name: &str) -> ParamDef {
     ParamDef {
+        type_capture: None,
         name: name.to_string(),
         default: None,
         multi_invocant: true,

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -427,6 +427,7 @@ impl Compiler {
         let wc_raw = is_whatever_code && param == "_" && whatever_lambda_body_mutates_topic(body);
         let wc_param_defs: Vec<crate::ast::ParamDef> = if wc_raw {
             vec![crate::ast::ParamDef {
+                type_capture: None,
                 name: "_".to_string(),
                 default: None,
                 multi_invocant: true,

--- a/src/method_signature_shared.rs
+++ b/src/method_signature_shared.rs
@@ -88,6 +88,7 @@ fn has_explicit_named_slurpy(param_defs: &[ParamDef]) -> bool {
 /// unless the declaration already has an explicit named slurpy.
 pub(crate) fn implicit_method_named_slurpy_param() -> ParamDef {
     ParamDef {
+        type_capture: None,
         name: "%_".to_string(),
         default: None,
         multi_invocant: true,
@@ -134,6 +135,7 @@ pub(crate) fn effective_method_param_defs(
 /// observes, regardless of how many arguments they happened to pass.
 fn implicit_method_positional_slurpy_param() -> ParamDef {
     ParamDef {
+        type_capture: None,
         name: "@_".to_string(),
         default: None,
         multi_invocant: true,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3322,6 +3322,7 @@ fn expr_uses_return_rw(expr: &Expr) -> bool {
 
 fn implicit_legacy_param(name: &str) -> ParamDef {
     ParamDef {
+        type_capture: None,
         name: name.to_string(),
         default: None,
         multi_invocant: true,

--- a/src/opcode_param_fills.rs
+++ b/src/opcode_param_fills.rs
@@ -147,6 +147,7 @@ mod param_fill_tests {
 
     fn param(name: &str) -> ParamDef {
         ParamDef {
+            type_capture: None,
             name: name.to_string(),
             default: None,
             multi_invocant: false,

--- a/src/parser/primary/ident/anon_sub.rs
+++ b/src/parser/primary/ident/anon_sub.rs
@@ -5,6 +5,7 @@ use crate::parser::primary::misc::parse_block_body_routine;
 
 pub(crate) fn invocant_param_def() -> crate::ast::ParamDef {
     crate::ast::ParamDef {
+        type_capture: None,
         name: "self".to_string(),
         default: None,
         multi_invocant: true,

--- a/src/parser/stmt/class/role_decl.rs
+++ b/src/parser/stmt/class/role_decl.rs
@@ -133,11 +133,7 @@ pub(crate) fn parse_optional_role_type_params(
         let params = param_defs
             .iter()
             .map(|pd| {
-                if let Some(captured) = pd
-                    .type_constraint
-                    .as_deref()
-                    .and_then(|t| t.strip_prefix("::"))
-                {
+                if let Some(captured) = pd.captured_type_name() {
                     captured.to_string()
                 } else {
                     pd.name.trim_start_matches(['$', '@', '%', '&']).to_string()
@@ -182,6 +178,7 @@ pub(crate) fn parse_optional_role_type_params(
                 };
                 params.push(name.clone());
                 param_defs.push(ParamDef {
+                    type_capture: None,
                     name,
                     default,
                     multi_invocant: true,
@@ -218,6 +215,7 @@ pub(crate) fn parse_optional_role_type_params(
                 {
                     params.push(name.clone());
                     param_defs.push(ParamDef {
+                        type_capture: None,
                         name: format!("__type_capture__{}", name),
                         default: Some(default_expr),
                         multi_invocant: true,
@@ -247,11 +245,7 @@ pub(crate) fn parse_optional_role_type_params(
         if let Ok((rest, pd)) = parse_single_param(part)
             && rest.trim().is_empty()
         {
-            let name = if let Some(captured) = pd
-                .type_constraint
-                .as_deref()
-                .and_then(|t| t.strip_prefix("::"))
-            {
+            let name = if let Some(captured) = pd.captured_type_name() {
                 captured.to_string()
             } else {
                 pd.name.trim_start_matches(['$', '@', '%', '&']).to_string()
@@ -435,11 +429,13 @@ pub(crate) fn role_decl_with_keyword<'a>(input: &'a str, kw: &str) -> PResult<'a
     // No package path is pushed for a role body: the scope inside a role is
     // generic, so Raku refuses to install an `our`-scoped declaration there and
     // there is no composed name to register.
-    let (rest, mut body) = match block(rest) {
-        Ok(ok) => ok,
-        Err(e) if e.is_fatal() => return Err(e),
-        Err(_) => consume_raw_braced_body(rest)?,
-    };
+    // A role body parses like any other block. It used to fall back to
+    // `consume_raw_braced_body` on a non-fatal failure, which DISCARDED the
+    // whole body: `role R { method m(::T R:D: $x) { 1 } }` compiled to an empty
+    // role and the call site then died with "No such method", with no
+    // diagnostic pointing at the signature that had not parsed (#7984). A role
+    // body that does not parse is a parse error, exactly as a class body is.
+    let (rest, mut body) = block(rest)?;
     // Handle `also is rw;` in the role body
     body.retain(|stmt| {
         if stmt_is_also_is_rw(stmt) {

--- a/src/parser/stmt/control/for_params.rs
+++ b/src/parser/stmt/control/for_params.rs
@@ -58,6 +58,7 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
             let (r, _) = skip_pointy_return_type(r)?;
             let unpack_name = "__for_unpack".to_string();
             let unpack_def = ParamDef {
+                type_capture: None,
                 name: unpack_name.clone(),
                 default: None,
                 multi_invocant: true,
@@ -105,6 +106,7 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
             }
             let unpack_name = "__for_unpack".to_string();
             let unpack_def = ParamDef {
+                type_capture: None,
                 name: unpack_name.clone(),
                 default: None,
                 multi_invocant: true,
@@ -170,6 +172,7 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
             let (r, _) = skip_pointy_return_type(r)?;
             let unpack_name = "__for_unpack".to_string();
             let unpack_def = ParamDef {
+                type_capture: None,
                 name: unpack_name.clone(),
                 default: None,
                 multi_invocant: true,
@@ -362,6 +365,7 @@ fn parse_destructuring_or_plain_param(input: &str) -> PResult<'_, ParamDef> {
     Ok((
         r,
         ParamDef {
+            type_capture: None,
             name: String::new(),
             default: None,
             multi_invocant: true,
@@ -451,6 +455,7 @@ fn parse_for_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         return Ok((
             rest,
             ParamDef {
+                type_capture: None,
                 name,
                 default: None,
                 multi_invocant: true,
@@ -539,6 +544,7 @@ fn parse_for_pointy_param(input: &str) -> PResult<'_, ParamDef> {
     Ok((
         rest,
         ParamDef {
+            type_capture: None,
             name: param_name,
             default,
             multi_invocant: true,

--- a/src/parser/stmt/control/pointy_param.rs
+++ b/src/parser/stmt/control/pointy_param.rs
@@ -52,6 +52,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
             return Ok((
                 r2,
                 ParamDef {
+                    type_capture: None,
                     name: "__type_only__".to_string(),
                     default: None,
                     multi_invocant: true,
@@ -89,6 +90,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         return Ok((
             rest,
             ParamDef {
+                type_capture: None,
                 name,
                 default: None,
                 multi_invocant: true,
@@ -167,6 +169,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         return Ok((
             r,
             ParamDef {
+                type_capture: None,
                 name,
                 default,
                 multi_invocant: true,
@@ -201,6 +204,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
             return Ok((
                 r,
                 ParamDef {
+                    type_capture: None,
                     name,
                     default: None,
                     multi_invocant: true,
@@ -233,6 +237,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
             return Ok((
                 r,
                 ParamDef {
+                    type_capture: None,
                     name,
                     default: None,
                     multi_invocant: true,
@@ -264,6 +269,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         return Ok((
             r,
             ParamDef {
+                type_capture: None,
                 name: "_capture".to_string(),
                 default: None,
                 multi_invocant: true,
@@ -327,6 +333,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         return Ok((
             rest,
             ParamDef {
+                type_capture: None,
                 name: "&".to_string(),
                 default: None,
                 multi_invocant: true,
@@ -368,6 +375,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         return Ok((
             rest,
             ParamDef {
+                type_capture: None,
                 name: "__literal__".to_string(),
                 default: None,
                 multi_invocant: true,
@@ -410,6 +418,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
             return Ok((
                 r,
                 ParamDef {
+                    type_capture: None,
                     name: "__literal__".to_string(),
                     default: None,
                     multi_invocant: true,
@@ -560,6 +569,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
     Ok((
         rest,
         ParamDef {
+            type_capture: None,
             name: param_name,
             default,
             multi_invocant: true,

--- a/src/parser/stmt/sub/param_list.rs
+++ b/src/parser/stmt/sub/param_list.rs
@@ -26,6 +26,28 @@ pub(crate) fn make_smiley_invocant_param(invocant_type: String) -> ParamDef {
     p
 }
 
+/// Split a leading `::T` type capture off an invocant marker:
+/// `method merge(::T CRDT:D: $x)` captures the invocant's type as `T` *and*
+/// constrains it to `CRDT:D` (#7984).
+///
+/// Only consumes the capture when a nominal invocant marker really follows, so
+/// `::T: $x` (capture-only invocant) and `::T $x` (an ordinary captured
+/// parameter) keep their existing readings. Returns the input unchanged with
+/// `None` otherwise.
+pub(crate) fn split_invocant_type_capture(input: &str) -> (&str, Option<String>) {
+    let Some((after_capture, name)) = crate::parser::stmt::sub_param::strip_type_capture(input)
+    else {
+        return (input, None);
+    };
+    let Ok((after_ws, _)) = ws(after_capture) else {
+        return (input, None);
+    };
+    if parse_implicit_invocant_marker(after_ws).is_none() {
+        return (input, None);
+    }
+    (after_ws, Some(name))
+}
+
 /// Strip sigil prefix from a parameter name, returning the bare name.
 pub(crate) fn strip_param_sigil(name: &str) -> &str {
     name.strip_prefix('@')
@@ -203,10 +225,24 @@ pub(crate) fn parse_param_list_inner(input: &str) -> PResult<'_, Vec<ParamDef>> 
         }
         rest = r;
     }
-    if let Some((r, _invocant_type)) = parse_implicit_invocant_marker(rest) {
+    let (head, invocant_capture) = split_invocant_type_capture(rest);
+    if let Some((r, invocant_type)) = parse_implicit_invocant_marker(head) {
         rest = r;
+        // A capture on the invocant has to survive as a real parameter — it is
+        // the only place `T` is recorded. An uncaptured anonymous marker
+        // (`Foo:`) is still discarded here, as before.
+        if let Some(name) = invocant_capture {
+            let mut inv = make_smiley_invocant_param(invocant_type);
+            inv.type_capture = Some(name);
+            inv.multi_invocant = multi_invocant;
+            params.push(inv);
+        }
         if rest.starts_with(')') {
             return Ok((rest, params));
+        }
+        if let Some(stripped) = rest.strip_prefix("-->") {
+            let r = skip_return_type_annotation(stripped)?;
+            return Ok((r, params));
         }
         let (r, mut p) = parse_single_param(rest)?;
         p.multi_invocant = multi_invocant;

--- a/src/parser/stmt/sub/return_type.rs
+++ b/src/parser/stmt/sub/return_type.rs
@@ -215,16 +215,25 @@ pub(crate) fn parse_param_list_with_return_inner(
         }
         rest = r;
     }
-    if let Some((r, invocant_type)) = parse_implicit_invocant_marker(rest) {
+    // `method merge(::T CRDT:D: $x)` captures the invocant's type *and*
+    // constrains it (#7984): split the capture off before reading the marker.
+    let (head, invocant_capture) = super::param_list::split_invocant_type_capture(rest);
+    if let Some((r, invocant_type)) = parse_implicit_invocant_marker(head) {
         let (r, _) = ws(r)?;
         rest = r;
         // A definedness smiley (`Foo:D:` / `Foo:U:`) on an anonymous invocant
         // constrains dispatch and must survive as an invocant param so that
         // `multi method g(Foo:U:)` and `multi method g(Foo:D:)` are distinct
-        // candidates rather than collapsing into an ambiguous pair. Other
-        // anonymous typed markers (`Foo:`) are still discarded as before.
-        if invocant_type.ends_with(":D") || invocant_type.ends_with(":U") {
+        // candidates rather than collapsing into an ambiguous pair. A type
+        // capture has to survive for the same reason — it is the only record of
+        // the captured name. Other anonymous typed markers (`Foo:`) are still
+        // discarded as before.
+        if invocant_capture.is_some()
+            || invocant_type.ends_with(":D")
+            || invocant_type.ends_with(":U")
+        {
             let mut inv = super::param_list::make_smiley_invocant_param(invocant_type);
+            inv.type_capture = invocant_capture;
             inv.multi_invocant = multi_invocant;
             params.push(inv);
         }

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -34,5 +34,5 @@ pub(super) use method_decl::{
 pub(super) use param_inner::parse_single_param;
 pub(super) use type_constraint::{
     check_invalid_type_smiley, parse_implicit_invocant_marker, parse_of_type_constraint_chain,
-    parse_type_constraint_expr,
+    parse_type_constraint_expr, strip_type_capture,
 };

--- a/src/parser/stmt/sub_param/helpers.rs
+++ b/src/parser/stmt/sub_param/helpers.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 /// Helper to construct a default ParamDef with only required fields.
 pub(crate) fn make_param(name: String) -> ParamDef {
     ParamDef {
+        type_capture: None,
         name,
         default: None,
         multi_invocant: true,

--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -294,30 +294,19 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
     }
 
     // Type-capture parameter: ::T $x  or bare ::T
-    if let Some(after_capture) = rest.strip_prefix("::")
-        && let Ok((r, capture_name)) = super::super::ident(after_capture)
-    {
-        type_constraint = Some(format!("::{}", capture_name));
-        // A type smiley may follow the capture: `::T:U`, `::T:D`, `::T:_`
-        // constrains the argument to a type object / instance while still binding
-        // the capture. Consume it before the `:`-named-marker check below, which
-        // would otherwise misread `:U` as a named-parameter marker. (YAMLish uses
-        // `::GrammarType:U :$schema`.)
-        if r.starts_with(":D") || r.starts_with(":U") || r.starts_with(":_") {
-            let smiley = &r[..2];
-            type_constraint = Some(format!("::{}{}", capture_name, smiley));
-            let (r, _) = ws(&r[2..])?;
-            rest = r;
-        } else {
-            let (r, _) = ws(r)?;
-            rest = r;
-        }
+    //
+    // The capture name lives in `ParamDef::type_capture`, NEVER as a `"::T"`
+    // spelling in `type_constraint` (#7984): a parameter can carry a capture and
+    // a nominal type at once, which one `Option<String>` cannot express.
+    if let Some((after_capture, capture_name)) = super::type_constraint::strip_type_capture(rest) {
+        let (r, _) = ws(after_capture)?;
+        rest = r;
         if rest.starts_with('=') && !rest.starts_with("==") {
             let r = &rest[1..];
             let (r, _) = ws(r)?;
             let (r, default) = super::helpers::parse_param_default_expr(r)?;
             let mut p = super::helpers::make_param(format!("__type_capture__{}", capture_name));
-            p.type_constraint = type_constraint;
+            p.type_capture = Some(capture_name);
             p.named = named;
             p.slurpy = slurpy;
             p.default = Some(default);
@@ -329,7 +318,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             || rest.starts_with(';')
         {
             let mut p = super::helpers::make_param(format!("__type_capture__{}", capture_name));
-            p.type_constraint = type_constraint;
+            p.type_capture = Some(capture_name);
             p.named = named;
             p.slurpy = slurpy;
             return Ok((rest, p));
@@ -350,29 +339,29 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
                 // Return the bare ::T as a standalone param; leave `:` for the
                 // outer param-list loop to handle as the invocant marker.
                 let mut p = super::helpers::make_param(format!("__type_capture__{}", capture_name));
-                p.type_constraint = type_constraint;
+                p.type_capture = Some(capture_name);
                 p.named = named;
                 p.slurpy = slurpy;
                 return Ok((rest, p));
             }
-            named = true;
-            rest = &rest[1..];
         }
+        // Anything else after the capture is a parameter in its own right:
+        // a variable (`::T $x`), a named one (`::T :$x`), or a nominal type
+        // (`::T Foo:D $x`). Parse it normally and hang the capture off the
+        // result — one choke point, so every later-built `ParamDef` shape
+        // (defaults, traits, `where`, sub-signatures) keeps the capture
+        // without each construction site having to remember it.
+        let (r, mut p) = parse_single_param_inner(rest)?;
+        p.type_capture = Some(capture_name);
+        p.named |= named;
+        p.slurpy |= slurpy;
+        return Ok((r, p));
     }
 
     // Type constraint (may be qualified: IO::Path)
-    // Skip type constraint parsing for named params with lowercase identifiers followed by '('
-    // Parametric type constraint: ::T
-    if let Some(after_colon) = rest.strip_prefix("::")
-        && let Ok((r, tc_name)) = super::super::ident(after_colon)
-    {
-        let tc = format!("::{}", tc_name);
-        let (r2, _) = ws(r)?;
-        if r2.starts_with('$') || r2.starts_with('@') || r2.starts_with('%') {
-            type_constraint = Some(tc);
-            rest = r2;
-        }
-    }
+    // Skip type constraint parsing for named params with lowercase identifiers
+    // followed by '('. A `::T` ident capture never reaches here — the
+    // type-capture branch above consumes every spelling of one and returns.
 
     // — those are named aliases like :x($r), not type constraints. The external
     // name may start with an uppercase letter too (`:PRUNED($p)`, `:ASTART($a)` in

--- a/src/parser/stmt/sub_param/type_constraint.rs
+++ b/src/parser/stmt/sub_param/type_constraint.rs
@@ -224,6 +224,30 @@ pub(crate) fn parse_of_type_constraint_chain(
     Some((rest, type_name))
 }
 
+/// Strip a leading `::T` **type capture** from a signature fragment, returning
+/// the remaining input and the captured name.
+///
+/// Only an identifier capture qualifies. The pseudo-types `::?CLASS` / `::?ROLE`
+/// and the indirect form `::(expr)` stay where they are: both are consumed as
+/// nominal constraints elsewhere, so they keep their `::` spelling inside
+/// `ParamDef::type_constraint`.
+///
+/// A definedness smiley directly after the capture (`::T:D`, `::GrammarType:U`)
+/// is consumed and discarded. Rakudo reports such a parameter's `.type` as
+/// `Any` and enforces nothing — `sub f(::T:U $x) { }; f(42)` runs — so keeping
+/// the smiley would type-check where the reference implementation does not.
+pub(crate) fn strip_type_capture(input: &str) -> Option<(&str, String)> {
+    let after_colons = input.strip_prefix("::")?;
+    if after_colons.starts_with('?') || after_colons.starts_with('(') {
+        return None;
+    }
+    let (rest, name) = super::super::ident(after_colons).ok()?;
+    if rest.starts_with(":D") || rest.starts_with(":U") || rest.starts_with(":_") {
+        return Some((&rest[2..], name));
+    }
+    Some((rest, name))
+}
+
 pub(crate) fn parse_implicit_invocant_marker(input: &str) -> Option<(&str, String)> {
     if input.starts_with('$')
         || input.starts_with('@')

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2500,11 +2500,9 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
     {
         return Err(unsupported("non-positional signature sub-signature"));
     }
-    let type_capture = match pd.type_constraint.as_deref() {
-        Some(type_constraint) if type_constraint.starts_with("::") => {
-            Some(type_capture_node(type_constraint)?)
-        }
-        _ => None,
+    let type_capture = match pd.captured_type_name() {
+        Some(name) => Some(type_capture_node(name)?),
+        None => None,
     };
     // A bare `::T` is represented internally by a synthetic parameter name,
     // but RakuAST models it as a Parameter with no target. Keep the synthetic
@@ -2582,10 +2580,7 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
 /// A basic `::T` capture is represented by `Parameter.type-captures` rather
 /// than by the parameter's ordinary `type` node. Smiley-constrained and other
 /// richer capture spellings need more internal metadata and remain deferred.
-fn type_capture_node(type_constraint: &str) -> Result<RakuAstNode, RuntimeError> {
-    let Some(name) = type_constraint.strip_prefix("::") else {
-        return Err(unsupported("type capture"));
-    };
+fn type_capture_node(name: &str) -> Result<RakuAstNode, RuntimeError> {
     if name.is_empty()
         || !name
             .chars()

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -907,7 +907,7 @@ fn lower_parameter(parameter: &RakuAstNode, owner: &RakuAstNode) -> Result<Param
         if def.type_constraint.is_some() {
             return Err(unsupported(owner));
         }
-        def.type_constraint = Some(format!("::{type_capture}"));
+        def.type_capture = Some(type_capture);
     }
     // `$y = EXPR` -> an optional positional with a default value.
     if let Some(d) = parameter.fields.iter().find(|f| f.name == Some("default")) {
@@ -945,6 +945,7 @@ fn lower_parameter(parameter: &RakuAstNode, owner: &RakuAstNode) -> Result<Param
 /// A default positional (required, non-slurpy, untyped) `ParamDef` for `name`.
 fn positional_param(name: &str) -> ParamDef {
     ParamDef {
+        type_capture: None,
         name: name.to_string(),
         default: None,
         multi_invocant: true,

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -479,16 +479,13 @@ impl Interpreter {
         // already refuses to *reclassify* such an error as the compile-time
         // `X::TypeCheck::Argument`; the message has to stay honest too.)
         //
-        // A capture is recorded as the DECLARING parameter's
-        // `type_constraint` (`::T $x` is `ParamDef { name: "x",
-        // type_constraint: Some("::T") }`), not as a parameter of its own.
+        // A capture is recorded on the DECLARING parameter's `type_capture`
+        // field (`::T $x` is `ParamDef { name: "x", type_capture: Some("T") }`),
+        // not as a parameter of its own.
         let signature_has_type_captures = param_defs.iter().any(|pd| {
             pd.name.starts_with("::")
                 || pd.name == "__type_capture__"
-                || pd
-                    .type_constraint
-                    .as_deref()
-                    .is_some_and(|tc| tc.starts_with("::"))
+                || pd.captured_type_name().is_some()
         });
         if signature_has_type_captures {
             return err;

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -273,8 +273,7 @@ fn collect_type_captures(
 ) -> Vec<String> {
     let mut added = Vec::new();
     for pd in param_defs {
-        if let Some(tc) = pd.type_constraint.as_deref()
-            && let Some(name) = tc.strip_prefix("::")
+        if let Some(name) = pd.captured_type_name()
             && !name.is_empty()
             && !name.contains("::")
             && captures.insert(name.to_string())

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -373,6 +373,7 @@ impl Interpreter {
 
     pub(super) fn make_invocant_param(class_name: &str) -> crate::ast::ParamDef {
         crate::ast::ParamDef {
+            type_capture: None,
             name: String::new(),
             default: None,
             multi_invocant: true,

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -717,6 +717,7 @@ impl Interpreter {
                     let mut params = vec!["self".to_string()];
                     params.extend(def.params.iter().filter(|p| p.as_str() != "self").cloned());
                     let mut param_defs = vec![crate::ast::ParamDef {
+                        type_capture: None,
                         name: "self".to_string(),
                         default: None,
                         multi_invocant: true,

--- a/src/runtime/methods_format.rs
+++ b/src/runtime/methods_format.rs
@@ -16,6 +16,7 @@ use super::Interpreter;
 /// Build a required positional `ParamDef` with the given (sigilless) name.
 fn positional_param(name: &str) -> ParamDef {
     ParamDef {
+        type_capture: None,
         name: name.to_string(),
         default: None,
         multi_invocant: true,

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -534,6 +534,9 @@ impl Interpreter {
                                         } else {
                                             5
                                         }
+                                    } else if pd.captured_type_name().is_some() {
+                                        // A bare `::T` type parameter is generic (#7984).
+                                        1
                                     } else {
                                         0
                                     };

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -155,8 +155,7 @@ impl Interpreter {
                 if !pd.named && !pd.slurpy {
                     if pos_idx < assumed_positional.len() {
                         if !is_placeholder(&assumed_positional[pos_idx])
-                            && let Some(tc) = &pd.type_constraint
-                            && let Some(capture_name) = tc.strip_prefix("::")
+                            && let Some(capture_name) = pd.captured_type_name()
                         {
                             let resolved_type = crate::runtime::utils::value_type_name(
                                 &assumed_positional[pos_idx],

--- a/src/runtime/methods_signature_candidates.rs
+++ b/src/runtime/methods_signature_candidates.rs
@@ -288,6 +288,7 @@ impl Interpreter {
                         data.params
                             .iter()
                             .map(|name| ParamDef {
+                                type_capture: None,
                                 name: name.clone(),
                                 default: None,
                                 multi_invocant: true,
@@ -328,6 +329,7 @@ impl Interpreter {
                             .is_some_and(|cc| cc.is_pointy_block);
                         if data.is_bare_block && !is_pointy && !use_positional {
                             defs.push(ParamDef {
+                                type_capture: None,
                                 name: "$_".to_string(),
                                 default: Some(Expr::Var("$_".to_string())),
                                 multi_invocant: true,
@@ -353,6 +355,7 @@ impl Interpreter {
                         }
                         if use_positional {
                             defs.push(ParamDef {
+                                type_capture: None,
                                 name: "@_".to_string(),
                                 default: None,
                                 multi_invocant: true,
@@ -378,6 +381,7 @@ impl Interpreter {
                         }
                         if use_named {
                             defs.push(ParamDef {
+                                type_capture: None,
                                 name: "%_".to_string(),
                                 default: None,
                                 multi_invocant: true,

--- a/src/runtime/methods_string_substr.rs
+++ b/src/runtime/methods_string_substr.rs
@@ -233,6 +233,7 @@ impl Interpreter {
         let len = end - start;
 
         let make_param_def = |name: &str| crate::ast::ParamDef {
+            type_capture: None,
             name: name.to_string(),
             default: None,
             multi_invocant: false,

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -175,6 +175,7 @@ impl Interpreter {
                     params
                         .into_iter()
                         .map(|name| ParamDef {
+                            type_capture: None,
                             name,
                             default: None,
                             multi_invocant: true,
@@ -257,6 +258,7 @@ impl Interpreter {
                     params
                         .into_iter()
                         .map(|name| ParamDef {
+                            type_capture: None,
                             name,
                             default: None,
                             multi_invocant: true,
@@ -377,6 +379,7 @@ impl Interpreter {
                 params
                     .into_iter()
                     .map(|name| ParamDef {
+                        type_capture: None,
                         name,
                         default: None,
                         multi_invocant: true,
@@ -536,8 +539,7 @@ impl Interpreter {
                 let capture_decls: std::collections::HashSet<&str> = next
                     .param_defs
                     .iter()
-                    .filter_map(|pd| pd.type_constraint.as_deref())
-                    .filter_map(|t| t.strip_prefix("::"))
+                    .filter_map(|pd| pd.captured_type_name())
                     .collect();
                 for (pos_idx, pd) in next
                     .param_defs

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -727,6 +727,7 @@ fn builtin_type_has_method(type_name: &str, method: &str) -> bool {
 /// `$name`, or a slurpy `*@name` when `slurpy` is true.
 fn walk_param(name: &str, slurpy: bool) -> crate::ast::ParamDef {
     crate::ast::ParamDef {
+        type_capture: None,
         name: name.to_string(),
         default: None,
         multi_invocant: true,

--- a/src/runtime/native_methods/supply_collector.rs
+++ b/src/runtime/native_methods/supply_collector.rs
@@ -82,6 +82,7 @@ impl Interpreter {
             (
                 vec!["v".to_string()],
                 vec![crate::ast::ParamDef {
+                    type_capture: None,
                     name: "v".to_string(),
                     default: None,
                     multi_invocant: true,

--- a/src/runtime/native_methods/supply_quit_forwarder.rs
+++ b/src/runtime/native_methods/supply_quit_forwarder.rs
@@ -139,6 +139,7 @@ impl Interpreter {
             name: Symbol::intern(""),
             params: std::sync::Arc::new(vec!["v".to_string()]),
             param_defs: std::sync::Arc::new(vec![crate::ast::ParamDef {
+                type_capture: None,
                 name: "v".to_string(),
                 default: None,
                 multi_invocant: true,

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -1672,6 +1672,7 @@ impl Interpreter {
             (
                 vec!["v".to_string()],
                 vec![crate::ast::ParamDef {
+                    type_capture: None,
                     name: "v".to_string(),
                     default: None,
                     multi_invocant: true,

--- a/src/runtime/react_whenever.rs
+++ b/src/runtime/react_whenever.rs
@@ -310,6 +310,7 @@ impl Interpreter {
         // news/2026-08/whenever-parameter-type-constraint-enforced.md.
         let main_param_defs: Vec<ParamDef> = match (param, param_type) {
             (Some(name), Some(tc)) => vec![ParamDef {
+                type_capture: None,
                 name: name.clone(),
                 default: None,
                 multi_invocant: true,

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -105,6 +105,7 @@ pub(super) fn apply_resolved_handles(
 /// This ensures the method matches any number of positional/named arguments.
 fn delegation_slurpy_param() -> ParamDef {
     ParamDef {
+        type_capture: None,
         name: "@_".to_string(),
         default: None,
         multi_invocant: false,
@@ -160,6 +161,7 @@ pub(super) fn make_delegation_method(attr_var_name: &str, target_method: &str) -
 /// Create the double-slurpy `**@_` parameter for named arg forwarding.
 fn delegation_double_slurpy_param() -> ParamDef {
     ParamDef {
+        type_capture: None,
         name: "%_".to_string(),
         default: None,
         multi_invocant: false,

--- a/src/runtime/registration_class_body_method_forms.rs
+++ b/src/runtime/registration_class_body_method_forms.rs
@@ -39,6 +39,7 @@ pub(super) fn method_sub_form_params(
                 .cloned(),
         );
         let self_param = crate::ast::ParamDef {
+            type_capture: None,
             name: "self".to_string(),
             default: None,
             multi_invocant: true,
@@ -101,6 +102,7 @@ impl Interpreter {
             &method_param_defs[1..]
         } else {
             sub_param_defs.push(ParamDef {
+                type_capture: None,
                 name: "self".to_string(),
                 default: None,
                 multi_invocant: true,

--- a/src/runtime/registration_class_compose_body.rs
+++ b/src/runtime/registration_class_compose_body.rs
@@ -294,7 +294,7 @@ impl Interpreter {
         // Remove type capture markers (but keep the variables
         // created by the deferred stmts for method closures)
         for param_name in role_param_values.keys() {
-            self.env.remove(&format!("__type_capture__{}", param_name));
+            self.env.remove(&Self::type_capture_marker_key(param_name));
             // Don't remove the param name itself - methods may need it
         }
         Ok(())

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -120,7 +120,12 @@ impl Interpreter {
     fn role_candidate_specificity_score(&self, param_defs: &[ParamDef]) -> i32 {
         let mut score = 0i32;
         for pd in param_defs.iter().filter(|pd| !pd.named) {
-            score += self.role_constraint_specificity(pd.type_constraint.as_deref());
+            // A bare `::T` type parameter is generic: it scores 1, like the
+            // legacy `"::T"` constraint spelling it replaced (#7984).
+            score += match (pd.type_constraint.as_deref(), pd.captured_type_name()) {
+                (None, Some(_)) => 1,
+                (constraint, _) => self.role_constraint_specificity(constraint),
+            };
             if pd.where_constraint.is_some() {
                 score += 20;
             }

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -290,8 +290,7 @@ impl Interpreter {
         // type names for the rest of the signature.
         let captures: std::collections::HashSet<&str> = param_defs
             .iter()
-            .filter_map(|pd| pd.type_constraint.as_deref())
-            .filter_map(|tc| tc.strip_prefix("::"))
+            .filter_map(|pd| pd.captured_type_name())
             .collect();
         for pd in param_defs {
             let Some(tc) = pd.type_constraint.as_deref() else {
@@ -466,8 +465,7 @@ impl Interpreter {
         // return type names too (`sub f(::T $x --> T) {...}`).
         let captures: std::collections::HashSet<&str> = param_defs
             .iter()
-            .filter_map(|pd| pd.type_constraint.as_deref())
-            .filter_map(|tc| tc.strip_prefix("::"))
+            .filter_map(|pd| pd.captured_type_name())
             .collect();
         // Only a bare identifier starting uppercase is considered; anything
         // decorated (`Positional[Int]`, `Int:D`, lowercase native, …) is skipped.
@@ -933,6 +931,7 @@ impl Interpreter {
             let mut defs = Vec::new();
             if use_positional {
                 defs.push(ParamDef {
+                    type_capture: None,
                     name: "@_".to_string(),
                     default: None,
                     multi_invocant: true,
@@ -958,6 +957,7 @@ impl Interpreter {
             }
             if use_named {
                 defs.push(ParamDef {
+                    type_capture: None,
                     name: "%_".to_string(),
                     default: None,
                     multi_invocant: true,

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -83,22 +83,18 @@ impl Interpreter {
             if !(pd.is_invocant || pd.traits.iter().any(|t| t == "invocant")) {
                 continue;
             }
+            // `::?CLASS` / `::?ROLE` are pseudo-types (the current class), NOT
+            // type captures — reading them as a capture named `?CLASS`/`?ROLE:U`
+            // would both bind a bogus capture and skip the invocant check, so a
+            // role's `multi method m(::?ROLE:U:)` / `(::?ROLE:D:)` pair became an
+            // ambiguous call once composed into a class. Only a genuine `::T`
+            // capture (not starting with `?`) binds here.
+            if let Some(captured_name) = pd.captured_type_name()
+                && !captured_name.starts_with('?')
+            {
+                self.bind_type_capture(captured_name, &Value::package(Symbol::intern(class_name)));
+            }
             if let Some(constraint) = pd.type_constraint.as_deref() {
-                // `::?CLASS` / `::?ROLE` are pseudo-types (the current class), NOT
-                // type captures — `constraint.strip_prefix("::")` would otherwise
-                // read them as a capture named `?CLASS`/`?ROLE:U` and both bind a
-                // bogus capture and skip the invocant check, so a role's
-                // `multi method m(::?ROLE:U:)` / `(::?ROLE:D:)` pair became an
-                // ambiguous call once composed into a class. Only a genuine
-                // `::T` capture (not starting with `?`) binds here.
-                if let Some(captured_name) = constraint.strip_prefix("::")
-                    && !captured_name.starts_with('?')
-                {
-                    self.bind_type_capture(
-                        captured_name,
-                        &Value::package(Symbol::intern(class_name)),
-                    );
-                }
                 // Check type constraint on the invocant (including :U/:D smileys).
                 // Resolve the `::?CLASS`/`::?ROLE` pseudo-types to the actual
                 // class name for matching. Pure type captures (e.g. ::T) don't

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -440,6 +440,7 @@ impl Interpreter {
                         method_params.push("%_".to_string());
                     }
                     let mut method_param_defs = vec![crate::ast::ParamDef {
+                        type_capture: None,
                         name: "self".to_string(),
                         default: None,
                         multi_invocant: true,
@@ -470,6 +471,7 @@ impl Interpreter {
                     );
                     if !method_param_defs.iter().any(|p| p.name == "%_") {
                         method_param_defs.push(crate::ast::ParamDef {
+                            type_capture: None,
                             name: "%_".to_string(),
                             default: None,
                             multi_invocant: true,

--- a/src/runtime/runtime_shared_vars_tests.rs
+++ b/src/runtime/runtime_shared_vars_tests.rs
@@ -7,6 +7,7 @@ use crate::value::Value;
 /// `parser::stmt::sub_param::helpers::make_param`.
 fn scalar_param(name: &str) -> crate::ast::ParamDef {
     crate::ast::ParamDef {
+        type_capture: None,
         name: name.to_string(),
         default: None,
         multi_invocant: true,

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -395,6 +395,14 @@ impl Interpreter {
                 // Filled in by the type-constraint block below, applied to
                 // `arg_for_checks` once its borrow of it has ended.
                 let mut coerced_for_checks: Option<Value> = None;
+                // Bind the `::T` capture before the nominal checks below, so a
+                // parameter that carries both (`::T Foo:D $x`) gets both (#7984).
+                if let Some(captured_name) = pd.captured_type_name()
+                    && let Some(arg) = arg_for_checks.as_ref()
+                {
+                    let arg = arg.clone();
+                    self.bind_type_capture(captured_name, &arg);
+                }
                 if let Some(constraint) = &pd.type_constraint
                     && let Some(arg) = arg_for_checks.as_ref()
                 {
@@ -453,8 +461,9 @@ impl Interpreter {
                             )
                         })
                     });
-                    if let Some(captured_name) = resolved_constraint.strip_prefix("::") {
-                        self.bind_type_capture(captured_name, &dispatch_arg);
+                    if resolved_constraint.starts_with("::") {
+                        // `::?CLASS` / `::?ROLE` / `::(expr)`: bound above, and
+                        // never a nominal check.
                     } else if pd.name == "__type_only__"
                         && !self.is_resolvable_type(&resolved_constraint)
                     {

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -329,6 +329,14 @@ impl Interpreter {
         {
             value = self.coerce_positional_bind_failover(value)?;
         }
+        // A `::T` capture records the argument's type under `T`; it is not a
+        // nominal check. Done before the constraint block so `::T Foo:D $x`
+        // binds the capture AND enforces `Foo:D` (#7984) — the two used to be
+        // mutually exclusive arms of one chain because both lived in the same
+        // `Option<String>`.
+        if let Some(captured_name) = pd.captured_type_name() {
+            self.bind_type_capture(captured_name, &value);
+        }
         if let Some(constraint) = &pd.type_constraint
             && (pd.name != "__type_only__" || self.is_resolvable_type(constraint))
         {
@@ -380,8 +388,10 @@ impl Interpreter {
                     err.exception = Some(Box::new(exception));
                     return Err(err);
                 }
-            } else if let Some(captured_name) = resolved_constraint.strip_prefix("::") {
-                self.bind_type_capture(captured_name, &value);
+            } else if resolved_constraint.starts_with("::") {
+                // `::?CLASS` / `::?ROLE` / `::(expr)`: reported as a capture by
+                // `captured_type_name` and already bound above. They are no
+                // nominal check, so skip the arms below as they always have.
             } else if let Some((target, source)) = parse_coercion_type(&resolved_constraint) {
                 // Coercion type: check source type if specified, then coerce.
                 // A `T(S)` parameter accepts a value that is already a `T`
@@ -799,11 +809,7 @@ impl Interpreter {
                 if !(pd.is_invocant || pd.traits.iter().any(|t| t == "invocant")) {
                     continue;
                 }
-                if let Some(captured_name) = pd
-                    .type_constraint
-                    .as_deref()
-                    .and_then(|constraint| constraint.strip_prefix("::"))
-                {
+                if let Some(captured_name) = pd.captured_type_name() {
                     self.bind_type_capture(captured_name, &invocant_value);
                 }
             }
@@ -1930,11 +1936,7 @@ impl Interpreter {
                 if !found && let Some(default_expr) = &pd.default {
                     let value = self.eval_param_default(pd, default_expr)?;
                     let value = self.checked_default_param_value(pd, value)?;
-                    let value = if pd
-                        .type_constraint
-                        .as_deref()
-                        .is_some_and(|constraint| constraint.starts_with("::"))
-                    {
+                    let value = if pd.captured_type_name().is_some() {
                         self.normalize_type_capture_value(value)
                     } else {
                         value
@@ -1956,11 +1958,7 @@ impl Interpreter {
                     // variable. A named variable with a destructuring
                     // sub-signature binds the outer parameter too.
                     let is_rename = pd.named_alias;
-                    if let Some(captured_name) = pd
-                        .type_constraint
-                        .as_deref()
-                        .and_then(|constraint| constraint.strip_prefix("::"))
-                    {
+                    if let Some(captured_name) = pd.captured_type_name() {
                         self.bind_type_capture(captured_name, &value);
                         if !pd.name.is_empty() && !is_rename {
                             self.bind_param_value_sym(&pd.name, pd_name_sym(), value.clone());
@@ -2803,11 +2801,7 @@ impl Interpreter {
                 } else if let Some(default_expr) = &pd.default {
                     let value = self.eval_param_default(pd, default_expr)?;
                     let value = self.checked_default_param_value(pd, value)?;
-                    if let Some(captured_name) = pd
-                        .type_constraint
-                        .as_deref()
-                        .and_then(|constraint| constraint.strip_prefix("::"))
-                    {
+                    if let Some(captured_name) = pd.captured_type_name() {
                         self.bind_type_capture(captured_name, &value);
                     } else if !pd.name.is_empty() {
                         self.bind_param_value_sym(&pd.name, pd_name_sym(), value);

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -793,8 +793,16 @@ impl Interpreter {
         }
     }
 
-    fn type_capture_marker_key(name: &str) -> String {
-        format!("__type_capture__{}", name)
+    /// Env key recording that `bind_type_capture` bound a capture named `name`.
+    ///
+    /// Deliberately NOT `__type_capture__<name>`: that is also the synthetic
+    /// *parameter name* a bare `::T` / `::T:` capture carries, so the binder's
+    /// own "bind the parameter under its name" step overwrote the marker with
+    /// the argument value. `has_type_capture_binding` then said no, and every
+    /// later `T` resolution — a `--> T` return constraint above all — fell back
+    /// to the literal name `T` (#7984).
+    pub(in crate::runtime) fn type_capture_marker_key(name: &str) -> String {
+        format!("__mutsu_type_capture_bound__{}", name)
     }
 }
 
@@ -1077,11 +1085,7 @@ impl Interpreter {
             .type_param_defs
             .iter()
             .filter_map(|pd| {
-                if let Some(captured) = pd
-                    .type_constraint
-                    .as_deref()
-                    .and_then(|constraint| constraint.strip_prefix("::"))
-                {
+                if let Some(captured) = pd.captured_type_name() {
                     self.env.get(captured).cloned()
                 } else {
                     self.env.get(&pd.name).cloned()

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -185,6 +185,9 @@ impl Interpreter {
                                     } else {
                                         5
                                     }
+                                } else if pd.captured_type_name().is_some() {
+                                    // A bare `::T` type parameter is generic (#7984).
+                                    1
                                 } else {
                                     0
                                 };
@@ -604,10 +607,7 @@ impl Interpreter {
                 // and the captured type under the bare capture name; the role
                 // body reads the latter. Same lookup `materialize_default_
                 // parametric_role` performs for the `.new` path.
-                let capture = candidate.type_param_defs[i]
-                    .type_constraint
-                    .as_deref()
-                    .and_then(|constraint| constraint.strip_prefix("::"));
+                let capture = candidate.type_param_defs[i].captured_type_name();
                 let Some(value) = self
                     .env
                     .get(capture.unwrap_or(sig_name.as_str()))

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -1137,6 +1137,7 @@ pub(in crate::runtime) fn callable_signature_info(
                 params
                     .into_iter()
                     .map(|name| ParamDef {
+                        type_capture: None,
                         name,
                         default: None,
                         multi_invocant: true,
@@ -1172,6 +1173,7 @@ pub(in crate::runtime) fn callable_signature_info(
                 params
                     .into_iter()
                     .map(|name| ParamDef {
+                        type_capture: None,
                         name,
                         default: None,
                         multi_invocant: true,

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -17,6 +17,12 @@ use std::sync::Mutex;
 pub(crate) struct SigParam {
     pub(crate) name: String,
     pub(crate) type_constraint: Option<String>,
+    /// The `::T` capture name this parameter declares, rendered before the
+    /// nominal type in `.gist` (`(::T  $x)`). Held apart from
+    /// `type_constraint` for the reason `ParamDef::type_capture` is (#7984): a
+    /// parameter can declare a capture and a nominal type at once.
+    #[serde(default)]
+    pub(crate) type_capture: Option<String>,
     pub(crate) multi_invocant: bool,
     pub(crate) named: bool,
     #[serde(default)]
@@ -262,6 +268,9 @@ pub(crate) fn param_def_to_sig_param(p: &ParamDef) -> SigParam {
         "_".to_string()
     } else if p.name == "_capture"
         || p.name == "__type_only__"
+        // A bare `::T` / `::T:` capture carries a synthetic parameter name; the
+        // parameter itself is anonymous, and rakudo renders it as a bare `$`.
+        || p.name.starts_with("__type_capture__")
         || p.name.starts_with("__ANON_STATE_")
         || p.name == "__ANON_OPTIONAL__"
         || p.name == "__subsig__"
@@ -300,6 +309,7 @@ pub(crate) fn param_def_to_sig_param(p: &ParamDef) -> SigParam {
     SigParam {
         name,
         type_constraint,
+        type_capture: p.type_capture.clone(),
         // The synthetic topic parameter is rendered after the top-level `;;`
         // separator, even though it is not an explicit invocant in the AST.
         multi_invocant: p.multi_invocant && !is_implicit_topic,
@@ -532,10 +542,21 @@ fn build_parameter_attrs(p: &SigParam, interp: Option<&Interpreter>) -> HashMap<
     // type: resolve to type object (Package) instead of string
     // type_captures: extract ::T style type capture names
     let mut type_captures: Vec<Value> = Vec::new();
+    if let Some(name) = &p.type_capture {
+        type_captures.push(Value::str(name.clone()));
+    }
     let type_val = match &p.type_constraint {
+        // `::?CLASS` / `::?ROLE` / `::(expr)` still reach here with their `::`
+        // prefix (see `ParamDef::captured_type_name`); an ident capture is
+        // carried by `type_capture` above and leaves `type_constraint` free for
+        // the nominal half.
         Some(t) if t.starts_with("::") => {
-            // Type capture like ::T — type is Any, capture name is T
             type_captures.push(Value::str(t[2..].to_string()));
+            Value::Package(crate::symbol::wk::any())
+        }
+        // A parameter that is ONLY a capture (`::T $x`) has no nominal type:
+        // rakudo reports `.type` as `Any`, not the sigil's container role.
+        None if !type_captures.is_empty() && p.sigil == '$' => {
             Value::Package(crate::symbol::wk::any())
         }
         // `Int @x` / `Int %h` constrain the *element* type; the parameter's
@@ -992,11 +1013,28 @@ fn render_signature(info: &SigInfo) -> String {
 
 fn render_param(p: &SigParam) -> String {
     let mut result = String::new();
+    // A `::T` capture is rendered before the nominal type, with its own
+    // trailing space — rakudo prints `(::T  $x)` for `sub f(::T $x)`, i.e. the
+    // capture, a space, the (empty) type, a space, the target.
+    let capture = |result: &mut String| {
+        if let Some(ref tc) = p.type_capture {
+            result.push_str("::");
+            result.push_str(tc);
+            result.push(' ');
+            // The nominal-type slot is rendered next and is empty when the
+            // parameter is a capture only; rakudo still emits its separator, so
+            // `sub f(::T $x)` gists as `(::T  $x)`, with two spaces.
+            if p.type_constraint.is_none() {
+                result.push(' ');
+            }
+        }
+    };
 
     // Invocant parameter: rendered as `TypeName $name::` (e.g., `B $self::`),
     // with an anonymous `$` standing in for an implicit/unnamed invocant
     // (`C $::`) -- raku only shows a name when the user wrote one explicitly.
     if p.is_invocant {
+        capture(&mut result);
         if let Some(ref tc) = p.type_constraint {
             result.push_str(tc);
             result.push(' ');
@@ -1024,6 +1062,7 @@ fn render_param(p: &SigParam) -> String {
 
     // Sigilless (backslash) parameters
     if p.sigilless {
+        capture(&mut result);
         if let Some(ref tc) = p.type_constraint {
             result.push_str(tc);
             result.push(' ');
@@ -1049,6 +1088,7 @@ fn render_param(p: &SigParam) -> String {
     }
 
     // Type constraint comes before the named marker: `Any :$x` not `:Any $x`
+    capture(&mut result);
     if p.named {
         if let Some(ref tc) = p.type_constraint {
             result.push_str(tc);

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -599,6 +599,7 @@ impl Interpreter {
                 2usize
             };
             let pd = crate::ast::ParamDef {
+                type_capture: None,
                 name: String::new(),
                 default: None,
                 multi_invocant: false,

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -137,6 +137,12 @@ impl Interpreter {
                     && pd.code_signature.is_none()
                     && !pd.sigilless
                     && !pd.is_invocant
+                    // A `::T` capture has to be BOUND, which only the general
+                    // binder does. It used to be excluded by the
+                    // `is_fast_type_name` test below, because the capture lived
+                    // in `type_constraint` as `"::T"`; now it is its own field
+                    // and the gate has to name it (#7984).
+                    && pd.captured_type_name().is_none()
                     && pd.traits.is_empty();
                 if !common {
                     return false;
@@ -210,11 +216,16 @@ impl Interpreter {
                     && pd.traits.is_empty()
                     && pd.sub_signature.is_none()
                     // Only allow basic type constraints that fast_type_check handles.
-                    // Excludes subset types, type captures (::T), parametric roles, etc.
+                    // Excludes subset types, parametric roles, etc.
                     && pd
                         .type_constraint
                         .as_deref()
                         .is_none_or(Self::is_fast_type_name)
+                    // A `::T` type capture needs the general binder to bind it
+                    // (#7984); the `is_fast_type_name` test above used to reject
+                    // it only because the capture was spelled into
+                    // `type_constraint`.
+                    && pd.captured_type_name().is_none()
                     // Exclude @/% params which need special collection semantics.
                     // A plain `&` parameter is a scalar Callable binding: the
                     // positional binder already installs its value in the
@@ -533,6 +544,7 @@ impl Interpreter {
             || pd.outer_sub_signature.is_some()
             || pd.code_signature.is_some()
             || pd.type_constraint.is_some()
+            || pd.captured_type_name().is_some()
             || pd.literal_value.is_some()
             || pd.shape_constraints.is_some()
         {

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -131,8 +131,18 @@ impl Interpreter {
         if !has_rw_params && !has_aliasable_container_params && !shares_scalar_container {
             let has_invocant_constraint = method_def.param_defs.iter().any(|pd| {
                 (pd.is_invocant || pd.traits.iter().any(|t| t == "invocant"))
-                    && pd.type_constraint.is_some()
+                    && (pd.type_constraint.is_some() || pd.type_capture.is_some())
             });
+            // A `::T` type capture has to be BOUND before the body runs, and the
+            // fast path has no binder step that does it. It used to be kept out
+            // by accident: the capture lived in `type_constraint`, so either
+            // `has_invocant_constraint` or the fast path's own nominal type check
+            // (which `::T` could never satisfy) bounced the call. Now that the
+            // capture is a field of its own, the gate has to name it (#7984).
+            let has_type_capture = method_def
+                .param_defs
+                .iter()
+                .any(|pd| pd.captured_type_name().is_some());
             let has_role_bindings = method_def.role_param_bindings.is_some()
                 || self.class_role_param_bindings(owner_class).is_some()
                 || self
@@ -290,6 +300,7 @@ impl Interpreter {
                 && !named_container_share
                 && !has_missing_required
                 && !has_invocant_constraint
+                && !has_type_capture
                 && !has_attr_aliases
                 && !has_role_bindings
                 && !has_complex_params
@@ -509,11 +520,20 @@ impl Interpreter {
                 .map(|pd| pd.is_invocant || pd.traits.iter().any(|t| t == "invocant"))
                 .unwrap_or(false);
             if is_invocant {
+                if let Some(pd) = method_def.param_defs.get(idx) {
+                    // `method m(::T Foo:D: ...)` captures the invocant's type
+                    // AND constrains it, so the capture is bound first and the
+                    // nominal check below still runs (#7984).
+                    if let Some(captured_name) = pd.captured_type_name() {
+                        loan_env!(self, bind_type_capture(captured_name, &base));
+                    }
+                }
                 if let Some(pd) = method_def.param_defs.get(idx)
                     && let Some(constraint) = &pd.type_constraint
                 {
-                    if let Some(captured_name) = constraint.strip_prefix("::") {
-                        loan_env!(self, bind_type_capture(captured_name, &base));
+                    if constraint.starts_with("::") {
+                        // `::?CLASS` / `::?ROLE` / `::(expr)`: bound above, not a
+                        // nominal constraint.
                     } else {
                         let coercion_target = if let Some(open) = constraint.find('(') {
                             if constraint.ends_with(')') && open > 0 {
@@ -939,6 +959,16 @@ impl Interpreter {
 
         self.stack.truncate(saved_stack_depth);
 
+        // A `--> T` return constraint names a type CAPTURE bound by this call's
+        // own signature, so it has to be resolved while the callee env is still
+        // live. The sub paths already do this before popping the frame; the
+        // method paths resolved it after the env had been restored, which left
+        // the literal `T` as the expected type (#7984).
+        let effective_return_spec = method_def
+            .return_type
+            .as_deref()
+            .map(|spec| loan_env!(self, resolved_type_capture_name(spec)));
+
         // Sync state variables back
         for (slot, key) in &cc.state_locals {
             let local_name = &cc.locals[*slot];
@@ -1161,8 +1191,7 @@ impl Interpreter {
         };
 
         // Apply return type spec (e.g. `--> 5` returns literal 5 from empty body)
-        let final_result = if let Some(ref return_spec) = method_def.return_type {
-            let effective_return_spec = loan_env!(self, resolved_type_capture_name(return_spec));
+        let final_result = if let Some(ref effective_return_spec) = effective_return_spec {
             self.finalize_return_with_spec(final_result, Some(effective_return_spec.as_str()))
         } else {
             match final_result {
@@ -2118,6 +2147,13 @@ impl Interpreter {
 
         self.stack.truncate(saved_stack_depth);
 
+        // Resolve a capture-valued `--> T` before the env teardown below (see
+        // the slow path's note, #7984).
+        let effective_return_spec = method_def
+            .return_type
+            .as_deref()
+            .map(|spec| loan_env!(self, resolved_type_capture_name(spec)));
+
         // Sync state variables
         for (slot, key) in &cc.state_locals {
             let val = self.locals[*slot].clone();
@@ -2266,8 +2302,7 @@ impl Interpreter {
             Err(e) => Err(e),
         };
 
-        let final_result = if let Some(ref return_spec) = method_def.return_type {
-            let effective_return_spec = loan_env!(self, resolved_type_capture_name(return_spec));
+        let final_result = if let Some(ref effective_return_spec) = effective_return_spec {
             self.finalize_return_with_spec(final_result, Some(effective_return_spec.as_str()))
         } else {
             match final_result {

--- a/src/whatever_curry/build.rs
+++ b/src/whatever_curry/build.rs
@@ -10,6 +10,7 @@ use crate::token_kind::TokenKind;
 
 pub(crate) fn make_wc_param(name: String) -> ParamDef {
     ParamDef {
+        type_capture: None,
         name,
         default: None,
         multi_invocant: true,

--- a/t/routines/signature/invocant-type-capture-param.t
+++ b/t/routines/signature/invocant-type-capture-param.t
@@ -1,0 +1,82 @@
+use Test;
+
+# A `::T` type capture and a nominal invocant type are two independent facts
+# about one parameter (`method m(::T Foo:D: $x --> T)`, #7984). mutsu used to
+# keep both in a single `ParamDef::type_constraint` string, so the combination
+# could not be expressed at all: the signature did not parse, and the two
+# spellings that did parse mis-bound `T`.
+
+plan 16;
+
+class Box {
+    has $.v = 1;
+    method same(::T Box:D: $x --> T) { $x }
+    method copy(::T Box:D: --> T)    { self }
+    method capture-only(::T: $x --> T) { $x }
+    method no-args(::T: --> T)       { self }
+    method plain(::T $x --> T)       { $x }
+}
+
+# 1-2. A type capture followed by a nominal invocant type parses, captures the
+# invocant's type, and enforces the nominal constraint.
+my $b = Box.new;
+is $b.same($b).WHAT.^name, 'Box', '::T Box:D: captures the invocant type for --> T';
+is $b.copy.WHAT.^name, 'Box', '::T Box:D: with no further params returns T';
+
+# 3-4. The capture must still be usable as a type when the invocant carries no
+# nominal type. `T` was bound for the body but the `--> T` return check resolved
+# against the literal name `T`, because the capture-bound marker collided with
+# the synthetic parameter name the bare capture carries.
+is $b.capture-only($b).WHAT.^name, 'Box', '::T: captures the invocant type for --> T';
+is $b.no-args.WHAT.^name, 'Box', '::T: with no params returns T';
+
+# 5. A non-invocant capture on a METHOD (not just a sub) binds too; it used to
+# be type-checked against the literal constraint `::T` and always failed.
+is $b.plain(42).WHAT.^name, 'Int', '::T $x on a method captures the argument type';
+
+# 6. The nominal half is genuinely enforced, not just parsed past.
+class Other {
+    method f(::T Box:D: $x --> T) { $x }
+}
+dies-ok { Other.f(1) }, 'the nominal invocant type of `::T Box:D:` is enforced';
+
+# 7-8. A role body that does not parse is a parse error, not a silently empty
+# role. `role R { method m(::T R:D: $x) {...} }` used to compile to an empty
+# role body, so the call site died with "No such method" and no diagnostic ever
+# named the signature that failed to parse.
+role Mergeable {
+    method merge(::T Mergeable:D: $other --> T) { self }
+}
+class Doc does Mergeable {}
+my $d = Doc.new;
+is $d.merge(Doc.new).WHAT.^name, 'Doc', 'a role method with `::T R:D:` is composed, not dropped';
+ok Doc.^can('merge'), 'the role method really reached the class';
+
+# 9. A role body with a genuine syntax error is now reported, rather than
+# yielding a role with no methods at all.
+throws-like 'role Broken { method m( } }; 1', Exception,
+    'an unparsable role body is a parse error';
+
+# 10-11. Subs keep working, and so does a capture shared across parameters.
+# (`try` rather than `dies-ok`: a capture-constrained parameter's binding
+# failure does not reach `dies-ok`'s handler — a separate, pre-existing
+# divergence, #8064.)
+sub pick(::T $x, T $y --> T) { $y }
+is pick(1, 2).WHAT.^name, 'Int', 'a capture declared by one param constrains the next';
+my $bad = try { pick(1, 'two') };
+ok $!.defined, 'a later param is checked against the captured type';
+
+# 12-13. Role type parameters are unaffected.
+role Holder[::E] { method elem { E } }
+is Holder[Str].new.elem.^name, 'Str', 'role type parameters still bind their capture';
+role Defaulted[::E = Int] { method elem { E } }
+is Defaulted.new.elem.^name, 'Int', 'a defaulted role type parameter still binds';
+
+# 14-16. The capture survives into signature introspection: `.type_captures`
+# names it, `.type` stays Any (the capture is not a nominal constraint), and
+# `.gist` renders it before the — here empty — nominal type slot, two spaces and
+# all, exactly as rakudo does.
+sub captured(::T $x) { $x }
+is &captured.signature.params[0].type_captures.join(','), 'T', 'Parameter.type_captures names the capture';
+is &captured.signature.params[0].type.^name, 'Any', 'a capture-only parameter has no nominal type';
+is &captured.signature.gist, '(::T  $x)', 'the gist renders the capture ahead of the type slot';


### PR DESCRIPTION
`method merge(::T CRDT:D: $other --> T)` — a type capture on the invocant *followed by* a nominal
invocant type — did not parse at all, and the two spellings that did parse mis-bound the captured
name. All of it was one representation bug: `ParamDef` carried a parameter's type as a single
`Option<String>` and encoded a capture *inside* that string as `"::T"`, which leaves no room for
both `::T` and `CRDT:D`.

```
$ mutsu -e 'class Foo { method m(::T Foo:D: $x --> T) { $x } }; say "ok"'       # before
===SORRY!=== Error while compiling -e
Confused. expected statement: ...
$ mutsu -e 'class Foo { method m(::T: $x --> T) { $x } }; say Foo.new.m(Foo.new).WHAT'
Type check failed for return value; expected T but got Any (Foo())
```

## The representation change

`ParamDef::type_capture` now holds the bare captured name (no `::` prefix, no smiley) and
`type_constraint` is only ever the nominal half. `ParamDef::captured_type_name()` is the one
accessor every binding, dispatch, role and RakuAST site asks; about twenty of them used to
re-derive the capture by stripping `"::"` off the constraint string, which is precisely why one
parameter could not hold both facts.

The parser attaches the capture at a **single choke point**: consume `::T`, parse whatever follows
as an ordinary parameter, hang the capture off the result. Defaults, traits, `where` clauses and
sub-signatures therefore keep it for free, instead of each of the ~25 `ParamDef` construction sites
in `param_inner.rs` having to remember it. `split_invocant_type_capture` peels the capture off
before the invocant marker is read, so `::T CRDT:D:` becomes one invocant parameter carrying both
halves — the capture binds **and** the nominal type is enforced, where the old code had them as
mutually exclusive arms of one `if`/`else` chain.

Role *type* parameters (`role R[::T]`) keep the legacy `"::T"` spelling in `type_constraint`,
because specificity scoring also reads that string as the "generic" marker; `captured_type_name()`
covers them, and it is the only accessor, so there is one read path for both populations. The same
fallback preserves the pseudo-types `::?CLASS` / `::?ROLE` and the indirect `::(expr)` form
verbatim — those are consumed as nominal constraints elsewhere and are not ident captures.

## Four more defects fell out of it

- **The capture-bound marker key collided with a parameter name.** `bind_type_capture` recorded
  "a capture named `T` is bound" under the env key `__type_capture__T` — which is also the synthetic
  *parameter name* a bare `::T` / `::T:` capture carries. The binder's own "bind the parameter under
  its name" step overwrote the marker with the argument value, `has_type_capture_binding` then said
  no, and every later resolution of `T` fell back to the literal name. That is why `--> T` reported
  "expected T". The key is now `__mutsu_type_capture_bound__<name>`, which no parameter name can
  reach.
- **Both method paths resolved a `--> T` return constraint after restoring the caller's env**, so a
  capture bound by the method's own signature was already gone. The sub paths resolve it before
  popping the frame; the method paths now do too.
- **Several fast paths had been excluding captures only by accident**, because `"::T"` was a
  constraint string no fast type check could satisfy. With the capture in a field of its own they
  have to name it: the method fast path (`vm_method_dispatch.rs`) and the sub light /
  positional-light paths (`vm_call_eligibility.rs`). Getting that wrong was immediately visible —
  `sub f(::T $x) { my T $y = 4.2 }` reported "Type 'T' is not declared", and
  `class Foo { method m(::T $x) { say T } }` failed outright even before this PR.
- **A role body that did not parse was silently discarded.** `role_decl` fell back to
  `consume_raw_braced_body`, producing a role with no methods; the call site then died with
  "No such method 'm'" and nothing pointed at the signature that had failed. Role bodies parse
  strictly now, exactly as class bodies do — this is the "worth separating out" half the issue's
  scope note names, and it is what would have turned the original report into an ordinary located
  parse failure.

## Signature introspection

`SigParam` grew the same `type_capture`, so `Parameter.type_captures` reads it there rather than by
slicing a `"::T"` constraint string, `.type` stays `Any` for a capture-only parameter, and `.gist`
renders the capture ahead of the nominal-type slot the way Rakudo does — two spaces and all
(`(::T  $x)`) — with a bare `::T` parameter showing as the anonymous `$` instead of leaking its
synthetic `$__type_capture__T` name.

## `::T:D`

No longer read as a capture *named* `T:D`. Rakudo reports such a parameter's `.type` as `Any` and
enforces nothing (`sub f(::T:U $x) { }; f(42)` runs there), so the smiley is consumed and discarded
and the capture is named `T` — which is what `::GrammarType:U :$schema` (YAMLish) has always meant.

## Verification

Every case below was diffed against `raku` 2026.07 and now matches:

| | before | after / raku |
|---|---|---|
| `method m(::T Foo:D: $x --> T)` | parse error | `(Foo)` |
| `role R { method m(::T R:D: $x --> T) }` | method silently dropped | return type check fires |
| `method m(::T: $x --> T)` | `expected T but got Any` | `(Foo)` |
| `method c(::T: --> T)` | `expected T but got Any` | `(Foo)` |
| `method m(::T $x)` | binding failure vs `::T` | capture binds |

- `cargo fmt --all`, `make lint` (default clippy, `jit`-off, wasm32, rustdoc): green.
- `make test`: **4057 files, 43195 tests, Result: PASS**.
- `make roast`: red only in the three environment-only files
  [`docs/agent-environments.md`](docs/agent-environments.md) documents for a remote container, by
  name and by subtest range — `6.c/S32-io/file-tests.t` (4, tests 6-8/10) and
  `S16-filehandles/filetest.t` (25) both because this container runs as `uid 0`, and
  `S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17) because of the network sandbox.
- New pin `t/routines/signature/invocant-type-capture-param.t` (16 tests), which passes under **real
  Rakudo** as well as mutsu.

One adjacent divergence surfaced while writing that test and was confirmed pre-existing on `main`,
so it is filed separately rather than widened into this PR: a capture-constrained parameter's
binding failure is catchable by `try` but does not reach `dies-ok`'s handler
([#8064](https://github.com/tokuhirom/mutsu/issues/8064)). The regression test uses `try` + `$!`
there and says why.

Closes #7984

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_