### PR TITLE
perf(env): move the built-in dynamics into a per-interpreter base tier

### DIFF
--- a/docs/adr/0086-builtin-dynamics-are-not-closure-capture-material.md
+++ b/docs/adr/0086-builtin-dynamics-are-not-closure-capture-material.md
@@ -1,6 +1,6 @@
 # ADR-0086: The built-in dynamics are not closure-capture material
 
-- Status: Proposed
+- Status: Accepted (implemented 2026-09-12)
 - Date: 2026-09-10
 - Related: [ADR-0084](0084-the-frame-env-is-not-the-programs-symbol-table.md)
   (the per-frame `Env` is not the program's symbol table) — this ADR refines the
@@ -200,6 +200,51 @@ unchanged: that is §2's work.
 - `t/start-dynamic-var-indir.t`, `t/start-inherits-dynamic-out.t`,
   `roast/S32-io/indir.t` and the `$DYNAMIC::`/`CALLER::` tests stay green.
 - `make test` and `make roast` stay green.
+
+## 6a. What was implemented (2026-09-12)
+
+`Env` carries a `dyn_base: Option<Arc<SymMap>>`, read at the chain's tail
+exactly where `GLOBAL_BASE` is read, and `Interpreter::hoist_builtin_dynamics`
+(`src/runtime/io_env.rs`, key list `BASE_TIER_DYNAMICS`) moves the ~20 entries
+into it — from `run()`, late enough that `set_program_path`/`set_args` have
+seeded `$*PROGRAM` and `@*ARGS`, and again on every thread clone so a spawned
+block's captures are no wider than its parent's.
+
+Two refinements the design did not anticipate:
+
+- **The tier absorbs `GLOBAL_BASE` instead of sitting beside it.** Consulting
+  two base maps made every env *miss* — which is every metadata key the VM
+  speculatively reads — pay a second probe, and that cost more on `word-count`
+  (~13M Ir in `Env::get_sym` alone) than the capture saved. `set_dyn_base`
+  copies the process-wide tier in, so the tail still costs exactly one probe.
+- **A flat env still never tombstones.** §4 said a write is promoted rather
+  than applied to the base, and that holds; but making a flat env's `remove`
+  *tombstone* a base key (rather than un-shadow it) would have put a base probe
+  on the hottest declaration path in the VM for no semantic gain — `GLOBAL_BASE`
+  has always un-shadowed there. `flattened`/`filtered_flat` still carry forward
+  a tombstone a *scoped* tier in the collapsed chain set on a base key.
+
+Three consumers had to learn the tier: `flatten()`/`visible_keys_where()`
+(which already merged `GLOBAL_BASE`), `dynamic_pseudo_stash_entries` (backing
+`DYNAMIC::`/`PROCESS::`), and the thread-clone spawn walk that collects the IO
+handle ids the child must keep working — `iter()` is map-only, and missing that
+last one made a plain `await start { print "X" }` die with `Invalid IO::Handle`.
+
+Measured with callgrind (deterministic instruction counts; a local A/B of two
+release binaries, with the precompilation cache warmed, not wall clock — the
+bench CI history remains the source of truth for tracked performance). A
+200000-iteration `my $c = * + 1;` loop **−38.4%**, which is **−44.0% per
+creation** (13,503 → 7,564 Ir) once the control loop — flat at +0.06% — is
+subtracted; the same loop with 30 extra enclosing lexicals −26.1% (−28.6% per
+creation); a 20000-iteration `sub make($n) { my $c = { $n + 1 } }` loop −12.6%;
+`bench-ctor` −7.6%, `bench-class` −3.3%, `bench-yaml-parse` −2.2%,
+`bench-grammar-parse` −1.0%. `bench-fib`, `bench-mandelbrot`, `bench-tak`,
+`bench-array` and `bench-string` are within +0.5%, `bench-hash` +1.0% and
+`word-count` +1.7% — the price of one more `Option<Arc<_>>` on `Env` and one
+more branch at the tail of a lookup, paid by a program that creates no closures.
+
+Acceptance test: `t/vm/scope/dynamic-vars-base-tier.t` (18 assertions, all green
+under rakudo too).
 
 ## 7. Alternatives rejected
 

--- a/news/2026-09/builtin-dynamics-leave-the-env.md
+++ b/news/2026-09/builtin-dynamics-leave-the-env.md
@@ -1,0 +1,123 @@
+# The built-in dynamics leave the env
+
+`Interpreter::capture_closure_env` keeps every visible env key that is not a
+plain user lexical, because mutsu stores scalars sigil-less and so cannot tell a
+user's `my $Foo` from a bare type name `Foo`. A closure created at the top of an
+otherwise empty program therefore captured **23 entries, 20 of them the built-in
+dynamic variables** the interpreter seeds once at startup — `$*OUT`, `$*ERR`,
+`$*IN`, `$*ARGFILES`, `$*CWD`, `$*TMPDIR`, `$*HOME`, `%*ENV`, `@*ARGS`,
+`$*PROGRAM`, `$*PROGRAM-NAME`, `$*REPO`, `$*SCHEDULER`, each under both its
+`$*X` and its sigil-less `*X` spelling. They were re-filtered, re-inserted,
+`Value`-cloned and later dropped on **every** closure creation: every
+`.map({…})`, every `.grep({…})`, every callback literal in a loop.
+
+And every one of them was then discarded unread. `call_compiled_closure_in_unit`
+installs the closure's overlay over the *live caller env* and merges the
+captured entries with `entry_or_insert_sym_with` — *don't overwrite what the
+chain already has*. Every frame chain bottoms out at the interpreter's root env,
+which holds those same dynamics for the whole program, so the captured copy of
+`$*OUT` never won. They were not an over-broad approximation that happened to be
+harmless; they were dead weight that was already never read.
+
+[ADR-0086](../../docs/adr/0086-builtin-dynamics-are-not-closure-capture-material.md)
+recorded that finding and the shape of the fix, and this change implements it:
+the built-in dynamics move into a **per-interpreter, never-copied base tier**.
+
+## What that is
+
+`Env` grows a `dyn_base: Option<Arc<SymMap>>` read exactly where the process-wide
+`GLOBAL_BASE` is read — at the chain's tail, after the overlay and every parent
+tier. It is per *interpreter* rather than per process because these values are
+not process constants: the IO handles and `$*PROGRAM`/`@*ARGS` belong to one
+interpreter (Test::Util's `is_run` fast path runs a nested one in the same
+process), and `$*CWD` is mutable. `GLOBAL_BASE` keeps the six that genuinely are
+process constants (`$*PID`, `$*TZ`, `$*INIT-INSTANT`, `$*EXECUTABLE`,
+`$*EXECUTABLE-NAME`, `$*SPEC`), and the lazily-materialized magic vars
+(`$*VM`, `$*DISTRO`, …) still live in no env at all.
+
+`Interpreter::hoist_builtin_dynamics` does the move, from `run()` — late enough
+that `set_program_path`/`set_args` have already seeded `$*PROGRAM` and `@*ARGS`
+— and again on every thread clone, so a spawned block's captures are no wider
+than the parent's. The base map never changes after that call, which is what
+lets every env share it by `Arc` with no copy-on-write; a *write* to a built-in
+dynamic is promoted into the writer's own overlay by the existing
+`Env::get_mut_sym` path, where it shadows the base exactly as an overlay entry
+already shadows `GLOBAL_BASE`.
+
+The soundness argument is structural rather than analytical, which is the point:
+nothing decides that a closure "does not need" `$*OUT`. A closure that calls
+`say` reaches `$*OUT` through a callee, not through a name the free-variable pass
+could ever see — so the capture stops carrying the key because the key is not in
+the env, and the read still resolves, through the tier, from wherever the closure
+runs.
+
+One refinement the design did not anticipate: the per-interpreter tier
+**absorbs** `GLOBAL_BASE` rather than sitting beside it. Two base maps meant
+every env *miss* — which is every metadata key the VM speculatively reads — paid
+a second probe, and on `word-count` that cost more (~13M Ir in `Env::get_sym`
+alone) than the capture saved. Merged, the tail of a lookup still costs exactly
+one probe, as it did before the tier existed.
+
+## What had to learn about the tier
+
+Reads (`get_sym`, `contains_key_sym`) and the two promotion paths (`get_mut_sym`,
+`remove_sym`) consult it at the tail; a flat env can now carry tombstones,
+because with a tier below it a `remove` again has something to hide. Both chain
+collapses (`flattened`, `filtered_flat`) carry the tier by reference and carry
+forward any tombstone that still hides a base key. `flatten()` and
+`visible_keys_where()` merge it as they already merged `GLOBAL_BASE`.
+
+Two consumers iterate an env as *the visible environment* and had to be taught
+explicitly, since `iter()` is map-only:
+
+- `dynamic_pseudo_stash_entries`, which backs `DYNAMIC::` and `PROCESS::` —
+  `PROCESS::<$OUT>` would otherwise have stopped finding the seeded handle.
+- the thread-clone spawn walk, which collects the IO handle ids the child must
+  keep working. Missing them made the child rebuild a handle it then could not
+  find: a plain `await start { print "X" }` died with `Invalid IO::Handle`.
+
+## Numbers
+
+Callgrind instruction counts — deterministic and load-independent, so a local
+A/B of two release binaries is meaningful where wall clock would not be. They
+are not wall-clock figures and do not replace the bench CI history, which stays
+the source of truth for tracked performance.
+
+| | main | this | |
+| --- | ---: | ---: | ---: |
+| `my $c = * + 1;` × 200000 | 3,096,805,546 | 1,909,249,834 | **−38.4%** |
+| — per creation, control loop subtracted | 13,503 | 7,564 | **−44.0%** |
+| the same + 30 enclosing lexicals | 4,555,820,087 | 3,367,123,793 | −26.1% |
+| — per creation | 20,798 | 14,853 | −28.6% |
+| `sub make($n) { my $c = { $n + 1 } }` × 20000 | 1,048,977,489 | 917,072,113 | −12.6% |
+| `bench-ctor` | 1,438,871,696 | 1,329,187,266 | −7.6% |
+| `bench-class` | 1,185,541,115 | 1,146,133,720 | −3.3% |
+| `bench-yaml-parse` | 597,848,254 | 584,912,644 | −2.2% |
+| `bench-grammar-parse` | 47,889,416 | 47,396,313 | −1.0% |
+| `bench-fib` | 1,230,729,592 | 1,230,738,762 | +0.0% |
+| `bench-mandelbrot` | 792,256,437 | 793,310,309 | +0.1% |
+| `bench-tak` | 1,521,783,637 | 1,525,319,286 | +0.2% |
+| `bench-array` | 241,206,753 | 242,212,609 | +0.4% |
+| `bench-string` | 504,742,311 | 506,998,734 | +0.5% |
+| `bench-hash` | 264,406,272 | 267,143,291 | +1.0% |
+| `word-count` | 1,058,126,579 | 1,076,057,078 | +1.7% |
+
+The control loop with the closure creation removed is flat (+0.06%), so the
+microbenchmark rows are the creation cost and nothing else. The sub-percent to
+1.7% costs at the bottom are the price of the mechanism: an `Env` grown by one
+`Option<Arc<_>>` and one more branch at the tail of a lookup, paid by programs
+that create no closures. `word-count` is the worst case — a mainline-only loop
+of hash-element increments, which is all env traffic and no capture.
+
+## Acceptance
+
+`t/vm/scope/dynamic-vars-base-tier.t` pins the behaviour the move must not change:
+reads from a closure, from a callee and from a closure created inside a sub
+frame; a `my $*CWD` shadow being what a closure actually captures; an assignment
+inside a sub still visible after it returns; `%*ENV` still writable;
+`PROCESS::`/`DYNAMIC::` still resolving; a lexically redirected `$*OUT` still
+winning, including across a `start` block. All 18 assertions pass under rakudo
+too. `t/vm/start-dynamic-var-indir.t`, `t/oo/class/start-inherits-dynamic-out.t`
+and `roast/S32-io/indir.t` — ADR-0086's named acceptance tests — stay green.
+
+#7557 stays open only for what ADR-0086 does not cover.

--- a/src/env.rs
+++ b/src/env.rs
@@ -52,6 +52,13 @@ fn global_base() -> Option<&'static SymMap> {
     GLOBAL_BASE.get()
 }
 
+/// True once [`set_global_base`] has run. The per-interpreter base tier copies
+/// `GLOBAL_BASE` in (see [`Env::set_dyn_base`]), so its installer checks this
+/// rather than silently building a tier that is missing the built-in enums.
+pub(crate) fn global_base_installed() -> bool {
+    GLOBAL_BASE.get().is_some()
+}
+
 /// True if `name` is a built-in global-base constant — the process-wide enum
 /// values such as `Endian` (`NativeEndian`/`LittleEndian`/`BigEndian`), `Order`
 /// (`Less`/`Same`/`More`), `ProtocolFamily`, `Signal`, .... Used to recognise a
@@ -528,6 +535,34 @@ pub struct Env {
     /// `Arc` for the same reason as `frame_writes`: an env clone stays a
     /// refcount bump.
     code_entries: Option<Arc<Vec<Symbol>>>,
+    /// The **per-interpreter** never-copied base tier: the built-in dynamic
+    /// variables (`$*OUT`, `$*CWD`, `%*ENV`, `@*ARGS`, `$*REPO`, ...) the
+    /// interpreter seeds once at startup. ADR-0086.
+    ///
+    /// Read exactly like [`GLOBAL_BASE`] — at the chain's tail, after the
+    /// overlay and every parent tier — but per interpreter rather than per
+    /// process, because these values are not process constants: the IO handles
+    /// and `$*PROGRAM`/`@*ARGS` belong to one interpreter (Test::Util's
+    /// `is_run` fast path runs a nested one in the same process) and `$*CWD`
+    /// is mutable. A write is *promoted* into the writer's own overlay, where
+    /// it shadows the base; the base map itself is immutable for the
+    /// interpreter's life, so it can be shared by `Arc` with no
+    /// copy-on-write.
+    ///
+    /// Why they are not in the env at all: a closure capture keeps every key
+    /// that is not a plain user lexical, so all ~20 of them were rebuilt —
+    /// inserted, `Value`-cloned, later dropped — on *every* closure creation,
+    /// and the call-time merge (`entry_or_insert_sym_with`, "don't overwrite
+    /// what the chain already has") then discarded all ~20 because the live
+    /// chain bottoms out at the same interpreter. See
+    /// [ADR-0086](../docs/adr/0086-builtin-dynamics-are-not-closure-capture-material.md)
+    /// §1.3 and [#7557](https://github.com/tokuhirom/mutsu/issues/7557).
+    ///
+    /// Carried only by a **flat** env (the chain's tail) and by anything
+    /// derived from one: [`Self::scoped_child`] deliberately does not copy it,
+    /// so the `Arc` refcount is not touched on the per-call frame path, and a
+    /// chain walk reaches the tail's copy anyway.
+    dyn_base: Option<Arc<SymMap>>,
 }
 
 /// Maximum overlay chain length before [`Env::scoped_child`] flattens the parent.
@@ -551,6 +586,40 @@ fn empty_overlay() -> Arc<Tier> {
 fn empty_overlay_ref() -> &'static Arc<Tier> {
     static EMPTY: std::sync::OnceLock<Arc<Tier>> = std::sync::OnceLock::new();
     EMPTY.get_or_init(|| Arc::new(Tier::default()))
+}
+
+/// The tombstones a chain collapse (`flattened`/`filtered_flat`) must carry
+/// into its flat result: keys removed somewhere in the chain that are still
+/// present in the per-interpreter base tier and were not re-inserted by a
+/// nearer tier.
+///
+/// Without a base tier there is nothing below the merged map for a tombstone to
+/// hide, so the answer is `None` — which is also the answer whenever no tier in
+/// the chain carries a tombstone, i.e. nearly always. The walk is O(chain
+/// depth) and [`MAX_OVERLAY_DEPTH`] bounds that at 16.
+fn residual_base_tombstones(
+    env: &Env,
+    merged: &SymMap,
+    base: Option<&SymMap>,
+) -> Option<rustc_hash::FxHashSet<Symbol>> {
+    let base = base?;
+    let mut out: Option<rustc_hash::FxHashSet<Symbol>> = None;
+    let mut cur = env;
+    loop {
+        if let Some(tomb) = &cur.tombstones {
+            for k in tomb {
+                if base.contains_key(k) && !merged.contains_key(k) {
+                    out.get_or_insert_with(rustc_hash::FxHashSet::default)
+                        .insert(*k);
+                }
+            }
+        }
+        match &cur.parent {
+            Some(parent) => cur = parent,
+            None => break,
+        }
+    }
+    out
 }
 
 /// The interned `"?FILE"` key. Interning it once keeps the maintenance hook in
@@ -580,6 +649,58 @@ impl Env {
             file_sym: None,
             frame_writes: None,
             code_entries: None,
+            dyn_base: None,
+        }
+    }
+
+    /// Install the per-interpreter base tier on this (flat) env — see
+    /// [`Self::dyn_base`]. Called by `Interpreter::hoist_builtin_dynamics`,
+    /// right after the built-in dynamics have been lifted out of the env's own
+    /// map — once for an ordinary interpreter, and once more for each thread
+    /// clone, which rebuilds some of them and so needs a tier of its own.
+    pub(crate) fn set_dyn_base(&mut self, mut base: SymMap) {
+        debug_assert!(
+            !base.contains_key(&file_key()),
+            "the hoist moves `*`-twigil dynamics only, never `?FILE` (whose value is cached on the env)"
+        );
+        // Absorb [`GLOBAL_BASE`] rather than sit beside it. The tail of a
+        // lookup already paid one map probe for the process-wide tier; a
+        // *second* probe for the per-interpreter one would make every env miss
+        // — which is every metadata key the VM speculatively reads — more
+        // expensive than before this tier existed. Merged, the tail still costs
+        // exactly one probe (measured: two probes cost `word-count` ~13M Ir in
+        // `Env::get_sym` alone). `GLOBAL_BASE` is a `OnceLock` installed by
+        // `Interpreter::new` before any `run()`, so this copy is complete, and
+        // `or_insert` keeps a hoisted dynamic ahead of it in the impossible
+        // case that both hold a key.
+        if let Some(global) = global_base() {
+            for (k, v) in global.iter() {
+                base.entry(*k).or_insert_with(|| v.clone());
+            }
+        }
+        self.dyn_base = Some(Arc::new(base));
+    }
+
+    /// This env's per-interpreter base tier, or the one its chain bottoms out
+    /// at. `None` for an env that was never given one (`Env::new()` and
+    /// friends — those hold no built-in dynamics today either).
+    pub(crate) fn dyn_base(&self) -> Option<&Arc<SymMap>> {
+        let mut cur = self;
+        while let Some(parent) = &cur.parent {
+            cur = parent;
+        }
+        cur.dyn_base.as_ref()
+    }
+
+    /// This env's own base-tier entry for `key`: the per-interpreter tier when
+    /// it has one (a superset of the process-wide tier — see
+    /// [`Self::set_dyn_base`]), else [`GLOBAL_BASE`]. Consults THIS env only,
+    /// never the parent chain, so it is the tail half of a lookup.
+    #[inline]
+    fn base_get(&self, key: Symbol) -> Option<&Value> {
+        match &self.dyn_base {
+            Some(base) => base.get(&key),
+            None => global_base().and_then(|b| b.get(&key)),
         }
     }
 
@@ -634,6 +755,7 @@ impl Env {
                     file_sym,
                     frame_writes: None,
                     code_entries: None,
+                    dyn_base: None,
                 };
             }
             return Self {
@@ -644,6 +766,7 @@ impl Env {
                 file_sym,
                 frame_writes: None,
                 code_entries: None,
+                dyn_base: None,
             };
         }
         let parent = if parent.depth >= MAX_OVERLAY_DEPTH {
@@ -659,6 +782,7 @@ impl Env {
             file_sym,
             frame_writes: None,
             code_entries: None,
+            dyn_base: None,
         }
     }
 
@@ -970,10 +1094,29 @@ impl Env {
                         merged.insert(*k, v.clone());
                     }
                 }
+                let dyn_base = cur.dyn_base.clone();
+                let any_tombstone = {
+                    let mut cur = self;
+                    let mut any = cur.tombstones.is_some();
+                    while let Some(parent) = &cur.parent {
+                        cur = parent;
+                        any |= cur.tombstones.is_some();
+                    }
+                    any
+                };
+                // A tombstone that hides a base-tier dynamic has to survive the
+                // collapse: the merged map does not contain the key (nothing
+                // ever wrote it into an overlay), so without the tombstone the
+                // base would shadow straight back through. `None` whenever the
+                // chain carries no tombstone or no base tier, which is nearly
+                // always.
+                let tombstones = any_tombstone
+                    .then(|| residual_base_tombstones(self, &merged, dyn_base.as_deref()))
+                    .flatten();
                 Self {
                     inner: Arc::new(Tier::new(merged)),
                     parent: None,
-                    tombstones: None,
+                    tombstones,
                     depth: 0,
                     // Flattening preserves every visible value, `?FILE` included.
                     file_sym: self.file_sym,
@@ -982,6 +1125,7 @@ impl Env {
                     // writes when a light frame needs them (#7630).
                     frame_writes: None,
                     code_entries: None,
+                    dyn_base,
                 }
             }
         }
@@ -1048,25 +1192,42 @@ impl Env {
         // starting at zero capacity, i.e. five reallocations and ~52 entry
         // moves, on every construction.
         let mut cap = 0usize;
+        // The same walk answers two more questions for free: which
+        // per-interpreter base tier the chain's tail carries (ADR-0086) and
+        // whether any tier holds a tombstone — so neither costs its own pass.
+        let mut dyn_base = None;
+        let mut any_tombstone = false;
         {
             let mut cur = Some(self);
             while let Some(env) = cur {
                 cap += env.inner.len();
+                any_tombstone |= env.tombstones.is_some();
+                dyn_base = env.dyn_base.as_ref();
                 cur = env.parent.as_deref();
             }
         }
+        let dyn_base = dyn_base.cloned();
         let mut out = SymMap::with_capacity_and_hasher(cap, Default::default());
         collect(self, &mut out, keep, true);
         // `keep` may have rejected `?FILE`, so re-derive rather than inherit.
         let file_sym = out.get(&file_key()).and_then(file_sym_of);
+        // The per-interpreter base tier rides along by reference, exactly as
+        // `GLOBAL_BASE` does: it is what stops the built-in dynamics from being
+        // rebuilt into every closure capture (ADR-0086). `keep` never sees them
+        // and so cannot reject them — which is the point, since a capture that
+        // dropped them would have to prove the caller's chain re-supplies them.
+        let tombstones = any_tombstone
+            .then(|| residual_base_tombstones(self, &out, dyn_base.as_deref()))
+            .flatten();
         Self {
             inner: Arc::new(Tier::new(out)),
             parent: None,
-            tombstones: None,
+            tombstones,
             depth: 0,
             file_sym,
             frame_writes: None,
             code_entries: None,
+            dyn_base,
         }
     }
 
@@ -1152,25 +1313,41 @@ impl Env {
         // (36 against 96 after a bare `use Test`), and over-reserving cost a
         // 2 KiB allocation and its zeroing per closure creation.
         let mut cap = 0usize;
+        // As in [`Self::filtered_flat`], the same walk also answers which
+        // per-interpreter base tier the chain's tail carries (ADR-0086) and
+        // whether any tier holds a tombstone.
+        let mut dyn_base = None;
+        let mut any_tombstone = false;
         {
             let mut cur = Some(self);
             while let Some(env) = cur {
                 cap += env.inner.capture_upper_bound();
+                any_tombstone |= env.tombstones.is_some();
+                dyn_base = env.dyn_base.as_ref();
                 cur = env.parent.as_deref();
             }
         }
+        let dyn_base = dyn_base.cloned();
         let mut out = SymMap::with_capacity_and_hasher(cap, Default::default());
         collect(self, &mut out, keep, true);
         // `keep` may have rejected `?FILE`, so re-derive rather than inherit.
         let file_sym = out.get(&file_key()).and_then(file_sym_of);
+        // The per-interpreter base tier rides along by reference, exactly as
+        // `GLOBAL_BASE` does: the built-in dynamics are not in any map for this
+        // walk to visit, which is what stops them being rebuilt into every
+        // capture (ADR-0086).
+        let tombstones = any_tombstone
+            .then(|| residual_base_tombstones(self, &out, dyn_base.as_deref()))
+            .flatten();
         Self {
             inner: Arc::new(Tier::new(out)),
             parent: None,
-            tombstones: None,
+            tombstones,
             depth: 0,
             file_sym,
             frame_writes: None,
             code_entries: None,
+            dyn_base,
         }
     }
 
@@ -1240,7 +1417,14 @@ impl Env {
         if let Some(parent) = &self.parent {
             return parent.get_sym(key);
         }
-        global_base().and_then(|b| b.get(&key))
+        // Chain tail: one base-tier probe. The per-interpreter tier (built-in
+        // dynamics, ADR-0086) is a superset of the process-wide one, so an env
+        // that has it needs no second look at `GLOBAL_BASE` — see
+        // [`Self::set_dyn_base`].
+        match &self.dyn_base {
+            Some(base) => base.get(&key),
+            None => global_base().and_then(|b| b.get(&key)),
+        }
     }
 
     #[inline]
@@ -1259,7 +1443,10 @@ impl Env {
         if let Some(parent) = &self.parent {
             return parent.contains_key_sym(key);
         }
-        global_base().is_some_and(|b| b.contains_key(&key))
+        match &self.dyn_base {
+            Some(base) => base.contains_key(&key),
+            None => global_base().is_some_and(|b| b.contains_key(&key)),
+        }
     }
 
     /// True if `key` is declared in THIS frame's own overlay tier specifically
@@ -1407,6 +1594,13 @@ impl Env {
         // a handle). Every `my` declaration speculatively removes several
         // metadata keys that the common program never creates, so this no-op
         // removal is on the hottest declaration path in the VM.
+        //
+        // Unchanged by the per-interpreter base tier (ADR-0086): a flat env's
+        // `remove` still never tombstones, so it costs no base probe here. The
+        // effect on a key the tier also holds is to *un-shadow* it — the
+        // overlay entry goes and the seeded value below shows through — which
+        // is what a tier below an overlay means, and what `GLOBAL_BASE` has
+        // always done for a flat env's enum constants.
         if self.parent.is_none() && !self.inner.contains_key(&key) {
             return None;
         }
@@ -1421,7 +1615,7 @@ impl Env {
                 .parent
                 .as_ref()
                 .and_then(|p| p.get_sym(key))
-                .or_else(|| global_base().and_then(|b| b.get(&key)))
+                .or_else(|| self.base_get(key))
                 .cloned();
             if parent_val.is_some() {
                 let visible = from_overlay.or(parent_val);
@@ -1455,7 +1649,7 @@ impl Env {
                 .parent
                 .as_ref()
                 .and_then(|p| p.get_sym(key))
-                .or_else(|| global_base().and_then(|b| b.get(&key)))
+                .or_else(|| self.base_get(key))
                 .cloned();
             if let Some(v) = promote {
                 self.untombstone(key);
@@ -1534,7 +1728,34 @@ impl Env {
         }
         if let Some(parent) = &self.parent {
             parent.visit_values(visitor);
+            return;
         }
+        // Chain tail: the per-interpreter base tier's built-in dynamics are
+        // roots too (ADR-0086) — they hold the IO handles, `%*ENV` and
+        // `$*REPO`. `GLOBAL_BASE` is deliberately not visited: it is a
+        // process-lifetime `OnceLock` that is never reclaimed.
+        if let Some(base) = &self.dyn_base {
+            for v in base.values() {
+                visitor.visit_value(v);
+            }
+        }
+    }
+
+    /// The per-interpreter base-tier entries this **flat** env still exposes:
+    /// the built-in dynamics neither shadowed by its own map nor tombstoned.
+    ///
+    /// For the consumers that present an env as *the visible environment*
+    /// rather than look one name up in it — the `DYNAMIC::` and `PROCESS::`
+    /// pseudo-stashes — which would otherwise lose `$*OUT` and friends when
+    /// they moved out of the map (ADR-0086 §4).
+    pub(crate) fn visible_base_dynamics(&self) -> Vec<(Symbol, Value)> {
+        let Some(base) = self.dyn_base() else {
+            return Vec::new();
+        };
+        base.iter()
+            .filter(|(k, _)| !self.inner.contains_key(k) && !self.is_tombstoned(**k))
+            .map(|(k, v)| (*k, v.clone()))
+            .collect()
     }
 
     /// Full name->value snapshot, merging the immutable base tier under the
@@ -1546,9 +1767,12 @@ impl Env {
         // layer this frame's tombstones and overlay on top.
         let mut out: HashMap<String, Value> = match &self.parent {
             Some(parent) => parent.flatten(),
-            None => global_base()
-                .map(|b| b.iter().map(|(k, v)| (k.resolve(), v.clone())).collect())
-                .unwrap_or_default(),
+            None => match &self.dyn_base {
+                Some(base) => base.iter().map(|(k, v)| (k.resolve(), v.clone())).collect(),
+                None => global_base()
+                    .map(|b| b.iter().map(|(k, v)| (k.resolve(), v.clone())).collect())
+                    .unwrap_or_default(),
+            },
         };
         if let Some(tomb) = &self.tombstones {
             for k in tomb {
@@ -1572,14 +1796,19 @@ impl Env {
     pub fn visible_keys_where(&self, keep: impl Fn(&str) -> bool + Copy) -> HashSet<String> {
         let mut out: HashSet<String> = match &self.parent {
             Some(parent) => parent.visible_keys_where(keep),
-            None => global_base()
-                .map(|b| {
+            None => {
+                let tier = match self.dyn_base.as_deref() {
+                    Some(base) => Some(base),
+                    None => global_base(),
+                };
+                tier.map(|b| {
                     b.keys()
                         .map(|k| k.resolve())
                         .filter(|k| keep(k))
                         .collect::<HashSet<String>>()
                 })
-                .unwrap_or_default(),
+                .unwrap_or_default()
+            }
         };
         if let Some(tomb) = &self.tombstones {
             for k in tomb {
@@ -1750,6 +1979,7 @@ impl From<HashMap<String, Value>> for Env {
             file_sym,
             frame_writes: None,
             code_entries: None,
+            dyn_base: None,
         }
     }
 }
@@ -1766,6 +1996,7 @@ impl From<HashMap<Symbol, Value>> for Env {
             file_sym,
             frame_writes: None,
             code_entries: None,
+            dyn_base: None,
         }
     }
 }

--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -3,6 +3,47 @@ use crate::symbol::Symbol;
 use crate::value::ValueView;
 use std::sync::OnceLock;
 
+/// The built-in dynamic variables that live in the **per-interpreter base
+/// tier** rather than in any env's own map — see
+/// [`Interpreter::hoist_builtin_dynamics`] and ADR-0086.
+///
+/// Each dynamic is seeded under both its `$*X` and its sigil-less `*X`
+/// spelling (mutsu stores scalars sigil-less, and different read paths reach
+/// for different spellings), so both are listed.
+///
+/// Not listed, deliberately:
+///
+/// * `$*PID` / `$*TZ` / `$*INIT-INSTANT` / `$*EXECUTABLE` / `$*EXECUTABLE-NAME`
+///   / `$*SPEC` — already hoisted further, into the process-wide `GLOBAL_BASE`
+///   (`IMMUTABLE_BASE_DYNAMICS`), because they are process constants.
+/// * `$*VM` / `$*PERL` / `$*RAKU` / `$*KERNEL` / `$*DISTRO` / `$*COLLATION` /
+///   `$*TOLERANCE` / `$*USER` / `$*GROUP` — never in an env at all; they
+///   materialize on first read through [`Interpreter::lazy_magic_dynamic_var`].
+/// * `=pod` and `?FILE` — not dynamics. `?FILE` in particular is mirrored on
+///   the `Env` itself (`source_file_sym`), so it must stay in the env's map.
+pub(crate) const BASE_TIER_DYNAMICS: &[&str] = &[
+    "$*OUT",
+    "*OUT",
+    "$*ERR",
+    "*ERR",
+    "$*IN",
+    "*IN",
+    "$*ARGFILES",
+    "*ARGFILES",
+    "$*CWD",
+    "*CWD",
+    "$*TMPDIR",
+    "*TMPDIR",
+    "$*HOME",
+    "*HOME",
+    "%*ENV",
+    "@*ARGS",
+    "*PROGRAM",
+    "*PROGRAM-NAME",
+    "*REPO",
+    "*SCHEDULER",
+];
+
 impl Interpreter {
     /// Rebuild the per-interpreter IO/dynamic-var environment. Called from
     /// `Interpreter::new()`; every `clone_for_thread` spawn uses the
@@ -32,6 +73,63 @@ impl Interpreter {
     /// ordinary programs).
     pub(super) fn init_io_environment(&mut self) {
         self.init_io_environment_impl(false)
+    }
+
+    /// Move the built-in dynamic variables out of `self.env`'s own map and into
+    /// the per-interpreter base tier ([`crate::env::Env::set_dyn_base`],
+    /// ADR-0086). Idempotent, and a no-op for a scratch interpreter (which
+    /// shares its caller's env wholesale) or a scoped env (there is no frame
+    /// tier to hoist *from*: the base belongs to the chain's tail).
+    ///
+    /// Why they leave the env. A closure capture keeps every key that is not a
+    /// plain user lexical, so all of [`BASE_TIER_DYNAMICS`] — ~20 entries, the
+    /// bulk of every capture — were re-inserted and `Value`-cloned on *each*
+    /// closure creation, and `call_compiled_closure_in_unit`'s merge then
+    /// discarded all of them, because it never overwrites what the live chain
+    /// already has and the live chain bottoms out at this same interpreter.
+    /// They are read through the base tier now, so an ordinary capture holds a
+    /// dynamic's key only when the *program* bound one (`my $*CWD = …`,
+    /// `indir`) — which is the only case the capture was ever read for.
+    ///
+    /// A later write is promoted into the writer's overlay by
+    /// [`crate::env::Env::get_mut_sym`] / `insert`, where it shadows the base
+    /// exactly as an overlay entry shadows `GLOBAL_BASE` today; the base map
+    /// itself never changes after this call, which is what lets every env share
+    /// it by `Arc`.
+    pub(crate) fn hoist_builtin_dynamics(&mut self) {
+        if Self::is_building_scratch() || self.env.is_scoped() {
+            return;
+        }
+        // `set_dyn_base` absorbs `GLOBAL_BASE` into the tier it installs, so
+        // the process-wide constants must already be there; they are installed
+        // by `Interpreter::new` (non-scratch), which always precedes a `run()`.
+        if !crate::env::global_base_installed() {
+            return;
+        }
+        let mut base: crate::env::SymMap = match self.env.dyn_base() {
+            Some(existing) => (**existing).clone(),
+            None => crate::env::SymMap::default(),
+        };
+        let mut moved = false;
+        for key in BASE_TIER_DYNAMICS {
+            let sym = Symbol::intern(key);
+            // `remove_overlay_sym`, not `remove_sym`: the entry is being moved
+            // one tier DOWN, not deleted, so it must not leave a tombstone.
+            if let Some(v) = self.env.remove_overlay_sym(sym) {
+                base.insert(sym, v);
+                moved = true;
+            }
+        }
+        // Count what was *taken out of the env*, not the base's size: a hoist
+        // that overwrites an existing base entry (every thread clone, which
+        // rebuilds its own `$*CWD`/`$*TMPDIR` over the inherited copy) leaves
+        // the length unchanged while carrying a value that must be installed.
+        if !moved && self.env.dyn_base().is_some() {
+            // Nothing moved and a base is already installed: re-installing
+            // would hand out a fresh `Arc` that no already-captured env shares.
+            return;
+        }
+        self.env.set_dyn_base(base);
     }
 
     /// [`Self::init_io_environment`] for a `clone_for_thread` spawn

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -557,6 +557,13 @@ impl Interpreter {
             self.env
                 .insert("*PROGRAM".to_string(), Value::str(String::new()));
         }
+        // ADR-0086: with `$*PROGRAM`/`@*ARGS` now seeded (`set_program_path` /
+        // `set_args` run between `Interpreter::new()` and here), move the
+        // built-in dynamics out of the env's own map and into the
+        // per-interpreter base tier, so no closure this program creates rebuilds
+        // the ~20 of them into its capture. Idempotent, so a REPL's second
+        // `run()` is a no-op.
+        self.hoist_builtin_dynamics();
         self.establish_pod_variables(&preprocessed)?;
         let file_name = self
             .program_path

--- a/src/runtime/runtime_caller_env.rs
+++ b/src/runtime/runtime_caller_env.rs
@@ -291,7 +291,17 @@ impl Interpreter {
             // parent tiers from this walk even though `Env::get()` would
             // find them. See ADR-0035 Mechanism 1 (docs/adr/0035-method-calls-observe-caller-frames.md).
             let merged = env.filtered_flat(&|_, _| true);
-            for (k, v) in merged.iter() {
+            // The built-in dynamics live in the per-interpreter base tier, not
+            // in any env's own map (ADR-0086), and `iter()` is map-only — so
+            // ask for them explicitly, before the map's entries, which shadow
+            // them. Without this, `DYNAMIC::<$*OUT>` / `PROCESS::<$OUT>` would
+            // stop finding what the interpreter seeded.
+            for (k, v) in merged
+                .visible_base_dynamics()
+                .iter()
+                .map(|(k, v)| (k, v))
+                .chain(merged.iter())
+            {
                 let key = k.resolve();
                 let spelled = if let Some(n) = key.strip_prefix("@*") {
                     format!("@*{n}")

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -258,6 +258,19 @@ impl Interpreter {
         // an excluded captured scalar or an already-visible name legitimately
         // could be).
         let mut referenced_handle_ids = std::collections::HashSet::new();
+        // The built-in dynamics live in the per-interpreter base tier, which
+        // `&self.env` (map-only) does not yield (ADR-0086) — but `$*OUT` /
+        // `$*ERR` / `$*IN` / `$*ARGFILES` are exactly the handles the child
+        // must be able to keep using, so collect their ids explicitly. The
+        // seeding walk below deliberately skips these names anyway (a dynamic
+        // is thread-local), so only the handle-id half applies to them.
+        if let Some(base) = self.env.dyn_base() {
+            for val in base.values() {
+                if let Some(id) = Self::handle_id_from_value(val) {
+                    referenced_handle_ids.insert(id);
+                }
+            }
+        }
         {
             // Slice 5 step A instrumentation: how many env entries this walk
             // visits vs. how many actually land in the store. Accumulated
@@ -1011,6 +1024,14 @@ impl Interpreter {
         cloned.env.insert("$/".to_string(), Value::NIL);
         cloned.env.insert("$!".to_string(), Value::NIL);
         cloned.init_io_environment_for_thread_clone();
+        // The rebuild above writes the child's own `$*CWD`/`$*TMPDIR`/… into
+        // its env map; hoist them straight back down into a base tier of the
+        // child's own, so a closure created inside the spawned block captures
+        // no more than one created on the parent would (ADR-0086). The child's
+        // base starts as a copy of the parent's, so an inherited `$*OUT`
+        // redirection is preserved and a later write on either side promotes
+        // into that side's overlay only.
+        cloned.hoist_builtin_dynamics();
         cloned
     }
 

--- a/t/vm/scope/dynamic-vars-base-tier.t
+++ b/t/vm/scope/dynamic-vars-base-tier.t
@@ -1,0 +1,72 @@
+use v6;
+use Test;
+
+# ADR-0086 / #7557: the built-in dynamic variables ($*OUT, $*CWD, %*ENV,
+# @*ARGS, $*REPO, ...) live in a per-interpreter never-copied base tier rather
+# than in every env's own map, so a closure capture no longer rebuilds ~20
+# entries the call-time merge would discard anyway. This pins the behaviour
+# that move must not change: they are still readable, writable, shadowable,
+# restorable and visible to the pseudo-stashes.
+
+plan 18;
+
+# --- plain reads, through a closure and through a callee -------------------
+ok $*CWD.defined, '$*CWD reads from the base tier';
+ok $*TMPDIR.defined, '$*TMPDIR reads from the base tier';
+ok %*ENV.defined, '%*ENV reads from the base tier';
+ok @*ARGS.defined, '@*ARGS reads from the base tier';
+
+my $in-closure = { $*CWD.defined };
+ok $in-closure(), 'a closure created at mainline still sees $*CWD';
+
+sub sees-cwd() { $*CWD.defined }
+ok sees-cwd(), 'a sub with no enclosing binding still sees $*CWD';
+
+sub makes-closure() { return { $*TMPDIR.defined } }
+ok makes-closure()(), 'a closure created inside a sub frame still sees $*TMPDIR';
+
+# --- a user binding shadows the base and is what actually gets captured ----
+{
+    my $*CWD = "/nonesuch-shadow".IO;
+    is $*CWD.Str, '/nonesuch-shadow', 'my $*CWD shadows the base tier';
+    my $inner = { $*CWD.Str };
+    is $inner(), '/nonesuch-shadow', 'the shadowing binding is what a closure captures';
+}
+isnt $*CWD.Str, '/nonesuch-shadow', 'the shadow is gone once its block exits';
+
+# --- assignment is promoted out of the base and persists ------------------
+{
+    my $saved = $*CWD;
+    sub set-cwd($p) { $*CWD = $p }
+    set-cwd("/".IO);
+    is $*CWD.Str, '/', 'assigning $*CWD inside a sub is visible after it returns';
+    $*CWD = $saved;
+    is $*CWD.Str, $saved.Str, '$*CWD restores to its seeded value';
+}
+
+# --- %*ENV stays mutable ---------------------------------------------------
+%*ENV<MUTSU_BASE_TIER_PROBE> = 'set';
+is %*ENV<MUTSU_BASE_TIER_PROBE>, 'set', '%*ENV is still writable through the base tier';
+
+# --- the pseudo-stashes still see them ------------------------------------
+ok PROCESS::<$OUT>.defined, 'PROCESS::<$OUT> still finds the seeded handle';
+my $*MUTSU-BASE-PROBE = 'bound';
+is DYNAMIC::<$*MUTSU-BASE-PROBE>, 'bound', 'DYNAMIC:: still finds a user-bound dynamic';
+sub stash-from-callee() { PROCESS::<$CWD>.defined }
+ok stash-from-callee(), 'PROCESS::<$CWD> resolves from inside a callee too';
+
+# --- output still routes through a redirected $*OUT -----------------------
+my $captured = '';
+{
+    my $*OUT = class { method print(*@a) { $captured ~= @a.join }; method flush { } }.new;
+    say 'redirected';
+}
+is $captured, "redirected\n", 'a lexically redirected $*OUT still wins over the base tier';
+
+# --- and through a thread clone -------------------------------------------
+my $threaded = '';
+{
+    my $*OUT = class { method print(*@a) { $threaded ~= @a.join }; method flush { } }.new;
+    await start { print 'from-thread' };
+}
+is $threaded, 'from-thread', 'a start block inherits the redirected $*OUT';


### PR DESCRIPTION
Implements [ADR-0086](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0086-builtin-dynamics-are-not-closure-capture-material.md), the one item left open on #7557.

## The problem

`capture_closure_env` keeps every visible env key that is not a plain user lexical, so all ~20 built-in dynamic variables the interpreter seeds at startup — `$*OUT`, `$*ERR`, `$*IN`, `$*ARGFILES`, `$*CWD`, `$*TMPDIR`, `$*HOME`, `%*ENV`, `@*ARGS`, `$*PROGRAM`, `$*PROGRAM-NAME`, `$*REPO`, `$*SCHEDULER`, each under both its `$*X` and its sigil-less `*X` spelling — were re-filtered, re-inserted, `Value`-cloned and later dropped on **every** closure creation. That is the bulk of every capture, and of every `.map({…})` / `.grep({…})` / callback literal in a loop.

Every one of them was then discarded unread. `call_compiled_closure_in_unit` merges a capture into an overlay over the live caller env with `entry_or_insert_sym_with` — *don't overwrite what the chain already has* — and every frame chain bottoms out at the interpreter's root env, which holds those same dynamics for the whole program.

## The change

They move into a **per-interpreter, never-copied base tier**, read exactly where the process-wide `GLOBAL_BASE` is read: at the chain's tail. Per interpreter rather than per process because they are not process constants — the IO handles and `$*PROGRAM`/`@*ARGS` belong to one interpreter (Test::Util's `is_run` fast path runs a nested one in the same process) and `$*CWD` is mutable. `Interpreter::hoist_builtin_dynamics` does the move from `run()`, late enough that `set_program_path`/`set_args` have seeded `$*PROGRAM` and `@*ARGS`, and again on every thread clone. The base map never changes after that, so every env shares it by `Arc`; a *write* is promoted into the writer's own overlay by the existing `Env::get_mut_sym` path, where it shadows the base exactly as an overlay entry already shadows `GLOBAL_BASE`.

The soundness argument is structural rather than analytical, which is the point: nothing decides that a closure "does not need" `$*OUT`. A closure that calls `say` reaches `$*OUT` through a callee, not through a name the free-variable pass could ever see — so the key leaves the capture because it leaves the env, and the read still resolves through the tier from wherever the closure runs.

Two things the design did not anticipate:

- **The tier absorbs `GLOBAL_BASE` instead of sitting beside it.** Two base maps made every env *miss* — which is every metadata key the VM speculatively reads — pay a second probe, and that cost more on `word-count` (~13M Ir in `Env::get_sym` alone) than the capture saved. Merged, the tail still costs exactly one probe.
- **A flat env's `remove` still never tombstones.** With a tier below it the effect is to *un-shadow* the seeded value, which is what `GLOBAL_BASE` has always done there; probing to decide otherwise would land on the hottest declaration path in the VM. A tombstone a *scoped* tier set on a base key is still carried forward through the collapses.

Consumers taught about the tier: all three chain collapses (`flattened`, `filtered_flat`, and #8059's `filtered_flat_capture`), `flatten()` / `visible_keys_where()` (which already merged `GLOBAL_BASE`), `dynamic_pseudo_stash_entries` (backing `DYNAMIC::` and `PROCESS::`), and the thread-clone spawn walk that collects the IO handle ids the child must keep working — `iter()` is map-only, and missing that last one made a plain `await start { print "X" }` die with `Invalid IO::Handle`.

## Numbers

Callgrind instruction counts — deterministic and load-independent, so a local A/B of two release binaries is meaningful where wall clock would not be. Baseline is `main` at 444c630 (i.e. *after* #8059's capture key-set memo), precompilation cache warmed. Not wall clock; the bench CI history remains the source of truth for tracked performance.

| | main | this | |
| --- | ---: | ---: | ---: |
| `my $c = * + 1;` × 200000 | 3,096,805,546 | 1,909,249,834 | **−38.4%** |
| — per creation, control loop subtracted | 13,503 | 7,564 | **−44.0%** |
| the same + 30 enclosing lexicals | 4,555,820,087 | 3,367,123,793 | −26.1% |
| — per creation | 20,798 | 14,853 | −28.6% |
| `sub make($n) { my $c = { $n + 1 } }` × 20000 | 1,048,977,489 | 917,072,113 | −12.6% |
| `bench-ctor` | 1,438,871,696 | 1,329,187,266 | −7.6% |
| `bench-class` | 1,185,541,115 | 1,146,133,720 | −3.3% |
| `bench-yaml-parse` | 597,848,254 | 584,912,644 | −2.2% |
| `bench-grammar-parse` | 47,889,416 | 47,396,313 | −1.0% |
| `bench-fib` | 1,230,729,592 | 1,230,738,762 | +0.0% |
| `bench-mandelbrot` | 792,256,437 | 793,310,309 | +0.1% |
| `bench-tak` | 1,521,783,637 | 1,525,319,286 | +0.2% |
| `bench-array` | 241,206,753 | 242,212,609 | +0.4% |
| `bench-string` | 504,742,311 | 506,998,734 | +0.5% |
| `bench-hash` | 264,406,272 | 267,143,291 | +1.0% |
| `word-count` | 1,058,126,579 | 1,076,057,078 | +1.7% |

The control loop with the closure creation removed is flat (+0.06%), so the microbenchmark rows are the creation cost and nothing else. The sub-percent to 1.7% costs at the bottom are the price of the mechanism — an `Env` grown by one `Option<Arc<_>>` and one more branch at the tail of a lookup, paid by programs that create no closures. `word-count` is the worst case: a mainline-only loop of hash-element increments, all env traffic and no capture.

## Testing

- `t/vm/scope/dynamic-vars-base-tier.t` — new, 18 assertions: reads from a closure, from a callee and from a closure created inside a sub frame; a `my $*CWD` shadow being what a closure actually captures; an assignment inside a sub still visible after it returns; `%*ENV` still writable; `PROCESS::`/`DYNAMIC::` still resolving; a lexically redirected `$*OUT` still winning, including across a `start` block. All 18 pass under rakudo too.
- ADR-0086's named acceptance tests stay green: `t/vm/start-dynamic-var-indir.t`, `t/oo/class/start-inherits-dynamic-out.t`, `roast/S32-io/indir.t`.
- Re-run after the rebase onto 444c630: `make test` green (4066 files, 43274 tests), `make lint` clean, `make roast` green apart from the three failures `docs/agent-environments.md` records as container-only (`roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t`, both `uid 0`; `roast/S32-io/IO-Socket-Async.t`, sandboxed network) — same files, same test numbers.

Refs #7557 (which stays open only for what ADR-0086 does not cover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rtFLuDLNqD45pfCwgPYpJ