### PR TITLE
fix(parser): five more parse-failure index rows -- parameter tails, negated set glyphs, subscript semilists

### DIFF
--- a/news/2026-09/parse-failure-index-param-tails-negated-set-glyphs-and-semilists.md
+++ b/news/2026-09/parse-failure-index-param-tails-negated-set-glyphs-and-semilists.md
@@ -1,0 +1,87 @@
+# Five more parse-failure index rows: parameter tails, negated set glyphs, subscript semilists
+
+Five more constructs off the `expected statement ...` index (#7954), the largest
+single bucket in the ecosystem sweep's `blocked_load` records. Each was reached
+the same way the earlier batches were: fetch the tarball named by the
+`ecosystem/dists/` record, run `mutsu --dump-ast` over every module the META6
+`provides` names, binary-search the failing file down to the smallest still-failing
+line range, and reduce that to a one-liner checked against rakudo.
+
+Four of the five are the same shape of bug — a parameter (or subscript) grammar
+that stopped one production short of what Raku allows, leaving the tail
+unconsumed so the *enclosing* construct failed at its closing bracket. That is
+why the index could only ever report a container: the reported line named the
+`sub`, the `class` or the block, never the parameter inside it.
+
+## A parameter trait written with a word-quote argument
+
+`sub MAIN(Bool :$timer is option<!>)` — App::Prove6's entire CLI signature, via
+`Trait::Option`. Parameter traits accepted only a parenthesized argument
+(`is encoded('utf8')`), so the `<!>` was left in the signature and the parameter
+list failed at its `)`. `skip_optional_trait_arg` now also skips a `<...>` /
+`«...»` word quote written directly after the trait name. The opener has to
+follow the name with no intervening whitespace, which keeps
+`$x is copy where * < 3` out of this path.
+
+## An anonymous optional parameter carrying a tail
+
+`multi sub build-xxhash(Int @data, Int $seed = 0, $? where { $*KERNEL.bits == 64 } --> Int)`
+— Digest::xxHash. The `$?` / `@?` / `%?` branch returned the parameter the moment
+it recognized the sigil, so an `is` trait, a `where` post-constraint or a default
+after it was never consumed. It now runs the same `parse_subsig_tail` every other
+parameter shape uses. An anonymous optional *invocant* (`method m($?: |)`) carries
+none of those, so it still falls through untouched.
+
+## The `!` meta-prefix over a Unicode set relation
+
+`@vars .= grep: * !∈ @$positional` — Math::Symbolic. The negated-set-operator
+parser listed the ASCII spellings (`!(elem)`, `!(<=)`, ...) by hand and knew only
+the four *precomposed* negated glyphs (`∉`, `∌`, `⊈`, `⊉`), so `!` followed by a
+glyph was not an operator at all. It now defers to `parse_set_op` and keeps
+whatever that returns when the relation is Bool-valued, which is the rule the `!`
+meta-prefix actually follows. The non-Bool set operators stay out, so `!∪` is
+still not an operator.
+
+## A sigilless pointy-block parameter carrying a trait
+
+`Proxy.new: :FETCH{ ... }, STORE => -> $, \v is raw { ... }` — Proxee. The
+sigilled and `+name` pointy-parameter branches each parsed an `is`-trait and
+default tail; the `\name` branch returned immediately, so the trait was left
+before the block's `{` and the whole `Proxy.new` argument list failed.
+
+## A semicolon terminating a subscript's semilist
+
+```raku
+@!kept[
+    $!nb-kept < $!nb-to-keep ?? $!nb-kept++ !! $!nb-to-keep.rand;
+] = [$!nb-seen, $item];
+```
+
+Data::RandomKeep. A subscript holds a semilist, so a `;` in it may *terminate*
+the last dimension rather than separate two — `@a[1;]` is `@a[1]`, not a
+two-dimensional index whose second dimension is missing. The dimension loop
+unconditionally parsed another expression after every `;`, so the statement died
+at the closing bracket. It now peeks for the subscript's own closer (`]` or `}`)
+first, and a single remaining dimension collapses back to an ordinary
+`Expr::Index` rather than a one-dimensional `MultiDimIndex`.
+
+## Result
+
+App::Prove6, Data::RandomKeep, Digest::xxHash and Proxee now parse every module
+their META6 `provides` names; so does Math::Symbolic's own `Math/Symbolic.rakumod`
+(`Language.rakumod` still fails on `our @.operations := @operations;`, an `our`-scoped
+attribute bound with `:=`, which remains on the index).
+
+Pins: `t/oo/trait/param-trait-word-quote-arg.t`,
+`t/routines/signature/anon-optional-param-tail.t`,
+`t/collections/set-bag-mix/negated-set-op-unicode-glyphs.t`,
+`t/routines/signature/pointy-sigilless-param-traits.t`,
+`t/collections/subscript/subscript-semilist-trailing-semicolon.t` — all five green
+under rakudo itself, so they pin rakudo's behaviour rather than mutsu's.
+
+One divergence found on the way and filed as #8089 rather than forced in here: an
+*optional* parameter's `where` constraint is skipped entirely when the argument is
+omitted, where rakudo runs it against the type object. That is what makes
+Digest::xxHash's `$? where { $*KERNEL.bits == 64 }` a real multi-dispatch
+discriminator, and it reaches well beyond this index — it lives in the binder and
+in multi-candidate matching, not in the parser.

--- a/src/parser/expr/postfix/call_method.rs
+++ b/src/parser/expr/postfix/call_method.rs
@@ -169,6 +169,21 @@ pub(crate) fn parse_bracket_indices_inner(input: &str) -> PResult<'_, ParsedBrac
             current_dim = Vec::new();
             let (r3, _) = parse_char(r2, ';')?;
             let (r3, _) = ws(r3)?;
+            // A subscript holds a *semilist*, so the `;` may be a terminator
+            // rather than a dimension separator: `@!kept[ $i ?? $a !! $b; ] = ...`
+            // (Data::RandomKeep) is the one-dimensional `@!kept[...]`, not a
+            // two-dimensional index whose second dimension is missing. Only the
+            // subscript's own closer can follow, so peeking at it is enough.
+            if r3.starts_with(']') || r3.starts_with('}') {
+                return Ok((
+                    r3,
+                    if dimensions.len() == 1 {
+                        ParsedBracketIndex::Single(dimensions.remove(0))
+                    } else {
+                        ParsedBracketIndex::MultiDim(dimensions)
+                    },
+                ));
+            }
             let (r3, next) = crate::parser::expr::expression(r3)?;
             current_dim.push(next);
             r = r3;

--- a/src/parser/expr/precedence_meta_ops/set_ops.rs
+++ b/src/parser/expr/precedence_meta_ops/set_ops.rs
@@ -97,31 +97,24 @@ fn parse_set_op(input: &str) -> Option<(TokenKind, usize)> {
 /// precomposed Unicode "negated" glyph. Returns the *positive* `TokenKind`,
 /// which the caller wraps in a `Bang` unary.
 ///
-/// Handles the ASCII forms `!(elem)`, `!(cont)`, `!(<=)`, `!(>=)`, `!(>)`,
-/// `!(==)` and the Unicode glyphs `\u{2209}` (\u{2209}), `\u{220C}` (\u{220C}),
-/// `\u{2288}` (\u{2288}), `\u{2289}` (\u{2289}). `!(<)` and `\u{2284}`/`\u{2285}`/`\u{2262}`
-/// already have dedicated handling in `parse_set_op`, so they are intentionally
-/// left out here.
+/// Handles the ASCII forms `!(elem)`, `!(cont)`, `!(<=)`, `!(>=)`, `!(<)`,
+/// `!(>)`, `!(==)`, the same relations spelled with their Unicode glyph
+/// (`!\u{2208}`, `!\u{2286}`, ...), and the precomposed negated glyphs `\u{2209}`,
+/// `\u{220C}`, `\u{2288}`, `\u{2289}`.
+///
+/// The `!` meta-prefix applies to any Bool-returning infix, so rather than
+/// listing the negatable spellings a second time this defers to `parse_set_op`
+/// and keeps whatever it returns if the relation is iffy. That is what admits
+/// `@vars .= grep: * !\u{2208} @$positional` (Math::Symbolic), which the ASCII-only
+/// list used to reject. The non-Bool set operators (`\u{222a}`, `\u{2229}`, `\u{2216}`, ...) stay
+/// out, so `!\u{222a}` is still not an operator.
 fn parse_negated_set_op(input: &str) -> Option<(TokenKind, usize)> {
     if let Some(rest) = input.strip_prefix('!') {
-        // Check the 4-char forms before the 3-char ones so that e.g. `(<=)`
-        // is not mis-parsed as `(<)` followed by stray `=`.
-        let positive = if rest.starts_with("(elem)") {
-            Some((TokenKind::SetElem, 6))
-        } else if rest.starts_with("(cont)") {
-            Some((TokenKind::SetCont, 6))
-        } else if rest.starts_with("(<=)") {
-            Some((TokenKind::SetSubset, 4))
-        } else if rest.starts_with("(>=)") {
-            Some((TokenKind::SetSuperset, 4))
-        } else if rest.starts_with("(>)") {
-            Some((TokenKind::SetStrictSuperset, 3))
-        } else if rest.starts_with("(==)") {
-            Some((TokenKind::Ident("(==)".to_string()), 4))
-        } else {
-            None
-        };
-        return positive.map(|(tok, len)| (tok, 1 + len));
+        let (tok, len) = parse_set_op(rest)?;
+        if !is_iffy_set_op(&tok) {
+            return None;
+        }
+        return Some((tok, 1 + len));
     }
     // Precomposed Unicode negated glyphs missing from `parse_set_op`.
     if input.starts_with('\u{2209}') {
@@ -134,6 +127,24 @@ fn parse_negated_set_op(input: &str) -> Option<(TokenKind, usize)> {
         Some((TokenKind::SetSuperset, '\u{2289}'.len_utf8()))
     } else {
         None
+    }
+}
+
+/// True for the set operators that return a Bool and can therefore carry the
+/// `!` meta-negation. `(==)`/`\u{2261}` are set equality, also Bool-valued.
+fn is_iffy_set_op(tok: &TokenKind) -> bool {
+    match tok {
+        TokenKind::SetElem
+        | TokenKind::SetCont
+        | TokenKind::SetSubset
+        | TokenKind::SetSuperset
+        | TokenKind::SetStrictSubset
+        | TokenKind::SetStrictSuperset => true,
+        TokenKind::Ident(name) => matches!(
+            name.as_str(),
+            "(==)" | "\u{2261}" | "\u{2262}" | "\u{2284}" | "\u{2285}"
+        ),
+        _ => false,
     }
 }
 

--- a/src/parser/stmt/control/pointy_param.rs
+++ b/src/parser/stmt/control/pointy_param.rs
@@ -86,13 +86,38 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
     // Sigilless parameter: \name, optionally preceded by a type constraint
     // (`-> Mu \type { ... }` — how JSON::Unmarshal writes its `where` lambdas).
     if let Some(r) = rest.strip_prefix('\\') {
-        let (rest, name) = ident(r)?;
+        let (r, name) = ident(r)?;
+        // ...and, like every other parameter shape, it may carry `is` traits and
+        // a default: `-> $, \v is raw { ... }` is how Proxee writes its `STORE`
+        // block. Only the sigilled and `+name` branches parsed a tail, so the
+        // trait was left unconsumed and the whole pointy block failed at its
+        // opening brace.
+        let mut traits = Vec::new();
+        let (mut r, _) = ws(r)?;
+        while let Some(after_is) = keyword("is", r) {
+            let (after_is, _) = ws1(after_is)?;
+            let (after_is, trait_name) = ident(after_is)?;
+            let (after_is, _) = sub::validate_param_trait_pub(&trait_name, &traits, after_is)?;
+            traits.push(trait_name);
+            let (after_is, _) = ws(after_is)?;
+            r = after_is;
+        }
+        let mut default = None;
+        if let Some(after_eq) = r.strip_prefix('=')
+            && !after_eq.starts_with('>')
+        {
+            let (after_eq, _) = ws(after_eq)?;
+            let (after_default, default_expr) = expression(after_eq)?;
+            default = Some(default_expr);
+            r = after_default;
+        }
+        let rest = r;
         return Ok((
             rest,
             ParamDef {
                 type_capture: None,
                 name,
-                default: None,
+                default,
                 multi_invocant: true,
                 required: false,
                 named: false,
@@ -107,7 +132,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                 outer_sub_signature: None,
                 code_signature: None,
                 where_constraint: None,
-                traits: Vec::new(),
+                traits,
                 optional_marker: false,
                 is_invocant: false,
                 shape_constraints: None,

--- a/src/parser/stmt/sub/param_validate.rs
+++ b/src/parser/stmt/sub/param_validate.rs
@@ -6,11 +6,15 @@ use crate::value::ValueView;
 /// that carries a parenthesized argument; see `skip_optional_trait_arg`.
 const VALID_PARAM_TRAITS: &[&str] = &["rw", "readonly", "copy", "required", "raw", "encoded"];
 
-/// After a parameter trait name, skip an optional parenthesized argument such as
-/// the `('utf8')` in `is encoded('utf8')`. Balances nested parens and ignores
-/// parens inside single/double-quoted string literals. Leading whitespace before
-/// the `(` is permitted. Returns the input unchanged when no `(` follows.
+/// After a parameter trait name, skip an optional argument such as the
+/// `('utf8')` in `is encoded('utf8')` or the `<!>` in `is option<!>`. Balances
+/// nested parens and ignores parens inside single/double-quoted string
+/// literals. Leading whitespace before the `(` is permitted. Returns the input
+/// unchanged when no argument follows.
 pub(crate) fn skip_optional_trait_arg(input: &str) -> &str {
+    if let Some(rest) = skip_optional_trait_word_arg(input) {
+        return rest;
+    }
     let trimmed = input.trim_start();
     if !trimmed.starts_with('(') {
         return input;
@@ -45,6 +49,37 @@ pub(crate) fn skip_optional_trait_arg(input: &str) -> &str {
     }
     // Unbalanced: leave the input as-is so the normal parser reports the error.
     input
+}
+
+/// A trait argument written as a word quote directly after the trait name —
+/// `Bool :$timer is option<!>` (App::Prove6, via `Trait::Option`), `is foo«a b»`.
+/// Rakudo lowers it to a named argument on `trait_mod:<is>`; mutsu keeps only
+/// the trait *name* on a parameter, so the argument is skipped like the
+/// parenthesized form. The opener must follow the name with no intervening
+/// whitespace, which keeps `$x is copy where * < 3` out of this path.
+/// `<...>` nests, matching the word-quote grammar. Returns `None` when no word
+/// quote follows, and also when it is unbalanced so the normal parser reports
+/// the error.
+fn skip_optional_trait_word_arg(input: &str) -> Option<&str> {
+    let (open, close) = if input.starts_with('<') {
+        ('<', '>')
+    } else if input.starts_with('\u{ab}') {
+        ('\u{ab}', '\u{bb}')
+    } else {
+        return None;
+    };
+    let mut depth = 0u32;
+    for (i, c) in input.char_indices() {
+        if c == open {
+            depth += 1;
+        } else if c == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(&input[i + c.len_utf8()..]);
+            }
+        }
+    }
+    None
 }
 
 /// Trait validation for a pointy-block parameter parsed by `parse_for_params`

--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -931,6 +931,16 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             p.onearg = onearg;
             p.type_constraint = type_constraint;
             p.optional_marker = true;
+            // An anonymous optional still takes the ordinary parameter tail:
+            // `Int @data, Int $seed = 0, $? where { $*KERNEL.bits == 64 }`
+            // (Digest::xxHash). Returning here used to leave the `where` (or an
+            // `is` trait, or a default) unconsumed, so the whole signature
+            // failed at the closing paren. An invocant marker (`method m($?: |)`)
+            // has none of those, so it still falls through untouched.
+            let (after_q, tail) = super::helpers::parse_subsig_tail(after_q)?;
+            p.traits = tail.traits;
+            p.where_constraint = tail.where_constraint;
+            p.default = tail.default;
             return Ok((after_q, p));
         }
     }

--- a/t/collections/set-bag-mix/negated-set-op-unicode-glyphs.t
+++ b/t/collections/set-bag-mix/negated-set-op-unicode-glyphs.t
@@ -1,0 +1,39 @@
+use Test;
+
+# The `!` meta-prefix negates any Bool-returning infix, so it composes with the
+# Unicode spellings of the set relations, not only their ASCII `(elem)` forms.
+# Math::Symbolic writes its variable filter with the glyph rather than
+# `!(elem)`, and the whole module used to fail to parse on it. The glyphs below
+# are the operators under test, so they are the one thing here that cannot be
+# spelled in ASCII.
+
+plan 14;
+
+ok  1 !(elem) (2, 3), 'ASCII !(elem) still works';
+ok  1 !∈ (2, 3), 'negated element-of with the glyph';
+nok 1 !∈ (1, 3), 'and it is false when the element is there';
+
+ok  (1, 2) !∋ 3, 'negated contains with the glyph';
+nok (1, 2) !∋ 1, 'and false when it does contain';
+
+ok  (1, 2) !⊆ (1,), 'negated subset with the glyph';
+nok (1,) !⊆ (1, 2), 'and false for a real subset';
+
+ok  (1,) !⊇ (1, 2), 'negated superset with the glyph';
+nok (1, 2) !⊇ (1,), 'and false for a real superset';
+
+ok  (1, 2) !⊂ (1, 2), 'negated strict subset with the glyph';
+ok  (1, 2) !⊃ (1, 2), 'negated strict superset with the glyph';
+
+# The precomposed negated glyph keeps working, and agrees with the `!` form.
+ok  1 ∉ (2, 3), 'the precomposed negated glyph still works';
+
+# Inside a whatever-curry, which is how Math::Symbolic reaches it.
+my @vars = 1, 2, 3;
+my @keep = @vars.grep: * !∈ (2,);
+is-deeply @keep, [1, 3], 'a negated glyph operator curries with *';
+
+# The non-Bool set operators are not negatable, so `!` before one is not an
+# operator at all.
+nok (try EVAL 'say (1,) !∪ (2,)').defined,
+    'a non-Bool set operator is still not negatable';

--- a/t/collections/subscript/subscript-semilist-trailing-semicolon.t
+++ b/t/collections/subscript/subscript-semilist-trailing-semicolon.t
@@ -1,0 +1,45 @@
+use Test;
+
+# A subscript holds a *semilist*, so its `;` may terminate the last dimension
+# rather than separate two. Data::RandomKeep writes
+#
+#     @!kept[ $!nb-kept < $!nb-to-keep ?? $!nb-kept++ !! $!nb-to-keep.rand; ] = ...
+#
+# which is the one-dimensional `@!kept[...]`, not a two-dimensional index whose
+# second dimension is missing. The unconditional "parse another dimension after
+# `;`" used to fail the whole statement at the closing bracket.
+
+plan 10;
+
+my @a = 1, 2, 3;
+is @a[1;], 2, 'a trailing semicolon in a positional subscript is a terminator';
+is @a[1], 2, 'and it means exactly the same as the plain subscript';
+
+my %h;
+%h{'a';} = 1;
+is-deeply %h, {a => 1}, 'a trailing semicolon works in an associative subscript';
+is %h{'a';}, 1, 'and reads back the same way';
+
+# The ternary from Data::RandomKeep: an expression looser than the one the
+# dimension splitter expects, terminated by the semicolon.
+my @dst = 0, 0, 0;
+my $flag = 0;
+@dst[ $flag ?? 0 !! 1; ] = 9;
+is-deeply @dst, [0, 9, 0], 'a ternary index terminated by a semicolon assigns';
+
+# Whitespace and a newline before the closer are fine, which is how the
+# distribution actually spells it.
+my @nl = 1, 2, 3;
+is @nl[
+    2;
+], 3, 'a multi-line subscript with a trailing semicolon parses';
+
+# A real multi-dimensional subscript is untouched.
+my @nested = [1, 2], [3, 4];
+is @nested[1;0], 3, 'a two-dimensional subscript still indexes both dimensions';
+is @nested[0;1], 2, 'and so does the other corner';
+
+# So is a slice, and a trailing comma (which builds a one-element list, unlike
+# a trailing semicolon).
+is-deeply @a[1, 2], (2, 3), 'a comma slice is unchanged';
+is-deeply @a[1,], (2,), 'a trailing comma still builds a one-element slice';

--- a/t/oo/trait/param-trait-word-quote-arg.t
+++ b/t/oo/trait/param-trait-word-quote-arg.t
@@ -1,0 +1,32 @@
+use Test;
+
+# A parameter trait may carry its argument as a word quote written directly
+# after the trait name -- `is option<!>` -- not only as `is encoded('utf8')`.
+# App::Prove6 declares its whole `sub MAIN` that way (via `Trait::Option`), so
+# the unparsed `<!>` used to fail the signature at its closing paren and cost
+# the distribution its only module.
+
+plan 6;
+
+multi sub trait_mod:<is>(Parameter:D $p, :$option!) { }
+
+lives-ok { EVAL 'sub m1(Bool :$timer is option<!>) { }' },
+    'is trait<arg> on a named parameter parses';
+
+lives-ok { EVAL 'sub m2($x is option<a b c>) { }' },
+    'a multi-word trait argument parses';
+
+lives-ok { EVAL 'sub m3($x is option«a b») { }' },
+    'a French-quoted trait argument parses';
+
+# The trait argument is skipped, so the parameter still behaves normally.
+sub taker(Int $n is option<!>) { $n * 2 }
+is taker(21), 42, 'a parameter carrying a word-quote trait argument still binds';
+
+# The opener has to follow the trait name directly, so a `where` clause whose
+# expression merely starts with `<` is untouched.
+sub bounded($x is copy where * < 3) { $x }
+is bounded(1), 1, 'is copy followed by a where clause with < still parses';
+
+dies-ok { EVAL 'sub m4($x is copy where * < 3) { }; m4(9)' },
+    'and that where clause is still enforced';

--- a/t/routines/signature/anon-optional-param-tail.t
+++ b/t/routines/signature/anon-optional-param-tail.t
@@ -1,0 +1,30 @@
+use Test;
+
+# An anonymous optional parameter (`$?`, `@?`, `%?`) takes the ordinary
+# parameter tail -- `is` traits, a `where` post-constraint, a default -- just
+# like a named one. Digest::xxHash ends a multi-line signature with
+# `$? where { $*KERNEL.bits == 64 }`; the unconsumed `where` used to fail the
+# whole signature at its closing paren.
+
+plan 7;
+
+sub gated(Int $x, $? where { True }) { $x }
+is gated(7), 7, 'an anonymous optional with a where clause parses and binds';
+
+sub checked($? where { $_ ~~ Int }) { 'ok' }
+is checked(5), 'ok', 'the where clause runs against a passed value';
+dies-ok { checked('nope') }, 'and rejects a value that fails it';
+
+sub defaulted($? = 7) { 'ran' }
+is defaulted(), 'ran', 'an anonymous optional may carry a default';
+
+sub arrayish(@? where { True }) { 'ran' }
+is arrayish(), 'ran', 'the @? form takes the same tail';
+
+sub hashish(%? where { True }) { 'ran' }
+is hashish(), 'ran', 'and so does %?';
+
+# An anonymous optional invocant is still just an invocant: the `:` marker
+# belongs to the parameter list, not to the tail.
+class Inv { method m($?: |) { 'method' } }
+is Inv.m, 'method', 'an anonymous optional invocant still parses';

--- a/t/routines/signature/pointy-sigilless-param-traits.t
+++ b/t/routines/signature/pointy-sigilless-param-traits.t
@@ -1,0 +1,37 @@
+use Test;
+
+# A sigilless pointy-block parameter takes the same tail as every other
+# parameter shape: `is` traits and a default. Proxee writes its STORE block as
+# `-> $, \v is raw { ... }`; the unconsumed `is raw` used to fail the block at
+# its opening brace, and with it the whole `Proxy.new` call.
+
+plan 7;
+
+my $raw = -> \v is raw { v };
+is $raw(5), 5, 'a sigilless pointy parameter may carry is raw';
+
+my $pair = -> $x, \v is raw { v + $x };
+is $pair(1, 2), 3, 'and it composes with an earlier sigilled parameter';
+
+my $defaulted = -> \v = 7 { v };
+is $defaulted(), 7, 'a sigilless pointy parameter may carry a default';
+is $defaulted(9), 9, 'and the default gives way to an argument';
+
+my $plain = -> \v { v };
+is $plain(3), 3, 'a bare sigilless pointy parameter still works';
+
+# `is raw` on a sigilless parameter really does alias, so writing through it
+# reaches the caller's container.
+my $n = 1;
+my $bump = -> \v is raw { v = v + 1 };
+$bump($n);
+is $n, 2, 'is raw on a sigilless pointy parameter aliases the argument';
+
+# The shape Proxee actually uses.
+my $store-target;
+my $p := Proxy.new(
+    FETCH => -> $ { $store-target },
+    STORE => -> $, \v is raw { $store-target = v },
+);
+$p = 42;
+is $store-target, 42, 'Proxy.new with a sigilless raw STORE parameter works';


### PR DESCRIPTION
Five more constructs off the `expected statement …` parse-failure index (#7954), the largest single bucket in the ecosystem sweep's `blocked_load` records. Each was reached the way the earlier batches were: fetch the tarball named by the `ecosystem/dists/` record, `--dump-ast` every module the META6 `provides` names, binary-search the failing file down to the smallest still-failing line range, and reduce that to a one-liner checked against rakudo.

Four of the five are the same shape of bug — a grammar that stopped one production short of what Raku allows, leaving a tail unconsumed so the *enclosing* construct failed at its closing bracket. That is exactly why the index could only ever report a container: the reported line named the `sub`, the `class` or the block, never the parameter inside it.

## What changed

**A parameter trait written with a word-quote argument** — `sub MAIN(Bool :$timer is option<!>)`, App::Prove6's entire CLI signature (via `Trait::Option`). Parameter traits accepted only a parenthesized argument (`is encoded('utf8')`), so the `<!>` was left in the signature and the parameter list failed at its `)`. `skip_optional_trait_arg` now also skips a `<…>` / `«…»` word quote written directly after the trait name. The opener has to follow the name with no intervening whitespace, which keeps `$x is copy where * < 3` out of this path.

**An anonymous optional parameter carrying a tail** — `multi sub build-xxhash(Int @data, Int $seed = 0, $? where { $*KERNEL.bits == 64 } --> Int)`, Digest::xxHash. The `$?` / `@?` / `%?` branch returned the parameter the moment it recognized the sigil, so an `is` trait, a `where` post-constraint or a default after it was never consumed. It now runs the same `parse_subsig_tail` every other parameter shape uses. An anonymous optional *invocant* (`method m($?: |)`) carries none of those and still falls through untouched.

**The `!` meta-prefix over a Unicode set relation** — `@vars .= grep: * !∈ @$positional`, Math::Symbolic. The negated-set-operator parser listed the ASCII spellings (`!(elem)`, `!(<=)`, …) by hand and knew only the four *precomposed* negated glyphs (`∉`, `∌`, `⊈`, `⊉`), so `!` followed by a glyph was not an operator at all. It now defers to `parse_set_op` and keeps whatever that returns when the relation is Bool-valued — the rule the `!` meta-prefix actually follows. The non-Bool set operators stay out, so `!∪` is still not an operator.

**A sigilless pointy-block parameter carrying a trait** — `Proxy.new: :FETCH{ … }, STORE => -> $, \v is raw { … }`, Proxee. The sigilled and `+name` pointy-parameter branches each parsed an `is`-trait and default tail; the `\name` branch returned immediately, so the trait was left before the block's `{` and the whole `Proxy.new` argument list failed.

**A semicolon terminating a subscript's semilist** — Data::RandomKeep:

```raku
@!kept[
    $!nb-kept < $!nb-to-keep ?? $!nb-kept++ !! $!nb-to-keep.rand;
] = [$!nb-seen, $item];
```

A subscript holds a semilist, so a `;` in it may *terminate* the last dimension rather than separate two: `@a[1;]` is `@a[1]`, not a two-dimensional index whose second dimension is missing. The dimension loop unconditionally parsed another expression after every `;`. It now peeks for the subscript's own closer (`]` or `}`) first, and a single remaining dimension collapses back to an ordinary `Expr::Index` rather than a one-dimensional `MultiDimIndex`.

## Result

App::Prove6, Data::RandomKeep, Digest::xxHash and Proxee now parse every module their META6 `provides` names; so does Math::Symbolic's own `Math/Symbolic.rakumod` (its `Language.rakumod` still fails on `our @.operations := @operations;`, an `our`-scoped attribute bound with `:=`, which stays on the index).

## Tests

- `t/oo/trait/param-trait-word-quote-arg.t`
- `t/routines/signature/anon-optional-param-tail.t`
- `t/collections/set-bag-mix/negated-set-op-unicode-glyphs.t`
- `t/routines/signature/pointy-sigilless-param-traits.t`
- `t/collections/subscript/subscript-semilist-trailing-semicolon.t`

All five are green under **rakudo itself**, so they pin rakudo's behaviour rather than mutsu's.

`cargo fmt`, `make lint`, `make test` (4073 files / 43349 tests, PASS) and `make roast` all run locally before publishing. `make roast`'s only failures are the three this container always produces and `docs/agent-environments.md` documents: `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` (running as `uid 0` makes the `chmod` tests meaningless) and `roast/S32-io/IO-Socket-Async.t` (sandboxed network).

## Follow-up filed, not forced in here

**#8089** (`todo:ticket`) — an *optional* parameter's `where` constraint is skipped entirely when the argument is omitted, where rakudo runs it against the type object (`Any`). That is what makes Digest::xxHash's trailing `$? where { $*KERNEL.bits == 64 }` a real multi-dispatch discriminator rather than decoration, and it reaches well beyond this index: it lives in the binder (`binding_signature.rs`) and in multi-candidate matching (`args_matching.rs`), not in the parser, and both have to agree.

Refs #7954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8


---
_Generated by [Claude Code](https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8)_