### PR TITLE
fix: stop a second `use` from clobbering a module's own %?RESOURCES

### DIFF
--- a/news/2026-09/percent-resources-second-use-clobber.md
+++ b/news/2026-09/percent-resources-second-use-clobber.md
@@ -1,0 +1,59 @@
+# `%?RESOURCES` no longer loses its own distribution to a second `use`
+
+Any `unit module` that made more than one `use` statement before reading its
+own `%?RESOURCES` lost the resource list entirely: `%?RESOURCES<name>` came
+back `Any` and the follow-on `.slurp` blew up with "No such method 'slurp'
+for invocant of type 'Any'", wrapped unhelpfully as "An exception occurred
+while evaluating a CHECK". `Net::Netmask`'s and `LLM::Prompts`'s
+`use JSON::Fast; use XDG::BaseDirectory :terms;` shape (and eight other
+distributions listed against #8004) hit this at load time and failed to
+import at all.
+
+## Root cause
+
+`load_module_inner` records which distribution owns a loading module's
+`%?RESOURCES` under two keys in `package_distributions`: the module's own
+declared name, and "the current runtime package" — meant to cover a bare
+file with no `unit module` declaration, whose top-level subs compile under
+the generic `GLOBAL` package rather than their own name.
+
+That second key was read via `self.current_package()` at the moment each
+module's *own* load began. For a *nested* `use` — a dependency loaded from
+inside another module's still-executing mainline — that ambient value is
+wrong: it reflects whatever the *importer's own* `unit module` declaration
+had already set `current_package` to, not the dependency's future package.
+So loading the dependency stamped `package_distributions[<importer's own
+package>]` with the dependency's distribution, clobbering the importer's own
+correct entry the moment it made a second `use`.
+
+`%?RESOURCES` resolution first tries a more precise, collision-immune route
+(the calling routine's own declaring source file, via `SubData::source_file`
+walking up to the nearest `META6.json`), but that route requires the
+`def_file` field to be populated — which it is not for a plain top-level
+named `sub` invoked from a module's own `BEGIN` block (the exact shape
+`ingest-prompt-stencil()`/`ingest-prompt-data()` use in `LLM::Prompts`, and
+`Net::Netmask`'s `ip2arr`/`ipmask2arr`). Resolution then fell through to the
+corrupted `package_distributions` entry.
+
+## Fix
+
+Compute the "current runtime package" key from a static fact of the file
+being loaded instead of the ambient dynamic package: `detect_unit_package_name`
+already tells us whether the module declares its own `unit module`/`unit
+class`/`unit package`, so the correct key is that name if present, or
+`"GLOBAL"` otherwise — never a value read from whatever package the
+*importer* happens to be running under. This is entirely independent of
+nesting, so a dependency loaded from inside another module's mainline can no
+longer stamp the wrong key.
+
+A regression test lives at `t/modules/resources-second-use-module.t`, backed
+by two fixture distributions (`t/lib/ResSecondUse/`, its own `unit module`
+that `use`s a second fixture distribution before reading its own
+`%?RESOURCES` from a `BEGIN`-invoked sub) — the minimized shape of the
+`Net::Netmask`/`LLM::Prompts` failure, verified to fail without the fix and
+pass with it.
+
+Fixes #8004. `LLM::Prompts` now gets past its own module load (reaching a
+separate, unrelated bug further into its own logic); the remaining eight
+distributions listed against the issue were not individually re-verified in
+this PR.

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -798,12 +798,6 @@ impl Interpreter {
             // so OTF compilation can resolve $?DISTRIBUTION later.
             crate::runtime::cow_table_mut(&mut self.package_distributions)
                 .insert(module.to_string(), dist.clone());
-            // Also record under the current runtime package (typically GLOBAL
-            // for unit modules) since the interpreter's current_package may not
-            // match the module name during function body evaluation.
-            let cur_pkg = self.current_package();
-            crate::runtime::cow_table_mut(&mut self.package_distributions)
-                .insert(cur_pkg, dist.clone());
         }
         // Save and restore the language version around module loading.
         // Each module may set its own `use v6.*` which should not leak
@@ -825,6 +819,29 @@ impl Interpreter {
         // (#7797) so the package-visibility bookkeeping after that branch can
         // read it too, for a use-only module that skips the branch entirely.
         let unit_name = Self::detect_unit_package_name(&stmts);
+        if let Some(dist) = &module_dist {
+            // Also record the distribution under the package this module's OWN
+            // top-level subs actually register under: `unit_name` if it declares
+            // one, else "GLOBAL" (every module body runs under "GLOBAL" per the
+            // `set_current_package` below, unless its own `unit module`/`unit
+            // class` statement changes it once execution reaches that
+            // statement). This is a static fact of the file being loaded, NOT
+            // `self.current_package()` read here: at this point that reflects
+            // whatever the *importer* left it as when this is a nested `use`
+            // reached from within another module's still-executing mainline
+            // (e.g. that importer's own `unit module Foo` statement already
+            // ran) -- reading it here inserted THIS dependency's distribution
+            // under the IMPORTER's own package key, clobbering the importer's
+            // correct entry the moment it made a second `use` (#8004: any
+            // module with `unit module Foo; use A; use B;` lost `%?RESOURCES`
+            // the moment it gained a second `use`, because loading B stamped
+            // `package_distributions["Foo"]` with B's own distribution).
+            let effective_pkg = unit_name.clone().unwrap_or_else(|| "GLOBAL".to_string());
+            if effective_pkg != *module {
+                crate::runtime::cow_table_mut(&mut self.package_distributions)
+                    .insert(effective_pkg, dist.clone());
+            }
+        }
         if !Self::should_skip_runtime_for_use_only_module(&stmts) {
             // Module files should be compiled in a fresh GLOBAL scope, not
             // inheriting the caller's current_package.  Otherwise the compiler

--- a/t/lib/ResSecondUse/META6.json
+++ b/t/lib/ResSecondUse/META6.json
@@ -1,0 +1,17 @@
+{
+  "name": "ResSecondUse",
+  "description": "Fixture distribution declared as `unit module` that `use`s a second distribution before its own BEGIN-time %?RESOURCES read",
+  "version": "0.0.1",
+  "auth": "zef:mutsu",
+  "perl": "6.d",
+  "provides": {
+    "ResSecondUse": "lib/ResSecondUse.rakumod"
+  },
+  "resources": [
+    "greeting.txt"
+  ],
+  "depends": [
+    "ResSecondUseDep"
+  ],
+  "license": "Artistic-2.0"
+}

--- a/t/lib/ResSecondUse/lib/ResSecondUse.rakumod
+++ b/t/lib/ResSecondUse/lib/ResSecondUse.rakumod
@@ -1,0 +1,23 @@
+unit module ResSecondUse;
+
+# `use`ing a second distribution BEFORE the module's own `%?RESOURCES` read is
+# the shape that broke #8004: any `unit module` that gains a second `use`
+# clobbered `package_distributions[<this module's own package>]` with the
+# just-loaded dependency's distribution, so a plain named sub (not the
+# module's own file-scope mainline) reading `%?RESOURCES` from a `BEGIN`
+# resolved against the WRONG distribution's (empty) resource list instead of
+# this one's -- exactly `Net::Netmask`/`LLM::Prompts`'s
+# `use JSON::Fast; use XDG::BaseDirectory :terms;` shape.
+use ResSecondUseDep;
+
+my $greeting;
+
+sub ingest() is export {
+    $greeting = %?RESOURCES<greeting.txt>.slurp(:close).trim;
+}
+
+BEGIN {
+    ingest();
+}
+
+sub greeting() is export { $greeting }

--- a/t/lib/ResSecondUse/resources/greeting.txt
+++ b/t/lib/ResSecondUse/resources/greeting.txt
@@ -1,0 +1,1 @@
+hello from ResSecondUse

--- a/t/lib/ResSecondUseDep/META6.json
+++ b/t/lib/ResSecondUseDep/META6.json
@@ -1,0 +1,13 @@
+{
+  "name": "ResSecondUseDep",
+  "description": "Fixture distribution with no resources of its own, used only to be `use`d as a second dependency by ResSecondUse",
+  "version": "0.0.1",
+  "auth": "zef:mutsu",
+  "perl": "6.d",
+  "provides": {
+    "ResSecondUseDep": "lib/ResSecondUseDep.rakumod"
+  },
+  "resources": [],
+  "depends": [],
+  "license": "Artistic-2.0"
+}

--- a/t/lib/ResSecondUseDep/lib/ResSecondUseDep.rakumod
+++ b/t/lib/ResSecondUseDep/lib/ResSecondUseDep.rakumod
@@ -1,0 +1,3 @@
+unit module ResSecondUseDep;
+
+sub dep-noop() is export { }

--- a/t/modules/resources-second-use-module.t
+++ b/t/modules/resources-second-use-module.t
@@ -1,0 +1,23 @@
+use v6;
+use lib 't/lib/ResSecondUse/lib', 't/lib/ResSecondUseDep/lib';
+use Test;
+
+plan 1;
+
+# #8004: `%?RESOURCES` inside a `unit module` that `use`s a second
+# distribution before reading its own resources. `package_distributions`
+# recorded the distribution both under the module's own name AND under
+# `self.current_package()` read at the moment each dependency load started --
+# but by the time the SECOND `use` runs, `current_package()` already reflects
+# the ENCLOSING module's own name (its `unit module` statement having already
+# set it), so loading the dependency stamped the enclosing module's own
+# `package_distributions` entry with the dependency's distribution instead.
+# A plain named sub (not the module's file-scope mainline, so the def_file-
+# based lookup does not apply) reading `%?RESOURCES` from a `BEGIN` then saw
+# the WRONG distribution's (empty) resource list and `%?RESOURCES<name>` came
+# back `Any`, blowing up `.slurp` — the `Net::Netmask`/`LLM::Prompts`
+# `use JSON::Fast; use XDG::BaseDirectory :terms;` shape.
+use ResSecondUse;
+
+is greeting(), 'hello from ResSecondUse',
+    '%?RESOURCES resolves correctly even after a second `use` inside the same unit module';


### PR DESCRIPTION
## Summary

- `load_module_inner` records the distribution owning a loading module's `%?RESOURCES` under two keys in `package_distributions`: the module's own declared name, and "the current runtime package" (meant to cover a bare file with no `unit module` declaration, whose top-level subs compile under the generic `GLOBAL` package).
- That second key was read via `self.current_package()` at the moment each module's *own* load began. For a **nested** `use` (a dependency loaded from inside another module's still-executing mainline), that ambient value is wrong — it reflects whatever the *importer's own* `unit module` declaration already set `current_package` to, not the dependency's. Loading the dependency then stamped `package_distributions[<importer's own package>]` with the dependency's distribution, clobbering the importer's correct entry.
- So any module shaped `unit module Foo; use A; use B; ...; %?RESOURCES<x>` lost its own resources the moment it gained a **second** `use` — exactly `Net::Netmask`'s and `LLM::Prompts`'s `use JSON::Fast; use XDG::BaseDirectory :terms;` shape from #8004.
- The more precise, collision-immune resolution route (walking up from the calling routine's own declaring source file to the nearest `META6.json`) requires `RoutineFrame::def_file` to be populated, which it is not for a plain top-level named `sub` invoked from a module's own `BEGIN` block (`ingest-prompt-stencil()` in `LLM::Prompts`) — so resolution fell through to the corrupted `package_distributions` entry.
- Fix: compute the "current runtime package" key from a **static fact of the file being loaded** (`detect_unit_package_name`'s result, or `"GLOBAL"` when it declares none) instead of the ambient dynamic package read at an arbitrary point during a nested load.

## Investigation

Minimized and confirmed against the real `LLM::Prompts` distribution named in #8004:

```
$ mutsu -e 'use LLM::Prompts;'   # before
An exception occurred while evaluating a CHECK
Exception details:
  Failed to slurp '(Any)': No such file or directory (os error 2)

$ mutsu -e 'use LLM::Prompts;'   # after
An exception occurred while evaluating a CHECK
Exception details:
  No such method 'value' for invocant of type 'Hash'
```

`%?RESOURCES` now resolves correctly and the module gets past its own load; the remaining error is a separate, unrelated bug further into the module's own logic (out of scope here). The other eight distributions listed against #8004 were not individually re-verified in this PR.

## Test plan

- Added `t/modules/resources-second-use-module.t`, backed by two fixture distributions (`t/lib/ResSecondUse/`: a `unit module` that `use`s a second fixture distribution `t/lib/ResSecondUseDep/` before reading its own `%?RESOURCES` from a `BEGIN`-invoked sub) — the minimized shape of the failure. Confirmed the test fails without the fix (`Failed to slurp` — exact upstream symptom) and passes with it, and matches `raku`.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run locally; `make roast`'s only red files are the three environment-only failures documented in `docs/agent-environments.md` (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t` — all match the documented shapes exactly), unrelated to this change.

Closes #8004

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_