### PR TITLE
fix: an `only` sub shadowing a CORE routine must refuse a mismatched call

### DIFF
--- a/news/2026-09/builtin-shadow-refuses-a-mismatched-call.md
+++ b/news/2026-09/builtin-shadow-refuses-a-mismatched-call.md
@@ -1,0 +1,46 @@
+# A user sub that shadows a CORE routine no longer hands a mismatched call back to CORE
+
+`sub pick(::T $x, T $y) { $y }` followed by `dies-ok { pick(1, 'two') }` reported the block as
+having *lived*, while `try { pick(1, 'two') }` caught the
+`X::TypeCheck::Binding::Parameter` the call really does raise (GH #8064). The type capture was a
+red herring: the same shape with a plainly typed signature (`sub pick(Int $x, Int $y)`) failed
+identically, and a sub whose name CORE does not use (`sub choose-it(::T $x, T $y)`) was fine all
+along.
+
+What actually happened is that the call reached CORE's `&pick` and returned its answer. Both
+dispatch chains decide whether a user sub shadows a same-named builtin by asking whether that sub
+*accepts these arguments*:
+
+* the VM's `dispatch_func_call_inner` consults `user_function_matches_call`, and on `false` goes
+  straight to `try_native_function`;
+* the interpreter's `call_function_fallback` computes `user_shadows_builtin` and, when it is
+  `false`, consults the native arity tables.
+
+For a `multi` that is the right answer — rakudo merges the setting's candidates into the same
+candidate list, so `multi sub min(Int $a) {...}; min(3, 4)` legitimately reaches CORE's `min`. For
+an `only` sub it is not: a lexical or package `sub pick` hides `&CORE::pick` entirely, so
+`pick(1, "two")` is a binding failure and nothing else. Answering it from CORE did not merely
+return a wrong value, it made the failure *disappear*, which is why a `dies-ok` around it inverted.
+
+The reason this survived the earlier builtin-shadow work (pinned by
+`t/routines/dispatch/builtin-shadow-dispatch.t`) is that the interpreter's gate was written as
+`is_builtin_function(name) && ...`, and `BUILTIN_FUNCTION_NAMES` is far narrower than the native
+surface: `pick` is answered by `builtins::native_function`'s arity tables without appearing in that
+list at all, so the shadow test said "not a builtin, nothing to shadow" and the native table then
+answered the call anyway.
+
+Both sites now ask one new predicate, `Interpreter::user_only_sub_hides_builtin`: does an `only`
+sub declared under this name resolve for this call, whether or not its signature accepts the
+arguments? It opens with the two cached registry lookups every dispatch already performs, so a
+program that declares no sub under the name pays nothing, and it deliberately excludes `multi`
+names so the candidate-merging behaviour above is untouched. When it answers yes, the call goes to
+the interpreter terminal, which resolves the routine and raises the binding or arity error the
+declared signature calls for.
+
+The `dies-ok` path was only the loudest symptom; the same fallback silently answered any
+sufficiently mismatched call to a shadowed CORE name. Pinned by
+`t/routines/dispatch/builtin-shadow-dispatch-refuses-bad-args.t`, which covers the type-capture
+repro from the issue, a plainly typed shadow, an arity mismatch, the calls that *do* fit (which
+must still reach the user sub), and the `multi` case that must still fall through to CORE.
+
+Closes #8064.

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -337,8 +337,16 @@ impl Interpreter {
         // same sub without the default won. Resolution happens through the normal
         // registry lookup, so a name with no user routine costs one miss and
         // reaches the native table exactly as before.
-        let user_shadows_builtin = Self::is_builtin_function(name)
-            && self.resolve_function_with_alias(name, args).is_some();
+        //
+        // `BUILTIN_FUNCTION_NAMES` is not the whole native surface: the arity
+        // tables behind `builtins::native_function` answer names it never
+        // lists (`pick` among them), so the shadow test also asks whether a
+        // user `only` sub is what this call resolves to at all (GH #8064 —
+        // without it `sub pick(Int, Int)` lost `pick(1, "two")` to the native
+        // `pick`, turning a binding failure into a silent success).
+        let user_shadows_builtin = (Self::is_builtin_function(name)
+            && self.resolve_function_with_alias(name, args).is_some())
+            || self.user_only_sub_hides_builtin(name, args);
         if !user_shadows_builtin {
             // ADR-0044 D1: `push`/`pop`/`shift`/`unshift`/`append`/`prepend`/
             // `splice` as native function-form routines, reached here

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -1070,6 +1070,40 @@ impl Interpreter {
         }
     }
 
+    /// Whether a user-declared **`only`** sub with this name hides a same-named
+    /// builtin for the code running right now, even though the call's arguments
+    /// do not fit its signature.
+    ///
+    /// [`Self::user_function_matches_call`] answers "does the user sub accept
+    /// THESE arguments", and every dispatch chain treats a `false` there as
+    /// "use the builtin". For a `multi` that is right — rakudo merges the
+    /// setting's candidates into the same candidate list, so a call no user
+    /// candidate accepts legitimately reaches the builtin one. For an `only`
+    /// sub it is not: a lexical/package `sub pick` hides `&CORE::pick`
+    /// *entirely*, so `sub pick(Int $x, Int $y) {...}; pick(1, "two")` is a
+    /// binding failure in rakudo, never a call to the setting's `pick`.
+    /// Falling back turned that failure into a silent success (GH #8064: a
+    /// `dies-ok` around such a call reported the block as having lived).
+    ///
+    /// Only ever consulted for a name that IS a builtin, and only after the
+    /// matching test above has already failed, so the extra resolution is off
+    /// every hot path.
+    pub(crate) fn user_only_sub_hides_builtin(&mut self, name: &str, args: &[Value]) -> bool {
+        // Two cached lookups first: this runs on the dispatch chain, and for a
+        // program that declared no sub under this name at all it must cost
+        // nothing more than they do. (`is_builtin_function` is deliberately NOT
+        // the gate: the native function tables are much wider than
+        // `BUILTIN_FUNCTION_NAMES` -- `pick`, the name in #8064, is dispatched
+        // by `builtins::native_function` without appearing there at all.)
+        if !self.has_declared_function_cached(name) || self.has_multi_function_cached(name) {
+            return false;
+        }
+        // Resolution, not mere registration: the registry is flat, so this is
+        // what decides whether the declaration is reachable from the running
+        // package at all.
+        self.resolve_function_with_types(name, args).is_some()
+    }
+
     /// A routine whose signature already pins the return value (`--> Nil`,
     /// `--> 42`, `--> "foo"`) may not also `return` an argument. Raku rejects
     /// this at compile time with an X::Comp::AdHoc carrying the offending value

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1903,6 +1903,22 @@ impl Interpreter {
                     self.set_pending_call_arg_sources(None);
                     let result = result?;
                     loan_env!(self, maybe_fetch_rw_proxy(result, true))
+                } else if loan_env!(self, user_only_sub_hides_builtin(name, &args)) {
+                    // An `only` sub the user declared under this name hides the
+                    // same-named builtin completely (rakudo: `sub pick(Int, Int)`
+                    // makes `pick(1, "two")` a binding failure, never a call to
+                    // `&CORE::pick`). The matching test above said the arguments
+                    // do NOT fit that signature, so without this arm the native
+                    // arm below would answer the call and the binding failure
+                    // would vanish (GH #8064). Hand it to the interpreter, which
+                    // raises the X::TypeCheck::Binding::Parameter / arity error
+                    // the declared signature calls for.
+                    crate::vm::vm_stats::record_function_fallback(name);
+                    self.set_pending_call_arg_sources(arg_sources);
+                    let result = self.vm_call_function_fallback(name, &args);
+                    self.set_pending_call_arg_sources(None);
+                    let result = result?;
+                    loan_env!(self, maybe_fetch_rw_proxy(result, true))
                 } else if let Some(native_result) =
                     self.try_native_function(Symbol::intern(name), &args)
                 {

--- a/t/routines/dispatch/builtin-shadow-dispatch-refuses-bad-args.t
+++ b/t/routines/dispatch/builtin-shadow-dispatch-refuses-bad-args.t
@@ -1,0 +1,42 @@
+use Test;
+
+# GH #8064. A user-declared `only` sub hides a same-named CORE routine
+# COMPLETELY: a call whose arguments do not fit the declared signature is a
+# binding failure, never a silent call to the builtin. Both dispatch chains
+# used to decide "the user sub does not accept these arguments" and then hand
+# the call to the native tables, so the binding failure disappeared -- most
+# visibly through `dies-ok`, which reported such a block as having lived.
+#
+# The two gates that got this wrong keyed on `BUILTIN_FUNCTION_NAMES`, which
+# is much narrower than the native arity tables: `pick` is answered by
+# `builtins::native_function` without appearing in that list at all, which is
+# why this shape survived the earlier builtin-shadow work pinned by
+# `builtin-shadow-dispatch.t`.
+
+plan 10;
+
+sub pick(::T $x, T $y) { "user:$x/$y" } #OK shadow
+
+# A type capture resolves `T` from `$x`, so `$y` must be an Int here.
+dies-ok { pick(1, 'two') }, 'capture-constrained mismatch dies inside dies-ok';
+dies-ok({ pick(1, 'two') }), 'the same, written with parens';
+lives-ok { pick(1, 2) }, 'a call that does fit the capture still lives';
+is pick(1, 2), "user:1/2", 'and reaches the user sub, not CORE pick';
+
+throws-like { pick(1, 'two') }, X::TypeCheck::Binding::Parameter,
+    'the mismatch is a parameter binding failure';
+
+# The same for a plainly typed shadow: no type capture is needed to reach it.
+sub roll(Int $x, Int $y) { "user:$x/$y" } #OK shadow
+dies-ok { roll(1, 'two') }, 'plainly typed shadow of a native-table name dies';
+is roll(1, 2), "user:1/2", 'the matching call reaches the user sub';
+
+# An arity mismatch is a binding failure too, not a call to CORE's routine.
+dies-ok { roll(1) }, 'too few positionals is a binding failure, not CORE roll';
+
+# A `multi`, unlike an `only` sub, ADDS candidates to the core ones rather
+# than hiding them, so a call no user candidate accepts still reaches CORE
+# (verified against rakudo: `multi sub min(Int $a) {...}; min(3, 4)` is 3).
+multi sub min(Int $a) { "user:$a" } #OK shadow
+is min(3), "user:3", 'the user multi candidate wins when it matches';
+is min(3, 4), 3, 'a call it does not match still reaches the core candidate';


### PR DESCRIPTION
## What #8064 actually was

`sub pick(::T $x, T $y) { $y }` + `dies-ok { pick(1, 'two') }` reported the block as having
**lived**, while `try` caught the `X::TypeCheck::Binding::Parameter` the call really does raise.

The type capture was a red herring. The same shape with a plainly typed signature
(`sub pick(Int $x, Int $y)`) failed identically, and the same signature under a name CORE does not
use (`sub choose-it(::T $x, T $y)`) was fine all along. What actually happened is that the call
reached **CORE's `&pick`** and returned its answer — instrumenting `Test.rakumod`'s `dies-ok`
showed `$code()` returning the `Seq` `("two")`, i.e. `pick(1, "two")` interpreted as "pick 1
element out of ('two')". The user sub's body never ran, and no failure existed for `dies-ok` to
see.

## Root cause

Both dispatch chains decide whether a user sub shadows a same-named builtin by asking whether that
sub **accepts these arguments**:

* the VM's `dispatch_func_call_inner` consults `user_function_matches_call` and, on `false`, goes
  straight to `try_native_function`;
* the interpreter's `call_function_fallback` computes `user_shadows_builtin` and, on `false`,
  consults the native arity tables.

For a `multi` that is correct — rakudo merges the setting's candidates into the same candidate
list, so `multi sub min(Int $a) {...}; min(3, 4)` legitimately answers `3` (verified against
`raku`). For an `only` sub it is not: a lexical/package `sub pick` hides `&CORE::pick` entirely, so
`pick(1, "two")` is a binding failure and nothing else (rakudo even rejects it at compile time:
`Calling pick(Int, Str) will never work with declared signature (Int $x, Int $y)`).

The reason this survived the earlier builtin-shadow work (pinned by
`t/routines/dispatch/builtin-shadow-dispatch.t`) is that the interpreter's gate was written as
`is_builtin_function(name) && ...`, and `BUILTIN_FUNCTION_NAMES` is far narrower than the native
surface: `pick` is answered by `builtins::native_function`'s arity tables without appearing in that
list at all, so the shadow test said "not a builtin, nothing to shadow" and the native table then
answered the call anyway.

## The change

* New `Interpreter::user_only_sub_hides_builtin(name, args)` — does an `only` sub declared under
  this name resolve for this call, whether or not its signature accepts the arguments? It opens
  with the two cached registry lookups dispatch already performs, so a name with no user sub under
  it pays nothing, and it deliberately excludes `multi` names so candidate merging is untouched.
* `vm_call_func_ops.rs`: a new arm before `try_native_function` that routes such a call to the
  interpreter terminal.
* `builtins_operators_fallback.rs`: `user_shadows_builtin` now also consults the new predicate, so
  the native arity tables are skipped and the flow reaches the resolve-and-call site that raises
  the declared signature's binding/arity error.

Both sites are needed — the VM reaches `try_native_function` before the interpreter fallback, and
removing either arm leaves the repro failing (measured).

The `dies-ok` inversion was only the loudest symptom; the same fallback silently answered any
sufficiently mismatched call to a shadowed CORE name.

## Tests

`t/routines/dispatch/builtin-shadow-dispatch-refuses-bad-args.t` (10 tests): the issue's
type-capture repro in both `dies-ok` spellings, a `throws-like` on the exception type, a plainly
typed shadow, an arity mismatch, the calls that *do* fit (which must still reach the user sub), and
the `multi` case that must still fall through to CORE.

News: `news/2026-09/builtin-shadow-refuses-a-mismatched-call.md`.

## Verification

* `make test` — **PASS** (4069 files, 43315 tests)
* `make roast` — the only failures are the three container-environment ones documented in
  `docs/agent-environments.md`, matching its recorded test numbers exactly:
  `6.c/S32-io/file-tests.t` (tests 6-8, 10 — runs as `uid 0`), `S16-filehandles/filetest.t`
  (tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125 — `uid 0`), and
  `S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17" — sandboxed network).
* `make lint` — all four configurations clean (default clippy, `jit` off, wasm32 lib, rustdoc).

Closes #8064

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_