### PR TITLE
fix: accept a `::`-qualified imported type in a role method's parameter

### DIFF
--- a/news/2026-09/role-param-qualified-imported-type.md
+++ b/news/2026-09/role-param-qualified-imported-type.md
@@ -1,0 +1,48 @@
+# A `::`-qualified imported type is now accepted in a role method's parameter
+
+A nested (`::`-qualified) type imported from a module `use`d inside a role
+body was accepted as a parameter type in a `class`/`module`/`package`, but
+rejected inside a `role` with `Invalid typename '...' in parameter
+declaration.`.
+
+## Root cause
+
+A role method's parameter-type validation runs before the role body's own
+`use` statements have loaded (registration happens ahead of the body
+running), so a type the `use`d module will eventually supply is not yet
+resolvable. The existing accept-heuristic for this deferred the check by
+comparing the constraint's name against the `use`d module's own name —
+sound only when the two share a textual prefix (`RoleParamImport::Result`
+supplied by `use RoleParamImport::Result;`), but unsound in general: nothing
+about a type's exported spelling predicts which module supplies it
+(`Event::Test`, exported from a module named `Types1` whose own internal
+package is `Outer`). A separate rule already existed for exactly this
+reasoning on an *unqualified* constraint (defer whenever the body has any
+`use`d module not yet loaded, since an unresolvable name really is a typo
+only once every such module has loaded) — extended here to qualified
+constraints too, since the same reasoning applies identically.
+
+## Test
+
+`t/oo/role/role-param-qualified-type-cross-file-import.t` and its
+`-no-smiley` sibling, backed by fixtures under `t/lib/RoleUnrelatedModule*`,
+each in their own process (see the follow-up bug below).
+
+## Follow-up work filed separately
+
+Two additional gaps surfaced while investigating and testing this one, out
+of scope for this fix and filed as their own issues per the project's
+"don't widen the fix" convention:
+
+- [#8083](https://github.com/tokuhirom/mutsu/issues/8083): a role method
+  whose parameter names a genuinely mistyped type is silently dropped
+  (rather than raising `X::Parameter::InvalidType`) when the accept-deferral
+  above applies — this is pre-existing, reproducing before this fix too, for
+  an unqualified name.
+- [#8084](https://github.com/tokuhirom/mutsu/issues/8084): the same
+  qualified type, resolved a *second* time via this deferred path anywhere
+  else in the same process (a second method in the same role, or a second,
+  independent role importing the same module), mistypes against the value's
+  fully-qualified name instead of the relative spelling.
+
+Fixes #8023.

--- a/src/runtime/registration_role_method.rs
+++ b/src/runtime/registration_role_method.rs
@@ -133,31 +133,26 @@ impl Interpreter {
                     // sub pre-pass accepts any type declared in the unit.
                     || (!tc.contains("::")
                         && self.type_known_by_short_name(tc_base))
-                    // A qualified type supplied by a module `use`d within
-                    // this role body is not yet loaded at registration
-                    // time (the body's `use` runs after this validation),
-                    // so accept it if a body import could provide it. The
-                    // call site resolves it for real.
-                    || (tc.contains("::")
-                        && cx.body_used_modules.iter().any(|m| {
-                            tc_base == m
-                                || tc_base.starts_with(&format!("{m}::"))
-                                || m.starts_with(&format!("{tc_base}::"))
-                        }))
-                    // The same deferral for an UNQUALIFIED constraint, which
-                    // the name comparison above cannot express: a module
-                    // exports a type under a bare name, so nothing about
-                    // `Event` predicts that `use Test::Async::Event` is what
-                    // supplies it (`unit package Test::Async; class Event is
-                    // export`). Only a body `use` of a module that has NOT
-                    // been loaded yet defers — once every module this body
-                    // names is loaded, an unresolvable name really is a typo
-                    // and still reports X::Parameter::InvalidType.
-                    || (!tc.contains("::")
-                        && cx
-                            .body_used_modules
-                            .iter()
-                            .any(|m| !self.is_module_loaded(m)));
+                    // A type supplied by a module `use`d within this role
+                    // body is not yet loaded at registration time (the
+                    // body's `use` runs after this validation), so accept
+                    // the constraint if a body import could still provide
+                    // it. Applies equally to a qualified name
+                    // (`Event::Test`) and a bare one (`Event`): nothing
+                    // about either spelling predicts which `use`d module
+                    // supplies it (`unit package Outer; class Event is
+                    // export; class Event::Test is Event { }` — `Event::Test`
+                    // shares no textual prefix with the module name
+                    // `Types1` that exports it, #8023), so a name-based match
+                    // against the module name is unsound either way. Only a
+                    // body `use` of a module that has NOT been loaded yet
+                    // defers — once every module this body names is loaded,
+                    // an unresolvable name really is a typo and still
+                    // reports X::Parameter::InvalidType.
+                    || cx
+                        .body_used_modules
+                        .iter()
+                        .any(|m| !self.is_module_loaded(m));
                 if !resolvable {
                     let mut attrs = std::collections::HashMap::new();
                     attrs.insert("type".to_string(), Value::str(tc.to_string()));

--- a/t/lib/RoleUnrelatedModuleShapes.rakumod
+++ b/t/lib/RoleUnrelatedModuleShapes.rakumod
@@ -1,0 +1,5 @@
+unit package Outer;
+
+class Event is export { }
+class Event::Test is Event { }
+class Plain is export { }

--- a/t/lib/RoleUnrelatedModuleUser.rakumod
+++ b/t/lib/RoleUnrelatedModuleUser.rakumod
@@ -1,0 +1,16 @@
+use v6;
+unit role RoleUnrelatedModuleUser;
+use RoleUnrelatedModuleShapes;
+
+# `Event::Test` shares no textual prefix with the module that supplies it
+# (`RoleUnrelatedModuleShapes`) -- its own internal package is named
+# `Outer`, unrelated to both the file name and the module name (#8023).
+method describe(Event::Test:U \x) { "qualified-ok" }
+
+# Exercised entirely from inside this compunit, so the test script itself
+# never needs to import `RoleUnrelatedModuleShapes` (which would load it
+# before this role's own body does, defeating the not-yet-loaded-module
+# condition #8023 is actually about).
+method self-test() {
+    self.describe(Event::Test);
+}

--- a/t/lib/RoleUnrelatedModuleUserNoSmiley.rakumod
+++ b/t/lib/RoleUnrelatedModuleUserNoSmiley.rakumod
@@ -1,0 +1,13 @@
+use v6;
+unit role RoleUnrelatedModuleUserNoSmiley;
+use RoleUnrelatedModuleShapes;
+
+# Same as RoleUnrelatedModuleUser.rakumod but with no definiteness smiley on
+# the parameter -- kept in a separate role so this doesn't also exercise the
+# unrelated pre-existing bug tracked as #8084 (two methods in the same role
+# constrained by the identical body-imported qualified type name).
+method describe-no-smiley(Event::Test \x) { "qualified-no-smiley-ok" }
+
+method self-test() {
+    self.describe-no-smiley(Event::Test);
+}

--- a/t/oo/role/role-param-qualified-type-cross-file-import-no-smiley.t
+++ b/t/oo/role/role-param-qualified-type-cross-file-import-no-smiley.t
@@ -1,0 +1,16 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+plan 1;
+
+# The no-smiley sibling of role-param-qualified-type-unrelated-module.t (see
+# that file for the full explanation of #8023). Kept in its own process,
+# like that file, for the reason explained there (#8084).
+
+use RoleUnrelatedModuleUserNoSmiley;
+
+class Consumer does RoleUnrelatedModuleUserNoSmiley {}
+
+is Consumer.new.self-test(), "qualified-no-smiley-ok",
+    'the same holds with no definiteness smiley';

--- a/t/oo/role/role-param-qualified-type-cross-file-import.t
+++ b/t/oo/role/role-param-qualified-type-cross-file-import.t
@@ -1,0 +1,34 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+plan 1;
+
+# #8023: a `::`-qualified type imported from a module `use`d inside a role
+# body was rejected in a role method's parameter ("Invalid typename '...' in
+# parameter declaration."), even though the identical parameter type is
+# accepted in a class/module/package. The role's own accept-heuristic for a
+# type supplied by a not-yet-loaded body `use` matched the constraint's name
+# against the MODULE's name -- sound only when the type's qualified spelling
+# happens to share a prefix with the module (`RoleParamImport::Result` from
+# `use RoleParamImport::Result;`), but `Event::Test` shares nothing with the
+# module that actually supplies it here (`RoleUnrelatedModuleShapes`, whose
+# own internal package is named `Outer`). Only `use`ing the role itself here
+# (not `RoleUnrelatedModuleShapes` too) keeps that module genuinely
+# not-yet-loaded at the role's own registration time -- loading it
+# independently first would resolve the type a different way and miss the
+# bug.
+#
+# Kept to a single role/method/process: a second body-deferred resolution of
+# the identical qualified name anywhere else in the same process (a second
+# method in this role, or a second role importing the same module) hits a
+# separate, pre-existing bug tracked as #8084. The `:U`-smiley sibling case
+# is covered by role-param-qualified-type-unrelated-module-no-smiley.t, in
+# its own process for the same reason.
+
+use RoleUnrelatedModuleUser;
+
+class Consumer does RoleUnrelatedModuleUser {}
+
+is Consumer.new.self-test(), "qualified-ok",
+    'a `::`-qualified imported type with a :U smiley is accepted in a role method parameter and resolves for real';


### PR DESCRIPTION
## Summary

A nested (`::`-qualified) type imported from a module `use`d inside a role body was accepted as a parameter type inside a `class`/`module`/`package`, but rejected inside a `role` with `Invalid typename '...' in parameter declaration.`:

```
$ mutsu -I lib -e 'use UseIt; say "ok"'   # before
Invalid typename 'Event::Test:U' in parameter declaration.

$ mutsu -I lib -e 'use UseIt; say "ok"'   # after
ok
```

## Root cause

A role method's parameter-type validation runs before the role body's own `use` statements have loaded (registration happens ahead of the body running), so a type the `use`d module will eventually supply is not yet resolvable. The existing accept-heuristic for this deferred the check by comparing the constraint's name against the `use`d module's own name — sound only when the two share a textual prefix (`RoleParamImport::Result` supplied by `use RoleParamImport::Result;`), but unsound in general: nothing about a type's exported spelling predicts which module supplies it (`Event::Test`, exported from a module named `Types1` whose own internal package is `Outer` — no relation to either).

A separate, more general rule already existed for the identical reasoning on an *unqualified* constraint (defer whenever the body has any `use`d module not yet loaded, since an unresolvable name really is a typo only once every such module has loaded). I extended it to cover qualified constraints too, since the reasoning applies identically either way, and dropped the now-redundant narrower name-matching rule.

## Test plan

- `t/oo/role/role-param-qualified-type-cross-file-import.t` and its `-no-smiley` sibling, backed by fixtures under `t/lib/RoleUnrelatedModule*`, each in their own process (see below for why).
- Verified the issue's own full repro matrix (role/class/module/package × smiley/no-smiley) matches `raku` after the fix.
- Re-ran `t/oo` + `t/modules` (778 files, 7171 tests) for regressions.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run locally; `make roast`'s only red files are the three environment-only failures documented in `docs/agent-environments.md` (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t` — all match the documented shapes exactly), unrelated to this change.

## Follow-up work filed separately

Two additional gaps surfaced while testing this fix, out of scope here and filed as their own issues:
- #8083 — a role method whose parameter names a genuinely mistyped type is silently dropped instead of raising `X::Parameter::InvalidType`, when the same accept-deferral applies. Pre-existing (reproduces before this PR too, for an unqualified name).
- #8084 — the same qualified type, resolved a *second* time via this deferred path anywhere else in the same process (a second method in the same role, or an independent second role importing the same module), mistypes against the value's fully-qualified name instead of the relative spelling.

Closes #8023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_