### PR TITLE
fix: a `-->` spec naming an enum value returns that value

### DIFF
--- a/news/2026-09/definite-return-enum-value.md
+++ b/news/2026-09/definite-return-enum-value.md
@@ -1,0 +1,54 @@
+# A `-->` return spec naming an enum value now returns that value
+
+`sub f($x --> B) { }` (where `enum E <A B C>`) is the idiomatic way to write
+a typed constant-returning routine — Raku treats a `-->` whose spec is a
+*constant value* rather than a type as an unconditional return of that
+value, regardless of the body. mutsu already got this right for literal
+spellings (`--> 42`, `--> "lit"`, `--> Nil`) but not for an enum value:
+`--> B` was read as a type constraint named `B`, the (empty) body's `Nil`
+passed that "constraint" unconditionally (since it never resolved to an
+actual type), and the routine answered `Nil` instead of `E::B`.
+
+## Root cause
+
+Whether a `-->` spec is a constant value or a type constraint is decided by
+`is_definite_return_spec`, which exists in two copies that must agree:
+`Compiler::is_definite_return_spec` (a static function with no interpreter
+access, driving whether the body's last expression is sunk) and
+`Interpreter::is_definite_return_spec` (driving the actual return-value
+substitution). Neither treated an uppercase enum-value spelling as
+anything but "an unrecognized uppercase name, therefore a type constraint".
+
+Fixed both to recognize a known enum value:
+
+- The compiler consults the parser's own thread-local enum-value registry
+  (`register_user_enum_value` / `is_user_declared_enum_value`), newly
+  re-exported crate-wide for this — the only enum-membership fact available
+  to a function with no interpreter to ask.
+- The interpreter consults the actual runtime enum-key namespace
+  (`Interpreter::enum_bare_value`).
+
+A third bug surfaced once the discriminators agreed: the value-construction
+path (`evaluate_definite_return_value`) fell back to `self.eval_eval_string(s)`
+for a bare name it did not special-case, but `EVAL`-compiled code does not
+resolve an enum's bare key from the enclosing lexical scope the way ordinary
+bareword resolution does (`EVAL('B')` itself fails with "Undeclared name"
+even outside this feature, a pre-existing and separate gap). Reading the
+value directly out of the enum-key bare-name namespace, alongside the other
+already-special-cased constants (`Nil`, `True`, `pi`, ...), sidesteps it.
+
+The enum's own TYPE name (`--> E`, or another enum entirely like `-->
+CardTypes2`) is unaffected: it is a separately-registered user type and
+still type-checks the return value.
+
+## Regression
+
+`t/types/enum-subset/definite-return.t` gained three assertions: a `-->`
+spec naming an enum value returns it, the enum's own type name in `-->`
+still constrains rather than substitutes, and a real type mismatch there
+still raises `X::TypeCheck::Return`.
+
+Fixes #8022 (found via `Business::CreditCard`'s
+`multi sub cardtype($, *% --> NotACreditCard) { }` dirty-input fallback
+candidate, which answered `Nil` for every non-card input instead of
+`NotACreditCard`).

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -31,6 +31,20 @@ impl Compiler {
         {
             return true;
         }
+        // An uppercase spec naming a known enum VALUE (`--> B` where `enum E
+        // <A B C>`) is a definite return of that value, not a type constraint
+        // named `B` -- the enum's own TYPE name (`E`) is a separate,
+        // parse-time-registered user type and is unaffected (#8022). Checked
+        // via the parser's own thread-local enum-value registry
+        // (`register_user_enum_value`/`is_user_declared_enum_value`), the only
+        // enum-membership fact a static function with no interpreter access
+        // can consult; the interpreter's twin check in
+        // `Interpreter::is_definite_return_spec` must agree.
+        if crate::runtime::utils::is_builtin_enum_value(s)
+            || crate::parser::is_user_declared_enum_value(s)
+        {
+            return true;
+        }
         matches!(s, "Nil" | "True" | "False" | "Empty" | "pi" | "e" | "tau")
             || (s.chars().next().is_some_and(|c| c.is_ascii_lowercase())
                 && !crate::runtime::utils::is_known_type_constraint(s))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -99,13 +99,13 @@ pub(crate) fn restore_slang_state(
     stmt::simple::set_slang_modes(modes);
     stmt::simple::set_l10n_vocabulary(vocabulary);
 }
-pub use stmt::simple::{
-    clear_parser_lib_paths, set_parser_lib_paths, set_parser_program_path, set_parser_source_file,
-};
 /// Re-exported crate-wide (not just within `parser`) so the compiler's
 /// `is_definite_return_spec` twin can consult the same parse-time enum-value
 /// registry (#8022) without interpreter access.
 pub(crate) use stmt::simple::is_user_declared_enum_value;
+pub use stmt::simple::{
+    clear_parser_lib_paths, set_parser_lib_paths, set_parser_program_path, set_parser_source_file,
+};
 
 pub(crate) use expr::precedence::lower_feed_node;
 /// Lower a deferred `Expr::Feed` node into its executable (sink-call) form.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -102,6 +102,10 @@ pub(crate) fn restore_slang_state(
 pub use stmt::simple::{
     clear_parser_lib_paths, set_parser_lib_paths, set_parser_program_path, set_parser_source_file,
 };
+/// Re-exported crate-wide (not just within `parser`) so the compiler's
+/// `is_definite_return_spec` twin can consult the same parse-time enum-value
+/// registry (#8022) without interpreter access.
+pub(crate) use stmt::simple::is_user_declared_enum_value;
 
 pub(crate) use expr::precedence::lower_feed_node;
 /// Lower a deferred `Expr::Feed` node into its executable (sink-call) form.

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -82,17 +82,17 @@ pub(in crate::parser) use module_exports::{
     import_inline_module_exports, note_type_index_incomplete, register_inline_module_exports,
     register_module_exports, register_module_type_names, type_index_is_complete,
 };
-pub(in crate::parser) use pragma_preseed::{
-    current_attributes_pragma, is_imported_value_term, is_user_declared_sub,
-    is_user_declared_type, push_package_path, register_imported_type, register_imported_value_term,
-    register_user_enum_value, register_user_type, reset_package_path, set_attributes_pragma,
-    set_eval_operator_assoc_preseed, set_eval_operator_preseed, set_eval_user_sub_preseed,
-    set_eval_user_type_preseed, set_eval_user_value_term_preseed,
-};
 /// Crate-wide (not just `pub(in crate::parser)` like its siblings above): the
 /// compiler's `is_definite_return_spec` twin needs this parse-time enum-value
 /// registry too (#8022), and has no interpreter to consult instead.
 pub(crate) use pragma_preseed::is_user_declared_enum_value;
+pub(in crate::parser) use pragma_preseed::{
+    current_attributes_pragma, is_imported_value_term, is_user_declared_sub, is_user_declared_type,
+    push_package_path, register_imported_type, register_imported_value_term,
+    register_user_enum_value, register_user_type, reset_package_path, set_attributes_pragma,
+    set_eval_operator_assoc_preseed, set_eval_operator_preseed, set_eval_user_sub_preseed,
+    set_eval_user_type_preseed, set_eval_user_value_term_preseed,
+};
 pub(in crate::parser) use registry::{
     declare_keywords_snapshot, is_declared_loop_label, lookup_custom_infix_precedence,
     lookup_postfix_precedence, lookup_prefix_precedence, lookup_user_infix_assoc,

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -83,12 +83,16 @@ pub(in crate::parser) use module_exports::{
     register_module_exports, register_module_type_names, type_index_is_complete,
 };
 pub(in crate::parser) use pragma_preseed::{
-    current_attributes_pragma, is_imported_value_term, is_user_declared_enum_value,
-    is_user_declared_sub, is_user_declared_type, push_package_path, register_imported_type,
-    register_imported_value_term, register_user_enum_value, register_user_type, reset_package_path,
-    set_attributes_pragma, set_eval_operator_assoc_preseed, set_eval_operator_preseed,
-    set_eval_user_sub_preseed, set_eval_user_type_preseed, set_eval_user_value_term_preseed,
+    current_attributes_pragma, is_imported_value_term, is_user_declared_sub,
+    is_user_declared_type, push_package_path, register_imported_type, register_imported_value_term,
+    register_user_enum_value, register_user_type, reset_package_path, set_attributes_pragma,
+    set_eval_operator_assoc_preseed, set_eval_operator_preseed, set_eval_user_sub_preseed,
+    set_eval_user_type_preseed, set_eval_user_value_term_preseed,
 };
+/// Crate-wide (not just `pub(in crate::parser)` like its siblings above): the
+/// compiler's `is_definite_return_spec` twin needs this parse-time enum-value
+/// registry too (#8022), and has no interpreter to consult instead.
+pub(crate) use pragma_preseed::is_user_declared_enum_value;
 pub(in crate::parser) use registry::{
     declare_keywords_snapshot, is_declared_loop_label, lookup_custom_infix_precedence,
     lookup_postfix_precedence, lookup_prefix_precedence, lookup_user_infix_assoc,

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -116,6 +116,15 @@ impl Interpreter {
         {
             return false;
         }
+        // An uppercase spec naming a known enum VALUE (`--> B` where
+        // `enum E <A B C>`) is a definite return of that value, not a type
+        // constraint named `B` (#8022) -- must agree with the compiler's
+        // twin check in `Compiler::is_definite_return_spec`, which consults
+        // the parser's enum-value registry instead (no interpreter access
+        // there); this checks the actual runtime enum-key namespace.
+        if crate::runtime::utils::is_builtin_enum_value(s) || self.enum_bare_value(s).is_some() {
+            return true;
+        }
         if s.chars().next().is_some_and(|c| c.is_ascii_uppercase())
             && s.chars()
                 .all(|c| c.is_ascii_alphanumeric() || c == ':' || c == '_')
@@ -398,6 +407,16 @@ impl Interpreter {
             && let Ok(i) = s.parse::<i64>()
         {
             return Ok(Value::int(i));
+        }
+        // A user-declared enum value (`--> B`, #8022): read directly out of
+        // the enum-key bare-name namespace rather than through `eval_eval_string`
+        // below. `EVAL` compiles a fresh compilation unit and does not resolve
+        // an enum's bare key from the enclosing scope the way ordinary
+        // bareword resolution does, so routing this through it would still
+        // answer "Undeclared name" for the exact case this discriminator
+        // exists to serve.
+        if let Some(v) = self.enum_bare_value(s) {
+            return Ok(v.clone());
         }
         self.eval_eval_string(s)
     }

--- a/t/types/enum-subset/definite-return.t
+++ b/t/types/enum-subset/definite-return.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 5;
+plan 8;
 
 my sub return-two(--> 2) { 3 }
 is return-two(), 2, 'definite return value overrides implicit final expression';
@@ -18,3 +18,19 @@ ok $sunk, 'final expression still runs in sink context';
 
 my $pointy = -> --> "done" { 42 };
 is $pointy(), "done", 'pointy blocks accept definite return values';
+
+# #8022: a `-->` spec naming an ENUM VALUE (not its type) is a definite
+# return of that value, regardless of the body -- exactly like `--> 42` or
+# `--> "lit"`. The enum's own TYPE name must still be a type constraint.
+enum E8022 <A8022 B8022 C8022>;
+my sub definite-enum-value($x --> B8022) { }
+is definite-enum-value(1), B8022, 'a `-->` spec naming an enum VALUE returns that value';
+
+my sub enum-type-constraint($x --> E8022) { $x }
+is enum-type-constraint(A8022), A8022,
+    "the enum's own TYPE name in `-->` stays a type constraint, not a value";
+
+throws-like
+    { enum-type-constraint(5) },
+    X::TypeCheck::Return,
+    'an enum TYPE constraint in `-->` still rejects a mismatched return value';


### PR DESCRIPTION
## Summary

`sub f($x --> B) { }` (where `enum E <A B C>`) makes the routine return `B` unconditionally, regardless of its body — the same "constant return value" rule mutsu already applied correctly to `--> 42` and `--> "lit"`:

```
$ mutsu -e 'enum E <A B C>; sub f($x --> B) { }; say f(1).raku'   # before
Nil
$ mutsu -e 'enum E <A B C>; sub f($x --> B) { }; say f(1).raku'   # after
E::B
```

## Root cause

Whether a `-->` spec is a constant value or a type constraint is decided by `is_definite_return_spec`, which exists in **two copies that must agree**: `Compiler::is_definite_return_spec` (static, no interpreter access, decides whether the body's last expression sinks) and `Interpreter::is_definite_return_spec` (decides the actual substitution). An uppercase enum value fell through both as "an unrecognized uppercase name, therefore a type constraint", so the body's own value (typically `Nil`) passed that non-existent "constraint" unconditionally.

Fixed both discriminators to recognize a known enum value:
- The compiler consults the parser's own thread-local enum-value registry (`register_user_enum_value` / `is_user_declared_enum_value`), newly re-exported crate-wide — the only enum-membership fact available with no interpreter to ask.
- The interpreter consults the actual runtime enum-key namespace (`Interpreter::enum_bare_value`).

A third bug surfaced once the discriminators agreed: the value-construction fallback (`evaluate_definite_return_value`) routed an unrecognized bare name through `eval_eval_string`, but `EVAL`-compiled code does not resolve an enum's bare key from the enclosing lexical scope the way ordinary bareword resolution does — a pre-existing, separate gap (`EVAL('B')` itself answers "Undeclared name" even outside this feature). Reading the value directly out of the enum-key bare-name namespace, alongside the other already-special-cased constants (`Nil`, `True`, `pi`, ...), sidesteps it.

The enum's own TYPE name in `-->` (or another enum's) is unaffected — still a type constraint that type-checks the return value.

## Test plan

- `t/types/enum-subset/definite-return.t` gained three assertions: a `-->` spec naming an enum value returns it, the enum's own type name in `-->` still constrains rather than substitutes, and a real type mismatch there still raises `X::TypeCheck::Return`. Matches `raku` exactly.
- Verified the issue's own `Business::CreditCard`-shaped repro (`multi sub cardtype($, *% --> NotACreditCard) { }`) and a plain enum-type-as-constraint case for no regression.
- Re-ran `t/types/enum-subset`, `t/oo/class/return-type-not-inherited*.t`, `t/oo/method/method-return-type-pseudo-class.t`, `t/routines/closure/pointy-block-return-type.t`, `t/routines/call/return-type-undeclared-invalidtype.t`, `t/modules/module-sub-return-type-otf.t` (394 tests) for regressions.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run locally; `make roast`'s only red files are the three environment-only failures documented in `docs/agent-environments.md` (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t` — all match the documented shapes exactly), unrelated to this change.

Closes #8022

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_