### PR TITLE
feat: give every mutable native instance method a cross-thread publish point

### DIFF
--- a/docs/adr/0095-native-mut-publish-before-wake.md
+++ b/docs/adr/0095-native-mut-publish-before-wake.md
@@ -1,0 +1,140 @@
+# ADR-0095: A mutable native instance method publishes before it wakes another thread
+
+- Status: Accepted (implemented)
+- Date: 2026-09-12
+- Supersedes: nothing
+- Extends: [ADR-0013](0013-container-interior-mutability-cellvalue.md) (the shared
+  attribute cell this publishes through)
+- Related: [#7943](https://github.com/tokuhirom/mutsu/issues/7943) (consequence 1 —
+  the visibility window), [#7923](https://github.com/tokuhirom/mutsu/issues/7923)
+  (consequence 2 — the lost update, fixed by the delta commit)
+
+## Context
+
+Every mutable native instance method in mutsu is a read-modify-write over a
+**private copy** of the receiver's attribute map. `call_native_instance_method_mut_in_place`
+reads the shared `Gc<InstanceAttrs>` cell into an owned `AttrMap`, hands that map
+to the per-class handler by value, and commits what the handler hands back:
+
+```rust
+let working = attributes.to_map();
+let before = working.bits_image();
+let (result, updated) = self.dispatch_native_instance_method_mut(...)?;
+attributes.commit_attrs_delta(&before, &updated);
+```
+
+`commit_attrs_delta` (ADR-0013's cell, #7923's fix) already solved the *lost
+update*: the commit stores only the keys whose boxed word changed, so a key
+another thread wrote in between survives.
+
+It does not solve the other half of #7943. The private copy is also a
+**visibility window**: nothing the handler writes reaches any other thread until
+it returns. A handler that wakes another thread *mid-flight* — keeps a promise,
+emits to a supply, sends on a channel, spawns — has published none of its writes
+at the moment the woken thread starts reading the receiver.
+
+`Proc::Async.start` is the case that bit first. It sets `started` and `pid`,
+keeps the `.ready` promise as soon as the child is spawned, and only then
+returns. A thread blocked on `await $p.ready` woke, read `started` straight back
+off the instance, saw the pre-spawn map, and `.kill` threw
+`X::Proc::Async::MustBeStarted` — 1 failure in 80 runs of
+`roast/S17-procasync/kill.t`, and the `.ready`-racing-`.start` variant hung about
+3 runs in 4.
+
+That was patched twice, both times locally. `fd3f1df3` moved the state onto a
+constructor-built `SharedPromise` (shared by reference, so every snapshot reaches
+the same object) and said so itself: *"This is targeted at Proc::Async, not
+general."* A later fix wrote the two keys straight through the cell
+(`live.insert("started", Value::TRUE)`) next to each working-map write. Neither is
+a convention; the second is also subtly wrong (below).
+
+## Decision
+
+**Keep the private working map, and make the publish point first-class.**
+
+1. The working map stays private and stays the default. It is what makes most
+   handlers simple and correct: a handler that fails part-way publishes nothing,
+   so a `?` cannot leave half a transition on the shared object. Converting every
+   handler to read-modify-write the cell directly — the `with_attr_mut` route
+   #7943 first proposed — would trade that for a per-handler audit of partial
+   failure, and would change behaviour in every handler, not just timing.
+
+2. Every mutable native handler receives an `AttrPublisher`
+   (`src/runtime/native_methods/attr_publish.rs`), opened once by the single
+   dispatcher that owns the snapshot-dispatch-commit triple. The convention is
+   one rule:
+
+   > **A mutable native handler must publish before any operation that can wake
+   > another thread which reads the receiver.**
+
+3. `AttrPublisher::publish(&working)` commits the delta accumulated so far **and
+   rebases the before-image onto it**. This is the part a raw `cell.insert` gets
+   wrong: writing through the cell publishes the value but leaves the
+   dispatcher's before-image describing the map as it was *read*, so the commit
+   at return still sees that key as changed and stores it a second time — over
+   whatever another thread wrote to it in between. That is precisely the lost
+   update `commit_attrs_delta` exists to prevent, reintroduced by the workaround
+   for the other half of the same ticket. After a rebase, a key the handler
+   published and never touched again is no longer part of its delta, so the
+   other thread's later write survives.
+
+4. `AttrPublisher::detached()` is the honest no-op for the two sites that run a
+   mutable handler purely for its return value and discard the map (the immutable
+   `IO::CatHandle` and `Supply.tap` entries): there is no shared receiver to
+   publish to.
+
+## Consequences
+
+- The publish point is uniform. A class that needs cross-thread visibility no
+  longer has to invent its own latch, as `Proc::Async` did with its
+  `SharedPromise`; the three hand-rolled `live.insert` calls in
+  `native_proc_async_mut` are now `publish.publish(&attrs)` and are covered by
+  the rebase.
+- `Supplier.done` and `Supplier.quit` gained publish points. Both write the
+  terminal state (`done`, `quit_reason`) and then run tap callbacks — user code
+  that can reach the same `Supplier` from another thread — and a concurrent
+  `.emit` gates on exactly that state through `supply_is_terminated`, which falls
+  back to the attribute map for a `Supplier` with no registry id. `Supplier.emit`
+  deliberately did *not* get one: the only key it writes, `emitted`, is appended
+  to and never read back anywhere, so a publish there would be a delta commit per
+  emission bought for nothing. That is the rule working as intended — the
+  question a publish point asks is "does anything the wake releases read this
+  key", not "did I write a key".
+- A publish is **atomic across keys**: one call commits the whole accumulated
+  delta under one write lock, so a handler that must publish a multi-key
+  transition indivisibly writes every key and then publishes once. That answers
+  #7943's `started`-plus-`pid` question, and shows why `Proc::Async.start`
+  deliberately does *not* do it: `started` has to be visible *during* the spawn,
+  and the pid does not exist until the spawn returns, so the two are separate
+  transitions rather than one.
+- Publishing is explicit, so it is auditable: a handler with no publish call
+  makes no cross-thread claim. Handlers that never wake anybody take the
+  parameter as `_publish`, which is the documentation that they do not.
+- The cost of a publish is one delta commit (one write lock, only the changed
+  keys) plus one `bits_image` rebase — `u64` per key, no `Value` clones. Handlers
+  that do not publish pay nothing: the parameter is a reference.
+- This does not make instance attributes a memory model. Two threads racing on
+  the same key still tie-break last-commit-wins, as `commit_attrs_delta`
+  documents. What the rule buys is the *happens-before* case, which is the one
+  Raku programs actually rely on: everything written before a wake is visible to
+  whoever the wake released.
+
+## Alternatives rejected
+
+- **Write-through working map** (publish on every `attrs.insert`). Removes the
+  audit, but also removes the rollback: a handler that returns `Err` after a
+  partial transition would leave that transition committed, and which handlers
+  depend on that rollback is exactly what is undocumented. Making every write a
+  publish would also change the *order* other threads observe a multi-key
+  transition in — `Proc::Async.start`'s `started` and `pid` become separately
+  visible by construction — which is the one question #7943 asked that an
+  explicit publish point lets a handler answer for itself.
+- **Convert all handlers to `with_attr_mut` on the cell.** The honest full fix,
+  and the reason #7943 was filed `todo:deep`. Rejected for now on the same
+  partial-failure grounds, and because it is ~8000 lines of handler across nine
+  files whose privacy assumptions are undocumented. The publish point makes the
+  incremental version of that conversion possible: a handler can be moved onto
+  the cell one method at a time without changing the dispatcher.
+- **Automatic publish inside the wake primitives** (`SharedPromise::keep`,
+  `supplier_emit`, …). No safe way to reach the handler's working map from
+  there, and it would publish on wakes that have nothing to do with the receiver.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -120,3 +120,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0092](0092-closure-capture-is-a-chained-tier-not-a-merged-copy.md) | Closure capture should be a chained tier, not a per-call merged copy | Proposed |
 | [0093](0093-core-only-infix-operators-are-shadowed-not-extended.md) | A core operator rakudo does not declare is *shadowed* by a user declaration, not extended | Accepted (implemented) |
 | [0094](0094-closure-capture-kept-set-is-not-narrowed.md) | The closure capture's kept set is not narrowed — its cost is the call-time merge | Accepted |
+| [0095](0095-native-mut-publish-before-wake.md) | A mutable native instance method publishes before it wakes another thread | Accepted (implemented) |

--- a/news/2026-09/native-mut-methods-publish-before-they-wake.md
+++ b/news/2026-09/native-mut-methods-publish-before-they-wake.md
@@ -1,0 +1,73 @@
+# A mutable native instance method now publishes before it wakes another thread
+
+Every mutable native instance method in mutsu is a read-modify-write over a
+**private copy** of the receiver's attribute map: the dispatcher reads the shared
+`Gc<InstanceAttrs>` cell into an owned `AttrMap`, the per-class handler mutates
+that copy, and the dispatcher commits the delta when the handler returns.
+
+[#7923](https://github.com/tokuhirom/mutsu/issues/7923) fixed the *lost update*
+half of that convention — `commit_attrs_delta` stores only the keys whose boxed
+word changed, so a key another thread wrote in between survives.
+[#7943](https://github.com/tokuhirom/mutsu/issues/7943) kept the other half open:
+the private copy is also a **visibility window**. Nothing the handler writes
+reaches another thread until it returns, so a handler that wakes a thread
+*mid-flight* — keeps a promise, emits to a supply, sends on a channel, spawns —
+has published none of its writes at the moment the woken thread starts reading
+the receiver.
+
+`Proc::Async.start` is the case that bit: it sets `started` and `pid`, keeps the
+`.ready` promise as soon as the child is spawned, and only then returns. A thread
+blocked on `await $p.ready` woke, read `started` off the instance, saw the
+pre-spawn map, and the `.kill` that followed threw
+`X::Proc::Async::MustBeStarted`. That had been patched twice, both times for one
+class only: first by moving the state onto a constructor-built `SharedPromise`
+(shared by reference, so every snapshot reaches the same object), then by writing
+the two keys straight through the cell next to the working-map write.
+
+## What changed
+
+The publish point is now a first-class part of the convention.
+`src/runtime/native_methods/attr_publish.rs` introduces `AttrPublisher`, opened
+once by `call_native_instance_method_mut_in_place` — the single dispatcher that
+owns the snapshot-dispatch-commit triple — and passed to **every** mutable native
+handler. The rule it carries is one line:
+
+> A mutable native handler must publish before any operation that can wake
+> another thread which reads the receiver.
+
+`publish(&working)` commits the delta accumulated so far **and rebases the
+before-image onto it**. That rebase is the part the hand-rolled
+`cell.insert(...)` got wrong: writing through the cell publishes the value but
+leaves the dispatcher's before-image describing the map as it was *read*, so the
+commit at return still sees that key as changed and stores it a second time —
+over whatever another thread wrote to it in between. Fixing the visibility window
+by hand had quietly reintroduced the lost update the delta commit exists to
+prevent. `a_published_key_is_not_re_committed_over_a_later_writer` pins it.
+
+The working map stays private, and stays the default: it is what lets a handler
+fail part-way without leaving half a transition on the shared object. Handlers
+that wake nobody take the parameter as `_publish`, which is the documentation
+that they make no cross-thread claim. `AttrPublisher::detached()` is the honest
+no-op for the two sites that run a mutable handler purely for its return value
+and discard the map (the immutable `IO::CatHandle` and `Supply.tap` entries).
+
+`Proc::Async.start`'s three hand-rolled `live.insert` calls became
+`publish.publish(&attrs)`, and `Supplier.done` and `Supplier.quit` gained publish
+points: both write the terminal state and then run tap callbacks — user code that
+can reach the same `Supplier` from another thread — and a concurrent `.emit`
+gates on exactly that state. `Supplier.emit` deliberately did not get one: the
+only key it writes is appended to and never read back, so a publish there would
+cost a delta commit per emission and buy nothing.
+
+## Pins
+
+Five unit tests in `attr_publish.rs` cover the mechanism: a mid-flight write is
+invisible until published and visible after; a published key is not re-committed
+over a later writer; a write *after* the publish still lands at return; a removal
+after the publish reaches the cell; a detached publish point does nothing.
+`t/concurrency/procasync-ready-publishes-started.t` remains the end-to-end pin.
+
+The decision, the alternatives weighed (write-through working map, converting
+every handler onto `with_attr_mut`, publishing from inside the wake primitives),
+and what this deliberately does *not* promise are recorded in
+[ADR-0095](../../docs/adr/0095-native-mut-publish-before-wake.md).

--- a/src/runtime/native_io/io_cathandle.rs
+++ b/src/runtime/native_io/io_cathandle.rs
@@ -560,12 +560,13 @@ impl Interpreter {
     /// Mutable dispatch for `IO::CatHandle` methods. All reads advance internal
     /// state, so every method goes through here and the caller writes the updated
     /// attributes back into the receiver's shared cell.
-    pub(crate) fn native_io_cathandle_mut(
+    pub(in crate::runtime) fn native_io_cathandle_mut(
         &mut self,
         class_name: Symbol,
         attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
+        _publish: &mut crate::runtime::native_methods::AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         let mut attrs = attributes;
         // Character-oriented reads are illegal on a binary-mode cat handle.

--- a/src/runtime/native_io/io_handle.rs
+++ b/src/runtime/native_io/io_handle.rs
@@ -25,11 +25,12 @@ impl Interpreter {
     /// `updated` map is written back to the receiver by the caller
     /// (`write_back_sharing`). Any other method falls back to the immutable path
     /// via the sentinel "No native mutable method" error.
-    pub(crate) fn native_io_handle_mut(
+    pub(in crate::runtime) fn native_io_handle_mut(
         &mut self,
         attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
+        _publish: &mut crate::runtime::native_methods::AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         if method == "open" {
             let result = self.native_io_handle(&attributes, "open", args)?;

--- a/src/runtime/native_methods/attr_publish.rs
+++ b/src/runtime/native_methods/attr_publish.rs
@@ -1,0 +1,210 @@
+//! The cross-thread publish point for a mutable native instance method.
+//!
+//! Every mutable native method is a read-modify-write over a **private** copy of
+//! the receiver's attribute map: the handler is given the map by value, mutates
+//! it freely, and the dispatcher
+//! ([`crate::runtime::Interpreter::call_native_instance_method_mut_in_place`])
+//! commits the delta into the shared cell when the handler returns. That private
+//! copy is what makes most handlers simple and correct — a handler that fails
+//! part-way publishes nothing, so a `?` cannot leave half a transition behind.
+//!
+//! It is also a visibility window. Nothing the handler writes is visible to any
+//! other thread until it returns, so a handler that *wakes another thread
+//! mid-flight* — keeps a promise, emits to a supply, sends on a channel, spawns
+//! — has published none of its writes at the moment the woken thread starts
+//! reading the receiver. `Proc::Async.start` is the case that first bit
+//! (tokuhirom/mutsu#7923): it keeps `.ready` as soon as the child is spawned, and
+//! a thread blocked on `await $p.ready` read `started` straight back off the
+//! instance and saw the pre-spawn map, so `.kill` threw
+//! `X::Proc::Async::MustBeStarted`.
+//!
+//! [`AttrPublisher`] is the publish point that makes the window closable, and
+//! the convention that goes with it is one rule:
+//!
+//! > **A mutable native handler must publish before any operation that can wake
+//! > another thread which reads the receiver.**
+//!
+//! See `docs/adr/0095-native-mut-publish-before-wake.md`.
+//!
+//! # Why this is not just `cell.insert(key, value)`
+//!
+//! Writing straight through the cell (what `Proc::Async.start` did by hand
+//! before this type existed) publishes the value but leaves the dispatcher's
+//! before-image describing the map as it was read. At return the delta commit
+//! then still sees that key as *changed* and stores it again — overwriting
+//! whatever another thread wrote to it in between, which is exactly the lost
+//! update `InstanceAttrs::commit_attrs_delta` exists to prevent. Publishing
+//! through this type **rebases** the before-image onto what was published, so a
+//! key the handler published and never touched again is no longer part of its
+//! delta, and the other thread's later write survives.
+
+use crate::value::{AttrBits, AttrMap, InstanceAttrs};
+
+/// The publish point handed to every mutable native instance handler.
+///
+/// Holds the receiver's live attribute cell (when the caller has one) together
+/// with the before-image the final delta commit diffs against, so that
+/// publishing mid-flight and committing at return compose correctly.
+pub(in crate::runtime) struct AttrPublisher<'a> {
+    /// The receiver's shared attribute cell. `None` when the receiver was not
+    /// dispatched from a live instance (the map is then the only copy there is,
+    /// and publishing is a no-op).
+    cell: Option<&'a InstanceAttrs>,
+    /// The boxed-word image the next commit diffs against: the map as it was
+    /// read, rebased onto every intervening [`AttrPublisher::publish`].
+    before: AttrBits,
+}
+
+impl<'a> AttrPublisher<'a> {
+    /// Open a publish point over `cell`, against the before-image `before` of the
+    /// working map the handler is about to be given.
+    pub(in crate::runtime) fn new(cell: Option<&'a InstanceAttrs>, before: AttrBits) -> Self {
+        Self { cell, before }
+    }
+
+    /// A publish point with no cell behind it, for the handful of sites that run
+    /// a mutable handler purely for its return value and discard the map (the
+    /// immutable `IO::CatHandle` and `Supply.tap` entries). Publishing through it
+    /// is a no-op, which is the truth: there is no shared receiver to publish to.
+    pub(in crate::runtime) fn detached() -> Self {
+        Self {
+            cell: None,
+            before: AttrBits::default(),
+        }
+    }
+
+    /// Publish everything the handler has written to `working` so far, making it
+    /// visible to every other thread holding this instance.
+    ///
+    /// Call this immediately **before** waking another thread that can read the
+    /// receiver — keeping a promise, emitting to a supply, sending on a channel,
+    /// spawning — never after: the woken thread may already be reading by the
+    /// time the wake primitive returns.
+    ///
+    /// Idempotent and cheap when nothing changed: an unchanged key is not in the
+    /// delta, and an empty delta takes no write lock at all.
+    pub(in crate::runtime) fn publish(&mut self, working: &AttrMap) {
+        let Some(cell) = self.cell else {
+            return;
+        };
+        cell.commit_attrs_delta(&self.before, working);
+        // Rebase: what was just published is the new baseline, so these keys are
+        // no longer part of this handler's delta and a write another thread lands
+        // on them from here on is not clobbered at return.
+        self.before = working.bits_image();
+    }
+
+    /// Commit the handler's final map. Consumes the publish point, so the
+    /// dispatcher's commit is the last word on the before-image.
+    pub(in crate::runtime) fn commit(self, updated: &AttrMap) {
+        if let Some(cell) = self.cell {
+            cell.commit_attrs_delta(&self.before, updated);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::symbol::Symbol;
+    use crate::value::Value;
+
+    fn cell() -> InstanceAttrs {
+        InstanceAttrs::new(Symbol::intern("T"), AttrMap::new(), 1, false)
+    }
+
+    /// The visibility window (tokuhirom/mutsu#7943 consequence 1): what a handler
+    /// writes into its private working map is invisible to every other holder of
+    /// the instance until it returns — unless it publishes.
+    #[test]
+    fn publish_makes_a_mid_flight_write_visible_before_the_handler_returns() {
+        let cell = cell();
+        let mut working = cell.to_map();
+        let mut publish = AttrPublisher::new(Some(&cell), working.bits_image());
+
+        // The handler writes, as a handler does: into its own copy.
+        working.insert("started", Value::TRUE);
+        assert_eq!(
+            cell.as_map().get("started"),
+            None,
+            "the private working map must not be visible on its own"
+        );
+
+        // ...and publishes before the wake.
+        publish.publish(&working);
+        assert_eq!(cell.as_map().get("started"), Some(&Value::TRUE));
+    }
+
+    /// Publishing **rebases** the before-image, so a key the handler published and
+    /// never touched again is no longer part of its delta. Writing straight
+    /// through the cell instead (the hand-rolled form this type replaced) leaves
+    /// the before-image stale, and the commit at return then stores the published
+    /// value a second time — over whatever another thread wrote in between.
+    #[test]
+    fn a_published_key_is_not_re_committed_over_a_later_writer() {
+        let cell = cell();
+        let working = cell.to_map();
+        let before = working.bits_image();
+        let mut publish = AttrPublisher::new(Some(&cell), before);
+
+        let mut working = working;
+        working.insert("pid", Value::int(41));
+        publish.publish(&working);
+
+        // Another thread corrects the key we published and are done with.
+        cell.insert("pid", Value::int(42));
+
+        // The handler returns; its final map still carries the published value.
+        publish.commit(&working);
+        assert_eq!(
+            cell.as_map().get("pid"),
+            Some(&Value::int(42)),
+            "a key the handler published and did not touch again must not be \
+             re-committed over a later write"
+        );
+    }
+
+    /// A key written after the publish is still the handler's, and still lands.
+    #[test]
+    fn a_write_after_the_publish_still_commits_at_return() {
+        let cell = cell();
+        let mut working = cell.to_map();
+        let mut publish = AttrPublisher::new(Some(&cell), working.bits_image());
+
+        working.insert("started", Value::TRUE);
+        publish.publish(&working);
+        working.insert("pid", Value::int(7));
+        publish.commit(&working);
+
+        assert_eq!(cell.as_map().get("started"), Some(&Value::TRUE));
+        assert_eq!(cell.as_map().get("pid"), Some(&Value::int(7)));
+    }
+
+    /// A removal after the publish is a removal, not a no-op: the rebased image
+    /// still records that the key was there.
+    #[test]
+    fn a_removal_after_the_publish_reaches_the_cell() {
+        let cell = cell();
+        let mut working = cell.to_map();
+        let mut publish = AttrPublisher::new(Some(&cell), working.bits_image());
+
+        working.insert("emitted", Value::int(1));
+        publish.publish(&working);
+        assert_eq!(cell.as_map().get("emitted"), Some(&Value::int(1)));
+
+        working.remove("emitted");
+        publish.commit(&working);
+        assert_eq!(cell.as_map().get("emitted"), None);
+    }
+
+    /// A detached publish point has no receiver to publish to, and says so by
+    /// doing nothing rather than by panicking.
+    #[test]
+    fn a_detached_publish_point_is_a_no_op() {
+        let mut working = AttrMap::new();
+        working.insert("a", Value::int(1));
+        let mut publish = AttrPublisher::detached();
+        publish.publish(&working);
+        publish.commit(&working);
+    }
+}

--- a/src/runtime/native_methods/concurrency.rs
+++ b/src/runtime/native_methods/concurrency.rs
@@ -265,6 +265,7 @@ impl Interpreter {
         mut attrs: AttrMap,
         method: &str,
         _args: Vec<Value>,
+        _publish: &mut crate::runtime::native_methods::AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "keep" => {
@@ -287,6 +288,7 @@ impl Interpreter {
         mut attrs: AttrMap,
         method: &str,
         args: Vec<Value>,
+        _publish: &mut crate::runtime::native_methods::AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "send" => {

--- a/src/runtime/native_methods/encoding.rs
+++ b/src/runtime/native_methods/encoding.rs
@@ -266,6 +266,7 @@ impl Interpreter {
         mut attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
+        _publish: &mut crate::runtime::native_methods::AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "add-bytes" => {

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -1,4 +1,5 @@
 // Native method dispatch submodules, split from the original native_methods.rs
+pub(in crate::runtime) mod attr_publish;
 mod compiler_config;
 mod concurrency;
 mod encoding;
@@ -31,6 +32,8 @@ pub(crate) use state::{
     split_supply_chunks_into_lines, take_supply_channel, whenever_closed_seq,
 };
 pub(crate) use state_lock::{acquire_lock, current_thread_id, lock_runtime_by_id, release_lock};
+
+pub(in crate::runtime) use attr_publish::AttrPublisher;
 
 // Re-export items accessed from sibling `runtime` modules. A handful are also
 // re-exported `pub(crate)` below for the VM-side react/supply drive loop
@@ -284,6 +287,12 @@ impl Interpreter {
     /// through [`crate::value::InstanceAttrs::commit_attrs_delta`] keeps the keys the handler
     /// never touched, so the concurrent write survives.
     ///
+    /// The commit is also the handler's *only* publish point unless it asks for
+    /// another: nothing it writes is visible to another thread until it returns.
+    /// A handler that wakes a thread mid-flight must therefore publish first,
+    /// through the [`AttrPublisher`] opened here — see
+    /// `docs/adr/0095-native-mut-publish-before-wake.md`.
+    ///
     /// This is the **only** entry to the mutable native handlers: having one place
     /// own the snapshot-dispatch-commit triple is what keeps the lost update from
     /// being reintroduced at a fifth call site.
@@ -295,15 +304,15 @@ impl Interpreter {
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
         let working = attributes.to_map();
-        let before = working.bits_image();
+        let mut publisher = AttrPublisher::new(Some(attributes), working.bits_image());
         let (result, updated) = self.dispatch_native_instance_method_mut(
             class_name,
             working,
             method,
             args,
-            Some(attributes),
+            &mut publisher,
         )?;
-        attributes.commit_attrs_delta(&before, &updated);
+        publisher.commit(&updated);
         Ok(result)
     }
 
@@ -315,19 +324,21 @@ impl Interpreter {
     /// whole-map write-back that lost concurrent updates
     /// (tokuhirom/mutsu#7923) cannot be written at a call site again.
     ///
-    /// `cell` is the receiver's live attribute cell, for handlers that must make a
-    /// mutation **visible before they return** because they also publish a promise
-    /// or wake another thread mid-flight: committing at return is too late,
-    /// whatever the commit does. `Proc::Async.start` is the case that forced it —
-    /// it keeps the `.ready` promise as soon as the child is spawned, and the
-    /// thread that wakes on it immediately reads `started`.
+    /// `publish` is the receiver's cross-thread publish point, for handlers that
+    /// must make a mutation **visible before they return** because they also keep
+    /// a promise or wake another thread mid-flight: committing at return is too
+    /// late, whatever the commit does. `Proc::Async.start` is the case that forced
+    /// it — it keeps the `.ready` promise as soon as the child is spawned, and the
+    /// thread that wakes on it immediately reads `started`. Every mutable handler
+    /// takes one, so the rule is uniform and no class has to invent its own
+    /// cross-thread latch; see [`AttrPublisher`].
     fn dispatch_native_instance_method_mut(
         &mut self,
         class_name: &str,
         attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
-        cell: Option<&crate::value::InstanceAttrs>,
+        publish: &mut AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         let dispatch_class = if matches!(
             class_name,
@@ -371,21 +382,27 @@ impl Interpreter {
                 })
         };
         match dispatch_class.as_deref().unwrap_or(class_name) {
-            "IO::Handle" => self.native_io_handle_mut(attributes, method, args),
-            "IO::CatHandle" => {
-                self.native_io_cathandle_mut(Symbol::intern(class_name), attributes, method, args)
-            }
-            "Proc" => self.native_proc_mut(attributes, method, args),
-            "Promise" => self.native_promise_mut(attributes, method, args),
-            "Channel" => self.native_channel_mut(attributes, method, args),
-            "Supply" => self.native_supply_mut(attributes, method, args),
+            "IO::Handle" => self.native_io_handle_mut(attributes, method, args, publish),
+            "IO::CatHandle" => self.native_io_cathandle_mut(
+                Symbol::intern(class_name),
+                attributes,
+                method,
+                args,
+                publish,
+            ),
+            "Proc" => self.native_proc_mut(attributes, method, args, publish),
+            "Promise" => self.native_promise_mut(attributes, method, args, publish),
+            "Channel" => self.native_channel_mut(attributes, method, args, publish),
+            "Supply" => self.native_supply_mut(attributes, method, args, publish),
             "Supplier" | "Supplier::Preserving" => {
-                self.native_supplier_mut(attributes, method, args)
+                self.native_supplier_mut(attributes, method, args, publish)
             }
-            "Proc::Async" => self.native_proc_async_mut(attributes, method, args, cell),
-            "Encoding::Decoder" => Self::native_encoding_decoder_mut(attributes, method, args),
+            "Proc::Async" => self.native_proc_async_mut(attributes, method, args, publish),
+            "Encoding::Decoder" => {
+                Self::native_encoding_decoder_mut(attributes, method, args, publish)
+            }
             "ThreadPoolScheduler" | "CurrentThreadScheduler" => {
-                Interpreter::native_scheduler_mut(attributes, method, args)
+                Interpreter::native_scheduler_mut(attributes, method, args, publish)
             }
             _ => Err(RuntimeError::new(format!(
                 "No native mutable method '{}' on '{}'",
@@ -511,6 +528,7 @@ impl Interpreter {
                     attributes.clone(),
                     method,
                     args,
+                    &mut AttrPublisher::detached(),
                 )?;
                 Ok(result)
             }

--- a/src/runtime/native_methods/proc.rs
+++ b/src/runtime/native_methods/proc.rs
@@ -15,6 +15,7 @@ impl Interpreter {
         attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
+        _publish: &mut crate::runtime::native_methods::AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         let new_proc = match method {
             "spawn" | "run" => self.builtin_run(&args)?,

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -440,6 +440,7 @@ impl Interpreter {
         attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
+        _publish: &mut crate::runtime::native_methods::AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "uncaught_handler" => {

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -222,18 +222,18 @@ pub(in crate::runtime) fn malformed_utf8_quit_value() -> Value {
 }
 
 impl Interpreter {
-    /// `live` is the receiver's shared attribute cell when the caller has it.
-    /// `start` needs it: it keeps the `.ready` promise as soon as the child is
-    /// spawned, and whatever wakes on that promise reads `started`/`pid` off the
-    /// cell straight away — long before this handler returns and its caller
-    /// commits. Publishing those two through the cell *before* the keep is what
-    /// makes `await $p.ready; $p.kill` well-defined (tokuhirom/mutsu#7923).
+    /// `publish` is the receiver's cross-thread publish point. `start` needs it:
+    /// it keeps the `.ready` promise as soon as the child is spawned, and whatever
+    /// wakes on that promise reads `started`/`pid` off the instance straight away
+    /// — long before this handler returns and the dispatcher commits. Publishing
+    /// those two *before* the keep is what makes `await $p.ready; $p.kill`
+    /// well-defined (tokuhirom/mutsu#7923).
     pub(super) fn native_proc_async_mut(
         &mut self,
         mut attrs: AttrMap,
         method: &str,
         args: Vec<Value>,
-        live: Option<&crate::value::InstanceAttrs>,
+        publish: &mut crate::runtime::native_methods::AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "start" => {
@@ -249,9 +249,7 @@ impl Interpreter {
                 // `$p.started` while we are still in here. Rakudo sets its
                 // `$!started` attribute first thing in `start` for the same
                 // reason, and that write is on the shared object too.
-                if let Some(live) = live {
-                    live.insert("started", Value::TRUE);
-                }
+                publish.publish(&attrs);
 
                 // The merged Supply may have been fetched before `.start()`;
                 // its later `.tap`/`whenever` registration must still reject
@@ -463,9 +461,7 @@ impl Interpreter {
                     // Published before the break below, for the same reason as
                     // `started`: whoever wakes on the broken `.ready` promise may
                     // ask this object about the failure before we return.
-                    if let Some(live) = live {
-                        live.insert("spawn_error", os_error.clone());
-                    }
+                    publish.publish(&attrs);
 
                     // Break ready promise if set
                     if let Some(ValueView::Promise(ready)) =
@@ -505,9 +501,7 @@ impl Interpreter {
                 // Same reason as `started` above: the `.ready` keep a few lines
                 // down hands the pid to another thread, which may then ask this
                 // object for it.
-                if let Some(live) = live {
-                    live.insert("pid", Value::int(pid as i64));
-                }
+                publish.publish(&attrs);
 
                 if let Some(ValueView::Instance {
                     attributes: stdout_attrs,

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -573,6 +573,7 @@ impl Interpreter {
         mut attrs: AttrMap,
         method: &str,
         args: Vec<Value>,
+        publish: &mut crate::runtime::native_methods::AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         // This construct handles `next`/`last`/`redo`, so a loop-control
         // statement raised anywhere in its dynamic extent has somewhere to go
@@ -896,6 +897,11 @@ impl Interpreter {
                 bump_supplier_done_count(supplier_id_from_attrs(&attrs));
                 let preserving = attrs.contains_key("preserving");
                 attrs.insert("done".to_string(), Value::TRUE);
+                // Everything from here on wakes the taps, and a concurrent
+                // `.emit` gates on exactly this flag (`supply_is_terminated`);
+                // publishing at return would let that emit slip past a `done`
+                // the taps have already been told about.
+                publish.publish(&attrs);
                 if let Some(supplier_id) = supplier_id_from_attrs(&attrs) {
                     // With a tap already listening the done is delivered now, so
                     // it is not left in the preserved replay list for a later
@@ -1042,6 +1048,10 @@ impl Interpreter {
                 };
                 attrs.insert("done".to_string(), Value::TRUE);
                 attrs.insert("quit_reason".to_string(), reason.clone());
+                // Same as `done` above: the quit propagation below wakes the taps
+                // and runs their QUIT phasers, so the terminal state must already
+                // be on the shared cell when they look.
+                publish.publish(&attrs);
                 if let Some(supplier_id) = supplier_id_from_attrs(&attrs) {
                     supplier_quit(supplier_id, reason.clone());
                 }

--- a/src/runtime/native_supply_dispatch.rs
+++ b/src/runtime/native_supply_dispatch.rs
@@ -365,7 +365,12 @@ impl Interpreter {
                 // there is a single source of truth. The &self path does not
                 // write the receiver attributes back, so the returned map is
                 // discarded (matching the prior immutable-tap behavior).
-                let (tap, _) = self.native_supply_mut(attributes.clone(), method, args)?;
+                let (tap, _) = self.native_supply_mut(
+                    attributes.clone(),
+                    method,
+                    args,
+                    &mut crate::runtime::native_methods::AttrPublisher::detached(),
+                )?;
                 Ok(tap)
             }
             "on-close" => {

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -11,6 +11,7 @@ impl Interpreter {
         mut attrs: AttrMap,
         method: &str,
         args: Vec<Value>,
+        _publish: &mut crate::runtime::native_methods::AttrPublisher<'_>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
         // This construct handles `next`/`last`/`redo`, so a loop-control
         // statement raised anywhere in its dynamic extent has somewhere to go

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -343,7 +343,7 @@ impl Interpreter {
         // compiles to a method call and already goes through that path, but
         // `$!field` (this op) does not, so it stayed stuck reading `Nil` (#8030).
         if !self.locals[idx].is_container_ref()
-            && let Some((bare, true)) = code.local_attr_key(idx)
+            && let Some((bare, true, _)) = code.local_attr_key(idx)
             && let Some(self_val) = self.get_env_self()
             && let Some(field_val) =
                 self.cstruct_field_value(&self_val.deref_container(), bare.as_str())


### PR DESCRIPTION
Closes #7943 (consequence 1 — the visibility window).

## The problem

Every mutable native instance method is a read-modify-write over a **private copy** of the receiver's attribute map: `call_native_instance_method_mut_in_place` reads the shared `Gc<InstanceAttrs>` cell into an owned `AttrMap`, the per-class handler mutates that copy, and the dispatcher commits the delta when the handler returns.

#7923 fixed the *lost update* half of that convention with `commit_attrs_delta`. The other half stayed open: the private copy is also a **visibility window**. Nothing a handler writes reaches another thread until it returns, so a handler that wakes a thread *mid-flight* — keeps a promise, emits to a supply, sends on a channel, spawns — has published none of its writes at the moment the woken thread starts reading the receiver.

`Proc::Async.start` is the case that bit: it sets `started` and `pid`, keeps the `.ready` promise as soon as the child is spawned, and only then returns. A thread blocked on `await $p.ready` woke, read `started` off the instance, saw the pre-spawn map, and the `.kill` that followed threw `X::Proc::Async::MustBeStarted`. That was patched twice, both times for one class only — a constructor-built `SharedPromise` latch (`fd3f1df3`, whose own message says "This is targeted at Proc::Async, not general"), then three `cell.insert` calls written next to the working-map writes.

## What this does

Makes the publish point first-class. `AttrPublisher` (`src/runtime/native_methods/attr_publish.rs`) is opened once by the single dispatcher that owns the snapshot-dispatch-commit triple, and passed to **every** mutable native handler, carrying one rule:

> A mutable native handler must publish before any operation that can wake another thread which reads the receiver.

`publish(&working)` commits the delta accumulated so far **and rebases the before-image onto it**. That rebase is the part the hand-rolled `cell.insert` got wrong: writing through the cell publishes the value but leaves the dispatcher's before-image describing the map as it was *read*, so the commit at return still sees that key as changed and stores it a second time — over whatever another thread wrote in between. **Closing the visibility window by hand had quietly reintroduced the lost update the delta commit exists to prevent.**

The working map stays private and stays the default: it is what lets a handler fail part-way without leaving half a transition on the shared object. Handlers that wake nobody take the parameter as `_publish`, which is the documentation that they make no cross-thread claim. `AttrPublisher::detached()` is the honest no-op for the two sites that run a mutable handler purely for its return value and discard the map (the immutable `IO::CatHandle` and `Supply.tap` entries).

Converted:

- `Proc::Async.start`'s three `cell.insert` calls → `publish.publish(&attrs)`, now covered by the rebase.
- `Supplier.done` / `Supplier.quit` gained publish points: both write terminal state (`done`, `quit_reason`) and then run tap callbacks — user code that can reach the same `Supplier` from another thread — and a concurrent `.emit` gates on exactly that state through `supply_is_terminated`, which falls back to the attribute map for a `Supplier` with no registry id.
- `Supplier.emit` deliberately did **not** get one: the only key it writes, `emitted`, is appended to and never read back anywhere, so a publish there would cost a delta commit per emission and buy nothing. That is the rule working as intended — the question a publish point asks is "does anything the wake releases read this key", not "did I write a key".

## Pins

Five unit tests in `attr_publish.rs`: a mid-flight write is invisible until published and visible after; a published key is not re-committed over a later writer (this one fails against the raw `cell.insert` form); a write *after* the publish still lands at return; a removal after the publish reaches the cell; a detached publish point does nothing. `t/concurrency/procasync-ready-publishes-started.t` remains the end-to-end pin.

## ADR

[ADR-0095](https://github.com/tokuhirom/mutsu/blob/claude/vibrant-dijkstra-e6djrd/docs/adr/0095-native-mut-publish-before-wake.md) records the decision, why the private working map is kept, that a publish is atomic across keys (answering #7943's `started`-plus-`pid` question), and the alternatives weighed: write-through working map, converting every handler onto `with_attr_mut`, and publishing from inside the wake primitives.

## Second commit: `main` was red

`main` at `64aedac7` does not compile. `5840d970` widened `Chunk::local_attr_key` to a three-field tuple while `43434cda` added a caller destructuring the old two-field shape; each branch was green alone, neither CI run compiled the pair. `0509e19e` binds the sigil as `_` at that one site — the CStruct read only gates on private-ness — which is exactly what that PR intended. Carried here because nothing on any branch builds until it lands and no open PR fixes it.

## Verification

- `make lint` — all four configurations green (default clippy, `jit` off, wasm32, rustdoc).
- `make test` — `Files=4072, Tests=43326, Result: PASS`.
- `make roast` — the only three failures are the documented container-caused set from `docs/agent-environments.md`: `6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` (this container runs as `uid 0`, so the `chmod`-based assertions cannot pass) and `S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17" — the network sandbox). All pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_