### PR TITLE
perf: a non-constant parameter default no longer forfeits the light path on full-arity calls

### DIFF
--- a/news/2026-09/nonconst-param-default-no-longer-forfeits-every-call.md
+++ b/news/2026-09/nonconst-param-default-no-longer-forfeits-every-call.md
@@ -1,0 +1,123 @@
+# A non-constant parameter default no longer forfeits the light path on calls that supply everything
+
+`sub f($x, $y = $x + 1)` was 6.6x slower per call than `sub f($x, $y = 2)` —
+**including on `f(1, 2)`, which never consults the default at all**. The routine
+is now served by the positional light-call path whenever the caller supplies
+every positional, which closes that gap completely: 744.5M instructions for a
+20 000-iteration loop of full-arity calls becomes 139.8M, against 139.6M for the
+same loop with a constant default.
+
+## What was happening
+
+`CompiledFunction::light_required_positionals` answers `None` for a signature
+with an optional parameter that `const_fill_for_param` cannot reduce to a shared
+constant — a default reading an earlier parameter (`$y = $x + 1`), an arbitrary
+expression (`$y = expensive()`), a container literal (`$y = []`, which must be a
+*fresh* container per call). `is_positional_light_call_eligible` required it to
+be `Some`, so the whole routine stayed on the general binder.
+
+That verdict is entirely about what the light bind would have to **produce for
+an omitted parameter**. It says nothing about a call that omits nothing — and
+those calls paid it anyway: a full by-name `resolve_function_with_types` and a
+full `bind_function_args_values` on every one. Measured with `MUTSU_VM_STATS=1`,
+2 000 calls of `f(1, 2)` cost 2 001 by-name resolves; the same loop against a
+constant default cost 1.
+
+## The fix
+
+A new `CompiledFunction::light_full_arity_only`, set where
+`light_required_positionals` is computed, marks exactly that signature. Every
+dispatch site pairs it with an exact arity test against `param_local_slots`
+(`Interpreter::positional_light_full_arity_call`); a call short of full arity
+still falls through to the general binder, which remains the only thing that can
+evaluate the default.
+
+The per-call re-check matters because `pos_light_call_cache` is keyed by
+**name**: one entry serves every arity the call sites use, so a routine admitted
+by `f(1, 2)` would otherwise be served at `f(1)` too, where the light bind has
+no value for the omitted parameter and would raise "Too few positionals" for a
+call the general binder defaults happily. `t/routines/signature/nonconst-param-default-full-arity-light.t`
+alternates the two arities against one routine to pin that.
+
+The flag is set only where the precompute actually ran, so a hand-built chunk —
+whose `light_required_positionals` is `None` because nothing computed it — is
+not admitted by it.
+
+## The admission refuses a call carrying a `Pair`, and that is not incidental
+
+The light bind takes every argument positionally, so it binds a named argument
+to a positional parameter where rakudo rejects the call: `sub f($x, $y = 2) { };
+f(1, :verbose)` answers `1/verbose` in mutsu and "Unexpected named argument" in
+rakudo. That bug predates this work and is filed separately as
+[#8077](https://github.com/tokuhirom/mutsu/issues/8077) — the fix needs a
+per-callsite "has a named argument" bit, because at bind time `f(1, :verbose)`
+and a legitimate positional `Pair` (`f(1, (y => 2))`) are the same `Value`.
+
+What matters here is that the admission must not *widen* it. A routine with a
+non-constant default has always reached the general binder, which rejects the
+call correctly, and an unguarded admission changed that answer — caught by
+running the case against both binaries rather than by any test. So
+`positional_light_full_arity_call` refuses any `Pair`-carrying call, which
+reproduces those routines' behaviour exactly; the cost is that
+`f(1, (y => 2))` merely forgoes the speedup. The guard can be dropped once
+#8077 is fixed.
+
+## Cost on the hot path: none measurable
+
+The guard is last in the cached dispatch's condition chain and behind the flag,
+so an ordinary routine pays one bool test: neither the `param_local_slots` load,
+the callsite-line marker peek, nor the `Pair` scan is reached for it.
+
+Callgrind instruction counts, release, `MUTSU_JIT=off MUTSU_GC=off`:
+
+| | before | after | |
+| --- | --- | --- | --- |
+| 20 000 full-arity calls, non-constant default | 744 296 141 | 140 928 064 | **-81.1%** |
+| 20 000 full-arity calls, constant default | 139 554 038 | 139 500 624 | -0.04% |
+| `fib(22)` | 224 434 376 | 224 324 859 | -0.05% |
+
+The first row lands on the second: the forfeit is gone, not merely reduced.
+
+**On the whole-program benchmarks, the noise is larger than the effect, so no
+delta is quoted.** Three callgrind runs of the *unmodified* binary on
+`bench-ctor.raku` gave 1 415 573 316, 1 411 120 289 and 1 424 610 493 — a 0.95%
+spread — so that program is not instruction-deterministic here and a sub-1%
+delta on it means nothing. The measured after/before pairs (`bench-ctor`
+-0.35%, `bench-class` +0.05%) sit inside that spread and inside the +/-0.8%
+codegen-drift band #7964's note documents for this area. The two probes above
+*are* deterministic (three runs of the baseline spanned 1 800 instructions on
+`fib(22)`, 0.0008%), which is why they carry the claim.
+
+Shape matters here at a level comparable to the whole effect, so two rejected
+shapes are worth recording. Hoisting the marker peek out of the branch — the
+obvious way to avoid testing it twice — put a `cl.is_some()` test on every
+cached light call and measured +0.317% on `bench-ctor` against +0.115% for the
+lazy form; the peek is therefore repeated inside the branch on purpose. And the
+guard is deliberately last in the `&&` chain, so the flag's load is the only
+thing an ordinary call pays.
+
+## What was measured and deliberately NOT built
+
+[#7581](https://github.com/tokuhirom/mutsu/issues/7581) also asked for tier 3 of
+the original plan: compiling each default expression into the callee's own
+prologue, so that an **omitted** parameter runs the default's bytecode instead
+of `eval_param_default` cloning the AST and compiling it afresh per call. The
+issue told whoever took it to count the remaining tail first and close the ticket
+rather than build the compiler change if it was thin. It is thin.
+
+Over the whole `t/` suite (4 062 files), with `MUTSU_VM_STATS=1`:
+
+| | count |
+| --- | --- |
+| parameter defaults **evaluated** (`eval_param_default`) | 140 |
+| parameter defaults filled from the constant table | 56 959 |
+| by-name function resolves | 251 330 |
+| calls the light path refused *only* because of a default | 146 |
+
+47 files evaluate a default at all, at most 13 times each; 46 lose a light call
+to one, at most 10 times each. Across every benchmark in `benchmarks/` both
+counts are **zero**. So the per-call recompile the issue called "the larger of
+the two" costs the entire test suite 140 evaluations, and a per-parameter entry
+point in the callee prologue — plus the JIT's view of it — would buy nothing
+measurable. That half stays unbuilt; the forfeit that ran on *every* call, which
+the original ticket did not separate out, is what was worth fixing.

--- a/src/compiler/helpers_method_body.rs
+++ b/src/compiler/helpers_method_body.rs
@@ -222,6 +222,7 @@ impl Compiler {
             param_itemize_on_bind: Vec::new(),
             param_const_fills: Vec::new(),
             light_required_positionals: None,
+            light_full_arity_only: false,
             return_fast_type: None,
             package: package_name.to_string(),
             compiled_fns: (!own_compiled_fns.is_empty())

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -590,6 +590,7 @@ impl Compiler {
             param_itemize_on_bind: Vec::new(),
             param_const_fills: Vec::new(),
             light_required_positionals: None,
+            light_full_arity_only: false,
             return_fast_type: None,
             // The declaring package, matching the package component of this
             // function's `compiled_fns` key (built from `key_package` above).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -9189,6 +9189,26 @@ pub(crate) struct CompiledFunction {
     /// stay off the routine entirely, exactly as they did before defaults were
     /// admitted at all.
     pub(crate) light_required_positionals: Option<usize>,
+    /// True when the light paths may serve this routine, but **only for a call
+    /// that supplies every positional**.
+    ///
+    /// [`Self::light_required_positionals`] answers `None` for a signature with
+    /// an optional parameter the const-fill table cannot represent — a
+    /// non-constant default (`$y = $x + 1`), a container literal (`$y = []`),
+    /// an arbitrary expression. That verdict is entirely about what the light
+    /// bind would have to *produce for an omitted parameter*, yet it forfeited
+    /// the routine on **every** call: `f(1, 2)` re-resolved `f` by name and ran
+    /// the whole general bind for a default it never evaluated (#7581).
+    ///
+    /// A call that supplies every positional consults no default, so none of
+    /// that verdict applies to it. This flag says so. It is paired at each
+    /// dispatch site with an exact arity test against
+    /// [`Self::param_local_slots`]; a call short of full arity still falls
+    /// through to the general binder, which is the only thing that can evaluate
+    /// the default. The flag is set only where the precompute actually ran, so
+    /// a hand-built chunk (whose `light_required_positionals` is `None` because
+    /// nothing computed it) is not admitted by it.
+    pub(crate) light_full_arity_only: bool,
     /// The declared return type's precomputed plan (see [`FastParamCheck`]).
     /// `None` when there is no return type, or when it is not one the light
     /// return check handles by tag.
@@ -9557,6 +9577,11 @@ impl CompiledFunction {
             .collect();
         self.light_required_positionals =
             Self::compute_light_required_positionals(&self.param_defs, &self.param_const_fills);
+        // Set here, not at construction, so it means "the precompute ran and
+        // could not reduce every optional to a constant" rather than the
+        // weaker "nobody computed it" — see the field's doc comment.
+        self.light_full_arity_only =
+            self.light_required_positionals.is_none() && !self.param_defs.is_empty();
     }
 
     /// True if `sym` names a *callee-local* of this function — a parameter, a
@@ -9659,6 +9684,7 @@ mod compiled_fns_identity {
             param_itemize_on_bind: Vec::new(),
             param_const_fills: Vec::new(),
             light_required_positionals: None,
+            light_full_arity_only: false,
             return_fast_type: None,
             package: "GLOBAL".to_string(),
             compiled_fns: None,

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -316,6 +316,7 @@ impl Interpreter {
             param_itemize_on_bind: Vec::new(),
             param_const_fills: Vec::new(),
             light_required_positionals: None,
+            light_full_arity_only: false,
             return_fast_type: None,
             package: pkg.clone(),
             compiled_fns: (!own_compiled_fns.is_empty())
@@ -448,7 +449,12 @@ impl Interpreter {
         // to one off the loading script's same-named lexical
         // (`t/module-file-scope-lexical.t`).
         let light_eligible = self.unit_of_source(cf.source_file.as_deref()) == self.current_unit
-            && Self::is_positional_light_call_eligible(&cf, &name)
+            && Self::is_positional_light_call_eligible(
+                &cf,
+                &name,
+                Self::positional_light_argc(&args),
+                &args,
+            )
             && !Self::call_shares_container_into_scalar_param(&cf, &args)
             && !loan_env!(self, routine_is_test_assertion_by_name(&name, &args))
             && self.wrap_sub_id_for_name(&name).is_none()

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -174,11 +174,84 @@ impl Interpreter {
             })
     }
 
+    /// The positional argument count an owned argument vector presents to the
+    /// light bind: its length minus the synthetic `__mutsu_test_callsite_line`
+    /// marker the parser appends to a parenthesized zero-argument call, which
+    /// [`Interpreter::call_compiled_function_positional_light`] filters out
+    /// before binding. Only the cold call sites that hold such a vector need
+    /// this; the hot cached dispatch already knows from its own argument scan
+    /// whether a marker is present.
+    pub(super) fn positional_light_argc(args: &[Value]) -> usize {
+        args.iter()
+            .filter(|v| !Self::is_callsite_line_marker(v))
+            .count()
+    }
+
+    /// Whether this call supplies every positional of a routine that the
+    /// light paths may serve *only* at full arity
+    /// ([`CompiledFunction::light_full_arity_only`]).
+    ///
+    /// Kept as one function because two very different call sites must agree
+    /// on it: [`Interpreter::is_positional_light_call_eligible`], which decides
+    /// whether to install a `pos_light_call_cache` entry, and the cached
+    /// dispatch itself, which re-checks per call because that cache is keyed by
+    /// NAME — one entry serves every arity the call sites use, so a routine
+    /// admitted by `f(1, 2)` would otherwise be served at `f(1)` too, where the
+    /// light bind has no value to give the omitted parameter and would raise
+    /// "Too few positionals" for a call the general binder defaults happily.
+    ///
+    /// `argc` excludes the synthetic callsite-line marker; see
+    /// [`Interpreter::call_compiled_function_positional_light_at`]'s
+    /// precondition. `args` is the call's argument slice, which may still
+    /// carry that marker — a marker-bearing call is by construction a
+    /// parenthesized ZERO-argument call, so it fails the arity test first and
+    /// never reaches the `Pair` scan below.
+    ///
+    /// The `Pair` scan is what keeps this admission from changing any answer.
+    /// The light bind takes every argument positionally, so it binds a named
+    /// argument to a positional parameter where rakudo rejects the call:
+    /// `sub f($x, $y = 2) { }; f(1, :verbose)` answers `1/verbose` here and
+    /// "Unexpected named argument" in rakudo. That bug predates this admission
+    /// and is not widened by it — a routine with a non-constant default has
+    /// always taken the general binder, which gets the call right, so refusing
+    /// a `Pair`-carrying call leaves its behaviour exactly as it was. The scan
+    /// cannot distinguish `f(1, :verbose)` from a legitimate positional `Pair`
+    /// (`f(1, (y => 2))`), so it conservatively refuses both; the second merely
+    /// forgoes a speedup. Run only for a flagged routine, and only once arity
+    /// matches.
+    #[inline]
+    pub(super) fn positional_light_full_arity_call(
+        cf: &CompiledFunction,
+        argc: usize,
+        args: &[Value],
+    ) -> bool {
+        cf.light_full_arity_only
+            && cf
+                .param_local_slots
+                .as_ref()
+                .is_some_and(|slots| slots.len() == argc)
+            && !args
+                .iter()
+                .any(|v| matches!(v.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
+    }
+
     /// Check if eligible for the positional light call path.
     /// This path avoids push_call_frame, Sub value creation, block/routine push,
     /// callable_id lookup, and full bind_function_args_values. Parameters are
     /// bound to pre-computed local slots and written to env.
-    pub(super) fn is_positional_light_call_eligible(cf: &CompiledFunction, fn_name: &str) -> bool {
+    ///
+    /// `argc` is the call's positional argument count with any synthetic
+    /// callsite-line marker already excluded. It is a parameter rather than a
+    /// per-callee property because a signature whose optional parameters the
+    /// const-fill precompute could not represent is still light-servable for
+    /// the calls that supply everything — see
+    /// [`CompiledFunction::light_full_arity_only`].
+    pub(super) fn is_positional_light_call_eligible(
+        cf: &CompiledFunction,
+        fn_name: &str,
+        argc: usize,
+        args: &[Value],
+    ) -> bool {
         !fn_name.is_empty()
             && cf.code.state_locals.is_empty()
             && !cf.is_cached
@@ -198,13 +271,16 @@ impl Interpreter {
                 .as_deref()
                 .is_none_or(Self::is_fast_type_name)
             && !cf.param_defs.is_empty()
-            // A defaulted / `?`-optional positional is admitted only when the
-            // precompute could reduce every one of them to a constant fill and
-            // they form a suffix (`light_required_positionals`). Without that,
-            // an omitted parameter would need `eval_param_default` — an
-            // arbitrary expression evaluated with the parameter shadowed — which
-            // only the general binder performs.
-            && cf.light_required_positionals.is_some()
+            // A call that may OMIT a defaulted / `?`-optional positional is
+            // admitted only when the precompute could reduce every one of them
+            // to a constant fill and they form a suffix
+            // (`light_required_positionals`) — an omitted parameter otherwise
+            // needs `eval_param_default`, an arbitrary expression evaluated
+            // with the parameter shadowed, which only the general binder
+            // performs. A call that supplies every positional omits nothing and
+            // so is admitted regardless (`positional_light_full_arity_call`).
+            && (cf.light_required_positionals.is_some()
+                || Self::positional_light_full_arity_call(cf, argc, args))
             && cf.param_defs.iter().all(|pd| {
                 !pd.named
                     && pd.where_constraint.is_none()

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -668,7 +668,39 @@ impl Interpreter {
                         // caller's container -> fall through to the slow path.
                         let share_into_scalar =
                             Self::call_shares_container_into_scalar_param(cf, stack_args);
-                        if !has_junction && !call_has_slip && !share_into_scalar {
+                        if !has_junction
+                            && !call_has_slip
+                            && !share_into_scalar
+                            // This cache is keyed by NAME, so one entry serves
+                            // every arity the call sites use. A routine the
+                            // light paths may serve only at full arity
+                            // (`light_full_arity_only` — a default the
+                            // const-fill precompute could not represent) must
+                            // therefore be re-checked per call, or a shorter
+                            // call would reach a light bind with no value to
+                            // give the omitted parameter and would raise "Too
+                            // few positionals" where the general binder
+                            // defaults happily.
+                            //
+                            // Last in the chain, and behind the flag, so an
+                            // ordinary routine pays exactly one bool test:
+                            // neither the `param_local_slots` load nor the
+                            // marker peek below is reached for it. The peek is
+                            // repeated inside the branch rather than hoisted
+                            // for the same reason — hoisting it put a
+                            // `cl.is_some()` test on every cached light call.
+                            && (!cf.light_full_arity_only
+                                || Self::positional_light_full_arity_call(
+                                    cf,
+                                    arity_usize
+                                        - (cl.is_some()
+                                            && Self::is_callsite_line_marker(
+                                                &self.stack[self.stack.len() - 1],
+                                            ))
+                                            as usize,
+                                    stack_args,
+                                ))
+                        {
                             // Bind straight out of the stack (no args buffer):
                             // the callee takes the arguments in place from
                             // `stack[start..]` and truncates back to `start` on
@@ -895,7 +927,12 @@ impl Interpreter {
                         } else if !share_into_scalar
                             && !named_share
                             && !mainline_capture_blocked
-                            && Self::is_positional_light_call_eligible(&cf, name_str)
+                            && Self::is_positional_light_call_eligible(
+                                &cf,
+                                name_str,
+                                Self::positional_light_argc(&args),
+                                &args,
+                            )
                         {
                             // Promote to the ultra-fast positional cache at the
                             // top of this function, so the next call skips this
@@ -1583,8 +1620,12 @@ impl Interpreter {
             if let Some(cf) = compiled {
                 // Try positional light call path first (ultra-fast, no env clone).
                 // Skip for multi functions since the cache doesn't differentiate by arg types.
-                if Self::is_positional_light_call_eligible(cf, name)
-                    && !Self::call_shares_container_into_scalar_param(cf, &args)
+                if Self::is_positional_light_call_eligible(
+                    cf,
+                    name,
+                    Self::positional_light_argc(&args),
+                    &args,
+                ) && !Self::call_shares_container_into_scalar_param(cf, &args)
                     && !self.has_multi_candidates_cached(name)
                     && !loan_env!(self, routine_is_test_assertion_by_name(name, &args))
                     && self.wrap_sub_id_for_name(name).is_none()

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -139,6 +139,22 @@ impl Interpreter {
             "positional light bind saw a callsite-line marker: its caller must strip it"
         );
 
+        // A routine the light paths may serve only at full arity
+        // (`CompiledFunction::light_full_arity_only` -- an optional parameter
+        // whose default the const-fill precompute could not represent) must be
+        // gated by every dispatch site, because the bind below has no value to
+        // give an omitted one: it would fill from `param_const_fills`, which is
+        // empty for exactly these parameters, or take the arity branch and
+        // report "Too few positionals" for a call the general binder defaults
+        // happily. Four sites do the gating (`is_positional_light_call_eligible`
+        // for the three cold ones, an inline re-check for the name-keyed cached
+        // dispatch); this is where a fifth one forgetting to would show up.
+        debug_assert!(
+            !cf.light_full_arity_only || actual_count == positional_count,
+            "a light_full_arity_only routine reached the light bind at {actual_count} of \
+             {positional_count} positionals: its dispatch site did not gate on arity"
+        );
+
         // A positional-light-eligible signature is either all-mandatory or a
         // mandatory prefix followed by parameters the precompute reduced to a
         // constant fill (`light_required_positionals`; no slurpy either way --

--- a/t/routines/signature/nonconst-param-default-full-arity-light.t
+++ b/t/routines/signature/nonconst-param-default-full-arity-light.t
@@ -1,0 +1,91 @@
+use Test;
+
+# A signature whose optional parameters the const-fill precompute cannot
+# represent -- a default that reads an earlier parameter, an arbitrary
+# expression, a container literal -- used to forfeit the positional light-call
+# path on EVERY call, including the calls that supply every positional and so
+# never consult the default at all (#7581). Such a call is now admitted.
+#
+# The point of the test is that admitting it did not change what these
+# signatures BIND, in either direction: a full-arity call must not evaluate the
+# default, and a short call must still get the general binder's per-call
+# evaluation. Every case below is pinned against rakudo's answer.
+
+plan 26;
+
+# --- a default that reads an earlier parameter -------------------------------
+sub reads-earlier($x, $y = $x + 1) { "$x/$y" }
+is reads-earlier(1, 9), "1/9", 'full arity binds the argument';
+is reads-earlier(1),    "1/2", 'omitted still evaluates the default against $x';
+is reads-earlier(7),    "7/8", 'the default tracks the argument, not a constant';
+
+# --- the default must NOT run when the call supplies the parameter -----------
+my $ran = 0;
+sub side($x, $y = do { $ran++; 100 }) { "$x/$y" }
+is side(5, 7), "5/7", 'full arity binds the argument';
+is $ran, 0,           'a supplied parameter does not evaluate its default';
+is side(5), "5/100",  'an omitted parameter does evaluate it';
+is $ran, 1,           'evaluated exactly once';
+is side(5), "5/100",  'and again on the next omitting call';
+is $ran, 2,           'evaluated per call, not memoized';
+
+# --- a container default is a FRESH container per omitting call --------------
+sub fresh($y = []) { $y.push(1); $y.elems }
+is fresh(), 1, 'container default is fresh (first call)';
+is fresh(), 1, 'container default is fresh (second call)';
+is fresh(), 1, 'container default is fresh (third call)';
+my @given = 9, 9;
+is fresh(@given), 3, 'a supplied container is the caller\'s own';
+is @given.elems,  3, 'and the push is visible to the caller';
+
+# --- a zero-argument parenthesized call (carries the callsite-line marker) ----
+sub zero($y = 40 + 2) { $y }
+is zero(),  42, 'a parenthesized zero-arg call still reaches the default';
+is zero(7), 7,  'and a supplied argument still wins';
+
+# --- type constraints still apply on the newly-admitted path -----------------
+sub typed(Int $x, Int $y = $x + 1) { $x + $y }
+is typed(1, 2), 3, 'full arity type-checks and binds';
+is typed(1),    3, 'omitted evaluates the default';
+# Through a variable, so rakudo's compile-time "will never work" analysis does
+# not reject the call outright and both implementations check it at run time --
+# which is the check the newly-admitted light bind performs.
+my $not-an-int = "s";
+dies-ok { typed(1, $not-an-int) }, 'a full-arity argument is still type-checked';
+
+# --- arity errors are unchanged ----------------------------------------------
+# Through a capture for the same reason: a literal over-long call is a
+# compile-time error in rakudo, so there would be nothing left to run.
+my @three = 1, 2, 3;
+dies-ok { reads-earlier(|@three) }, 'too many positionals still dies';
+sub two-required($a, $b, $c = $a + $b) { "$a/$b/$c" }
+my @one = (1,);
+dies-ok { two-required(|@one) }, 'short of the mandatory prefix still dies';
+# The case the light path itself must get right: short of FULL arity but at or
+# above the mandatory prefix, which has to reach the general binder rather than
+# the light bind's "Too few positionals".
+is two-required(1, 2),    "1/2/3", 'the fillable tail still defaults';
+is two-required(1, 2, 9), "1/2/9", 'and is overridden when supplied';
+
+# --- a named argument is not swallowed as a positional -----------------------
+# The light bind takes every argument positionally, so admitting a call to it
+# must not turn `f(1, :verbose)` into a positional bind of the Pair. Pinned
+# because the newly-admitted full-arity path is exactly where that could start
+# happening: these routines have always reached the general binder, which
+# rejects the call, and must continue to.
+sub named-taker($x, $y = $x + 1) { "$x/$y" }
+dies-ok { named-taker(1, :verbose) }, 'a named argument is still rejected';
+is named-taker(1, 2), "1/2", 'and the ordinary full-arity call still works';
+
+# --- the routine keeps working after being served on both paths --------------
+# The positional light-call cache is keyed by NAME, so one entry serves every
+# arity this file calls `mixed` with. Alternating the two arities is what would
+# catch a cached full-arity entry being reused for a short call.
+sub mixed($x, $y = $x * 10) { "$x/$y" }
+my @seen;
+for 1..3 -> $i {
+    @seen.push(mixed($i));
+    @seen.push(mixed($i, 0));
+}
+is @seen.join(','), '1/10,1/0,2/20,2/0,3/30,3/0',
+    'alternating full-arity and short calls each bind correctly';


### PR DESCRIPTION
`sub f($x, $y = $x + 1)` was **6.6x slower per call** than `sub f($x, $y = 2)` — including on `f(1, 2)`, which never consults the default at all. This admits those calls to the positional light-call path, which closes the gap completely.

Closes #7581.

## Root cause

`CompiledFunction::light_required_positionals` answers `None` for a signature with an optional parameter that `const_fill_for_param` cannot reduce to a shared constant — a default reading an earlier parameter (`$y = $x + 1`), an arbitrary expression, a container literal (`$y = []`, which must be a *fresh* container per call). `is_positional_light_call_eligible` required it to be `Some`, so the routine stayed on the general binder.

That verdict is entirely about what the light bind would have to **produce for an omitted parameter**. It says nothing about a call that omits nothing — and those calls paid it anyway. With `MUTSU_VM_STATS=1`, 2 000 calls of `f(1, 2)` cost **2 001** by-name `resolve_function_with_types`; the same loop against a constant default cost **1**.

## The fix

A new `CompiledFunction::light_full_arity_only`, set where `light_required_positionals` is computed, marks exactly that signature. Every dispatch site pairs it with an exact arity test against `param_local_slots` (`positional_light_full_arity_call`); a call short of full arity still falls through to the general binder, which remains the only thing that can evaluate the default.

The per-call re-check matters because `pos_light_call_cache` is keyed by **name**: one entry serves every arity the call sites use, so a routine admitted by `f(1, 2)` would otherwise be served at `f(1)` too, where the light bind has no value for the omitted parameter and would raise "Too few positionals" for a call the general binder defaults happily. A `debug_assert!` at the light bind's single choke point catches a future dispatch site that forgets to gate.

The flag is set only where the precompute actually ran, so a hand-built chunk — whose `light_required_positionals` is `None` because nothing computed it — is not admitted by it.

### The admission refuses a call carrying a `Pair`

The light bind takes every argument positionally, so it binds a named argument to a positional parameter where rakudo rejects the call: `sub f($x, $y = 2) { }; f(1, :verbose)` answers `1/verbose` here and "Unexpected named argument" in rakudo. That bug predates this PR and is filed as #8077.

What matters here is that this admission must not *widen* it. A routine with a non-constant default has always reached the general binder, which rejects the call correctly, and an unguarded admission changed that answer — caught by running the case against both binaries, not by any existing test. `positional_light_full_arity_call` therefore refuses any `Pair`-carrying call, reproducing those routines' behaviour exactly; the cost is that a legitimate positional `Pair` (`f(1, (y => 2))`) merely forgoes the speedup. The guard can be dropped once #8077 is fixed.

## Measurements

Callgrind instruction counts, release, `MUTSU_JIT=off MUTSU_GC=off`:

| | before | after | |
| --- | --- | --- | --- |
| 20 000 full-arity calls, non-constant default | 744 296 141 | 140 928 064 | **-81.1%** |
| 20 000 full-arity calls, constant default | 139 554 038 | 139 500 624 | -0.04% |
| `fib(22)` | 224 434 376 | 224 324 859 | -0.05% |

The affected shape lands on the constant-default cost (140.9M vs 139.5M) — the forfeit is gone, not merely reduced.

**No whole-program delta is quoted, because the noise there is larger than the effect.** Three callgrind runs of the *unmodified* binary on `bench-ctor.raku` gave 1 415 573 316 / 1 411 120 289 / 1 424 610 493 — a 0.95% spread — so that program is not instruction-deterministic on this box and a sub-1% delta on it means nothing. The measured pairs (`bench-ctor` −0.35%, `bench-class` +0.05%) sit inside that spread and inside the ±0.8% codegen-drift band #7964's note documents for this area. The two probes above *are* deterministic (three baseline runs of `fib(22)` spanned 1 800 instructions, 0.0008%), which is why they carry the claim.

The guard is last in the cached dispatch's condition chain and behind the flag, so an ordinary routine pays one bool test — neither the `param_local_slots` load, the marker peek, nor the `Pair` scan is reached for it. An earlier shape that hoisted the marker peek out of the branch put a `cl.is_some()` test on every cached light call and measured **+0.317%** on `bench-ctor` against +0.115% for the lazy form, so the peek is repeated inside the branch on purpose.

## What was measured and deliberately NOT built

#7581 also asked for tier 3 of the original plan: compiling each default into the callee's prologue so an **omitted** parameter runs bytecode instead of `eval_param_default` cloning and recompiling the AST per call. The issue said to count the remaining tail first and close the ticket rather than build the compiler change if it was thin. It is thin.

Over the whole `t/` suite (4 062 files), with `MUTSU_VM_STATS=1`:

| | count |
| --- | --- |
| parameter defaults **evaluated** (`eval_param_default`) | 140 |
| parameter defaults filled from the constant table | 56 959 |
| by-name function resolves | 251 330 |
| calls the light path refused *only* because of a default | 146 |

47 files evaluate a default at all, at most 13 times each; 46 lose a light call to one, at most 10 times each. Across every benchmark in `benchmarks/` both counts are **zero**. So the per-call recompile the issue called "the larger of the two" costs the entire suite 140 evaluations, and a per-parameter entry point in the callee prologue — plus the JIT's view of it — would buy nothing measurable. That half stays unbuilt; the forfeit that ran on *every* call, which the original ticket did not separate out, is what was worth fixing.

## Tests

`t/routines/signature/nonconst-param-default-full-arity-light.t`, 26 assertions, all pinned against rakudo: a supplied parameter must not evaluate its default (side-effect counter), an omitted one must evaluate it per call and not memoize it, a container default must stay fresh per omitting call, a parenthesized zero-arg call must still reach its default, type constraints and arity errors are unchanged, a named argument is still rejected, and one routine is called at both arities alternately to pin the name-keyed cache.

Run locally before publishing:

- `cargo fmt --all`, and all four `make lint` configurations — green.
- `make test` — 4 063 files, 43 241 tests, `Result: PASS`, zero `not ok`.
- `make roast` — 1 437 files, 219 635 tests. The only failures are the three files [`docs/agent-environments.md`](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) documents as impossible in a remote container, each matching its recorded shape exactly: `6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8/10) and `S16-filehandles/filetest.t` (`Failed: 25`) both run as `uid 0`, where root bypasses the permission bits they assert on (`id -u` confirms 0), and `S32-io/IO-Socket-Async.t` times out under the network sandbox (`exited 124`, "planned 40 but ran 17"). No fourth file.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8)_