### PR TITLE
feat(nqp): implement defined, isconcrete, list, and unshift ops

### DIFF
--- a/src/runtime/nqp_ops_process.rs
+++ b/src/runtime/nqp_ops_process.rs
@@ -107,6 +107,55 @@ impl Interpreter {
                 Ok(Value::array(parts))
             }
 
+            // nqp::defined($v) / nqp::isconcrete($v) — int 0/1: false for a
+            // type object or the VM null, true for everything else. nqp draws
+            // a finer HLL-vs-REPR distinction between the two upstream, but
+            // both collapse to the same test here, matching the raku-observed
+            // behavior driving this op (Test::Async's `HubHOW` bundle
+            // registry, #8024).
+            "defined" | "isconcrete" => Ok(Value::int(i64::from(
+                crate::runtime::types::value_is_defined(args.first().unwrap_or(&Value::NIL)),
+            ))),
+
+            // nqp::list(...) — an untyped VM list; mutsu represents one as an
+            // ordinary array, same as the typed `list_s`/`list_i`/`list_n`.
+            "list" => Ok(Value::array(args.to_vec())),
+
+            // nqp::unshift(@l, $v) — the positional peer of
+            // `push_s`/`push_i`/`push_n` (nqp_ops_text.rs): insert at the
+            // front of an nqp list / native array in place, returning the
+            // list.
+            "unshift" => {
+                let target = args.first().cloned().unwrap_or(Value::NIL);
+                let val = args.get(1).cloned().unwrap_or(Value::NIL);
+                match target.view() {
+                    ValueView::Array(items, _) => {
+                        // SAFETY: audited aliased in-place container write
+                        // (see value::aliased_mut) — the same pattern
+                        // `push_elem` uses; no borrow into the node is live.
+                        let data = unsafe { crate::value::gc_contents_mut(&items) };
+                        data.items_mut().insert(0, val);
+                        Ok(target)
+                    }
+                    ValueView::Instance { attributes, .. } => {
+                        let stored = val.clone();
+                        let done =
+                            crate::value::value_buf::with_buf_elems_mut(&attributes, |elems| {
+                                elems.insert(0, stored)
+                            });
+                        match done {
+                            Some(()) => Ok(target),
+                            None => Err(RuntimeError::new(
+                                "nqp::unshift: expected a Buf/Blob or array".to_string(),
+                            )),
+                        }
+                    }
+                    _ => Err(RuntimeError::new(
+                        "nqp::unshift: expected a Buf/Blob or array".to_string(),
+                    )),
+                }
+            }
+
             _ => return self.call_nqp_op_text(op, args),
         })
     }

--- a/t/vm/nqp-defined-list-unshift-ops.t
+++ b/t/vm/nqp-defined-list-unshift-ops.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+use nqp;
+
+# nqp::defined, nqp::isconcrete, nqp::list, and nqp::unshift — the positional
+# peer of the existing push_s/push_i/push_n. `nqp::unless` was already a
+# compiled special form (compiler/nqp_forms.rs) once its operands stopped
+# throwing on the missing ops below; see #8024, driven by Test::Async's
+# HubHOW bundle registry:
+#
+#   nqp::unless(nqp::isconcrete($bundle-typeobjs), ($bundle-typeobjs := nqp::list()));
+#   nqp::unshift($bundle-typeobjs, bundle-typeobj);
+
+plan 12;
+
+# -- nqp::defined / nqp::isconcrete: 0/1, false for a type object -----------
+
+is nqp::defined(1), 1, 'nqp::defined is 1 for a concrete value';
+is nqp::isconcrete(1), 1, 'nqp::isconcrete is 1 for a concrete value';
+my Any $undef;
+is nqp::defined($undef), 0, 'nqp::defined is 0 for an unassigned Any (a type object)';
+is nqp::isconcrete($undef), 0, 'nqp::isconcrete is 0 for the same type object';
+is nqp::defined(Int), 0, 'nqp::defined is 0 for a bare type object';
+
+# -- nqp::list: an untyped VM list, readable via the existing elems/atpos ---
+
+my $l := nqp::list(1, 2, 3);
+is nqp::elems($l), 3, 'nqp::list builds a list nqp::elems can read';
+is nqp::atpos($l, 1), 2, 'and nqp::atpos can index into it';
+
+# -- nqp::unshift: insert at the front, in place -----------------------------
+
+nqp::unshift($l, 0);
+is nqp::elems($l), 4, 'nqp::unshift grows the list by one';
+is nqp::atpos($l, 0), 0, 'and the new element lands at the front';
+is nqp::atpos($l, 1), 1, 'shifting the old elements one slot up';
+
+# -- the exact repro from #8024: unless + isconcrete + list + unshift -------
+
+my $bundle;
+nqp::unless(nqp::isconcrete($bundle), ($bundle := nqp::list()));
+nqp::unshift($bundle, 'a');
+is nqp::defined($bundle), 1, 'the #8024 idiom leaves the list defined';
+is nqp::elems($bundle), 1, 'and holding the unshifted element';


### PR DESCRIPTION
## Summary

Four `nqp::` value ops used by Test::Async 0.1.17's `HubHOW` bundle registry
(and ordinary nqp-level list-building code generally) were unimplemented,
failing loudly with `Unsupported nqp:: op`. `nqp::unless` was already a
compiled special form (`compiler/nqp_forms.rs`) and needed no change — the
repro's real blocker was `nqp::isconcrete`.

- `nqp::defined` / `nqp::isconcrete`: both collapse to the existing
  `runtime::types::value_is_defined` check (0 for a type object or the VM
  null, 1 otherwise).
- `nqp::list`: the untyped VM list, same representation as the existing
  typed `list_s`/`list_i`/`list_n` (an ordinary array).
- `nqp::unshift`: the positional peer of `push_s`/`push_i`/`push_n`,
  inserting at the front of an nqp list / native array in place.

Closes #8024

## Test plan

- Added `t/vm/nqp-defined-list-unshift-ops.t`, including the exact
  `nqp::unless`/`nqp::isconcrete`/`nqp::list`/`nqp::unshift` idiom from the
  issue's repro.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run locally.
  `make roast` comes back with only the three environment-only failures
  documented in `docs/agent-environments.md` for a remote container
  (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t` — both
  `uid 0` chmod-based file tests — and `roast/S32-io/IO-Socket-Async.t`,
  sandboxed network); everything else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_