### PR TITLE
perf(regex): move the capture accumulator's cold fields behind one boxed payload

### DIFF
--- a/news/2026-09/regex-captures-cold-field-split.md
+++ b/news/2026-09/regex-captures-cold-field-split.md
@@ -1,0 +1,100 @@
+# The regex capture accumulator was 336 bytes, and every match candidate paid for it
+
+`RegexCaptures` is the accumulator the regex engine builds for **one match
+candidate**. A grammar parse constructs, moves, clones and drops millions of
+them — 2.59 M over the 60-row YAMLish document
+[#7576](https://github.com/tokuhirom/mutsu/issues/7576) has been profiled
+against since round 10. It carried sixteen fields inline, including three
+`HashMap`s, and came to 336 bytes, so every candidate paid a 336-byte `memcpy`
+and three empty-map drops to carry state almost none of them had.
+
+Instructions retired on that document go **2,178,652,179 -> 2,010,535,421
+(-7.72%)**. Attribution is callgrind Ir throughout (deterministic,
+load-independent), as in rounds 10-14.
+
+## (a) The cold fields move behind one boxed payload (-6.75%)
+
+This is the ADR-0016 P2 `CapNode`/`CapChildren` split applied one level up, to
+the accumulator instead of the stored node. Eight fields are written by a
+minority of patterns — `:my` declarators (`regex_vars`), capture aliases
+(`capture_alias_map`), `%<name>=` hash captures (`hash_captures`), the
+pcre2/`:P5` slot axis (`positional_slots`), a protoregex `:sym<>` win (`sym`),
+an aliased rule name (`action_name`), and the two engine-entry links (`target`,
+`outer_backref`) — and now live in a `RareCaps` payload behind one
+`Option<Box<_>>`. `RegexCaptures` is **336 -> 128 bytes**, pinned by
+`regex_captures_size_guard`.
+
+Call sites reach the fields through accessors: the read-only ones hand back a
+shared empty value when no payload was ever allocated, the `_mut` ones
+materialize it. Two properties matter more than the size number and are pinned
+by their own tests:
+
+- an accumulator that takes no cold-field write **never allocates** the
+  payload, and reading one back does not allocate one to look at (so
+  `caps.regex_vars().is_empty()` on a plain candidate is a null check);
+- a payload that is drained or cleared again is **dropped**, so an accumulator
+  that briefly held a `:my` variable does not make every later clone copy an
+  empty payload. That is what `prune_rare` is for, and why the setters take an
+  `Option` rather than being paired with separate clear methods.
+
+The merge paths were the subtle part. `dst.regex_vars_mut().extend(src)` would
+allocate a payload on `dst` even when `src` is empty — which is the common case
+— so the merges go through `extend_regex_vars` / `extend_capture_alias_map` /
+`merge_hash_captures`, which look at the source first and return without
+touching `dst` when there is nothing to move. Likewise `delta.X_mut().drain()`
+grew a payload just to drain it empty; those are `take_X()` now.
+
+Effect on the profile: `memcpy` **154,718,384 (7.10%) -> 77,609,917 (3.82%)**,
+`RawTable::drop` 54.1 M -> 34.9 M, `RawTable::clone` 34.0 M -> 28.5 M,
+`regex_walk_ends_in_pkg` 37.3 M -> 28.5 M.
+
+## (b) …and the in-regex lexicals are shared, not copied per atom (-1.04%)
+
+Round 14 named this as the item behind item 4: every inline sub-pattern (a
+group, an alternative, a lookaround body) publishes the `:my`/`:let` lexicals
+in scope to the store it is about to build, and `InlineVarsSeed::arm` did it by
+**cloning the whole map**, once per atom match, with
+`take_inline_regex_vars_seed` cloning it back out again. YAMLish computes its
+block indent in a `{ … }` inside a `<?before …>`, so its parse is exactly the
+shape that pays.
+
+`RareCaps::regex_vars` is an `Option<Arc<RegexVarMap>>` now; arming and seeding
+are refcount bumps, and the copy is paid only by a level that actually writes a
+lexical, through `Arc::make_mut`. `take_inline_regex_vars_seed` leaves the
+profile entirely (4.5 M -> not listed); `arm_inline_vars_seed` goes 24.3 M ->
+20.7 M.
+
+**A measured wrong turn worth recording:** the first version of this made the
+field a plain `Arc<RegexVarMap>`, and it read as a **0.7% regression**
+(2,031,713,138 -> 2,045,936,861) with `malloc` and `free` both up. `Arc<T>` has
+no empty representation, so `Arc::default()` *allocates* — and `RareCaps`
+constructs one on every payload materialization, turning an allocation-free
+`HashMap::default()` into a heap allocation. The `Option` wrapper is not
+defensive style here; it is the difference between a win and a regression.
+Wrapping a rarely-populated collection in `Arc` for sharing is only free if the
+absent case stays absent.
+
+## Method note, extending rounds 10-14
+
+Round 14's lesson was procedural: warm the module precompilation cache before
+taking a profile. Round 15's is about **where a size win actually lands**. The
+336 bytes were never visible under a function's own name — they were `memcpy`,
+`_int_malloc` and `RawTable::drop`, exactly the "irreducible allocator tail"
+that rounds 11-14 each had to look past. The tell was a struct-size question
+(`size_of::<RegexCaptures>()`) rather than a profile line, which is why round
+14 could only name the item after it measured the type instead of the run.
+Both new guard tests exist so the next field added to the accumulator has to
+answer that question at compile time.
+
+## What is left
+
+The profile stays flat: `LocalKey::with` 7.3% across a dozen callers, the
+allocator ~19%, `memcpy` 3.9%, and the largest single mutsu function is
+`regex_match_atom_all_with_capture_in_pkg_inner` at 1.85%. Two items from
+round 14's list are untouched: `resolve_parsed_token_candidates_in_pkg` still
+interns its *package* name on every probe (~0.7%), which wants a `Symbol`
+threaded down rather than another memo; and the remaining 128 bytes are
+dominated by `named` (a 48-byte `HashMap` inline) plus two `Option<usize>`
+span-marker fields that could be `u32`-with-sentinel. Neither has a measured
+size yet — re-run the caller attribution rather than carrying this paragraph
+forward as a conclusion.

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -722,7 +722,7 @@ impl Interpreter {
                 self.env
                     .insert(i.to_string(), Value::str(captures.slot_text(v)));
             }
-            let alias_map = std::mem::take(&mut captures.capture_alias_map);
+            let alias_map = captures.take_capture_alias_map();
             let match_obj = Value::make_match_object_full(
                 captures.from as i64,
                 captures.to as i64,

--- a/src/runtime/methods_string_subst_repl.rs
+++ b/src/runtime/methods_string_subst_repl.rs
@@ -68,7 +68,7 @@ impl Interpreter {
             self.env.insert("$_".to_string(), match_obj.clone());
             self.env.insert("_".to_string(), match_obj.clone());
             let positional_len = captures
-                .positional_slots
+                .positional_slots()
                 .len()
                 .max(captures.positional.len());
             for i in 0..positional_len {
@@ -88,7 +88,7 @@ impl Interpreter {
                             .map(|(a, b, _)| Value::str(t.span_str(*a, *b)))
                             .collect(),
                     )
-                } else if let Some(Some((a, b))) = captures.positional_slots.get(i) {
+                } else if let Some(Some((a, b))) = captures.positional_slots().get(i) {
                     let t = captures.target_or_new(orig_text.unwrap_or_default());
                     Value::str(t.span_str(*a, *b))
                 } else if let Some(slot) = captures.positional.get(i) {

--- a/src/runtime/regex/regex_cursor.rs
+++ b/src/runtime/regex/regex_cursor.rs
@@ -366,8 +366,8 @@ impl Interpreter {
         match caps {
             Some(caps) => {
                 let target = caps
-                    .target
-                    .clone()
+                    .target()
+                    .cloned()
                     .unwrap_or_else(|| MatchTarget::new(orig));
                 Value::make_match_object_full(
                     caps.from as i64,

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -243,7 +243,7 @@ impl Interpreter {
         // block wrote to them). They are lexical to the regex, so they are
         // installed here and restored with the rest of the regex bindings —
         // `:my $x = 'y'; <?{ $x eq 'y' }>` must see 'y', not an outer `$x`.
-        for (k, v) in &caps.regex_vars {
+        for (k, v) in caps.regex_vars() {
             env.push((k.clone(), v.clone()));
         }
         // The engine-scope subject: derives `$0…` texts from the live
@@ -384,7 +384,7 @@ impl Interpreter {
                 .into_iter()
                 .filter(|(name, _)| {
                     name != "made"
-                        && !caps.regex_vars.contains_key(name)
+                        && !caps.regex_vars().contains_key(name)
                         && !block_locals.contains(name)
                 })
                 .collect();
@@ -412,9 +412,9 @@ impl Interpreter {
         // interpolation or `<?{ … }>` assertion in the same match reads it, while
         // `self.env` goes back to what the enclosing scope had.
         let mut writes: HashMap<String, Value> = HashMap::new();
-        for k in caps.regex_vars.keys() {
+        for k in caps.regex_vars().keys() {
             if let Some(now) = self.env.get(k)
-                && caps.regex_vars.get(k) != Some(now)
+                && caps.regex_vars().get(k) != Some(now)
             {
                 writes.insert(k.clone(), now.clone());
             }

--- a/src/runtime/regex/regex_eval_class.rs
+++ b/src/runtime/regex/regex_eval_class.rs
@@ -189,7 +189,7 @@ impl Interpreter {
                 {
                     caps.from = caps.capture_start.unwrap_or(0);
                     caps.to = caps.capture_end.unwrap_or(end);
-                    caps.target = Some(target.clone());
+                    caps.set_target(Some(target.clone()));
                     found = Some((0, end, caps));
                 }
             } else {
@@ -199,7 +199,7 @@ impl Interpreter {
                     {
                         caps.from = caps.capture_start.unwrap_or(start);
                         caps.to = caps.capture_end.unwrap_or(end);
-                        caps.target = Some(target.clone());
+                        caps.set_target(Some(target.clone()));
                         found = Some((start, end, caps));
                         break;
                     }

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -312,7 +312,7 @@ impl Interpreter {
         // The binding for THIS match, installed before the subtree reduces so a
         // child's *action* accumulates into this match's binding (the
         // `:my %*PLAYED = (); <card>+` shape) rather than a sibling match's.
-        let recorded = caps.regex_vars.clone();
+        let recorded = caps.regex_vars().clone();
         let declared_keys = self.install_fresh_rule_dynvars(rule_name, &recorded);
         self.reduce_child_axes(&mut caps.named, &mut caps.positional, target);
         // A declaring match whose value had to be re-derived must record what its
@@ -466,7 +466,7 @@ impl Interpreter {
     fn record_rule_dynvars(&mut self, caps: &mut RegexCaptures, keys: &[String]) {
         for key in keys {
             if let Some(v) = self.env.get(key).cloned() {
-                caps.regex_vars.insert(key.clone(), v);
+                caps.regex_vars_mut().insert(key.clone(), v);
             }
         }
     }

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -88,7 +88,7 @@ thread_local! {
     /// block indent in a `{ … }` inside a `<?before …>` and reads it back after).
     /// A *subrule* is a different regex and must NOT inherit them, so every other
     /// atom arms this *empty* for the duration of its match.
-    pub(crate) static INLINE_REGEX_VARS_SEED: RefCell<Option<HashMap<String, Value>>> = const { RefCell::new(None) };
+    pub(crate) static INLINE_REGEX_VARS_SEED: RefCell<Option<std::sync::Arc<crate::runtime::RegexVarMap>>> = const { RefCell::new(None) };
     /// Whether [`INLINE_REGEX_VARS_SEED`] currently holds anything. Read once per
     /// atom match to skip the `RefCell` entirely on the overwhelmingly common path
     /// where no regex in flight declares a `:my`/`:let` lexical.
@@ -194,14 +194,17 @@ pub(crate) fn atom_contains_backref(atom: &RegexAtom) -> bool {
 /// reference above all — arms it *empty*, which is what stops a `:my` lexical
 /// from leaking into a different regex.
 pub(crate) struct InlineVarsSeed {
-    prev: Option<HashMap<String, Value>>,
+    prev: Option<std::sync::Arc<crate::runtime::RegexVarMap>>,
     armed: bool,
 }
 
 impl InlineVarsSeed {
-    pub(crate) fn arm(vars: &HashMap<String, Value>) -> Self {
+    /// Publish `vars` (already a shared handle — `None` means "publish
+    /// nothing", which is what a subrule reference arms) for the duration of
+    /// one atom match.
+    pub(crate) fn arm(vars: Option<&std::sync::Arc<crate::runtime::RegexVarMap>>) -> Self {
         let active = INLINE_REGEX_VARS_ACTIVE.with(Cell::get);
-        if vars.is_empty() && !active {
+        if vars.is_none() && !active {
             // Nothing to publish and nothing published: the atom cannot change
             // what any nested store would see, so leave the slot untouched.
             return InlineVarsSeed {
@@ -209,11 +212,7 @@ impl InlineVarsSeed {
                 armed: false,
             };
         }
-        let next = if vars.is_empty() {
-            None
-        } else {
-            Some(vars.clone())
-        };
+        let next = vars.cloned();
         INLINE_REGEX_VARS_ACTIVE.with(|f| f.set(next.is_some()));
         let prev = INLINE_REGEX_VARS_SEED.with(|s| std::mem::replace(&mut *s.borrow_mut(), next));
         InlineVarsSeed { prev, armed: true }
@@ -233,13 +232,11 @@ impl Drop for InlineVarsSeed {
 
 /// The in-regex lexicals a freshly built capture store should start from (see
 /// [`INLINE_REGEX_VARS_SEED`]).
-pub(crate) fn take_inline_regex_vars_seed() -> HashMap<String, Value> {
+pub(crate) fn take_inline_regex_vars_seed() -> Option<std::sync::Arc<crate::runtime::RegexVarMap>> {
     if !INLINE_REGEX_VARS_ACTIVE.with(Cell::get) {
-        return HashMap::default();
+        return None;
     }
-    INLINE_REGEX_VARS_SEED
-        .with(|s| s.borrow().clone())
-        .unwrap_or_default()
+    INLINE_REGEX_VARS_SEED.with(|s| s.borrow().clone())
 }
 
 thread_local! {
@@ -784,9 +781,11 @@ pub(super) fn remap_caps_spans_offset(
         caps.from = m(caps.from);
         caps.to = m(caps.to);
     }
-    for slot in caps.positional_slots.iter_mut().flatten() {
-        slot.0 = m(slot.0);
-        slot.1 = m(slot.1);
+    if !caps.positional_slots().is_empty() {
+        for slot in caps.positional_slots_mut().iter_mut().flatten() {
+            slot.0 = m(slot.0);
+            slot.1 = m(slot.1);
+        }
     }
     for sc in caps
         .named
@@ -985,21 +984,15 @@ pub(super) fn merge_regex_captures(
     for (k, v) in src.named.drain() {
         dst.named.entry(k).or_default().merge(v);
     }
-    for (k, v) in src.capture_alias_map.drain() {
-        dst.capture_alias_map.insert(k, v);
-    }
+    dst.extend_capture_alias_map(src.take_capture_alias_map());
     dst.positional.append(&mut src.positional);
     // Writes an inline `{ … }` made to the regex's own `:my`/`:let` lexicals are
     // in the same lexical scope as the level being merged into (this helper only
     // folds inline sub-patterns — a conjunction branch, a `~` goal), so they come
     // with it. Without this a `[ … { $x = … } … ]` inside one of those shapes
     // silently lost the write.
-    for (k, v) in src.regex_vars.drain() {
-        dst.regex_vars.insert(k, v);
-    }
-    for (k, v) in src.hash_captures.drain() {
-        dst.hash_captures.entry(k).or_default().extend(v);
-    }
+    dst.extend_regex_vars(src.take_regex_vars());
+    dst.merge_hash_captures(src.take_hash_captures());
     // Propagate `<(` / `)>` capture-marker positions from the merged-in side so a
     // sub-pattern that sets the match boundaries is not lost when its captures are
     // folded into an outer result — e.g. `'<' ~ '>' [<( \w+ )>]`, where the

--- a/src/runtime/regex/regex_ltm_rank.rs
+++ b/src/runtime/regex/regex_ltm_rank.rs
@@ -199,9 +199,7 @@ impl Interpreter {
                 }
                 new_caps.positional.append(&mut inner_caps.positional);
                 super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
-                new_caps
-                    .regex_vars
-                    .extend(std::mem::take(&mut inner_caps.regex_vars));
+                new_caps.extend_regex_vars(inner_caps.take_regex_vars());
                 out.push((end, new_caps));
             }
         }
@@ -448,9 +446,7 @@ impl Interpreter {
                     }
                     new_caps.positional.append(&mut inner_caps.positional);
                     super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
-                    new_caps
-                        .regex_vars
-                        .extend(std::mem::take(&mut inner_caps.regex_vars));
+                    new_caps.extend_regex_vars(inner_caps.take_regex_vars());
                     best = (end, new_caps);
                 }
             }

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -50,14 +50,10 @@ impl Interpreter {
             for (k, v) in inner_caps.named.drain() {
                 new_caps.named.entry(k).or_default().merge(v);
             }
-            for (k, v) in inner_caps.capture_alias_map.drain() {
-                new_caps.capture_alias_map.insert(k, v);
-            }
+            new_caps.extend_capture_alias_map(inner_caps.take_capture_alias_map());
             new_caps.positional.append(&mut inner_caps.positional);
             super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
-            new_caps
-                .regex_vars
-                .extend(std::mem::take(&mut inner_caps.regex_vars));
+            new_caps.extend_regex_vars(inner_caps.take_regex_vars());
             group.push((next, new_caps));
         }
         group.reverse();
@@ -133,14 +129,10 @@ impl Interpreter {
                     for (k, v) in inner_caps.named.drain() {
                         new_caps.named.entry(k).or_default().merge(v);
                     }
-                    for (k, v) in inner_caps.capture_alias_map.drain() {
-                        new_caps.capture_alias_map.insert(k, v);
-                    }
+                    new_caps.extend_capture_alias_map(inner_caps.take_capture_alias_map());
                     new_caps.positional.append(&mut inner_caps.positional);
                     super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
-                    new_caps
-                        .regex_vars
-                        .extend(std::mem::take(&mut inner_caps.regex_vars));
+                    new_caps.extend_regex_vars(inner_caps.take_regex_vars());
                     (end, new_caps)
                 })
                 .collect();
@@ -482,14 +474,10 @@ impl Interpreter {
                     for (k, v) in inner_caps.named.drain() {
                         new_caps.named.entry(k).or_default().merge(v);
                     }
-                    for (k, v) in inner_caps.capture_alias_map.drain() {
-                        new_caps.capture_alias_map.insert(k, v);
-                    }
+                    new_caps.extend_capture_alias_map(inner_caps.take_capture_alias_map());
                     new_caps.positional.append(&mut inner_caps.positional);
                     super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
-                    new_caps
-                        .regex_vars
-                        .extend(std::mem::take(&mut inner_caps.regex_vars));
+                    new_caps.extend_regex_vars(inner_caps.take_regex_vars());
                     out.push((end, new_caps));
                 }
             }
@@ -690,7 +678,7 @@ impl Interpreter {
                             };
                             for (end, mut caps) in matches_to_use {
                                 if sym_key.is_some() {
-                                    caps.sym = sym_key.clone();
+                                    caps.set_sym(sym_key.clone());
                                 }
                                 raw_out.push((end, caps));
                             }
@@ -710,7 +698,7 @@ impl Interpreter {
                             // can set subcap.sym correctly for action method dispatch.
                             for (end, mut caps) in matches_to_use {
                                 if sym_key.is_some() {
-                                    caps.sym = sym_key.clone();
+                                    caps.set_sym(sym_key.clone());
                                 }
                                 raw_out.push((end, caps));
                             }
@@ -1030,8 +1018,8 @@ impl Interpreter {
                 subcap.to = ce;
                 // sym is already set on subcap from raw_out collection loop.
                 // Fall back to sym_key parameter for the is_active (seed) path.
-                if subcap.sym.is_none() && sym_key.is_some() {
-                    subcap.sym = sym_key.cloned();
+                if subcap.sym().is_none() && sym_key.is_some() {
+                    subcap.set_sym(sym_key.cloned());
                 }
                 // The subrule's own inline `{ … }` code blocks stay ON the subcap
                 // (a queryable Match node) rather than bubbling into the parent, so
@@ -1057,7 +1045,7 @@ impl Interpreter {
                 let is_alias = spec.capture_name.is_some() && capture_name != spec.lookup_name;
                 let mut subcap = subcap;
                 if is_alias {
-                    subcap.action_name = Some(spec.lookup_name.clone());
+                    subcap.set_action_name(Some(spec.lookup_name.clone()));
                 }
                 let subcap = std::sync::Arc::new(subcap.into_cap_node());
                 // This subrule has just REDUCED. Log it so a parse that fails
@@ -1082,7 +1070,7 @@ impl Interpreter {
                     .push(subcap);
                 if is_alias {
                     new_caps
-                        .capture_alias_map
+                        .capture_alias_map_mut()
                         .insert(capture_name.to_string(), spec.lookup_name.clone());
                 }
                 if let Some(orig_subcap) = shared_under_original {
@@ -1111,10 +1099,10 @@ impl Interpreter {
                 let mut subcap = inner_caps;
                 subcap.from = cs;
                 subcap.to = ce;
-                if subcap.sym.is_none() && sym_key.is_some() {
-                    subcap.sym = sym_key.cloned();
+                if subcap.sym().is_none() && sym_key.is_some() {
+                    subcap.set_sym(sym_key.cloned());
                 }
-                subcap.action_name = Some(spec.lookup_name.clone());
+                subcap.set_action_name(Some(spec.lookup_name.clone()));
                 // Keep the silent subrule's inline blocks on its own (marker) node
                 // for the reduce-time walk to run once — see the non-silent branch.
                 let marker = format!(

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -36,9 +36,9 @@ impl Interpreter {
     ) {
         let inline = Self::atom_is_inline_subpattern(atom);
         let vars = if inline {
-            super::regex_helpers::InlineVarsSeed::arm(&current_caps.regex_vars)
+            super::regex_helpers::InlineVarsSeed::arm(current_caps.regex_vars_shared())
         } else {
-            super::regex_helpers::InlineVarsSeed::arm(&Default::default())
+            super::regex_helpers::InlineVarsSeed::arm(None)
         };
         (vars, Self::arm_outer_caps_seed(atom, current_caps))
     }
@@ -94,7 +94,7 @@ impl Interpreter {
         OuterCapsSeed::arm(Some(std::sync::Arc::new(OuterBackrefCaps {
             named: current_caps.named.clone(),
             positional: current_caps.positional.clone(),
-            parent: current_caps.outer_backref.clone(),
+            parent: current_caps.outer_backref().cloned(),
         })))
     }
 
@@ -186,10 +186,8 @@ impl Interpreter {
                         for (k, v) in inner_caps.named.drain() {
                             new_caps.named.entry(k).or_default().merge(v);
                         }
-                        for (k, v) in inner_caps.capture_alias_map.drain() {
-                            new_caps.capture_alias_map.insert(k, v);
-                        }
-                        new_caps.positional.extend(inner_caps.positional);
+                        new_caps.extend_capture_alias_map(inner_caps.take_capture_alias_map());
+                        new_caps.positional.append(&mut inner_caps.positional);
                         // Propagate a `<(` / `)>` capture marker set inside the group.
                         if inner_caps.capture_start.is_some() {
                             new_caps.capture_start = inner_caps.capture_start;
@@ -200,7 +198,7 @@ impl Interpreter {
                         // Writes an inline `{ … }` made to the regex's `:my`
                         // lexicals are part of the same lexical scope as the
                         // enclosing pattern, so they leave the group with it.
-                        new_caps.regex_vars.extend(inner_caps.regex_vars);
+                        new_caps.extend_regex_vars(inner_caps.take_regex_vars());
                         (next, new_caps)
                     });
             }
@@ -261,12 +259,10 @@ impl Interpreter {
                         for (k, v) in inner_caps.named.drain() {
                             new_caps.named.entry(k).or_default().merge(v);
                         }
-                        for (k, v) in inner_caps.capture_alias_map.drain() {
-                            new_caps.capture_alias_map.insert(k, v);
-                        }
+                        new_caps.extend_capture_alias_map(inner_caps.take_capture_alias_map());
                         new_caps.positional.append(&mut inner_caps.positional);
                         super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
-                        new_caps.regex_vars.extend(inner_caps.regex_vars);
+                        new_caps.extend_regex_vars(inner_caps.take_regex_vars());
                         let rank = self.ltm_branch_rank_key(alt, chars, pos, pkg);
                         let replace = best
                             .as_ref()
@@ -318,12 +314,10 @@ impl Interpreter {
                         for (k, v) in inner_caps.named.drain() {
                             new_caps.named.entry(k).or_default().merge(v);
                         }
-                        for (k, v) in inner_caps.capture_alias_map.drain() {
-                            new_caps.capture_alias_map.insert(k, v);
-                        }
+                        new_caps.extend_capture_alias_map(inner_caps.take_capture_alias_map());
                         new_caps.positional.append(&mut inner_caps.positional);
                         super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
-                        new_caps.regex_vars.extend(inner_caps.regex_vars);
+                        new_caps.extend_regex_vars(inner_caps.take_regex_vars());
                         return Some((next, new_caps));
                     }
                 }
@@ -355,11 +349,11 @@ impl Interpreter {
                 let matched = if *is_behind {
                     let mut found = false;
                     for start in 0..=pos {
-                        if let Some((end, inner)) =
+                        if let Some((end, mut inner)) =
                             self.regex_match_end_from_caps_in_pkg(pattern, chars, start, pkg)
                             && end == pos
                         {
-                            inner_vars = inner.regex_vars;
+                            inner_vars = inner.take_regex_vars();
                             found = true;
                             break;
                         }
@@ -367,8 +361,8 @@ impl Interpreter {
                     found
                 } else {
                     match self.regex_match_end_from_caps_in_pkg(pattern, chars, pos, pkg) {
-                        Some((_, inner)) => {
-                            inner_vars = inner.regex_vars;
+                        Some((_, mut inner)) => {
+                            inner_vars = inner.take_regex_vars();
                             true
                         }
                         None => false,
@@ -382,7 +376,7 @@ impl Interpreter {
                     // measures the indent in a `<?before … { … } >` and matches it
                     // afterwards).
                     let mut new_caps = RegexCaptures::default();
-                    new_caps.regex_vars.extend(inner_vars);
+                    new_caps.extend_regex_vars(inner_vars);
                     Some((pos, new_caps))
                 } else {
                     None
@@ -459,7 +453,7 @@ impl Interpreter {
                     let pass = if *negated { !result } else { result };
                     if pass {
                         let mut new_caps = RegexCaptures::default();
-                        new_caps.regex_vars.extend(outcome.writes);
+                        new_caps.extend_regex_vars(outcome.writes);
                         new_caps.ast = outcome.made;
                         return Some((pos, new_caps));
                     } else {
@@ -490,7 +484,7 @@ impl Interpreter {
                     return None;
                 }
                 let mut new_caps = RegexCaptures::default();
-                new_caps.regex_vars.extend(outcome.writes);
+                new_caps.extend_regex_vars(outcome.writes);
                 // The `make` belongs to the rule node being matched: it rides
                 // the capture delta so the trail undoes it if this branch is
                 // abandoned, and `build_named_candidates_from_inner` commits it
@@ -553,7 +547,7 @@ impl Interpreter {
                 let slot = match current_caps.positional.get(*idx) {
                     Some(slot) => slot,
                     None => current_caps
-                        .outer_backref
+                        .outer_backref()
                         .as_ref()
                         .and_then(|outer| outer.lookup_positional(*idx))?,
                 };
@@ -594,7 +588,7 @@ impl Interpreter {
                     // `Backref` arm above (`/ $<x>=(\w) [ $<x> ] /`).
                     .or_else(|| {
                         current_caps
-                            .outer_backref
+                            .outer_backref()
                             .as_ref()
                             .and_then(|outer| outer.lookup_named(&sym))
                     });
@@ -615,9 +609,9 @@ impl Interpreter {
                 // undefined value matches nothing (zero-width, like an empty
                 // literal) rather than failing.
                 let val = current_caps
-                    .regex_vars
+                    .regex_vars()
                     .get(name.as_str())
-                    .or_else(|| current_caps.regex_vars.get(&format!("${name}")))
+                    .or_else(|| current_caps.regex_vars().get(&format!("${name}")))
                     .cloned()
                     .or_else(|| self.env.get(name).cloned())
                     .or_else(|| self.env.get(&format!("${name}")).cloned());
@@ -678,7 +672,11 @@ impl Interpreter {
                             continue;
                         }
                         let mut saved: Vec<(String, Option<Value>)> = Vec::new();
-                        for (k, v) in current_caps.regex_vars.iter().chain(&new_caps.regex_vars) {
+                        for (k, v) in current_caps
+                            .regex_vars()
+                            .iter()
+                            .chain(new_caps.regex_vars())
+                        {
                             saved.push((k.clone(), self.env.get(k).cloned()));
                             self.env.insert(k.clone(), v.clone());
                         }
@@ -710,7 +708,7 @@ impl Interpreter {
                                 None => self.env.remove(&k),
                             };
                         }
-                        new_caps.regex_vars.insert(name.clone(), v);
+                        new_caps.regex_vars_mut().insert(name.clone(), v);
                     }
                     if scratch_stmts.is_empty() {
                         for (k, orig) in capture_saved {
@@ -727,7 +725,11 @@ impl Interpreter {
                         ..self.new_regex_scratch_sharing_io()
                     };
                     self.copy_decl_registry_into(&mut interp);
-                    for (k, v) in current_caps.regex_vars.iter().chain(&new_caps.regex_vars) {
+                    for (k, v) in current_caps
+                        .regex_vars()
+                        .iter()
+                        .chain(new_caps.regex_vars())
+                    {
                         interp.env.insert(k.clone(), v.clone());
                     }
                     let _ = interp.eval_block_value(&scratch_stmts);
@@ -741,7 +743,7 @@ impl Interpreter {
                             continue;
                         }
                         if !self.env.contains_key_sym(*k) || self.env.get_sym(*k) != Some(v) {
-                            new_caps.regex_vars.insert(k.resolve(), v.clone());
+                            new_caps.regex_vars_mut().insert(k.resolve(), v.clone());
                         }
                     }
                     // The env diff above only sees a *change*. The scratch env is
@@ -756,11 +758,11 @@ impl Interpreter {
                         let Stmt::VarDecl { name, .. } = stmt else {
                             continue;
                         };
-                        if name == "_" || new_caps.regex_vars.contains_key(name) {
+                        if name == "_" || new_caps.regex_vars().contains_key(name) {
                             continue;
                         }
                         if let Some(v) = interp.env.get(name) {
-                            new_caps.regex_vars.insert(name.clone(), v.clone());
+                            new_caps.regex_vars_mut().insert(name.clone(), v.clone());
                         }
                     }
                     for (k, orig) in capture_saved {
@@ -838,7 +840,7 @@ impl Interpreter {
                 // action channel behave identically on both paths.
                 if let Some((inner_end, mut inner_caps)) = best {
                     if best_sym.is_some() {
-                        inner_caps.sym = best_sym;
+                        inner_caps.set_sym(best_sym);
                     }
                     return Self::build_named_candidates_from_inner(
                         vec![(inner_end, inner_caps)],
@@ -940,7 +942,7 @@ impl Interpreter {
                         && !spec.alias_replaces_original
                     {
                         new_caps
-                            .capture_alias_map
+                            .capture_alias_map_mut()
                             .insert(capture_name.to_string(), spec.lookup_name.clone());
                         new_caps
                             .named

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -314,18 +314,20 @@ impl Interpreter {
         stop_at_full: bool,
         sink: &mut MatchSink<'_>,
     ) -> bool {
-        let mut store = CapStore::new(RegexCaptures {
+        let mut base = RegexCaptures {
             match_from: start,
-            // Inline sub-patterns (lookaround/group/alternative) inherit the
-            // enclosing regex's `:my`/`:let` lexicals; a subrule does not. The
-            // seed is take-once, so only the store the arming site is about to
-            // build gets it.
-            regex_vars: super::regex_helpers::take_inline_regex_vars_seed(),
-            // Backreference read-through to the enclosing pattern level (see
-            // `OuterBackrefCaps`). Never published outward — cleared below.
-            outer_backref: super::regex_helpers::take_inline_outer_caps_seed(),
             ..Default::default()
-        });
+        };
+        // Inline sub-patterns (lookaround/group/alternative) inherit the
+        // enclosing regex's `:my`/`:let` lexicals; a subrule does not. The
+        // seed is take-once, so only the store the arming site is about to
+        // build gets it. Both of these go in the cold payload, which the
+        // seeded-empty common case therefore never allocates.
+        base.set_regex_vars_shared(super::regex_helpers::take_inline_regex_vars_seed());
+        // Backreference read-through to the enclosing pattern level (see
+        // `OuterBackrefCaps`). Never published outward — cleared below.
+        base.set_outer_backref(super::regex_helpers::take_inline_outer_caps_seed());
+        let mut store = CapStore::new(base);
         let ctx = WalkCtx {
             pattern,
             chars,
@@ -337,7 +339,7 @@ impl Interpreter {
         // must not travel out with this level's captures, so strip it from
         // every reported match on the way to the caller's sink.
         let mut strip = |interp: &mut Interpreter, end: usize, mut caps: RegexCaptures| -> bool {
-            caps.outer_backref = None;
+            caps.set_outer_backref(None);
             sink.accept(interp, end, caps)
         };
         self.walk_tokens(&ctx, 0, start, &mut store, &mut MatchSink::Cont(&mut strip))

--- a/src/runtime/regex/regex_match_delta.rs
+++ b/src/runtime/regex/regex_match_delta.rs
@@ -41,14 +41,10 @@ pub(super) fn group_merge_delta(mut inner_caps: RegexCaptures) -> RegexCaptures 
     for (k, v) in inner_caps.named.drain() {
         new_caps.named.entry(k).or_default().merge(v);
     }
-    for (k, v) in inner_caps.capture_alias_map.drain() {
-        new_caps.capture_alias_map.insert(k, v);
-    }
+    new_caps.extend_capture_alias_map(inner_caps.take_capture_alias_map());
     new_caps.positional.append(&mut inner_caps.positional);
     super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
-    new_caps
-        .regex_vars
-        .extend(std::mem::take(&mut inner_caps.regex_vars));
+    new_caps.extend_regex_vars(inner_caps.take_regex_vars());
     if inner_caps.capture_start.is_some() {
         new_caps.capture_start = inner_caps.capture_start;
     }
@@ -68,7 +64,7 @@ pub(super) fn capture_group_delta(
     let mut new_caps = RegexCaptures::default();
     let mut inner_caps = inner_caps;
     super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
-    new_caps.regex_vars.extend(inner_caps.regex_vars.clone());
+    new_caps.extend_regex_vars(inner_caps.regex_vars().clone());
     let mut subcap = inner_caps;
     subcap.from = pos;
     subcap.to = end;
@@ -96,13 +92,9 @@ pub(super) fn alternation_branch_delta(
     for (k, v) in inner_caps.named.drain() {
         new_caps.named.entry(k).or_default().merge(v);
     }
-    for (k, v) in inner_caps.capture_alias_map.drain() {
-        new_caps.capture_alias_map.insert(k, v);
-    }
+    new_caps.extend_capture_alias_map(inner_caps.take_capture_alias_map());
     new_caps.positional.append(&mut inner_caps.positional);
     super::regex_helpers::adopt_inline_ast(&mut new_caps, &mut inner_caps);
-    new_caps
-        .regex_vars
-        .extend(std::mem::take(&mut inner_caps.regex_vars));
+    new_caps.extend_regex_vars(inner_caps.take_regex_vars());
     new_caps
 }

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -56,7 +56,7 @@ impl Interpreter {
             caps.from = caps.capture_start.unwrap_or(0);
             caps.to = caps.capture_end.unwrap_or(end);
             super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
-            caps.target = Some(target);
+            caps.set_target(Some(target));
             return Some(caps);
         }
 
@@ -76,7 +76,7 @@ impl Interpreter {
                 let (end, mut caps) = matches.swap_remove(0);
                 caps.from = caps.capture_start.unwrap_or(0);
                 caps.to = caps.capture_end.unwrap_or(end);
-                caps.target = Some(target);
+                caps.set_target(Some(target));
                 *partial = Some(caps);
             }
             return None;
@@ -84,7 +84,7 @@ impl Interpreter {
         let (end, mut caps) = matches.swap_remove(full_idx);
         caps.from = caps.capture_start.unwrap_or(0);
         caps.to = caps.capture_end.unwrap_or(end);
-        caps.target = Some(target);
+        caps.set_target(Some(target));
         Some(caps)
     }
 
@@ -130,7 +130,7 @@ impl Interpreter {
                     caps.from = caps.capture_start.unwrap_or(stripped_pos);
                     caps.to = caps.capture_end.unwrap_or(end);
                     super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
-                    caps.target = Some(target.clone());
+                    caps.set_target(Some(target.clone()));
                     caps
                 });
         }
@@ -138,7 +138,7 @@ impl Interpreter {
             .map(|(end, mut caps)| {
                 caps.from = caps.capture_start.unwrap_or(pos);
                 caps.to = caps.capture_end.unwrap_or(end);
-                caps.target = Some(target.clone());
+                caps.set_target(Some(target.clone()));
                 caps
             })
     }
@@ -187,7 +187,7 @@ impl Interpreter {
                     caps.from = caps.capture_start.unwrap_or(start);
                     caps.to = caps.capture_end.unwrap_or(end);
                     super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
-                    caps.target = Some(target.clone());
+                    caps.set_target(Some(target.clone()));
                     return Some(caps);
                 }
             }
@@ -200,7 +200,7 @@ impl Interpreter {
             {
                 caps.from = caps.capture_start.unwrap_or(start);
                 caps.to = caps.capture_end.unwrap_or(end);
-                caps.target = Some(target.clone());
+                caps.set_target(Some(target.clone()));
                 return Some(caps);
             }
         }
@@ -300,7 +300,7 @@ impl Interpreter {
                     caps.from = caps.capture_start.unwrap_or(start);
                     caps.to = caps.capture_end.unwrap_or(end);
                     super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
-                    caps.target = Some(target.clone());
+                    caps.set_target(Some(target.clone()));
                     if skip_covered {
                         if caps.from < last_end {
                             break;
@@ -341,7 +341,7 @@ impl Interpreter {
             for (end, mut caps) in ends {
                 caps.from = caps.capture_start.unwrap_or(start);
                 caps.to = caps.capture_end.unwrap_or(end);
-                caps.target = Some(target.clone());
+                caps.set_target(Some(target.clone()));
                 // A capture group can report a span starting BEFORE this start
                 // position (`caps.capture_start`), so the barrier is re-tested
                 // against the reported span, not against `start`.

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -167,7 +167,7 @@ impl Interpreter {
         caps: &RegexCaptures,
         already_handled: &HashSet<String>,
     ) {
-        for (name, value) in &caps.regex_vars {
+        for (name, value) in caps.regex_vars() {
             if already_handled.contains(name)
                 || super::regex_helpers::is_dynamic_regex_var_key(name)
             {
@@ -208,7 +208,7 @@ impl Interpreter {
                         caps.from = caps.capture_start.unwrap_or(0);
                         caps.to = caps.capture_end.unwrap_or(end);
                         super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
-                        caps.target = Some(target.clone());
+                        caps.set_target(Some(target.clone()));
                         caps
                     });
             }
@@ -222,7 +222,7 @@ impl Interpreter {
                     caps.from = caps.capture_start.unwrap_or(start);
                     caps.to = caps.capture_end.unwrap_or(end);
                     super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
-                    caps.target = Some(target.clone());
+                    caps.set_target(Some(target.clone()));
                     return Some(caps);
                 }
             }
@@ -260,7 +260,7 @@ impl Interpreter {
                         caps.from = caps.capture_start.unwrap_or(0);
                         caps.to = end_pos;
                         super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
-                        caps.target = Some(target.clone());
+                        caps.set_target(Some(target.clone()));
                         Some(caps)
                     });
             }
@@ -283,7 +283,7 @@ impl Interpreter {
                     caps.from = caps.capture_start.unwrap_or(start);
                     caps.to = end_pos;
                     super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
-                    caps.target = Some(target.clone());
+                    caps.set_target(Some(target.clone()));
                     return Some(caps);
                 }
             }
@@ -297,7 +297,7 @@ impl Interpreter {
                 .map(|(end, mut caps)| {
                     caps.from = caps.capture_start.unwrap_or(0);
                     caps.to = caps.capture_end.unwrap_or(end);
-                    caps.target = Some(target.clone());
+                    caps.set_target(Some(target.clone()));
                     caps
                 });
         }
@@ -307,7 +307,7 @@ impl Interpreter {
             {
                 caps.from = caps.capture_start.unwrap_or(start);
                 caps.to = caps.capture_end.unwrap_or(end);
-                caps.target = Some(target.clone());
+                caps.set_target(Some(target.clone()));
                 return Some(caps);
             }
         }
@@ -391,13 +391,13 @@ impl Interpreter {
             if let Some(mut best) = best {
                 // Store the winning :sym<> variant name
                 if best_sym.is_some() {
-                    best.sym = best_sym.clone();
+                    best.set_sym(best_sym.clone());
                 }
                 // Ensure subcapture exists for the subrule so sym_variant
                 // propagates to the child Match object via make_subcap_match
                 if !spec.silent {
                     let mut subcap = best.clone();
-                    subcap.sym = best_sym;
+                    subcap.set_sym(best_sym);
                     best.named
                         .entry(Symbol::intern(&spec.lookup_name))
                         .or_default()
@@ -564,12 +564,12 @@ impl Interpreter {
                 // and deliberately leaves it installed for the action walk. Only
                 // the plain lexicals belong here.
                 if super::regex_helpers::is_dynamic_regex_var_key(name)
-                    || caps.regex_vars.contains_key(name)
+                    || caps.regex_vars().contains_key(name)
                 {
                     continue;
                 }
                 if let Some(v) = self.env.get(name).cloned() {
-                    caps.regex_vars.insert(name.clone(), v);
+                    caps.regex_vars_mut().insert(name.clone(), v);
                 }
             }
         }

--- a/src/runtime/regex/regex_match_sep.rs
+++ b/src/runtime/regex/regex_match_sep.rs
@@ -460,8 +460,8 @@ impl Interpreter {
                 slot.merge(v.clone());
                 slot.quantified = true;
             }
-            for (k, v) in &src.hash_captures {
-                caps.hash_captures
+            for (k, v) in src.hash_captures() {
+                caps.hash_captures_mut()
                     .entry(k.clone())
                     .or_default()
                     .extend(v.clone());

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -661,7 +661,7 @@ impl Interpreter {
         // a subrule argument `<sequence($new-indent)>`, a `<{ … }>` interpolation,
         // a dynamic quantifier — reads the value the regex computed rather than an
         // outer variable of the same name (or nothing at all).
-        for (k, v) in &caps.regex_vars {
+        for (k, v) in caps.regex_vars() {
             env.insert(k.clone(), v.clone());
         }
         env

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -141,7 +141,7 @@ impl Interpreter {
         let Some((end, mut caps)) = matches.into_iter().next() else {
             return Ok(Value::NIL);
         };
-        caps.target = Some(target.clone());
+        caps.set_target(Some(target.clone()));
         let m = Value::make_match_object_full(
             pos as i64,
             end as i64,
@@ -278,7 +278,7 @@ impl Interpreter {
                 ..RegexCaptures::default()
             },
         };
-        let sym = inner_caps.sym.clone();
+        let sym = inner_caps.sym().cloned();
         Some(Self::build_named_candidates_from_inner(
             vec![(to_abs, inner_caps)],
             pos,

--- a/src/runtime/regex/regex_trail.rs
+++ b/src/runtime/regex/regex_trail.rs
@@ -140,30 +140,30 @@ impl CapStore {
                 }
                 Undo::HashCapTrunc { key, len, present } => {
                     if !present {
-                        caps.hash_captures.remove(&key);
-                    } else if let Some(v) = caps.hash_captures.get_mut(&key) {
+                        caps.hash_captures_mut().remove(&key);
+                    } else if let Some(v) = caps.hash_captures_mut().get_mut(&key) {
                         v.truncate(len);
                     }
                 }
                 Undo::AliasRestore { key, prev } => match prev {
                     Some(v) => {
-                        caps.capture_alias_map.insert(key, v);
+                        caps.capture_alias_map_mut().insert(key, v);
                     }
                     None => {
-                        caps.capture_alias_map.remove(&key);
+                        caps.capture_alias_map_mut().remove(&key);
                     }
                 },
                 Undo::RegexVarRestore { key, prev } => match prev {
                     Some(v) => {
-                        caps.regex_vars.insert(key, v);
+                        caps.regex_vars_mut().insert(key, v);
                     }
                     None => {
-                        caps.regex_vars.remove(&key);
+                        caps.regex_vars_mut().remove(&key);
                     }
                 },
                 Undo::CaptureStart(prev) => caps.capture_start = prev,
                 Undo::CaptureEnd(prev) => caps.capture_end = prev,
-                Undo::Sym(prev) => caps.sym = prev,
+                Undo::Sym(prev) => caps.set_sym(prev),
                 Undo::Ast(prev) => caps.ast = prev,
             }
         }
@@ -189,7 +189,7 @@ impl CapStore {
     }
 
     fn record_hash_cap_key(&mut self, key: &str) {
-        let (len, present) = match self.caps.hash_captures.get(key) {
+        let (len, present) = match self.caps.hash_captures().get(key) {
             Some(v) => (v.len(), true),
             None => (0, false),
         };
@@ -213,19 +213,23 @@ impl CapStore {
             slot.nodes.extend(v.nodes);
             slot.quantified |= v.quantified;
         }
-        for (k, v) in delta.capture_alias_map.drain() {
+        for (k, v) in delta.take_capture_alias_map() {
             self.insert_alias(k, v);
         }
         if !delta.positional.is_empty() {
             self.record_pos_lens();
             self.caps.positional.append(&mut delta.positional);
         }
-        for (k, v) in delta.hash_captures.drain() {
+        for (k, v) in delta.take_hash_captures() {
             self.record_hash_cap_key(&k);
-            self.caps.hash_captures.entry(k).or_default().extend(v);
+            self.caps
+                .hash_captures_mut()
+                .entry(k)
+                .or_default()
+                .extend(v);
         }
-        for (k, v) in delta.regex_vars.drain() {
-            let prev = self.caps.regex_vars.insert(k.clone(), v);
+        for (k, v) in delta.take_regex_vars() {
+            let prev = self.caps.regex_vars_mut().insert(k.clone(), v);
             self.trail.push(Undo::RegexVarRestore { key: k, prev });
         }
         if delta.capture_start.is_some() {
@@ -236,9 +240,9 @@ impl CapStore {
             self.trail.push(Undo::CaptureEnd(self.caps.capture_end));
             self.caps.capture_end = delta.capture_end;
         }
-        if delta.sym.is_some() {
-            self.trail.push(Undo::Sym(self.caps.sym.take()));
-            self.caps.sym = delta.sym;
+        if delta.sym().is_some() {
+            self.trail.push(Undo::Sym(self.caps.take_sym()));
+            self.caps.set_sym(delta.take_sym());
         }
         // An inline `{ make … }` in this pattern (or in a `[ … ]` group / `|`
         // branch of it, whose captures merge into this level) sets the value of
@@ -267,14 +271,14 @@ impl CapStore {
     }
 
     pub(super) fn insert_alias(&mut self, key: String, val: String) {
-        let prev = self.caps.capture_alias_map.insert(key.clone(), val);
+        let prev = self.caps.capture_alias_map_mut().insert(key.clone(), val);
         self.trail.push(Undo::AliasRestore { key, prev });
     }
 
     pub(super) fn push_hash_capture(&mut self, key: &str, entry: (String, Option<String>)) {
         self.record_hash_cap_key(key);
         self.caps
-            .hash_captures
+            .hash_captures_mut()
             .entry(key.to_string())
             .or_default()
             .push(entry);
@@ -383,7 +387,7 @@ mod tests {
         assert_eq!(store.caps().named[&x].nodes.len(), 1);
         assert!(!store.caps().named[&x].quantified);
         assert!(store.caps().capture_start.is_none());
-        assert!(store.caps().sym.is_none());
+        assert!(store.caps().sym().is_none());
     }
 
     #[test]
@@ -401,7 +405,7 @@ mod tests {
         y.merge(NamedSlot::leaf(3, 4));
         y.quantified = true;
         delta.capture_start = Some(3);
-        delta.sym = Some("s".to_string());
+        delta.set_sym(Some("s".to_string()));
         store.merge_delta(delta);
         assert_eq!(store.caps().positional.len(), 2);
         let x = Symbol::intern("x");
@@ -410,7 +414,7 @@ mod tests {
         assert_eq!(store.caps().named[&y].nodes.len(), 1);
         assert!(store.caps().named[&y].quantified);
         assert_eq!(store.caps().capture_start, Some(3));
-        assert_eq!(store.caps().sym.as_deref(), Some("s"));
+        assert_eq!(store.caps().sym().map(String::as_str), Some("s"));
         store.rewind(m);
         assert_base(&store);
         assert!(!store.caps().named.contains_key(&y));

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -247,8 +247,8 @@ impl RegexCaptures {
     /// The subject this capture tree was published with (set by the engine
     /// entry point), else one built fresh from `text` (ADR-0016 P3).
     pub(crate) fn target_or_new(&self, text: &str) -> crate::runtime::MatchTarget {
-        self.target
-            .clone()
+        self.target()
+            .cloned()
             .unwrap_or_else(|| crate::runtime::MatchTarget::new(text))
     }
 
@@ -261,8 +261,7 @@ impl RegexCaptures {
 
     /// The text of an arbitrary recorded span through the published subject.
     pub(crate) fn span_text(&self, from: usize, to: usize) -> String {
-        self.target
-            .as_ref()
+        self.target()
             .map(|t| t.span_str(from, to))
             .unwrap_or_default()
     }
@@ -277,27 +276,119 @@ impl RegexCaptures {
     /// fields nothing reads through a stored node (`hash_captures`,
     /// `positional_slots`, `capture_start`/`capture_end`, `match_from`). The
     /// child payload is allocated only when something would go in it.
-    pub(crate) fn into_cap_node(self) -> CapNode {
+    pub(crate) fn into_cap_node(mut self) -> CapNode {
+        // Take the cold payload whole: a leaf (the common case) never had one,
+        // so the conversion neither allocates nor touches the fields below.
+        let rare = self.rare.take().map(|rare| *rare);
+        let (capture_alias_map, regex_vars, sym, action_name) = match rare {
+            Some(rare) => (
+                rare.capture_alias_map,
+                rare.regex_vars,
+                rare.sym,
+                rare.action_name,
+            ),
+            None => Default::default(),
+        };
         let has_children = !self.named.is_empty()
-            || !self.capture_alias_map.is_empty()
+            || !capture_alias_map.is_empty()
             || !self.positional.is_empty()
-            || !self.regex_vars.is_empty();
+            || regex_vars.as_ref().is_some_and(|vars| !vars.is_empty());
         let children = has_children.then(|| {
             Box::new(CapChildren {
                 named: self.named,
-                capture_alias_map: self.capture_alias_map,
+                capture_alias_map,
                 positional: self.positional,
-                regex_vars: self.regex_vars,
+                regex_vars: regex_vars.map(Arc::unwrap_or_clone).unwrap_or_default(),
             })
         });
         CapNode {
             from: self.from,
             to: self.to,
-            sym: self.sym,
-            action_name: self.action_name,
+            sym,
+            action_name,
             ast: self.ast,
             children,
         }
+    }
+}
+
+/// The hash-capture map shape (`%<name>=(...)` aliasing in regex).
+pub(crate) type HashCaptureMap = HashMap<String, Vec<(String, Option<String>)>>;
+
+/// The capture-alias map shape (`<str=.str_escape>` → original rule name).
+pub(crate) type CaptureAliasMap = HashMap<String, String>;
+
+/// The cold half of [`RegexCaptures`], behind one allocation that most
+/// accumulators never make.
+///
+/// The engine constructs, moves, clones and drops a `RegexCaptures` **per
+/// match candidate** — millions of times over one grammar parse — while every
+/// field in here is written by a minority of patterns: `:my` declarators,
+/// capture aliases, `%<name>=` hash captures, the pcre2/`:P5` slot axis, a
+/// protoregex `:sym<>` win, and the two engine-entry-point links (`target`,
+/// `outer_backref`). Keeping them inline made the accumulator 336 bytes, so
+/// the per-candidate `memcpy` traffic and three `HashMap` drops were paid by
+/// every candidate to carry state almost none of them had
+/// ([#7576](https://github.com/tokuhirom/mutsu/issues/7576) item 4). This is
+/// the ADR-0016 P2 [`CapNode`]/[`CapChildren`] split applied one level up, to
+/// the accumulator instead of the stored node.
+///
+/// Reach it through the accessors on [`RegexCaptures`]: the `_mut` ones
+/// materialize the payload, the read-only ones hand back a shared empty value
+/// when it was never allocated.
+#[derive(Clone, Default)]
+pub(crate) struct RareCaps {
+    /// Unnamed capture slots by capture index (for $0, $1, ...) as recorded
+    /// spans, where `None` represents an unmatched capture. A separate
+    /// numbering axis from `positional` (it has `None` holes where
+    /// `positional` has no entry at all); written only by the pcre2/`:P5`
+    /// path.
+    pub(crate) positional_slots: Vec<Option<(usize, usize)>>,
+    /// Variables declared via `:my $var = expr;` inside regex.
+    /// These are made available to `<{ code }>` closures.
+    ///
+    /// Shared rather than owned: every inline sub-pattern (a group, an
+    /// alternative, a lookaround body) publishes the lexicals in scope to the
+    /// store it is about to build, and doing that by value cloned the whole
+    /// map per atom match — 1.25% of a YAML parse in `arm_inline_vars_seed`
+    /// alone. An `Arc` makes arming and seeding refcount bumps; the copy is
+    /// paid only by a level that actually writes a lexical, through
+    /// `Arc::make_mut`.
+    pub(crate) regex_vars: Option<Arc<RegexVarMap>>,
+    /// The winning :sym<> variant name, if this match was from a protoregex.
+    pub(crate) sym: Option<String>,
+    /// For aliased captures like `<str=.str_escape>`, maps capture name to
+    /// original rule name for grammar action dispatch.
+    pub(crate) capture_alias_map: CaptureAliasMap,
+    /// The original rule name when this capture was stored under an alias.
+    pub(crate) action_name: Option<String>,
+    /// Hash captures from `%<name>=(...)` aliasing in regex.
+    pub(crate) hash_captures: HashCaptureMap,
+    /// The shared subject this match ran against (ADR-0016 P3). Set once by
+    /// the engine entry point on the returned top-level accumulator — the
+    /// engine itself never touches it. Consumers derive captured text from
+    /// recorded spans through it instead of a stored `matched` string.
+    pub(crate) target: Option<crate::runtime::MatchTarget>,
+    /// The enclosing pattern level's captures, for backreference READS only
+    /// (see [`OuterBackrefCaps`]). Set once on a nested walk's base store and
+    /// never merged, propagated, or published — it is a read-through link to
+    /// the parent walk, not a capture of this level.
+    pub(crate) outer_backref: Option<Arc<OuterBackrefCaps>>,
+}
+
+impl RareCaps {
+    /// True when nothing is left worth keeping the allocation for. Checked
+    /// after a drain/take so a payload that has been emptied out again does
+    /// not make every later clone copy an empty one.
+    fn is_empty(&self) -> bool {
+        self.positional_slots.is_empty()
+            && self.regex_vars.as_ref().is_none_or(|vars| vars.is_empty())
+            && self.sym.is_none()
+            && self.capture_alias_map.is_empty()
+            && self.action_name.is_none()
+            && self.hash_captures.is_empty()
+            && self.target.is_none()
+            && self.outer_backref.is_none()
     }
 }
 
@@ -309,12 +400,6 @@ pub(crate) struct RegexCaptures {
     /// Positional captures as span-bearing slots (ADR-0016 P4): span, nested
     /// subcaptures, quantified iteration lists, and the Nil marker in one axis.
     pub(crate) positional: Vec<PosSlot>,
-    /// Unnamed capture slots by capture index (for $0, $1, ...) as recorded
-    /// spans, where `None` represents an unmatched capture. A separate
-    /// numbering axis from `positional` (it has `None` holes where
-    /// `positional` has no entry at all); written only by the pcre2/`:P5`
-    /// path.
-    pub(crate) positional_slots: Vec<Option<(usize, usize)>>,
     pub(crate) from: usize,
     pub(crate) to: usize,
     pub(crate) capture_start: Option<usize>,
@@ -323,34 +408,238 @@ pub(crate) struct RegexCaptures {
     /// Set at the beginning of regex matching to allow code blocks to compute
     /// the matched-so-far text.
     pub(crate) match_from: usize,
-    /// Variables declared via `:my $var = expr;` inside regex.
-    /// These are made available to `<{ code }>` closures.
-    pub(crate) regex_vars: HashMap<String, Value>,
-    /// The winning :sym<> variant name, if this match was from a protoregex.
-    pub(crate) sym: Option<String>,
-    /// For aliased captures like `<str=.str_escape>`, maps capture name to
-    /// original rule name for grammar action dispatch.
-    pub(crate) capture_alias_map: HashMap<String, String>,
-    /// The original rule name when this capture was stored under an alias.
-    pub(crate) action_name: Option<String>,
-    /// Hash captures from `%<name>=(...)` aliasing in regex.
-    pub(crate) hash_captures: HashMap<String, Vec<(String, Option<String>)>>,
     /// The AST value produced by this node's inline `{ make … }` code block(s),
     /// computed at reduce time (`reduce_regex_captures_made`). Carried into the
     /// Match object built by `make_match_object_full_q` so `$<sub>.made` /
     /// `$<sub>».made` resolve in a parent inline action and post-parse. `None`
     /// when the rule ran no `make`.
     pub(crate) ast: Option<Value>,
-    /// The shared subject this match ran against (ADR-0016 P3). Set once by
-    /// the engine entry point on the returned top-level accumulator — the
-    /// engine itself never touches it. Consumers derive captured text from
-    /// recorded spans through it instead of a stored `matched` string.
-    pub(crate) target: Option<crate::runtime::MatchTarget>,
-    /// The enclosing pattern level's captures, for backreference READS only
-    /// (see [`OuterBackrefCaps`]). Set once on a nested walk's base store and
-    /// never merged, propagated, or published — it is a read-through link to
-    /// the parent walk, not a capture of this level.
-    pub(crate) outer_backref: Option<Arc<OuterBackrefCaps>>,
+    /// The cold fields, allocated on first write (see [`RareCaps`]).
+    pub(crate) rare: Option<Box<RareCaps>>,
+}
+
+static EMPTY_REGEX_VARS: std::sync::LazyLock<RegexVarMap> =
+    std::sync::LazyLock::new(RegexVarMap::default);
+static EMPTY_HASH_CAPTURES: std::sync::LazyLock<HashCaptureMap> =
+    std::sync::LazyLock::new(HashCaptureMap::default);
+
+impl RegexCaptures {
+    /// The cold payload, if this accumulator ever wrote one.
+    #[inline]
+    pub(crate) fn rare(&self) -> Option<&RareCaps> {
+        self.rare.as_deref()
+    }
+
+    /// The cold payload, allocating it on first use. Prefer the read-only
+    /// accessors on a path that only inspects — this is what turns a
+    /// few-word accumulator back into an allocating one.
+    #[inline]
+    pub(crate) fn rare_mut(&mut self) -> &mut RareCaps {
+        self.rare.get_or_insert_with(Default::default)
+    }
+
+    /// Drop the payload again if a drain/take emptied it.
+    #[inline]
+    pub(crate) fn prune_rare(&mut self) {
+        if self.rare.as_deref().is_some_and(RareCaps::is_empty) {
+            self.rare = None;
+        }
+    }
+
+    #[inline]
+    pub(crate) fn regex_vars(&self) -> &RegexVarMap {
+        self.rare()
+            .and_then(|rare| rare.regex_vars.as_deref())
+            .unwrap_or(&EMPTY_REGEX_VARS)
+    }
+
+    /// The shared handle, for publishing these lexicals to an inline
+    /// sub-pattern without copying them.
+    #[inline]
+    pub(crate) fn regex_vars_shared(&self) -> Option<&Arc<RegexVarMap>> {
+        self.rare()
+            .and_then(|rare| rare.regex_vars.as_ref())
+            .filter(|vars| !vars.is_empty())
+    }
+
+    /// Adopt an already-shared lexical map wholesale (the inline-sub-pattern
+    /// seed). Replaces whatever this accumulator held.
+    pub(crate) fn set_regex_vars_shared(&mut self, vars: Option<Arc<RegexVarMap>>) {
+        match vars {
+            Some(vars) if !vars.is_empty() => self.rare_mut().regex_vars = Some(vars),
+            _ => {
+                if let Some(rare) = self.rare.as_deref_mut() {
+                    rare.regex_vars = None;
+                }
+                self.prune_rare();
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn regex_vars_mut(&mut self) -> &mut RegexVarMap {
+        Arc::make_mut(
+            self.rare_mut()
+                .regex_vars
+                .get_or_insert_with(Default::default),
+        )
+    }
+
+    /// Move the `:my` variable map out, leaving an empty one behind.
+    pub(crate) fn take_regex_vars(&mut self) -> RegexVarMap {
+        let taken = self
+            .rare
+            .as_deref_mut()
+            .and_then(|rare| rare.regex_vars.take());
+        self.prune_rare();
+        // Free while this level owned the only handle, which is the usual case
+        // — a shared one means an inline sub-pattern is reading it right now.
+        taken.map(Arc::unwrap_or_clone).unwrap_or_default()
+    }
+
+    /// Merge another accumulator's `:my` variables into this one, without
+    /// allocating a payload when there is nothing to merge.
+    pub(crate) fn extend_regex_vars<I: IntoIterator<Item = (String, Value)>>(&mut self, vars: I) {
+        let mut it = vars.into_iter();
+        let Some(first) = it.next() else { return };
+        let dst = self.regex_vars_mut();
+        dst.insert(first.0, first.1);
+        dst.extend(it);
+    }
+
+    #[inline]
+    pub(crate) fn capture_alias_map_mut(&mut self) -> &mut CaptureAliasMap {
+        &mut self.rare_mut().capture_alias_map
+    }
+
+    /// Merge another accumulator's capture aliases into this one, without
+    /// allocating a payload when there is nothing to merge.
+    pub(crate) fn extend_capture_alias_map<I: IntoIterator<Item = (String, String)>>(
+        &mut self,
+        aliases: I,
+    ) {
+        let mut it = aliases.into_iter();
+        let Some(first) = it.next() else { return };
+        let dst = self.capture_alias_map_mut();
+        dst.insert(first.0, first.1);
+        dst.extend(it);
+    }
+
+    /// Move the capture-alias map out, leaving an empty one behind.
+    pub(crate) fn take_capture_alias_map(&mut self) -> CaptureAliasMap {
+        let taken = self
+            .rare
+            .as_deref_mut()
+            .map(|rare| std::mem::take(&mut rare.capture_alias_map))
+            .unwrap_or_default();
+        self.prune_rare();
+        taken
+    }
+
+    #[inline]
+    pub(crate) fn hash_captures(&self) -> &HashCaptureMap {
+        self.rare()
+            .map_or(&EMPTY_HASH_CAPTURES, |rare| &rare.hash_captures)
+    }
+
+    #[inline]
+    pub(crate) fn hash_captures_mut(&mut self) -> &mut HashCaptureMap {
+        &mut self.rare_mut().hash_captures
+    }
+
+    /// Move the hash-capture map out, leaving an empty one behind.
+    pub(crate) fn take_hash_captures(&mut self) -> HashCaptureMap {
+        let taken = self
+            .rare
+            .as_deref_mut()
+            .map(|rare| std::mem::take(&mut rare.hash_captures))
+            .unwrap_or_default();
+        self.prune_rare();
+        taken
+    }
+
+    /// Fold another accumulator's hash captures into this one (per-name append),
+    /// without allocating a payload when there is nothing to fold.
+    pub(crate) fn merge_hash_captures(&mut self, other: HashCaptureMap) {
+        if other.is_empty() {
+            return;
+        }
+        let dst = self.hash_captures_mut();
+        for (k, v) in other {
+            dst.entry(k).or_default().extend(v);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn positional_slots(&self) -> &[Option<(usize, usize)>] {
+        self.rare().map_or(&[], |rare| &rare.positional_slots)
+    }
+
+    #[inline]
+    pub(crate) fn positional_slots_mut(&mut self) -> &mut Vec<Option<(usize, usize)>> {
+        &mut self.rare_mut().positional_slots
+    }
+
+    #[inline]
+    pub(crate) fn sym(&self) -> Option<&String> {
+        self.rare().and_then(|rare| rare.sym.as_ref())
+    }
+
+    /// Set (or clear) the winning `:sym<>` variant name. Clearing an
+    /// accumulator that never had a payload does not allocate one.
+    pub(crate) fn set_sym(&mut self, sym: Option<String>) {
+        if sym.is_none() && self.rare.is_none() {
+            return;
+        }
+        self.rare_mut().sym = sym;
+        self.prune_rare();
+    }
+
+    /// Move the `:sym<>` variant name out.
+    pub(crate) fn take_sym(&mut self) -> Option<String> {
+        let taken = self.rare.as_deref_mut().and_then(|rare| rare.sym.take());
+        self.prune_rare();
+        taken
+    }
+
+    /// Set (or clear) the aliased-capture rule name. Clearing an accumulator
+    /// that never had a payload does not allocate one.
+    pub(crate) fn set_action_name(&mut self, action_name: Option<String>) {
+        if action_name.is_none() && self.rare.is_none() {
+            return;
+        }
+        self.rare_mut().action_name = action_name;
+        self.prune_rare();
+    }
+
+    #[inline]
+    pub(crate) fn target(&self) -> Option<&crate::runtime::MatchTarget> {
+        self.rare().and_then(|rare| rare.target.as_ref())
+    }
+
+    /// Publish the shared subject on this accumulator (ADR-0016 P3).
+    pub(crate) fn set_target(&mut self, target: Option<crate::runtime::MatchTarget>) {
+        if target.is_none() && self.rare.is_none() {
+            return;
+        }
+        self.rare_mut().target = target;
+        self.prune_rare();
+    }
+
+    #[inline]
+    pub(crate) fn outer_backref(&self) -> Option<&Arc<OuterBackrefCaps>> {
+        self.rare().and_then(|rare| rare.outer_backref.as_ref())
+    }
+
+    /// Link this level's base store to the enclosing pattern level, for
+    /// backreference reads only.
+    pub(crate) fn set_outer_backref(&mut self, outer: Option<Arc<OuterBackrefCaps>>) {
+        if outer.is_none() && self.rare.is_none() {
+            return;
+        }
+        self.rare_mut().outer_backref = outer;
+        self.prune_rare();
+    }
 }
 
 #[cfg(test)]
@@ -383,6 +672,62 @@ mod cap_node_tests {
         let node = caps.into_cap_node();
         assert!(node.children.is_none());
         assert_eq!((node.from, node.to), (3, 4));
+    }
+
+    /// #7576 item 4: the engine constructs, moves, clones and drops one of
+    /// these per match candidate — millions of times over a grammar parse — so
+    /// its size is the per-candidate `memcpy` bill. It was 336 bytes with the
+    /// cold fields inline. If a change pushes it past this, the new field
+    /// almost certainly belongs in [`RareCaps`].
+    #[test]
+    fn regex_captures_size_guard() {
+        assert!(
+            std::mem::size_of::<RegexCaptures>() <= 128,
+            "RegexCaptures grew to {} bytes",
+            std::mem::size_of::<RegexCaptures>()
+        );
+    }
+
+    /// The point of the split: an accumulator that took no cold-field write
+    /// never allocates the payload, and reading one back gives the empty
+    /// value rather than allocating one to look at.
+    #[test]
+    fn plain_accumulator_allocates_no_rare_payload() {
+        let mut caps = RegexCaptures::default();
+        assert!(caps.rare().is_none());
+        assert!(caps.regex_vars().is_empty());
+        assert!(caps.hash_captures().is_empty());
+        assert!(caps.positional_slots().is_empty());
+        assert!(caps.sym().is_none());
+        assert!(caps.target().is_none());
+        assert!(caps.outer_backref().is_none());
+        // Clearing an absent field, and merging in nothing, stay allocation-free.
+        caps.set_sym(None);
+        caps.set_target(None);
+        caps.set_outer_backref(None);
+        caps.extend_regex_vars(RegexVarMap::default());
+        caps.extend_capture_alias_map(CaptureAliasMap::default());
+        caps.merge_hash_captures(HashCaptureMap::default());
+        assert!(caps.rare().is_none());
+        assert!(caps.take_regex_vars().is_empty());
+        assert!(caps.rare().is_none());
+    }
+
+    /// A write materializes the payload; emptying it again drops it, so a
+    /// drained accumulator does not make every later clone copy an empty one.
+    #[test]
+    fn rare_payload_is_dropped_once_emptied() {
+        let mut caps = RegexCaptures::default();
+        caps.regex_vars_mut()
+            .insert("$x".to_string(), Value::int(1));
+        assert!(caps.rare().is_some());
+        assert_eq!(caps.take_regex_vars().len(), 1);
+        assert!(caps.rare().is_none());
+
+        caps.set_sym(Some("foo".to_string()));
+        assert_eq!(caps.sym().map(String::as_str), Some("foo"));
+        caps.set_sym(None);
+        assert!(caps.rare().is_none());
     }
 }
 

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -73,9 +73,9 @@ impl Interpreter {
         attrs.insert("str".to_string(), Value::str(captures.matched_text()));
         attrs.insert("from".to_string(), Value::int(captures.from as i64));
         attrs.insert("to".to_string(), Value::int(captures.to as i64));
-        let positional: Vec<Value> = if !captures.positional_slots.is_empty() {
+        let positional: Vec<Value> = if !captures.positional_slots().is_empty() {
             captures
-                .positional_slots
+                .positional_slots()
                 .iter()
                 .map(|slot| match slot {
                     Some((from, to)) => {
@@ -109,7 +109,7 @@ impl Interpreter {
             }
         }
         // Add hash captures from %<name>=(...) aliasing
-        for (hash_name, entries) in &captures.hash_captures {
+        for (hash_name, entries) in captures.hash_captures() {
             let mut hash_map: HashMap<String, Value> = HashMap::new();
             for (key, value) in entries {
                 let val: Value = match value {
@@ -127,14 +127,14 @@ impl Interpreter {
         // Reset stale numeric/named captures before applying new ones.
         self.reset_capture_env_vars();
 
-        for (i, slot) in captures.positional_slots.iter().enumerate() {
+        for (i, slot) in captures.positional_slots().iter().enumerate() {
             let value = match slot {
                 Some((from, to)) => make_capture_match(&captures.span_text(*from, *to), *from, *to),
                 None => Value::NIL,
             };
             self.env.insert(i.to_string(), value);
         }
-        if captures.positional_slots.is_empty() {
+        if captures.positional_slots().is_empty() {
             self.env.insert("0".to_string(), Value::NIL);
         }
         // Set named capture env vars from the match object's named hash
@@ -490,17 +490,17 @@ impl Interpreter {
         let mut out = RegexCaptures {
             from: to_char(m0.start()),
             to: to_char(m0.end()),
-            target: Some(crate::runtime::MatchTarget::new(text)),
             ..RegexCaptures::default()
         };
+        out.set_target(Some(crate::runtime::MatchTarget::new(text)));
         for idx in 1..locs.len() {
             if names.get(idx).is_some_and(Option::is_none) {
                 if let Some((start, end)) = locs.get(idx) {
                     let (cs, ce) = (to_char(start), to_char(end));
                     out.positional.push(crate::runtime::PosSlot::span(cs, ce));
-                    out.positional_slots.push(Some((cs, ce)));
+                    out.positional_slots_mut().push(Some((cs, ce)));
                 } else {
-                    out.positional_slots.push(None);
+                    out.positional_slots_mut().push(None);
                 }
                 continue;
             }
@@ -543,9 +543,9 @@ impl Interpreter {
             let mut item = RegexCaptures {
                 from: to_char(m0.start()),
                 to: to_char(m0.end()),
-                target: Some(target.clone()),
                 ..RegexCaptures::default()
             };
+            item.set_target(Some(target.clone()));
             for idx in 1..locs.len() {
                 if names.get(idx).is_some_and(Option::is_none) {
                     if let Some((c_start, c_end)) = locs.get(idx) {
@@ -554,9 +554,9 @@ impl Interpreter {
                         }
                         let (cs, ce) = (to_char(c_start), to_char(c_end));
                         item.positional.push(crate::runtime::PosSlot::span(cs, ce));
-                        item.positional_slots.push(Some((cs, ce)));
+                        item.positional_slots_mut().push(Some((cs, ce)));
                     } else {
-                        item.positional_slots.push(None);
+                        item.positional_slots_mut().push(None);
                     }
                     continue;
                 }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -986,7 +986,7 @@ impl Interpreter {
                     self.reduce_regex_captures_made(&mut captures, Some(&starget));
                     // Merge hash captures into named for Match object
                     let mut named_with_hash = captures.named.clone();
-                    for hash_name in captures.hash_captures.keys() {
+                    for hash_name in captures.hash_captures().keys() {
                         // Don't overwrite existing named captures; an empty
                         // placeholder slot makes the builder create the key.
                         named_with_hash
@@ -1001,13 +1001,13 @@ impl Interpreter {
                         starget,
                     );
                     // Apply hash captures: set named entries to Hash values
-                    if !captures.hash_captures.is_empty()
+                    if !captures.hash_captures().is_empty()
                         && let ValueView::Instance { attributes, .. } = match_obj.view()
                     {
                         attributes.with_attr_mut("named", |named| {
                             named.with_hash_mut(|named_hash| {
                                 let named_hash = crate::gc::Gc::make_mut(named_hash);
-                                for (hash_name, entries) in &captures.hash_captures {
+                                for (hash_name, entries) in captures.hash_captures() {
                                     let mut hash_map: HashMap<String, Value> = HashMap::new();
                                     for (key, value) in entries {
                                         let val = match value {


### PR DESCRIPTION
Round 15 of #7576, picking up **item 4** exactly as round 14 measured it.

`RegexCaptures` is the accumulator the regex engine builds for **one match candidate**, and a grammar parse constructs, moves, clones and drops millions of them — 2.59 M over the 60-row YAMLish document this ticket has been profiled against since round 10. It carried sixteen fields inline, including three `HashMap`s, and came to **336 bytes**, so every candidate paid a 336-byte `memcpy` and three empty-map drops to carry state almost none of them had.

Instructions retired on that document go **2,178,652,179 -> 2,010,535,421 (-7.72%)**. Attribution is callgrind Ir throughout (deterministic, load-independent), as in rounds 10-14, with the module precompilation cache warmed first per round 14's measurement note.

## (a) The cold fields move behind one boxed payload (-6.75%)

The ADR-0016 P2 `CapNode`/`CapChildren` split applied one level up, to the accumulator instead of the stored node. Eight fields written by a minority of patterns — `regex_vars`, `capture_alias_map`, `hash_captures`, `positional_slots`, `sym`, `action_name`, `target`, `outer_backref` — move into a `RareCaps` payload behind one `Option<Box<_>>`. **`RegexCaptures` is 336 -> 128 bytes.**

Call sites reach the fields through accessors: the read-only ones hand back a shared empty value when no payload was ever allocated (so `caps.regex_vars().is_empty()` on a plain candidate is a null check), the `_mut` ones materialize it. Two properties matter more than the size number:

- an accumulator that takes no cold-field write **never allocates** the payload;
- a payload that is drained or cleared again is **dropped**, so an accumulator that briefly held a `:my` variable does not make every later clone copy an empty one.

The merge paths were the subtle part. `dst.regex_vars_mut().extend(src)` would allocate a payload on `dst` even for an empty `src` — the common case — so the merges go through `extend_regex_vars` / `extend_capture_alias_map` / `merge_hash_captures`, which inspect the source first and return without touching `dst`. Likewise `delta.X_mut().drain()` grew a payload just to drain it empty; those are `take_X()` now.

Profile effect: `memcpy` **154,718,384 (7.10%) -> 77,609,917 (3.82%)**, `RawTable::drop` 54.1 M -> 34.9 M, `RawTable::clone` 34.0 M -> 28.5 M, `regex_walk_ends_in_pkg` 37.3 M -> 28.5 M.

## (b) …and the in-regex lexicals are shared, not copied per atom (-1.04%)

Round 14 named this as the item behind item 4: every inline sub-pattern (a group, an alternative, a lookaround body) publishes the `:my`/`:let` lexicals in scope to the store it is about to build, and `InlineVarsSeed::arm` did it by **cloning the whole map**, once per atom match, with `take_inline_regex_vars_seed` cloning it back out again. YAMLish computes its block indent in a `{ … }` inside a `<?before …>`, so its parse is exactly the shape that pays.

`RareCaps::regex_vars` is an `Option<Arc<RegexVarMap>>` now; arming and seeding are refcount bumps, and the copy is paid only by a level that actually writes a lexical, through `Arc::make_mut` — which is also what keeps the parent's map correct when a nested store writes, with no static analysis of who might mutate. `take_inline_regex_vars_seed` leaves the profile entirely (4.5 M -> not listed); `arm_inline_vars_seed` goes 24.3 M -> 20.7 M.

**A measured wrong turn worth recording:** the first version of (b) used a plain `Arc<RegexVarMap>` and read as a **0.7% regression** (2,031,713,138 -> 2,045,936,861), with `malloc` and `free` both up. `Arc<T>` has no empty representation, so `Arc::default()` *allocates* — and `RareCaps` constructs one on every payload materialization, turning an allocation-free `HashMap::default()` into a heap allocation. The `Option` wrapper is the difference between a win and a regression.

## Tests

Three new guards in `src/runtime/regex_types.rs`:

- `regex_captures_size_guard` — the accumulator stays <= 128 bytes, so the next field added has to answer the hot/cold question at compile time;
- `plain_accumulator_allocates_no_rare_payload` — reads, no-op clears and empty merges stay allocation-free;
- `rare_payload_is_dropped_once_emptied` — a drained payload is released again.

Run locally before publishing: `cargo fmt --all`, `make lint` (all four configurations), `make test` (4056 files, 43179 tests, all pass), `make roast` (green except the three documented container-only failures — `6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t` under `uid 0` and `S32-io/IO-Socket-Async.t` under the network sandbox; subtest ranges match `docs/agent-environments.md` exactly, no fourth file).

## What is left

The profile stays flat: `LocalKey::with` 7.3% across a dozen callers, the allocator ~19%, `memcpy` 3.9%, largest single mutsu function `regex_match_atom_all_with_capture_in_pkg_inner` at 1.85%. Untouched from round 14's list: `resolve_parsed_token_candidates_in_pkg` still interns its *package* name on every probe (~0.7%). The ticket stays open.

Refs #7576

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_