### PR TITLE
perf(parser,runtime): index the source newlines, and stop scratch interpreters seeding an env they never read

### DIFF
--- a/news/2026-09/parser-line-numbers-were-quadratic-in-the-source.md
+++ b/news/2026-09/parser-line-numbers-were-quadratic-in-the-source.md
@@ -1,0 +1,118 @@
+# The parser's line numbers were quadratic in the source, and a scratch interpreter still seeded an env it never read
+
+Round 16 of [#7576](https://github.com/tokuhirom/mutsu/issues/7576). Instructions
+retired on the ticket's 60-row YAMLish document go **1,983,139,212 ->
+1,841,091,693 (-7.16%)**. Attribution is callgrind Ir throughout (deterministic
+and load-independent), with the module precompilation cache warmed before each
+profiled run per round 14's note.
+
+Round 15 handed off "the profile is flat: `LocalKey::with` 7.3% across a dozen
+callers, allocator ~19%, `memcpy` 3.9%, largest single mutsu function 1.85%",
+with one named item (`resolve_parsed_token_candidates_in_pkg` interning its
+package name) worth ~0.7%. A fresh `callgrind_annotate --tree=caller` found
+three larger things instead, none of them in the regex matcher and none of them
+visible under their own name.
+
+## (a) `current_line_number` rescanned the whole source prefix, per call (-3.07%)
+
+`$?LINE` — and every parse warning, every `X::Comp` location, every
+`test-assertion-line` record — resolves a parser position to a line number by
+counting the newlines that precede it. It did so by reconstructing the prefix as
+a `&str` and calling `.matches('\n').count()`: **O(offset) per lookup**, and
+therefore quadratic in the source length. The parser asks once per statement
+*attempt*, backtracking included, so parsing the 26 KB `YAMLish.rakumod` made
+**347,485** of those lookups, scanning an average of several kilobytes each.
+
+`set_original_source` now builds the newline offsets once (the parse already
+reads every byte) and each lookup is a `partition_point`. The heredoc
+`LeakedRegion` path — whose line numbering jumps at the terminator, so it counts
+newlines in `[jump_offset, offset)` rather than in a plain prefix — carries the
+same index, expressed as a difference of two `partition_point`s. `next_match`
+inclusive **63,315,136 (3.19%) -> 2,441,692 (0.13%)**, `memchr_aligned`
+**34,747,454 -> 1,592,214**. Pinned by `t/lang/quoting/line-number-after-heredoc.t`
+(verified against rakudo 2026.07).
+
+This one is not specific to YAMLish: it is paid by every mutsu parse, and its
+cost grows with the square of the file.
+
+## (b) The grammar dynamic-variable scan built one `String` per character (-1.03%, and -2.6% of the program's allocations)
+
+`.parse` establishes a grammar's parse-wide `:my $*/@*/%*NAME` declarations by
+scanning every rule pattern for them. `collect_dynamic_var_decls` walked *every
+character position* of the pattern and, at each one, materialized the entire
+remaining pattern as an owned `String` in order to `strip_prefix(":my ")` it —
+quadratic again, for an answer that is "no declarations" for almost every rule.
+It now walks the `:` positions with `str::find` and tests borrowed slices.
+
+Two things around it went with the same change: the scan ran **twice over every
+pattern** (once to collect the declarations, once to build the per-rule map that
+gives each match of a declaring rule its own binding), and the registry walk that
+collects the patterns spelled its prefix test `k.resolve()` — an owned `String`
+per `token_defs` key per `.parse` call, the exact shape round 11 (a) removed from
+the proto-variant scan. `collect_dynamic_var_decls` inclusive **25,652,327
+(1.29%) -> 0** (it no longer appears in the profile at all). Pinned by
+`t/grammar/grammar-dynvar-decl-scan-with-adverbs.t`, which puts regex adverbs,
+`:sym<…>` proto variants and a multi-byte literal in the scanner's path.
+
+## (c) A scratch interpreter still seeded the process magicals (-2.69%)
+
+Rounds 10 and 12 stopped a regex/grammar scratch interpreter from building the
+built-in registry, from re-scanning the bundled-battery directory, and from
+running `init_io_environment`. What survived is that `Interpreter::new` still
+built `$*PID`, `$*TZ`, `@*ARGS`, `$*INIT-INSTANT` and `$*SCHEDULER` on every
+construction — a `getpid`, a `localtime_r`, a `SystemTime::now`, a
+`make_instance` and five `String` keys — and **every one of the ten scratch
+construction sites spells `Interpreter { env: <the caller's env>, .. }`**
+(directly, or through `make_regex_eval_env`, which starts from
+`self.env.clone()`), so all of it was dropped unread. `%*ENV`'s OS sweep was the
+only part already behind the guard. This document builds **1,609** scratch
+interpreters.
+
+Two smaller process constants went the same way: the built-in encoding table
+(~30 `String`s per construction) is a shared `Arc` template now, like the
+built-in registry, safe for the same reason — `register_encoding` goes through
+`cow_table_mut`, so the first interpreter to add a user encoding forks itself a
+private copy. And `precomp::enabled_by_default` read `MUTSU_PRECOMP` — an
+environment lock plus a `String` — once per construction; it is a process-wide
+switch, so it is read once.
+
+`Interpreter::new` inclusive **93M (4.7%) -> 64.2M (3.49%)**;
+`make_instant_from_posix` **3,566,796 -> 0**; `std::env::_var` **3,252 calls ->
+1,644**. Pinned by `t/regex/regex-code-block-process-magicals.t`, which checks
+that all six magicals still resolve inside an embedded regex code block —
+through the caller's env, which is where they were always coming from.
+
+## Method note
+
+Round 12's lesson was "a profile's flat tail regenerates itself; re-run the
+caller attribution after every round rather than carrying the previous round's
+*what is left* forward as a conclusion." Round 16 is that lesson twice over, and
+sharpens it in one direction: **the tail regenerates from a different subsystem
+than the one you have been working on.** Rounds 10-15 each found their item in
+the regex engine or the interpreter constructor; two of round 16's three are in
+the *parser*, which no previous round had profiled at all, because the module
+parse hides behind `LocalKey::with`, `malloc` and `memchr` exactly the way every
+earlier round's item hid behind `malloc` and `memcpy`. The tell was the same
+ratio-in-one-line as rounds 11 and 12: `CharSearcher::next_match` entered
+347,485 times under a thread-local accessor, in a program that parses one 1,116-
+line module.
+
+The corollary is procedural: a `--separate-callers=2` run is what turned
+"`next_match` is called from `LocalKey::with`" (useless — every thread-local
+access is) into "`next_match` is called from `LocalKey::with` called from
+`stmt_list_with_mode`". One extra callgrind run, and worth reaching for whenever
+the immediate caller of a hot leaf is a generic wrapper.
+
+## What is left
+
+Re-measured rather than carried forward: the profile is flat again
+(`LocalKey::with` 7.6% across a dozen callers, allocator ~20%, `memcpy` 4.2%),
+and `Symbol::intern` is its largest single caller at 427,652 calls. The one item
+with a measured mechanism is new, and it is not in this benchmark's inner loop at
+all: **`use YAMLish` costs 324 M instructions, 17.6% of the whole run, and 209 M
+of that is the parser re-parsing the module's source to collect its exported
+names** while a precompiled AST for exactly that file already sits in the on-disk
+cache that the *runtime* load consults. Filed separately as
+[#8095](https://github.com/tokuhirom/mutsu/issues/8095), because caching the
+scan result on disk has a transitive-invalidation question (a scan harvests
+names from the modules it recursively scans) that wants deciding before code.

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -28,8 +28,9 @@ use crate::value::Value;
 thread_local! {
     static PRIMARY_MEMO_TLS: RefCell<HashMap<MemoKey, MemoEntry<Expr>>> = RefCell::new(HashMap::new());
     static PRIMARY_MEMO_STATS_TLS: RefCell<MemoStats> = RefCell::new(MemoStats::default());
-    /// Original source pointer and length, set at parse_program start for $?LINE computation.
-    static ORIGINAL_SOURCE: RefCell<(usize, usize)> = const { RefCell::new((0, 0)) };
+    /// Original source pointer, length and newline index, set at parse_program
+    /// start for $?LINE computation.
+    static ORIGINAL_SOURCE: RefCell<SourceOrigin> = const { RefCell::new(SourceOrigin::EMPTY) };
     /// Leaked string regions from heredoc parsing.
     /// Used to compute correct line numbers when the parser operates on leaked strings
     /// that are outside the original source buffer.
@@ -37,6 +38,51 @@ thread_local! {
 }
 
 static PRIMARY_MEMO: ParseMemo<Expr> = ParseMemo::new(&PRIMARY_MEMO_TLS, &PRIMARY_MEMO_STATS_TLS);
+
+/// Byte offsets of every `\n` in a source buffer, ascending.
+///
+/// `current_line_number` is called once per statement *attempt*, backtracking
+/// included — hundreds of thousands of times over one module parse — and used
+/// to count the newlines in the prefix by rescanning it, which is O(offset) per
+/// call and therefore quadratic in the source length. The index turns each
+/// lookup into a `partition_point`, so it is built once per parse (the parse
+/// already reads every byte) and read in O(log lines) thereafter. Shared as an
+/// `Rc` because `snapshot_source_state` clones the origin around every nested
+/// sub-parse.
+type NewlineIndex = std::rc::Rc<[usize]>;
+
+/// Count the newlines that precede `offset` in a buffer whose newline offsets
+/// are `newlines`.
+fn newlines_before(newlines: &[usize], offset: usize) -> i64 {
+    newlines.partition_point(|&n| n < offset) as i64
+}
+
+/// Collect the newline offsets of `source`.
+fn newline_index(source: &str) -> NewlineIndex {
+    source.match_indices('\n').map(|(i, _)| i).collect()
+}
+
+/// The source buffer `$?LINE` is computed against: where it lives, how long it
+/// is, and where its lines break.
+#[derive(Clone)]
+struct SourceOrigin {
+    ptr: usize,
+    len: usize,
+    newlines: Option<NewlineIndex>,
+}
+
+impl SourceOrigin {
+    /// No source recorded yet. `const` so the thread-local needs no lazy init.
+    const EMPTY: Self = Self {
+        ptr: 0,
+        len: 0,
+        newlines: None,
+    };
+
+    fn newlines(&self) -> &[usize] {
+        self.newlines.as_deref().unwrap_or(&[])
+    }
+}
 
 /// A leaked string region from heredoc parsing, with a line-number jump.
 #[derive(Clone)]
@@ -49,12 +95,20 @@ struct LeakedRegion {
     line_before_jump: i64,
     /// Line number after the jump (start of after_terminator content).
     line_after_jump: i64,
+    /// Newline offsets within the leaked buffer, for the same reason the
+    /// original source carries one.
+    newlines: NewlineIndex,
 }
 
 /// Set the original source for $?LINE computation.
 pub(super) fn set_original_source(source: &str) {
+    let newlines = newline_index(source);
     ORIGINAL_SOURCE.with(|s| {
-        *s.borrow_mut() = (source.as_ptr() as usize, source.len());
+        *s.borrow_mut() = SourceOrigin {
+            ptr: source.as_ptr() as usize,
+            len: source.len(),
+            newlines: Some(newlines),
+        };
     });
     LEAKED_REGIONS.with(|r| r.borrow_mut().clear());
 }
@@ -65,13 +119,13 @@ pub(super) fn set_original_source(source: &str) {
 /// or `EVAL` parse does not leave `ORIGINAL_SOURCE` dangling at a dropped buffer
 /// — which would collapse the enclosing parse's line numbers to 1.
 pub(in crate::parser) struct SourceState {
-    original: (usize, usize),
+    original: SourceOrigin,
     leaked: Vec<LeakedRegion>,
 }
 
 /// Snapshot the current source-location state.
 pub(in crate::parser) fn snapshot_source_state() -> SourceState {
-    let original = ORIGINAL_SOURCE.with(|s| *s.borrow());
+    let original = ORIGINAL_SOURCE.with(|s| s.borrow().clone());
     let leaked = LEAKED_REGIONS.with(|r| r.borrow().clone());
     SourceState { original, leaked }
 }
@@ -92,6 +146,7 @@ pub(in crate::parser) fn register_leaked_region_with_jump(
     line_before_jump: i64,
     line_after_jump: i64,
 ) {
+    let newlines = newline_index(leaked);
     LEAKED_REGIONS.with(|r| {
         r.borrow_mut().push(LeakedRegion {
             ptr: leaked.as_ptr() as usize,
@@ -99,6 +154,7 @@ pub(in crate::parser) fn register_leaked_region_with_jump(
             jump_offset,
             line_before_jump,
             line_after_jump,
+            newlines,
         });
     });
 }
@@ -110,21 +166,14 @@ pub(crate) fn angle_word_value(word: &str) -> Value {
 /// Compute the 1-based line number of `input` within the original source.
 pub(in crate::parser) fn current_line_number(input: &str) -> i64 {
     ORIGINAL_SOURCE.with(|s| {
-        let (src_ptr, src_len) = *s.borrow();
-        if src_ptr == 0 {
+        let origin = s.borrow();
+        if origin.ptr == 0 {
             return 1;
         }
         let input_ptr = input.as_ptr() as usize;
-        if input_ptr >= src_ptr && input_ptr <= src_ptr + src_len {
-            let offset = input_ptr - src_ptr;
-            // SAFETY: offset is within the original source bounds
-            let src_slice = unsafe {
-                std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                    src_ptr as *const u8,
-                    offset,
-                ))
-            };
-            return (src_slice.matches('\n').count() + 1) as i64;
+        if input_ptr >= origin.ptr && input_ptr <= origin.ptr + origin.len {
+            let offset = input_ptr - origin.ptr;
+            return newlines_before(origin.newlines(), offset) + 1;
         }
         // Check leaked regions (from heredoc parsing)
         LEAKED_REGIONS.with(|r| {
@@ -132,21 +181,13 @@ pub(in crate::parser) fn current_line_number(input: &str) -> i64 {
                 if input_ptr >= region.ptr && input_ptr <= region.ptr + region.len {
                     let offset = input_ptr - region.ptr;
                     if offset < region.jump_offset {
-                        let slice = unsafe {
-                            std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                                region.ptr as *const u8,
-                                offset,
-                            ))
-                        };
-                        return region.line_before_jump + slice.matches('\n').count() as i64;
+                        return region.line_before_jump + newlines_before(&region.newlines, offset);
                     } else {
-                        let slice = unsafe {
-                            std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                                (region.ptr + region.jump_offset) as *const u8,
-                                offset - region.jump_offset,
-                            ))
-                        };
-                        return region.line_after_jump + slice.matches('\n').count() as i64;
+                        // Newlines in `[jump_offset, offset)`: the ones before
+                        // the offset, minus the ones before the jump.
+                        return region.line_after_jump
+                            + (newlines_before(&region.newlines, offset)
+                                - newlines_before(&region.newlines, region.jump_offset));
                     }
                 }
             }
@@ -163,7 +204,8 @@ pub(in crate::parser) fn current_line_number(input: &str) -> i64 {
 /// original source buffer (e.g. a leaked heredoc region).
 pub(in crate::parser) fn source_span_at(eject: &str) -> Option<(String, String)> {
     ORIGINAL_SOURCE.with(|s| {
-        let (src_ptr, src_len) = *s.borrow();
+        let origin = s.borrow();
+        let (src_ptr, src_len) = (origin.ptr, origin.len);
         if src_ptr == 0 {
             return None;
         }
@@ -196,21 +238,16 @@ pub(in crate::parser) fn source_span_at(eject: &str) -> Option<(String, String)>
 /// writes "(`{{` was at line 1)" for an unterminated embedded comment).
 pub(in crate::parser) fn source_line_at(eject: &str) -> Option<usize> {
     ORIGINAL_SOURCE.with(|s| {
-        let (src_ptr, src_len) = *s.borrow();
-        if src_ptr == 0 {
+        let origin = s.borrow();
+        if origin.ptr == 0 {
             return None;
         }
         let eject_ptr = eject.as_ptr() as usize;
-        if eject_ptr < src_ptr || eject_ptr > src_ptr + src_len {
+        if eject_ptr < origin.ptr || eject_ptr > origin.ptr + origin.len {
             return None;
         }
-        let offset = eject_ptr - src_ptr;
-        // SAFETY: as in `source_span_at` — the pointer/length pair came from a
-        // live `&str` and `offset` is inside it.
-        let full = unsafe {
-            std::str::from_utf8_unchecked(std::slice::from_raw_parts(src_ptr as *const u8, src_len))
-        };
-        Some(full[..offset].matches('\n').count() + 1)
+        let offset = eject_ptr - origin.ptr;
+        Some(newlines_before(origin.newlines(), offset) as usize + 1)
     })
 }
 
@@ -218,12 +255,12 @@ pub(in crate::parser) fn source_line_at(eject: &str) -> Option<usize> {
 /// or a registered leaked region.
 pub(in crate::parser) fn is_within_original_source(input: &str) -> bool {
     ORIGINAL_SOURCE.with(|s| {
-        let (src_ptr, src_len) = *s.borrow();
-        if src_ptr == 0 {
+        let origin = s.borrow();
+        if origin.ptr == 0 {
             return false;
         }
         let input_ptr = input.as_ptr() as usize;
-        if input_ptr >= src_ptr && input_ptr <= src_ptr + src_len {
+        if input_ptr >= origin.ptr && input_ptr <= origin.ptr + origin.len {
             return true;
         }
         // Also check leaked regions

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -135,9 +135,18 @@ fn interpreter_version() -> String {
 pub(crate) fn enabled_by_default() -> bool {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        std::env::var("MUTSU_PRECOMP")
-            .map(|v| v != "0")
-            .unwrap_or(true)
+        // Read once per process: `Interpreter::new` asks on every construction,
+        // and `std::env::var` locks the environment and allocates a `String` for
+        // the answer. The variable is a process-wide switch, so a later
+        // `set_var` was never meant to change an already-built interpreter's
+        // default anyway (`precomp_enabled` is a per-interpreter field the CLI
+        // overrides directly).
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            std::env::var("MUTSU_PRECOMP")
+                .map(|v| v != "0")
+                .unwrap_or(true)
+        })
     }
     #[cfg(target_arch = "wasm32")]
     {

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -22,19 +22,23 @@ impl Interpreter {
                     .filter(|p| p != package),
             );
             let prefixes: Vec<String> = packages.iter().map(|p| format!("{p}::")).collect();
+            // Filter on the interned `&'static str`: `Symbol::resolve` is
+            // `as_str().to_owned()`, so spelling this with `resolve()` would
+            // build (and drop) an owned `String` for every key in the registry
+            // on every `.parse` call.
             let defs: Vec<(String, std::sync::Arc<FunctionDef>)> = self
                 .registry()
                 .token_defs
                 .iter()
                 .filter(|(k, _)| {
-                    let ks = k.resolve();
+                    let ks = k.as_str();
                     prefixes.iter().any(|pre| ks.starts_with(pre.as_str()))
                 })
                 .flat_map(|(k, v)| {
                     // `Pkg::rule` / `Pkg::rule:sym<x>` -> the bare rule name a
                     // capture is stored under (`rule`).
-                    let ks = k.resolve();
-                    let bare = ks.rsplit("::").next().unwrap_or(&ks);
+                    let ks = k.as_str();
+                    let bare = ks.rsplit("::").next().unwrap_or(ks);
                     let bare = bare.split(':').next().unwrap_or(bare).to_string();
                     v.iter().map(move |d| (bare.clone(), d.clone()))
                 })
@@ -45,23 +49,24 @@ impl Interpreter {
                 }
             }
         }
-        // Extract `:my $*/%*/@*NAME = INIT;` declarations from the patterns.
+        // Extract `:my $*/%*/@*NAME = INIT;` declarations from the patterns, and
+        // at the same time remember which RULE declared what, so the reduce walk
+        // can give each match of a declaring rule its own binding instead of
+        // letting every match share the one parse-wide slot established below.
+        // Keyed by the bare rule name, which is what a capture is stored under.
+        // One scan feeds both: the per-rule map used to re-scan every pattern a
+        // second time for the identical answer.
         let mut decls: Vec<String> = Vec::new();
-        for (_, pat) in &patterns {
-            Self::collect_dynamic_var_decls(pat, &mut decls);
-        }
-        // Remember which RULE declared what, so the reduce walk can give each
-        // match of a declaring rule its own binding instead of letting every
-        // match share the one parse-wide slot established below. Keyed by the
-        // bare rule name, which is what a capture is stored under.
         {
             let mut per_rule: HashMap<String, Vec<String>> = HashMap::new();
             for (rule, pat) in &patterns {
                 let mut rule_decls: Vec<String> = Vec::new();
                 Self::collect_dynamic_var_decls(pat, &mut rule_decls);
-                if !rule_decls.is_empty() {
-                    per_rule.entry(rule.clone()).or_default().extend(rule_decls);
+                if rule_decls.is_empty() {
+                    continue;
                 }
+                decls.extend(rule_decls.iter().cloned());
+                per_rule.entry(rule.clone()).or_default().extend(rule_decls);
             }
             self.grammar_rule_dynvar_decls = per_rule;
         }
@@ -131,34 +136,32 @@ impl Interpreter {
 
     /// Collect `:my $*/%*/@*… = …;` declaration substrings (main-slang code
     /// between `:my ` and the terminating `;`) from a rule pattern.
+    ///
+    /// Walks the `:` positions rather than every character: the declaration can
+    /// only start at one, and testing a position used to mean materializing the
+    /// whole remaining pattern as an owned `String`, which made the scan
+    /// quadratic in the pattern length (1.3% of a YAMLish parse, and 2.6% of the
+    /// allocations in it, for an answer that is almost always "no declarations").
     fn collect_dynamic_var_decls(pattern: &str, out: &mut Vec<String>) {
-        let bytes: Vec<char> = pattern.chars().collect();
-        let mut i = 0;
-        while i < bytes.len() {
-            let rest: String = bytes[i..].iter().collect();
-            if let Some(after) = rest
-                .strip_prefix(":my ")
-                .or_else(|| rest.strip_prefix(":our "))
-            {
-                // Only dynamic (`*`-twigil) declarations concern us.
-                let trimmed = after.trim_start();
-                if matches!(trimmed.chars().next(), Some('$' | '@' | '%'))
-                    && trimmed.chars().nth(1) == Some('*')
-                {
-                    // Collect `my … ` up to the `;`.
-                    let decl: String = rest
-                        .strip_prefix(':')
-                        .unwrap_or(&rest)
-                        .chars()
-                        .take_while(|&c| c != ';')
-                        .collect();
-                    out.push(decl.trim().to_string());
-                }
-                // Skip past this `:my`.
-                i += 4;
+        let mut rest = pattern;
+        while let Some(colon) = rest.find(':') {
+            let at = &rest[colon..];
+            // `:` is one byte, so the tail is on a char boundary.
+            rest = &at[1..];
+            let Some(after) = at.strip_prefix(":my ").or_else(|| at.strip_prefix(":our ")) else {
                 continue;
+            };
+            // Only dynamic (`*`-twigil) declarations concern us.
+            let trimmed = after.trim_start();
+            let mut sigil_and_twigil = trimmed.chars();
+            if matches!(sigil_and_twigil.next(), Some('$' | '@' | '%'))
+                && sigil_and_twigil.next() == Some('*')
+            {
+                // Collect `my … ` up to the `;`.
+                let decl = &at[1..];
+                let decl = decl.split(';').next().unwrap_or(decl);
+                out.push(decl.trim().to_string());
             }
-            i += 1;
         }
     }
 

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -1,6 +1,24 @@
 use super::*;
 
 impl Interpreter {
+    /// The built-in encoding table, built **once per process** and handed out
+    /// as a shared `Arc`.
+    ///
+    /// Building it allocates ~30 `String`s, and `Interpreter::new` ran it on
+    /// every construction — including the 1,609 regex/grammar scratch
+    /// interpreters one YAMLish parse builds. Sharing is safe because
+    /// `encoding_registry` is already copy-on-write: `register_encoding` goes
+    /// through `cow_table_mut`, so the first interpreter to add a user encoding
+    /// forks itself a private copy. Same mechanism as
+    /// `Interpreter::shared_builtin_registry`.
+    pub(crate) fn shared_builtin_encodings() -> std::sync::Arc<Vec<EncodingEntry>> {
+        static TEMPLATE: std::sync::OnceLock<std::sync::Arc<Vec<EncodingEntry>>> =
+            std::sync::OnceLock::new();
+        std::sync::Arc::clone(
+            TEMPLATE.get_or_init(|| std::sync::Arc::new(Self::builtin_encodings())),
+        )
+    }
+
     pub(crate) fn builtin_encodings() -> Vec<EncodingEntry> {
         vec![
             EncodingEntry {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2995,26 +2995,37 @@ impl Interpreter {
         if !Self::is_building_scratch() {
             crate::gc::gc_safepoint(crate::gc::SafepointKind::Construct);
         }
-        let mut env = HashMap::new();
-        env.insert("*PID".to_string(), Value::int(current_process_id()));
-        env.insert("*TZ".to_string(), Value::int(local_timezone_offset_secs()));
-        env.insert("@*ARGS".to_string(), Value::real_array(Vec::new()));
-        env.insert("*INIT-INSTANT".to_string(), Value::make_instant_now());
-        // Populate %*ENV with all OS environment variables so that
-        // %*ENV.keys, %*ENV.elems, and copying %*ENV work correctly. A scratch
-        // interpreter inherits the caller's env (which already carries %*ENV), so
-        // skip the OS-env sweep there.
-        if !Self::is_building_scratch() {
+        // Seed the process-wide magicals. A scratch interpreter skips ALL of
+        // it: every one of the ten scratch construction sites spells
+        // `Interpreter { env: <the caller's env>, .. }` (directly, or through
+        // `make_regex_eval_env`, which starts from `self.env.clone()`), so this
+        // whole map — `%*ENV`'s OS sweep, `$*TZ`'s `localtime_r`,
+        // `$*INIT-INSTANT`'s clock read, `$*SCHEDULER`'s instance — is built and
+        // dropped unread. That is the same argument `init_io_environment` was
+        // put behind this guard on (round 12 of #7576); the `%*ENV` sweep was
+        // the only part of it excluded then. A YAMLish parse builds 1,609
+        // scratch interpreters.
+        let env = if Self::is_building_scratch() {
+            HashMap::new()
+        } else {
+            let mut env = HashMap::new();
+            env.insert("*PID".to_string(), Value::int(current_process_id()));
+            env.insert("*TZ".to_string(), Value::int(local_timezone_offset_secs()));
+            env.insert("@*ARGS".to_string(), Value::real_array(Vec::new()));
+            env.insert("*INIT-INSTANT".to_string(), Value::make_instant_now());
+            // Populate %*ENV with all OS environment variables so that
+            // %*ENV.keys, %*ENV.elems, and copying %*ENV work correctly.
             let env_hash = os_env_hash();
             env.insert(
                 "%*ENV".to_string(),
                 Value::hash_with_data(Value::hash_arc(env_hash)),
             );
-        }
-        env.insert(
-            "*SCHEDULER".to_string(),
-            Value::make_instance(Symbol::intern("ThreadPoolScheduler"), HashMap::new()),
-        );
+            env.insert(
+                "*SCHEDULER".to_string(),
+                Value::make_instance(Symbol::intern("ThreadPoolScheduler"), HashMap::new()),
+            );
+            env
+        };
 
         let mut interpreter = Self {
             open_role_group: None,
@@ -3229,7 +3240,7 @@ impl Interpreter {
             shared_vars_dirty: Arc::new(RwLock::new(HashSet::new())),
             shared_critical_dirty: Arc::new(RwLock::new(HashSet::new())),
             critical_section_depth: 0,
-            encoding_registry: std::sync::Arc::new(Self::builtin_encodings()),
+            encoding_registry: Self::shared_builtin_encodings(),
             skip_pseudo_method_native: None,
             dispatch_ambiguous: false,
             role_pun_construction: Vec::new(),

--- a/t/grammar/grammar-dynvar-decl-scan-with-adverbs.t
+++ b/t/grammar/grammar-dynvar-decl-scan-with-adverbs.t
@@ -1,0 +1,40 @@
+use Test;
+
+# Establishing a grammar's parse-wide dynamic variables means scanning every
+# rule pattern in the grammar for `:my $*/@*/%*NAME` declarations. The scan
+# walks the `:` positions of each pattern, so a pattern full of *other* colons
+# — regex adverbs, `:sym<…>` proto variants — and one whose literals are
+# multi-byte must not confuse it: neither by missing a real declaration that
+# sits behind them, nor by mistaking an adverb for one.
+# Verified against rakudo 2026.07.
+
+plan 3;
+
+grammar G {
+    token TOP { :my %*TALLY; <item>+ % ',' { } }
+    token item { :i [ 'x' | 'λ' ] }
+}
+
+class A {
+    method item($/) { %*TALLY{~$/.lc}++ }
+    method TOP($/) { make %*TALLY.clone }
+}
+
+my $m = G.parse('x,X,λ', :actions(A));
+ok $m.defined, 'the grammar parses with an adverb-carrying sibling token';
+is $m.made.sort(*.key).map({ "{.key}={.value}" }).join(' '), 'x=2 λ=1',
+    'the rule-declared %*TALLY is visible to, and shared by, the action methods';
+
+grammar H {
+    proto token sigil { * }
+    token sigil:sym<dollar> { :i '$' }
+    token sigil:sym<at>     { :i '@' }
+    token TOP { :my $*COUNT = 0; <sigil>+ { $*COUNT++ } }
+}
+
+class B {
+    method TOP($/) { make $*COUNT }
+}
+
+is H.parse('$@$', :actions(B)).made, 1,
+    'a declaration is still found with `:sym<…>` variants and adverbs in the grammar';

--- a/t/lang/quoting/line-number-after-heredoc.t
+++ b/t/lang/quoting/line-number-after-heredoc.t
@@ -1,0 +1,27 @@
+use Test;
+
+# `$?LINE` is resolved by counting the newlines that precede the parser's
+# current position. A heredoc body is parsed out of a *leaked* buffer whose
+# line numbering jumps at the terminator, so the count has to be taken against
+# that region's own line-jump bookkeeping rather than the file's. Both sides
+# are indexed now (one pass per buffer, a binary search per lookup, instead of
+# rescanning the prefix on every one of the hundreds of thousands of lookups a
+# parse makes); this pins that the answers did not move.
+# Verified against rakudo 2026.07.
+
+plan 4;
+
+my $first = q:to/END/;
+alpha
+beta
+gamma
+END
+is $?LINE, 19, '$?LINE after a three-line heredoc counts the body lines';
+
+my $second = q:to/END2/;
+one
+END2
+is $?LINE, 24, '$?LINE after a second heredoc stays in step';
+
+is $first.lines.elems, 3, 'the first heredoc body survived intact';
+is $second.chomp, 'one', 'the second heredoc body survived intact';

--- a/t/regex/regex-code-block-process-magicals.t
+++ b/t/regex/regex-code-block-process-magicals.t
@@ -1,0 +1,28 @@
+use Test;
+
+# An embedded regex code block runs in a scratch interpreter, which is built
+# once per code block (1,609 of them on a 60-row YAMLish document). A scratch
+# is handed the CALLER's env wholesale, so it no longer seeds the process
+# magicals itself — `$*PID`, `$*TZ`, `$*INIT-INSTANT`, `%*ENV`, `@*ARGS` and
+# `$*SCHEDULER` were built and dropped unread on every construction. They must
+# still resolve inside the block, through the caller's env.
+
+plan 7;
+
+my @seen;
+my $matched = 'abc' ~~ / a {
+    @seen.push: $*PID ~~ Int && $*PID > 0;
+    @seen.push: $*TZ ~~ Int;
+    @seen.push: $*INIT-INSTANT ~~ Instant;
+    @seen.push: %*ENV.elems > 0;
+    @seen.push: @*ARGS ~~ Positional;
+    @seen.push: $*SCHEDULER.defined;
+} bc /;
+
+ok $matched, 'the regex with the embedded code block matched';
+ok @seen[0], '$*PID resolves inside an embedded regex code block';
+ok @seen[1], '$*TZ resolves inside an embedded regex code block';
+ok @seen[2], '$*INIT-INSTANT resolves inside an embedded regex code block';
+ok @seen[3], '%*ENV resolves inside an embedded regex code block';
+ok @seen[4], '@*ARGS resolves inside an embedded regex code block';
+ok @seen[5], '$*SCHEDULER resolves inside an embedded regex code block';


### PR DESCRIPTION
Round 16 of #7576. Instructions retired on the ticket's 60-row YAMLish document go **1,983,139,212 -> 1,841,091,693 (-7.16%)**. Attribution is callgrind Ir throughout (deterministic, load-independent), with the module precompilation cache warmed before each profiled run per round 14's note.

Round 15 handed off "the profile is flat: `LocalKey::with` 7.3% across a dozen callers, allocator ~19%, `memcpy` 3.9%, largest single mutsu function 1.85%", with one named item worth ~0.7%. A fresh `callgrind_annotate --tree=caller` found three larger things instead — none of them in the regex matcher, and none visible under their own name.

## (a) `current_line_number` rescanned the whole source prefix, per call (-3.07%)

`$?LINE`, every parse warning, every `X::Comp` location and every test-assertion line resolve a parser position to a line number by counting the newlines that precede it. It did so by reconstructing the prefix as a `&str` and calling `.matches('\n').count()` — **O(offset) per lookup**, and therefore quadratic in the source length. The parser asks once per statement *attempt*, backtracking included, so parsing the 26 KB `YAMLish.rakumod` made **347,485** of those lookups.

`set_original_source` builds the newline offsets once now (the parse already reads every byte) and each lookup is a `partition_point`. The heredoc `LeakedRegion` path — whose line numbering jumps at the terminator, so it counts newlines in `[jump_offset, offset)` rather than in a plain prefix — carries the same index, expressed as a difference of two `partition_point`s.

`CharSearcher::next_match` inclusive **63,315,136 (3.19%) -> 2,441,692 (0.13%)**, `memchr_aligned` **34,747,454 -> 1,592,214**.

This one is not specific to YAMLish: every mutsu parse pays it, and the cost grows with the square of the file.

## (b) The grammar dynamic-variable scan built one `String` per character (-1.03%)

`collect_dynamic_var_decls` walked *every character position* of each rule pattern and, at each one, materialized the entire remaining pattern as an owned `String` in order to `strip_prefix(":my ")` it. It walks the `:` positions with `str::find` and tests borrowed slices now.

Two things around it went with the same change: the scan ran **twice over every pattern** (once for the declaration list, once for the per-rule map that gives each match of a declaring rule its own binding), and the registry walk that collects the patterns spelled its prefix test `k.resolve()` — an owned `String` per `token_defs` key per `.parse` call, the shape round 11 (a) removed from the proto-variant scan.

`collect_dynamic_var_decls` inclusive **25,652,327 (1.29%) -> 0** (it no longer appears in the profile).

## (c) A scratch interpreter still seeded the process magicals (-2.69%)

Rounds 10 and 12 stopped a regex/grammar scratch interpreter from building the built-in registry, re-scanning the bundled-battery directory, and running `init_io_environment`. What survived is that `Interpreter::new` still built `$*PID`, `$*TZ`, `@*ARGS`, `$*INIT-INSTANT` and `$*SCHEDULER` on every construction — a `getpid`, a `localtime_r`, a `SystemTime::now`, a `make_instance` and five `String` keys — although **all ten scratch construction sites spell `Interpreter { env: <the caller's env>, .. }`** (directly, or through `make_regex_eval_env`, which starts from `self.env.clone()`), so none of it was ever read. `%*ENV`'s OS sweep was the only part already behind the guard. This document builds **1,609** scratch interpreters.

Two smaller process constants went the same way: the built-in encoding table (~30 `String`s per construction) is a shared `Arc` template, safe for the same copy-on-write reason as the built-in registry (`register_encoding` goes through `cow_table_mut`); and `precomp::enabled_by_default` read `MUTSU_PRECOMP` — an environment lock plus a `String` — once per construction, where it is a process-wide switch read once now.

`Interpreter::new` inclusive **93M (4.7%) -> 64.2M (3.49%)**; `make_instant_from_posix` **3,566,796 -> 0**; `std::env::_var` **3,252 calls -> 1,644**.

## Tests

Three new pins, all verified against rakudo 2026.07:

- `t/lang/quoting/line-number-after-heredoc.t` — `$?LINE` across the heredoc leaked-region line-jump arithmetic;
- `t/grammar/grammar-dynvar-decl-scan-with-adverbs.t` — the declaration scan with regex adverbs, `:sym<…>` proto variants and a multi-byte literal in its path;
- `t/regex/regex-code-block-process-magicals.t` — all six magicals still resolve inside an embedded regex code block, through the caller's env.

`cargo fmt --all`, `make lint`, `make test` (4071 files, 43319 tests) and `make roast` (1437 files, 219635 tests) were all run locally. roast's only failures are the three documented container-only ones — `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` (running as `uid 0`) and `roast/S32-io/IO-Socket-Async.t` (sandboxed network), each matching `docs/agent-environments.md` exactly, test numbers included.

## Method note

Round 12's lesson was "a profile's flat tail regenerates itself; re-run the caller attribution after every round rather than carrying the previous round's *what is left* forward as a conclusion." Round 16 sharpens it in one direction: **the tail regenerates from a different subsystem than the one you have been working on.** Rounds 10-15 each found their item in the regex engine or the interpreter constructor; two of round 16's three are in the *parser*, which no previous round had profiled at all, because the module parse hides behind `LocalKey::with`, `malloc` and `memchr` exactly the way every earlier round's item hid behind `malloc` and `memcpy`.

The corollary is procedural: a `--separate-callers=2` run is what turned "`next_match` is called from `LocalKey::with`" (useless — every thread-local access is) into "`next_match` is called from `LocalKey::with` called from `stmt_list_with_mode`". One extra callgrind run, worth reaching for whenever the immediate caller of a hot leaf is a generic wrapper.

## Found on the way, filed separately

- #8095 — the parser re-parses a module's source to collect its exports even though a precompiled AST for that file is already on the disk cache the *runtime* load consults. `use YAMLish` costs 324 M Ir, 209 M of it that redundant parse. Filed rather than fixed because caching the scan result has a transitive-invalidation question (a scan harvests names from the modules it recursively scans) that wants deciding first.
- #8096 — a rule-local `:my $*VAR` declaration is established parse-wide and leaks past `.parse` into the caller's dynamic scope (rakudo scopes it to the rule's own match).

The ticket stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_