### PR TITLE
fix(nativecall): a private $!field on a CStruct handle reads native memory

### DIFF
--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -334,6 +334,24 @@ impl Interpreter {
             self.stack.push(cell_val);
             return Ok(());
         }
+        // A CStruct handle keeps no Raku attributes at all -- the C struct its
+        // `address` points at is the only storage there is -- so the cell
+        // lookup above (which only ever finds something in an *instance's*
+        // attribute map) cannot see a private field. Read it the same way the
+        // public accessor already does (`vm_call_method_ops.rs`'s
+        // `cstruct_field_value` call for `$obj.field`): a `$.field` read
+        // compiles to a method call and already goes through that path, but
+        // `$!field` (this op) does not, so it stayed stuck reading `Nil` (#8030).
+        if !self.locals[idx].is_container_ref()
+            && let Some((bare, true)) = code.local_attr_key(idx)
+            && let Some(self_val) = self.get_env_self()
+            && let Some(field_val) =
+                self.cstruct_field_value(&self_val.deref_container(), bare.as_str())
+        {
+            self.locals[idx] = field_val.clone();
+            self.stack.push(field_val);
+            return Ok(());
+        }
         // Method frames seed attribute locals from their declarations. On a
         // type-object invocant those defaults are metadata, not instance
         // storage: reading `$!attr` must fail before the seeded local can make

--- a/t/nativecall/cstruct-private-attr-read.t
+++ b/t/nativecall/cstruct-private-attr-read.t
@@ -1,0 +1,36 @@
+use Test;
+use NativeCall;
+
+# A private `$!field` on a CStruct handle used to read Nil instead of native
+# memory (#8030): the public accessor (`$obj.field`) already went through
+# `cstruct_field_value` (it compiles to a method call), but `$!field` compiles
+# to a direct local-slot read, which had no CStruct fallback and always saw
+# the instance's (empty) Raku attribute map.
+
+plan 4;
+
+sub calloc(size_t, size_t --> Pointer) is native { * }
+sub free(Pointer) is native { * }
+
+class S is repr('CStruct') {
+    has int32 $!a;
+    has int32 $.b is rw;
+    method peek() { $!a }
+}
+class Flat is repr('CStruct') { has int32 $.a is rw; has int32 $.b is rw }
+
+my $blk = calloc(1, 32);
+my $s = nativecast(S, $blk);
+is $s.peek, 0, 'a private scalar attribute reads zeroed native memory, not Nil';
+
+nativecast(Flat, $blk).a = 17;
+is $s.peek, 17, 'and a write through a different handle to the same bytes is visible';
+
+nativecast(Flat, $blk).a = -5;
+is $s.peek, -5, 'a private int32 read is signed, matching the public accessor';
+
+# The public half already worked before this fix; pin it alongside so a
+# regression in either direction is caught by the same file.
+is $s.b, 0, 'the public accessor still reads the same native memory';
+
+free($blk);

--- a/t/nativecall/nativecall-has-embedded-struct.t
+++ b/t/nativecall/nativecall-has-embedded-struct.t
@@ -15,7 +15,7 @@ use NativeCall;
 #
 # The sizes asserted here are C's, and were measured against rakudo.
 
-plan 22;
+plan 23;
 
 sub calloc(size_t, size_t --> Pointer) is native { * }
 sub free(Pointer) is native { * }
@@ -79,16 +79,17 @@ free($block);
 }
 
 # `HAS Type $!x` -- the private-twigil spelling -- is the same declaration and
-# takes up the same storage, which the public tail behind it proves.
-#
-# (Reading it back as `$!x` from inside a method is a *separate*, pre-existing
-# gap: mutsu resolves `$!a` on a CStruct handle through the instance's Raku
-# attributes rather than through native memory, so even a plain
-# `has int32 $!a` reads as Nil there -- see GH #8030.)
+# takes up the same storage, which the public tail behind it proves. Reading
+# it back as `$!x` from inside a method used to be a *separate* gap (GH
+# #8030): mutsu resolved `$!a` on a CStruct handle through the instance's
+# (empty) Raku attributes instead of through native memory, so even a plain
+# `has int32 $!a` read as Nil there. Fixed alongside this test's restored
+# assertion.
 {
     class Priv is repr('CStruct') {
         HAS Point $!p;
         has int32 $.tail is rw;
+        method px() { $!p.x }
     }
     is nativesizeof(Priv), 12,  'a private HAS member is laid out the same way';
     my $blk = calloc(1, 32);
@@ -96,6 +97,8 @@ free($block);
     $p.tail = 17;
     is nativecast(Flat, $blk).c, 17,
                                 'the tail sits past the private member, not past a pointer';
+    nativecast(Point, $blk).x = 42;
+    is $p.px, 42,               'a private $!x read reaches native memory, not Nil';
     free($blk);
 }
 


### PR DESCRIPTION
## Summary

A `has int32 $!a` on an `is repr('CStruct')` handle read `Nil` instead of the
C struct's own bytes. The public accessor (`$obj.field`) compiles to a
method call and already went through `cstruct_field_value` (all five of its
call sites are method dispatch), but `$!field` (the private-twigil form)
compiles to a direct local-slot read (`GetLocal`) with no CStruct fallback,
so it always found the instance's empty Raku attribute map and read `Nil`.

`exec_get_local_op_inner` (`src/vm/vm_var_assign_local_get.rs`) now tries
`cstruct_field_value` for a private-attribute local once the ordinary
self-cell lookup comes back empty — the same lookup the public accessor's
method-dispatch path already uses.

The write half (`$!a = 42` inside a method) is a separate, wider touch:
`write_attr_cell_by_key` and its callers are `&self`, not `&mut self`, all
the way up through several files (`vm_smartmatch_ops.rs`,
`vm_var_assign_post_incdec.rs`, `vm_var_assign_typed.rs`,
`vm_exec_dispatch.rs`, `vm_method_dispatch.rs`, `vm_misc_codevar.rs`,
`vm_misc_coerce.rs`, `methods_mut_method_lvalue.rs`, ...), so threading
`&mut self` through for a `cstruct_field_assign` fallback is a bigger change
than this ticket's read-only repro calls for. Left for a follow-up.

Closes #8030

## Test plan

- Added `t/nativecall/cstruct-private-attr-read.t` (the issue's minimal
  repro, plus a couple of related assertions).
- Restored the private-read assertion in
  `t/nativecall/nativecall-has-embedded-struct.t` that had been left as a
  comment pending this fix (a `HAS`-declared private member read through a
  method).
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run locally.
  `make roast` comes back with only the three environment-only failures
  documented in `docs/agent-environments.md` for a remote container
  (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t` — both
  `uid 0` chmod-based file tests — and `roast/S32-io/IO-Socket-Async.t`,
  sandboxed network); everything else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_