### PR TITLE
fix(runtime): protect a unit module's my constant from an importer's same-named my

### DIFF
--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -1071,14 +1071,41 @@ impl Interpreter {
             // module's own routines still read it through `module_scope_lexicals`,
             // and the `saved_plain_env` restore below puts back whatever the
             // loading scope had under the same name.
-            if unit_name.is_some() {
-                for name in Self::collect_unit_package_scope_names(&stmts) {
-                    self.env.remove(&name);
+            if let Some(unit) = unit_name.as_deref() {
+                let package_scope_names = Self::collect_unit_package_scope_names(&stmts);
+                // Also protect these names the same way a plain file-scope `my`
+                // is protected (below): `module_scope_lexicals` is consulted only
+                // as a LAST RESORT, after `env`, so a `my constant @x` (unlike a
+                // package-qualified `our constant`/bare `constant`, which also
+                // gets a `@Unit::x` global the reads below find first) is
+                // reachable ONLY through the bare `env` key until it is removed
+                // a few lines down -- and in that window an IMPORTER's own
+                // same-named declaration (sharing the identical bare env key)
+                // can shadow it. Copying the value into `unit_lexicals` here
+                // gives the module's own routines the same env-independent
+                // read `unit_scope_lexical` already gives a plain `my` (#8027).
+                // A copy, not a move: `module_scope_names` keeps the value too,
+                // unlike the `unit_lex_names` loop below.
+                for name in &package_scope_names {
+                    if let Some(value) = module_scope_names.get(name) {
+                        let cell = if value.is_container_ref() {
+                            value.clone()
+                        } else {
+                            value.clone().into_container_ref()
+                        };
+                        crate::runtime::cow_table_mut(&mut self.unit_lexicals)
+                            .entry(unit.to_string())
+                            .or_default()
+                            .insert(name.clone(), cell);
+                    }
+                }
+                for name in &package_scope_names {
+                    self.env.remove(name);
                     // An enum value's bare binding lives in the enum-key namespace
                     // (#7914), so dropping the plain key alone would leave it
                     // resolvable in the loading scope.
                     self.env
-                        .remove(&crate::runtime::enum_bare_names::enum_bare_key(&name));
+                        .remove(&crate::runtime::enum_bare_names::enum_bare_key(name));
                 }
             }
             module_type_aliases = self.module_type_aliases_of(&module_scope_names);

--- a/t/lib/UnitMyConstantCollide.rakumod
+++ b/t/lib/UnitMyConstantCollide.rakumod
@@ -1,0 +1,15 @@
+# Fixture for t/modules/import-export/unit-my-constant-name-collision.t.
+#
+# A `my constant @x`/`%x` in a `unit module` is readable from the module's own
+# routines through a bare env key that the loading scope shares — see
+# UnitMyConstant.rakumod. Nothing protected that bare key from a same-named
+# `my @x`/`my %x` the IMPORTER declares AFTER `use`ing this module: the
+# importer's own fresh (empty) declaration and the module's constant collide
+# on the identical bare name, and whichever ran last wins the shared slot.
+unit module UnitMyConstantCollide;
+
+my constant @collide-arr = 'a', 'b', 'c';
+my constant %collide-hash = (a => 1, b => 2);
+
+our sub get-arr()  is export { @collide-arr }
+our sub get-hash() is export { %collide-hash }

--- a/t/modules/import-export/unit-my-constant-name-collision.t
+++ b/t/modules/import-export/unit-my-constant-name-collision.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+use lib 't/lib';
+use UnitMyConstantCollide;
+
+# An importer's `my @x`/`my %x` reads empty when a used `unit module` has a
+# file-scope `my constant @x`/`%x` of the same bare name (#8027).
+#
+# A module body runs against the loading scope's `env`, so a compunit's own
+# `my constant @collide-arr` and the importer's own `my @collide-arr` share
+# ONE bare env key. A plain `my` file-scope lexical is protected from this by
+# `unit_lexicals` (consulted before `env`), but `my constant` was excluded
+# from that store (only a bare `constant`/`our constant` gets a
+# package-qualified global that happens to sidestep the collision). So
+# calling the module's own accessor from inside a declaration that shadows
+# the constant's bare name read back whatever the importer's own
+# (not-yet-initialized, empty) declaration currently held — not the
+# module's constant.
+
+plan 4;
+
+my @collide-arr = get-arr();
+is-deeply @collide-arr, ['a', 'b', 'c'], 'importer @x reads the call result, not its own empty declaration';
+is @collide-arr.elems, 3, 'importer @x has all 3 elements';
+
+my %collide-hash = get-hash();
+is-deeply %collide-hash.Hash, {a => 1, b => 2}, 'importer %x reads the call result, not its own empty declaration';
+is %collide-hash.elems, 2, 'importer %x has both elements';


### PR DESCRIPTION
## Summary

- A `unit module`'s body runs against the loading scope's `env`, so a file-scope `my` lexical is protected from a same-named caller variable by `unit_lexicals` (consulted before `env`). `my constant` was excluded from that store: only a bare `constant`/`our constant` gets a package-qualified global that happens to sidestep the bare-env-key collision, so a `my constant @x` was reachable only through the shared bare env key until it was removed a few statements later.
- In that window, an importer's own `my @x`/`my %x` declared *after* `use`-ing the module shared the identical bare key, and the module's own routine reading that name read back the importer's not-yet-initialized (empty) declaration instead of the constant.
- Fixed `import_module` (`src/runtime/run_modules.rs`) to also copy each unit compunit's own `constant`/enum name into `unit_lexicals`, sourced from `module_scope_names` (which still holds the value) rather than `env` (whose bare key gets removed a few lines later) to avoid an ordering hazard. `module_scope_names` itself is left untouched, so the existing bare-`constant`/`my constant` own-routine reads keep working exactly as before.
- Unblocks the `Locale::US` distribution's test suite (its own repro was the exact `my constant @codes`/`my constant @states` collision with an importer's same-named `my @states`/`my @codes`).

Closes #8027

## Test plan

- [x] New regression test: `t/modules/import-export/unit-my-constant-name-collision.t` (+ fixture `t/lib/UnitMyConstantCollide.rakumod`), confirmed it fails without the fix and passes with it.
- [x] Existing regression test `t/modules/import-export/unit-my-constant-visible-to-own-routines.t` still passes (no regression to the module's own-routine constant reads).
- [x] `cargo fmt --all`
- [x] `make lint` (default clippy, `--no-default-features --features native`, wasm32, rustdoc) — green
- [x] `make test` — `Files=4072, Tests=43320` — PASS
- [x] `make roast` — the only red files are the three documented environment-only failures for this remote container (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t` — both `uid 0` bypassing `chmod` permission checks — and `roast/S32-io/IO-Socket-Async.t`, sandboxed-network timeout); everything else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_