### PR TITLE
fix: let a module's own body call the operator multis it exports

### DIFF
--- a/news/2026-09/module-own-body-exported-infix.md
+++ b/news/2026-09/module-own-body-exported-infix.md
@@ -1,0 +1,51 @@
+# A module's own body can now call the operator multis it exports
+
+A package (with or without `unit module`) that declares
+`multi infix:<OP>(...) is export` made the operator work for its
+*importers*, but the module's own routines could not use it: the call fell
+through to the core operator as if no user candidate existed at all
+(`Cannot resolve caller Numeric(...)`).
+
+## Root cause
+
+Operator scoping is lexical: `user_declared_infix_ops` maps each operator
+name to the set of compilation units that declared it, and a call site only
+sees the operator when its own executing unit is in that set (an empty set
+is the documented escape hatch, "provenance unknown / visible everywhere",
+used for exports).
+
+Two bugs combined to break the module-internal case:
+
+1. **`current_unit` was never scoped to a module's own mainline while it
+   loaded.** Every per-call site (`vm_call_fast.rs`, `vm_call_light.rs`, …)
+   sets `current_unit` from the callee's own declaring file, but a module's
+   top-level statements run directly, not through a call — so while
+   `multi infix:<*>(...) is export { ... }` executed as a plain top-level
+   declaration, `current_unit` was still whatever the *importer* had left it
+   as. The operator's own declaration recorded the wrong (importer's) unit
+   as its "declaring unit".
+2. **The export-time registration was dead code.** `install_export_symbol`
+   was meant to force an exported operator's file set to empty ("visible
+   everywhere"), but it only filled the entry in *if absent*
+   (`.entry(op).or_default()`) — and the entry was never absent, because bug
+   1 had already inserted a (wrong) unit for it at declaration time. So the
+   "make it visible everywhere" step never actually ran.
+
+With only bug 1 fixed, the module's own body worked (now correctly recorded
+as the declaring unit) but *importers* broke, because the file set was no
+longer empty and no longer happened to equal the importer's own unit. Both
+had to be fixed together: `current_unit` now tracks the module's own
+compilation unit for the duration of its mainline (mirroring the existing
+`?FILE` save/restore around module loading), and the export-time
+registration now genuinely forces the file set empty, so the operator is
+visible both inside its declaring module and to every importer.
+
+## Test
+
+`t/modules/import-export/module-export-slash-operator.t` gained a ninth
+assertion (`inside-div()`, added to the `SlashOperatorExport` fixture) that
+calls the module's own exported `infix:</>` from within the module's own
+body — the assertion the file's own comment noted had to be dropped when
+that ticket was originally fixed, because of this gap.
+
+Fixes #8008.

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -857,6 +857,21 @@ impl Interpreter {
                 self.unit_of_source(Some(&source_path.to_string_lossy()));
             self.module_loading_unit_stack
                 .push((module_unit_for_loading_stack, self.routine_stack_len()));
+            // Scope `current_unit` to this module's own compilation unit while
+            // its mainline runs, exactly like `?FILE` just below. Without this,
+            // a top-level declaration made directly in the module's own body
+            // (not inside a call, which sets `current_unit` per-call from the
+            // callee's own source file) is attributed to whatever unit
+            // TRIGGERED the load -- the importer's, not the module's own.
+            // `sub infix:<...>(...) is export` recording ITS OWN declaring
+            // unit (`registration_sub.rs`'s `user_declared_infix_ops`) is
+            // exactly this shape: the operator was scoped to the IMPORTER's
+            // unit, so the module's own other routines (which run with
+            // `current_unit` correctly set to the module, via the per-call
+            // restore) saw the operator as declared in a foreign unit and
+            // fell back to the core operator (#8008).
+            let saved_unit = self.current_unit;
+            self.current_unit = module_unit_for_loading_stack;
             // If the module file is a `unit module X` (or unit package/class),
             // record X so that `register_exported_sub` can mirror exports into
             // `unit_module_exported_subs` for tag validation.
@@ -1117,6 +1132,7 @@ impl Interpreter {
                 self.unit_module_loading_stack.pop();
             }
             self.module_loading_unit_stack.pop();
+            self.current_unit = saved_unit;
             self.set_current_package(saved_package);
             if result.is_ok() {
                 // A `sub MAIN` defined in a used module is NOT the program's MAIN

--- a/src/runtime/runtime_module_export_sub.rs
+++ b/src/runtime/runtime_module_export_sub.rs
@@ -315,10 +315,19 @@ impl Interpreter {
             }
             if op.starts_with("infix:<") {
                 // Exported: visible in the importing unit, so no
-                // declaring-file restriction (see the field's doc comment).
+                // declaring-file restriction (see the field's doc comment:
+                // an empty file set means "visible everywhere"). This must
+                // force the set empty, not merely fill it in when absent
+                // (`.entry().or_default()`): the declaring module's OWN
+                // decl-time registration (`registration_sub.rs`) already
+                // populated a non-empty entry scoped to ITS unit, so a
+                // fill-if-absent here was a no-op, leaving the operator
+                // invisible to every importer — including the declaring
+                // module's own body once that decl-time entry correctly
+                // named it instead of (by a since-fixed bug, #8008) the
+                // unit that had triggered the module's load.
                 crate::runtime::cow_table_mut(&mut self.user_declared_infix_ops)
-                    .entry(op.to_string())
-                    .or_default();
+                    .insert(op.to_string(), std::collections::HashSet::new());
                 crate::vm::vm_jit::note_user_infix_decl();
             }
         }

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -442,10 +442,14 @@ impl Interpreter {
             if name.starts_with("infix:<") {
                 // An EXPORTED operator becomes lexically visible in whatever
                 // unit imported it, so it carries no declaring-file
-                // restriction (empty set == visible everywhere).
+                // restriction (empty set == visible everywhere). Force the
+                // set empty rather than filling it in only when absent: see
+                // the matching comment in
+                // `runtime_module_export_sub.rs::install_export_symbol`
+                // (#8008) — the declaring module's own decl-time entry is
+                // never absent by the time export runs.
                 crate::runtime::cow_table_mut(&mut self.user_declared_infix_ops)
-                    .entry(name.clone())
-                    .or_default();
+                    .insert(name.clone(), HashSet::new());
                 crate::vm::vm_jit::note_user_infix_decl();
             }
             let source_single = format!("{module}::{name}");

--- a/t/lib/SlashOperatorExport.rakumod
+++ b/t/lib/SlashOperatorExport.rakumod
@@ -18,3 +18,13 @@ multi infix:<%>(SlashVec $a, $b) is export { $a.scale($b) }
 multi infix:<**>(SlashVec $a, $b) is export { $a.scale($b) }
 
 sub slashvec($a, $b, $c) is export { SlashVec.new($a, $b, $c) }
+
+# The module's OWN body must be able to reach the operator multis it exports
+# (#8008) -- not just its importers. Before that fix, a call to `infix:</>`
+# made from HERE (still inside this compunit) fell through to the core
+# numeric operator, because the operator's declaring unit was recorded as
+# whichever unit TRIGGERED this module's load, not this module's own unit.
+sub inside-div() is export {
+    my $v = SlashVec.new(2, 4, 6);
+    ($v / 2).components.join(',');
+}

--- a/t/modules/import-export/module-export-slash-operator.t
+++ b/t/modules/import-export/module-export-slash-operator.t
@@ -10,7 +10,7 @@ use SlashOperatorExport;
 # match that, so the candidate was deleted and `$vec / 2` fell through to
 # numeric division ("Cannot resolve caller Numeric(...)"). From Math::Vector.
 
-plan 8;
+plan 9;
 
 my $v = slashvec(2, 4, 6);
 
@@ -30,3 +30,8 @@ is 7 / 2, 3.5, 'core infix:</> still applies to numbers';
 # split listed it as `&infix:<`.
 ok UNIT::.keys.grep({ $_ eq '&infix:</>' }).elems >= 0,
    'the pseudo-stash listing does not crash on an operator name containing /';
+
+# #8008: the module's OWN body must be able to reach the operator multis it
+# exports, not just its importers.
+is inside-div(), '1,2,3',
+   "the module's own body can call the multi infix:</> it exports (#8008)";


### PR DESCRIPTION
## Summary

A `multi infix:<OP>(...) is export` made the operator work for its *importers*, but the declaring module's own routines could not use it — the call fell through to the core operator as if no user candidate existed:

```
$ ./target/debug/mutsu -I lib repro.raku
Cannot resolve caller Numeric(P8:D: ); none of these signatures matches:
    (Mu:U \v:: *%_)
```

Two bugs combined to cause this:

1. **`current_unit` was never scoped to a module's own compilation unit while its mainline ran.** Every per-call site (`vm_call_fast.rs`, `vm_call_light.rs`, …) sets `current_unit` from the callee's own declaring file, but a module's top-level statements — including its own `multi infix:<...> is export` declarations — run directly, not through a call. So while the operator's declaration executed, `current_unit` was still whatever the *importer* had left it as, and the declaration recorded the importer's unit as the operator's "declaring unit" instead of the module's own.
2. **The export-time registration meant to make an exported operator visible everywhere was dead code.** `user_declared_infix_ops[op] = {}` (an empty file set means "visible everywhere", per the field's own doc comment) was only filled in *if absent* (`.entry(op).or_default()`) — and by the time export ran, bug 1 had already inserted a non-empty (and wrong) entry for it at declaration time, so the fill-if-absent step never actually fired.

Fixing only bug 1 in isolation flips which side breaks: the module's own body starts working (correctly recorded as its own declaring unit now), but *importers* break, because the file set is no longer empty and no longer happens to equal the importer's own unit (which is what let the pre-existing bug pass for importers by accident). Both had to be fixed together.

## Fix

- `current_unit` now tracks the module's own compilation unit for the duration of its mainline execution, mirroring the `?FILE` save/restore `run_modules.rs` already does around module loading.
- The export-time registration (`runtime_module_export_sub.rs`, `runtime_module_exports.rs`) now unconditionally clears the operator's file set to empty, instead of only filling it in when absent.

## Test plan

- `t/modules/import-export/module-export-slash-operator.t` gained a ninth assertion (`inside-div()`, added to its `SlashOperatorExport` fixture) calling the module's own exported `infix:</>` from inside the module's own body — the exact assertion that file's own comment noted had to be dropped when that (unrelated, already-fixed) ticket landed, because of this gap. Confirmed matching `raku` output.
- Ran the issue's own repro (`multi infix:<*>`/`infix:</>` on a custom class, called both from inside and outside the declaring module) before/after; also re-ran the full `t/modules` + `t/routines` categories (738 files) for regressions.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run locally; `make roast`'s only red files are the three environment-only failures documented in `docs/agent-environments.md` (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t` — all match the documented shapes exactly), unrelated to this change.

Closes #8008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_