### PR TITLE
perf(vm): serve the plain `@a[$i] = $v` element store without re-deriving its declaration

### DIFF
--- a/news/2026-09/fast-array-element-assign.md
+++ b/news/2026-09/fast-array-element-assign.md
@@ -1,0 +1,119 @@
+# `@a[$i] = $v` stops re-deriving the array's declaration on every store
+
+`bench-threads` is the only row in `bench-history.tsv` where mutsu is slower than rakudo, and the
+root cause turned out to be mostly not about threads at all
+([#8069](https://github.com/tokuhirom/mutsu/issues/8069)): an ordinary indexed element store —
+one thread, no `start` anywhere in the program — cost **13,069 instructions, 20 `Symbol::intern`
+calls, 6 heap allocations and 1940 ns**, against roughly 40 ns of marginal cost in rakudo.
+
+The Associative half of that statement had had a fast path for a long time
+(`try_fast_hash_element_assign`). The Positional half had none, so **every** `@a[$i] = $v` went
+through `exec_index_assign_expr_named_op_inner`, which re-derives the target's whole *declaration*,
+by string key, on each write: is this a sigilless alias, is it shaped, is it `:=`-bound, does it
+have a type or key constraint, a default, a readonly flag, a bound index, a `Proxy` element, a lazy
+tail. Each question is a fresh `String`, a fresh intern and a hash probe of the frame `Env` — and
+not one of them is a property of *this store*. They are all properties of *that container*, settled
+when the binding was declared.
+
+No benchmark in `benchmarks/` exercised indexed assignment, which is why a ~46x gap on one of the
+most common statements in the language had stayed invisible: `bench-array` measures `push` / `map` /
+`grep` / `sort`, `bench-hash` measures whole-hash construction and lookup, and neither writes
+through a subscript in a loop. `benchmarks/bench-index-store.raku` (#8086) closed that hole just
+before this landed, so the store now has a bench-CI row to be measured against.
+
+## What landed
+
+`try_fast_array_element_assign` (`src/vm/vm_var_assign_element_fast.rs`) is the Positional twin of
+the hash lane. It answers the declaration questions the way the rest of the VM already answers its
+own hot probes — from the container's *embedded* metadata (`ArrayData::has_type_meta`, `ArrayKind`,
+the element slot's own shape) and from the monotonic `env::*_possible()` latches, which are false
+for any program that never declared the feature. A plain array store therefore asks no name-keyed
+env question at all and reaches a `Vec` slot write.
+
+It fires for a positional subscript on an `@`-sigiled name with a plain non-negative in-range `Int`
+index, a plain rvalue, and a plain mutable untyped `Array`/`ItemArray` target whose destination slot
+is not itself a container. Everything else — autovivification past the end, typed and native arrays,
+shaped arrays, `:=`-bound and `Proxy` elements, `Nil` rvalues, `is default(...)`, slices, `Range`
+and `Whatever` subscripts, `List` targets, `:delete`d indices — makes it return `None`, and the full
+store runs unchanged. Like its hash twin the lane never *errors*: anything it is not certain about
+falls through to the path that owns the rule.
+
+Two decline routes are worth naming, because reading env directly is exactly what makes them
+necessary and the suites caught both:
+
+- **A module routine's own `our @arr`.** `env_root_descended_mut_tracked`, the write chokepoint the
+  full store funnels through, resolves a name in a strict precedence order — a captured unit lexical,
+  then the running routine's package `our` mirror, then env — because the bare env key belongs to
+  whatever scope *loaded* the module. Reading env without those two probes made the module's
+  `@arr[0] = $v` write the loading script's same-named array
+  (`t/modules/our-container-bare-name-resolution.t`). Both probes open with their own emptiness
+  gate, so a program with no unit lexicals and no `our` variables pays two `is_empty` checks.
+- **Any program that has spawned a second VM mutator thread.** There an element store is routed by
+  the name-keyed cross-thread lanes, or excluded by ADR-0068's `ContainerStructGuard` — five
+  documented routes whose interaction this lane reproduces none of, and an unguarded
+  `gc_contents_mut` under twenty concurrent writers is a `double free or corruption (out)`, which is
+  what `t/concurrency/concurrent-lane-decline-routes.t` produced. Taking the guard alone would buy
+  exclusion but not the lane's accumulate-instead-of-snapshot semantics, so the lane stands down
+  entirely once `multi_mutator_threads_live()` is set: one relaxed atomic load, the same latch the
+  guard itself consults.
+
+Two mechanical pieces came with it:
+
+- A `SHAPED_ARRAY_DIMS_SEEN` latch for `__mutsu_shaped_array_dims::*`, joining the six latches
+  already in `src/env.rs`. That probe ran on every element store and on every multi-dim assignment,
+  costing a `format!` plus an interning env lookup for a key a program without a single `my @a[2;3]`
+  can never hold. There is exactly one insert site for the key and it goes through the String-keyed
+  `Env::insert`, so `note_env_key` catches it and the usual monotonic-over-set argument applies.
+- Container identity (§3) is preserved: the store writes **through** the backing node rather than
+  copy-on-writing it, so a `:=` alias, a `\(@a)` capture and an array passed to a sub all observe
+  the write; Raku's `=` copy semantics stay enforced at copy time by `detach_shared_container`.
+
+## Measured
+
+All figures are before/after on the SAME base (`a8298ea0`), not against the issue's original
+snapshot -- upstream's `MetaNs` key memoization had already trimmed the before side since #8069 was
+filed, so its 14,053 / 22 / 8.1 are no longer the number to compare against.
+
+| per in-range store | before | after |
+| --- | ---: | ---: |
+| wall clock | 1940 ns | **351 ns** |
+| instructions | 13,069 | **2,231** |
+| `Symbol::intern` calls | 20.0 | **0** |
+| heap allocations | 6.0 | **1.0** |
+
+Wall clock is the best of five in-process rounds differencing the same loop with and without the
+store (release build, 4 cores): the 400,000-store loop itself goes from 1054 ms to 425 ms.
+Instruction and intern counts are callgrind differences on a `--profile profiling` build; allocation
+counts come from the `alloc-stats` feature's per-opcode scope (`op:IndexAssignExprNamed`). The last
+three are deterministic and load-independent. The one remaining allocation is ~2 bytes and sits in
+the opcode's shared preamble, not in the store itself.
+
+A note on the *marginal* figure, since it drifts for a reason that has nothing to do with this
+change: it is a subtraction, and `2fe3a800` ("decide a plain scalar store's flavour once instead of
+2,000 lines") made the subtrahend -- the identical loop with `$s = $i +& 15` in place of the store --
+drop from ~270 ms to ~185 ms. On that later base the same store measures ~600 ns marginal while its
+absolute loop time is unchanged at 425 ms. The loop times and the deterministic counters are the
+figures that mean the same thing from one base to the next.
+
+End to end, `benchmarks/bench-index-store.raku` goes from ~1.70 s to ~0.95 s, against rakudo's
+~0.73 s on the same container -- a ratio of 2.3 down to 1.3. (Re-checked at 0.95 s on `30491c43`.)
+
+## What this does not do
+
+**It does not move `bench-threads`.** That row is a concurrent program, and the lane declines for
+the whole process once a thread is spawned (above), so the benchmark that motivated the
+investigation is untouched; §3 and §4.2-4.4 are what address it. What this change buys is the
+single-threaded half — every program that writes an array element, which is most of them.
+
+Beyond that, this is #8069 §2 only, and only for the Positional single-index shape. The issue's §4.1 asks for a
+**resolved container descriptor** addressed by slot, so that the descriptor is the *only* path
+rather than a fast path bolted beside a name-keyed one — and it asks for its own ADR, because the
+invariant it establishes ("no store-time probe may be keyed by a variable name") has to be enforced
+or the probes grow back one feature at a time. That remains open, as do §4.2 (collapsing the
+name-keyed cross-thread lane into the container), §4.3 (lock-free container reads), §4.4 (biased
+reference counting) and §4.5 (letting the JIT see the store). The shared-container scaling numbers
+in §3 are untouched by this change: it is the single-threaded half of the row.
+
+Pinned by `t/collections/fast-array-element-assign.t`, whose 34 assertions all pass under rakudo as well —
+every construct in it either goes through the fast lane and must still be right, or makes it decline
+and must still reach the path that handles it.

--- a/src/env.rs
+++ b/src/env.rs
@@ -311,6 +311,18 @@ static SCALAR_NO_CONTAINER_KEY_SEEN: AtomicBool = AtomicBool::new(false);
 /// over-set only makes the (correct) probe run.
 static ELEM_INDEX_META_SEEN: AtomicBool = AtomicBool::new(false);
 
+/// Monotonic, process-global flag for `__mutsu_shaped_array_dims::*` keys (the
+/// declared-shape markers of `my @a[2;3]`).
+///
+/// The probe runs on *every* element write (`@a[i] = x`) -- both fast paths and
+/// the full store -- and each miss costs a `format!` plus a `Symbol::intern`ing
+/// env lookup for a key a program without a single shaped-array declaration can
+/// never hold. Same soundness argument as [`ELEM_INDEX_META_SEEN`]: the only
+/// creation sites are String-keyed [`Env::insert`]s (so [`note_env_key`] catches
+/// them all), the flag is monotonic, and an over-set only makes the (correct)
+/// probe run.
+static SHAPED_ARRAY_DIMS_SEEN: AtomicBool = AtomicBool::new(false);
+
 /// Monotonic, process-global flag for `^name` placeholder-parameter keys (`$^a`
 /// & co, bound under their careted name). Every by-name env *write* and *read*
 /// (`set_env_with_main_alias` / `get_env_with_main_alias` — i.e. every mirrored
@@ -386,6 +398,13 @@ pub(crate) fn elem_index_meta_possible() -> bool {
     ELEM_INDEX_META_SEEN.load(Ordering::Relaxed)
 }
 
+/// True if any `__mutsu_shaped_array_dims::*` marker may exist in some env. See
+/// [`SHAPED_ARRAY_DIMS_SEEN`].
+#[inline]
+pub(crate) fn shaped_array_dims_possible() -> bool {
+    SHAPED_ARRAY_DIMS_SEEN.load(Ordering::Relaxed)
+}
+
 /// True if any `^name` placeholder-parameter key may exist in some env. See
 /// [`PLACEHOLDER_KEY_SEEN`].
 #[inline]
@@ -430,6 +449,8 @@ pub(crate) fn note_env_key(key: &str) {
             BOUND_SLICE_KEY_SEEN.store(true, Ordering::Relaxed);
         } else if key.starts_with("__mutsu_scalar_bind_no_container::") {
             SCALAR_NO_CONTAINER_KEY_SEEN.store(true, Ordering::Relaxed);
+        } else if key.starts_with("__mutsu_shaped_array_dims::") {
+            SHAPED_ARRAY_DIMS_SEEN.store(true, Ordering::Relaxed);
         } else if key.starts_with("__mutsu_bound_index::")
             || key.starts_with("__mutsu_elem_share::")
             || key.starts_with("__mutsu_deleted_index::")

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -258,6 +258,7 @@ mod vm_value_helpers;
 mod vm_var_assign_coerce;
 mod vm_var_assign_computed_attr;
 mod vm_var_assign_element;
+mod vm_var_assign_element_fast;
 mod vm_var_assign_index_named;
 mod vm_var_assign_local;
 mod vm_var_assign_local_get;

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -295,6 +295,9 @@ impl Interpreter {
                 .and_then(|v| v.with_deref(crate::runtime::utils::shaped_array_shape))
                 .or_else(|| {
                     // Also check declared shape metadata for multi-dim
+                    if !crate::env::shaped_array_dims_possible() {
+                        return None;
+                    }
                     let key = format!("__mutsu_shaped_array_dims::{}", name);
                     self.env().get(&key).and_then(|v| {
                         if let ValueView::Array(dims, ..) = v.view() {

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -169,9 +169,11 @@ impl Interpreter {
             }
         }
         {
-            let shaped_key = format!("__mutsu_shaped_array_dims::{}", var_name);
-            if self.env().contains_key(&shaped_key) {
-                return None;
+            if crate::env::shaped_array_dims_possible() {
+                let shaped_key = format!("__mutsu_shaped_array_dims::{}", var_name);
+                if self.env().contains_key(&shaped_key) {
+                    return None;
+                }
             }
             // See the hash twin above for why the bound-index probe is gated.
             if crate::env::elem_index_meta_possible() {
@@ -937,6 +939,21 @@ impl Interpreter {
         if let Some(result) =
             self.try_fast_hash_element_assign(code, name_idx, is_positional, target_slot)
         {
+            return result;
+        }
+        // --- Fast path for simple positional array element assignment ---
+        // The Positional twin of the hash lane above: `@a[$i] = $v` on a plain,
+        // untyped, unbound array with an in-range Int index is a `Vec` slot
+        // write, not a re-derivation of the variable's declaration (#8069 §2).
+        // `elem_share_mark` is passed through because this lane cannot honour a
+        // pending `=`-element share and must decline when one is set.
+        if let Some(result) = self.try_fast_array_element_assign(
+            code,
+            name_idx,
+            is_positional,
+            target_slot,
+            elem_share_mark.is_some(),
+        ) {
             return result;
         }
         // Save type metadata and container default by pointer BEFORE the

--- a/src/vm/vm_var_assign_element_fast.rs
+++ b/src/vm/vm_var_assign_element_fast.rs
@@ -1,0 +1,262 @@
+//! Fast path for the plain positional element store `@a[$i] = $v`.
+//!
+//! The Associative twin of this lane (`try_fast_hash_element_assign`) has
+//! existed for a long time; the Positional one did not, so **every** `@a[$i] =
+//! $v` -- one of the most common statements in the language -- went through
+//! `exec_index_assign_expr_named_op_inner`, which re-derives the target's whole
+//! *declaration* by string key on each write: is this a sigilless alias, is it
+//! shaped, is it `:=`-bound, does it have a type/key constraint, a default, a
+//! readonly flag, a bound index, a `Proxy` element, a lazy tail. Measured on a
+//! `--profile profiling` build (#8069), that cost **14,053 instructions, 22
+//! `Symbol::intern` calls and 8 heap allocations per store**, against roughly
+//! 40 ns of marginal cost in rakudo.
+//!
+//! None of those questions is a property of *this store*; all of them are
+//! properties of *that container*, settled when the binding was declared. Until
+//! the resolved-descriptor architecture of #8069 §4.1 replaces the name-keyed
+//! lane outright, this module answers them the way the rest of the VM already
+//! does for its own hot probes: from the container's *embedded* metadata
+//! (`ArrayData::has_type_meta`, `ArrayKind`) and from the monotonic
+//! `env::*_possible()` latches, which are false for any program that never
+//! declared the feature -- so a plain array store asks no env question at all
+//! and reaches a `Vec` slot write.
+//!
+//! The deliberate shape, mirroring the hash twin: this lane never *errors*. Any
+//! condition it is not certain about makes it return `None` and the caller falls
+//! through to the full store, which is unchanged and remains the authority on
+//! semantics.
+
+use super::*;
+
+impl Interpreter {
+    /// Fast path for a simple positional element store: `@a[$i] = $v`.
+    ///
+    /// Returns `Some(Ok(()))` when it handled the store, `None` when the caller
+    /// must fall through to [`Self::exec_index_assign_expr_named_op_inner`].
+    /// It never returns `Some(Err(_))`.
+    ///
+    /// Preconditions (all must hold):
+    /// - a positional subscript on an `@`-sigiled name, with no `:=` bindings in
+    ///   scope and no pending `=`-element share;
+    /// - a plain non-negative `Int` index that is already **in range** (an
+    ///   autovivifying store needs the full path's native-fill and hole
+    ///   bookkeeping);
+    /// - a plain rvalue (not a bind marker, not `Nil`);
+    /// - the variable resolves, in env, to a plain mutable `Array`/`ItemArray`
+    ///   with no embedded type metadata, no declared shape, no `is default`,
+    ///   and not readonly;
+    /// - the destination slot is not itself a container (`ContainerRef` /
+    ///   `Scalar` / `Proxy` / a varref / a `__mutsu_bound*` marker), which would
+    ///   mean the store must write *through* it;
+    /// - no per-element index metadata and no shaped-array declaration exists
+    ///   anywhere in the program (the two monotonic latches).
+    pub(crate) fn try_fast_array_element_assign(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        is_positional: bool,
+        target_slot: Option<u32>,
+        share_pending: bool,
+    ) -> Option<Result<(), RuntimeError>> {
+        if !is_positional || share_pending {
+            return None;
+        }
+        // A `:=` binding in scope can make any name an alias; the slow path owns
+        // that resolution.
+        if !self.local_bind_pairs.is_empty() {
+            return None;
+        }
+        // Once a second VM mutator thread exists, an element store is no longer
+        // just a slot write: it is routed by the name-keyed cross-thread lanes
+        // (`__mutsu_atomic_arr::`, `shared_array_elem_set`) or, where those
+        // decline, excluded by ADR-0068's `ContainerStructGuard` -- five
+        // documented routes whose interaction this lane reproduces none of.
+        // Taking the guard alone would buy exclusion but not the lane's
+        // accumulate-instead-of-snapshot semantics, so the honest answer is to
+        // stand down entirely and let the audited path run. One relaxed atomic
+        // load, and the same latch `ContainerStructGuard` itself consults.
+        //
+        // The cost is real and deliberate: a program that spawns a thread gets
+        // no fast store anywhere, for the rest of the process. #8069 §3 (the
+        // shared-container half of that issue) is what addresses the concurrent
+        // case; this lane is the single-threaded half.
+        if crate::value::container_lock::multi_mutator_threads_live() {
+            return None;
+        }
+        // Both latches are false for the overwhelming majority of programs, and
+        // each one being true means a *name-keyed* side table may describe this
+        // element (`__mutsu_bound_index::`, `__mutsu_elem_share::`,
+        // `__mutsu_deleted_index::`, `__mutsu_ro_index::`, or a declared shape).
+        // This lane deliberately knows nothing about those: it declines instead.
+        if crate::env::elem_index_meta_possible() || crate::env::shaped_array_dims_possible() {
+            return None;
+        }
+        let var_name = Self::const_str(code, name_idx);
+        // Only a real `@` array. A sigilless alias (`my \a = @x`) has no sigil,
+        // so this also excludes the `__mutsu_sigilless_alias::` redirect the
+        // slow path resolves -- same reasoning as the `%` hash twin.
+        if !var_name.as_bytes().starts_with(b"@") {
+            return None;
+        }
+        // `env_root_descended_mut_tracked` -- the write chokepoint the full
+        // store funnels through -- resolves a name in a strict precedence
+        // order: a captured unit lexical, then the running routine's own
+        // package `our @a`/`our %h` mirror, then env. The bare env key belongs
+        // to whatever scope *loaded* the module, so for a module routine's own
+        // `our @arr` it holds the loading script's same-named array. Reading
+        // env directly, as the commit below does, is therefore only correct
+        // when neither higher-precedence root claims the name; without this the
+        // module's `@arr[0] = $v` wrote the script's array
+        // (`t/modules/our-container-bare-name-resolution.t`).
+        //
+        // Both probes open with their own emptiness gate, so a program with no
+        // unit lexicals and no `our` variables pays two `is_empty` checks. The
+        // chokepoint's third root needs no probe here: it is keyed on
+        // SIGIL-LESS names (an `our $a = [...]` reached as bare `a`), which the
+        // `@` requirement above has already excluded.
+        if self.unit_lexical_slot(var_name).is_some()
+            || self.our_package_container_key(var_name).is_some()
+        {
+            return None;
+        }
+        let stack_len = self.stack.len();
+        if stack_len < 2 {
+            return None;
+        }
+        // Only a plain non-negative Int subscript: a slice, `Whatever`, `Range`,
+        // `Junction`, negative or lazy index all mean something else entirely.
+        let ValueView::Int(idx_i) = self.stack[stack_len - 1].view() else {
+            return None;
+        };
+        if idx_i < 0 {
+            return None;
+        }
+        let i = idx_i as usize;
+        let val_ref = &self.stack[stack_len - 2];
+        // A `:=` element bind arrives wrapped in this marker Pair; `Nil` needs
+        // the full path's container-default / type-object handling.
+        if matches!(val_ref.view(), ValueView::Pair(name, _) if name == "__mutsu_bind_index_value")
+            || matches!(val_ref.view(), ValueView::Nil)
+        {
+            return None;
+        }
+        let var_sym = code.const_sym(name_idx);
+        // `is default(...)` and `:=`-bound-container readonly are both cheap
+        // (an empty-map short-circuit and one interned-symbol probe).
+        if self.var_default(var_name).is_some() || self.is_readonly_sym(var_sym) {
+            return None;
+        }
+        // The target, read from env. `@` containers are not subject to the
+        // (B) per-store scalar-slot seeding the slow path does for `$`-held
+        // containers, so env is the right place to look -- but the local slot
+        // must be pointing at the SAME backing node, or an in-place write here
+        // would be invisible to the half the next read consults. That is
+        // verified below, after the kind checks.
+        // The `Gc` handle is cloned out so the env borrow ends here: every check
+        // below, and the commit, needs `&mut self`. (The clone is what makes the
+        // node's `strong_count` unusable as an aliasing signal afterwards -- see
+        // the in-place write at the bottom, which does not consult it.)
+        let (items, kind) = self.env().get_sym(var_sym).and_then(|v| match v.view() {
+            ValueView::Array(items, kind) => Some((items.clone(), kind)),
+            _ => None,
+        })?;
+        // A `List`/`ItemList` is immutable as a container (its element slots
+        // cannot be replaced), and `Shaped`/`Lazy` have their own store rules.
+        if !matches!(
+            kind,
+            crate::value::ArrayKind::Array | crate::value::ArrayKind::ItemArray
+        ) {
+            return None;
+        }
+        // A typed array (`my Int @a`, `my int @a`) needs the full path's
+        // constraint check and native wrapping. Read from the array's own
+        // embedded metadata (ADR-0042), not a name-keyed map.
+        if items.has_type_meta() {
+            return None;
+        }
+        // ... and the name-keyed constraint the declaration may still carry.
+        // Latched: no typed lexical in the program, no probe.
+        if self.var_type_constraint_sym(var_sym).is_some() {
+            return None;
+        }
+        // In-range only: an autovivifying store must resize with the right
+        // native fill and materialize the hole set, which is the slow path's job.
+        if i >= items.len() {
+            return None;
+        }
+        // The destination slot must be a plain value. Anything container-shaped
+        // there means the store writes THROUGH it (a `:=`-bound cell, a `Proxy`,
+        // an itemized `Scalar` element, a varref back-reference) and the slow
+        // path owns every one of those rules.
+        match items.items().get(i).map(Value::view) {
+            Some(
+                ValueView::ContainerRef(_)
+                | ValueView::Scalar(_)
+                | ValueView::Proxy { .. }
+                | ValueView::VarRef { .. },
+            ) => return None,
+            Some(ValueView::Pair(name, _)) if name.as_str().starts_with("__mutsu_bound") => {
+                return None;
+            }
+            None => return None,
+            Some(_) => {}
+        }
+        // `@a[0] = @a` stores the array *itself* (a genuinely circular
+        // structure, as in rakudo) rather than an itemized copy -- a distinction
+        // the slow path makes and this lane does not reproduce.
+        if matches!(
+            self.stack[stack_len - 2].view(),
+            ValueView::Array(source_items, ..) if crate::gc::Gc::ptr_eq(&items, &source_items)
+        ) {
+            return None;
+        }
+        // Dual-store coherence: if this frame has a local slot for the name, it
+        // must hold the same backing node, so the single in-place write below is
+        // seen by both halves. A diverged slot (a stale COW copy) falls through
+        // to the slow path, which has the machinery to reconcile it.
+        if let Some(slot) = self.resolve_local_slot(code, target_slot, var_name) {
+            match self.locals[slot].view() {
+                ValueView::Array(local_items, ..)
+                    if crate::gc::Gc::ptr_eq(&items, &local_items) => {}
+                // An untouched/absent slot is fine: nothing there to diverge.
+                ValueView::Nil => {}
+                _ => return None,
+            }
+        }
+
+        // ---- All checks passed; commit. ----
+        self.stack.pop();
+        let val = self.stack.pop().unwrap();
+        // ADR-0040 slice 1: an element is a Scalar container, so an aggregate
+        // stored into it itemizes. (`exec_index_assign_expr_named_op_seeded_inner`
+        // has already applied `itemize_for_element_store` to the stack value for
+        // this exact index shape; `itemize_value` is idempotent over that.)
+        let stored = Self::itemize_value(val.clone());
+        // Container identity (§3): an element write on a SHARED array mutates
+        // through the backing node so every by-value holder of the same
+        // container observes it. COW would detach it; copies detach at copy time
+        // via `detach_shared_container`. This mirrors the slow path's
+        // `use_inplace` choice exactly.
+        // (A sole-owner array takes the same route: with `strong_count == 1`
+        // `Gc::make_mut` could not clone anyway, and the `ValueView` hands out a
+        // `&Gc`, not the `&mut Gc` `make_mut` would need.)
+        //
+        // SAFETY: audited aliased in-place container write (see
+        // `value::aliased_mut`). No borrow into this node is live across the
+        // write -- `items` is a `Gc` handle, the `ValueView` it came from is not
+        // read again below, and this lane runs on the executing thread only.
+        let data: &mut crate::value::ArrayData = unsafe { crate::value::gc_contents_mut(&items) };
+        data.items_mut()[i] = stored;
+        // The hole set, maintained exactly as `mark_initialized_index` does:
+        // materializing it from `None` is what makes the OTHER gap-marker slots
+        // read as holes, so this lane must not skip that transition.
+        data.initialized
+            .get_or_insert_with(std::collections::HashSet::new)
+            .insert(i);
+        // A single positional index names one scalar slot, so the assignment's
+        // rvalue is itemized (`@z = (@a[0] = 1, 2)` has two elements, the first
+        // itemized) -- the same rule the slow path's final push applies.
+        self.stack.push(Self::itemize_value(val));
+        Some(Ok(()))
+    }
+}

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -476,9 +476,15 @@ impl Interpreter {
         let _target_is_mixhash = declared_type.as_deref().is_some_and(|t| t == "MixHash");
         let _target_is_baghash = declared_type.as_deref().is_some_and(|t| t == "BagHash");
         let _target_is_sethash = declared_type.as_deref().is_some_and(|t| t == "SetHash");
-        let has_declared_shape = self
-            .env()
-            .contains_key_sym(MetaNs::ShapedArrayDims.key(var_sym));
+        // Gated on the monotonic latch: a program that never declares a shaped
+        // array (`my @a[2;3]`) can hold no such key, and this probe runs on
+        // EVERY element store. `MetaNs::key` memoizes the key symbol per
+        // (namespace, name), but the latch skips even that lookup and the env
+        // probe behind it.
+        let has_declared_shape = crate::env::shaped_array_dims_possible()
+            && self
+                .env()
+                .contains_key_sym(MetaNs::ShapedArrayDims.key(var_sym));
         let mut idx = self.stack.pop().unwrap_or(Value::NIL);
         // ADR-0058: the INDEX may itself be a not-yet-run `.map`/`.grep` Seq
         // (`@n[@n.map(*+0)] = <a b>.sort`, `roast/S32-list/seq.t` #12/#14).

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -943,8 +943,12 @@ impl Interpreter {
         }
 
         // Check if target is a shaped array - use bounds-checked assignment
-        let declared_shape_key = format!("__mutsu_shaped_array_dims::{var_name}");
-        let has_declared_shape = self.env().contains_key(&declared_shape_key);
+        // See the element-store twin: gated on the monotonic latch so a program
+        // with no shaped-array declaration never builds the key.
+        let has_declared_shape = crate::env::shaped_array_dims_possible() && {
+            let declared_shape_key = format!("__mutsu_shaped_array_dims::{var_name}");
+            self.env().contains_key(&declared_shape_key)
+        };
         let is_shaped = has_declared_shape
             || self
                 .env()

--- a/t/collections/fast-array-element-assign.t
+++ b/t/collections/fast-array-element-assign.t
@@ -1,0 +1,151 @@
+use Test;
+
+# `@a[$i] = $v` on a plain, untyped, unbound array with an in-range Int index
+# is served by `try_fast_array_element_assign` (#8069 §2), which bypasses the
+# full name-keyed store. This file pins that the fast lane agrees with the slow
+# lane it short-circuits: every construct below either goes THROUGH the fast
+# lane (and must still be right) or makes it decline (and must still reach the
+# path that handles it).
+
+plan 34;
+
+# --- the fast lane itself -----------------------------------------------
+
+my @a = 0 xx 4;
+@a[2] = 7;
+is @a[2], 7, 'plain in-range store lands';
+is @a.elems, 4, 'plain store does not resize';
+is @a.raku, '[0, 0, 7, 0]', 'the other slots are untouched';
+
+# The assignment expression's rvalue is itemized: one positional index names one
+# scalar slot, so an aggregate stored there contributes exactly ONE element in
+# list context rather than flattening.
+my @z = (@a[0] = [7, 8]), 2;
+is @z.elems, 2, 'single-index store yields an itemized rvalue';
+is @z.raku, '[[7, 8], 2]', 'the rvalue did not flatten into the list';
+
+# An aggregate stored into an element itemizes (ADR-0040).
+my @nest = 0 xx 2;
+@nest[0] = [1, 2, 3];
+is @nest[0].raku, '$[1, 2, 3]', 'an aggregate itemizes at the element store';
+is @nest[0][1], 2, 'and is still subscriptable';
+
+# Container identity (S3): an element write on a SHARED array is seen by every
+# by-value holder of the same container.
+my @src = 0 xx 3;
+my @alias := @src;
+@alias[1] = 42;
+is @src[1], 42, 'in-place write reaches the := alias';
+@src[2] = 43;
+is @alias[2], 43, 'and the other way round';
+
+sub touch(@arr) { @arr[0] = 99 }
+my @passed = 0 xx 2;
+touch(@passed);
+is @passed[0], 99, 'a write through a parameter reaches the caller container';
+
+# Raku `=` copy semantics still detach at COPY time, not at write time.
+my @orig = 1, 2, 3;
+my @copy = @orig;
+@copy[0] = 9;
+is @orig[0], 1, 'assigning a copy does not write through to the source';
+is @copy[0], 9, 'and the copy itself changed';
+
+# --- shapes the fast lane must decline ----------------------------------
+#
+# Two of its decline routes are pinned by the tests that caught them rather than
+# duplicated here: a module routine's own `our @arr` must not resolve to the
+# loading script's same-named array (t/modules/our-container-bare-name-resolution.t
+# -- the write chokepoint's package-mirror root outranks the bare env key), and
+# once a second mutator thread exists the store belongs to the ADR-0068 lanes and
+# guard (t/concurrency/concurrent-lane-decline-routes.t).
+
+# Autovivification past the end.
+my @grow;
+@grow[3] = 'x';
+is @grow.elems, 4, 'a past-the-end store still autovivifies';
+is @grow[3], 'x', 'and stores at the right index';
+nok @grow[0]:exists, 'the skipped slots read as holes';
+
+# Typed arrays keep their constraint check and their native fill.
+my Int @typed = 1, 2, 3;
+@typed[1] = 5;
+is @typed[1], 5, 'a typed array still accepts a conforming value';
+dies-ok { @typed[0] = 'nope' }, 'and still refuses a non-conforming one';
+
+my int @native = 1, 2, 3;
+@native[0] = 7;
+is @native[0], 7, 'a native int array still stores';
+
+# A shaped array keeps its bounds check.
+my @shaped[2;2];
+@shaped[1;1] = 'v';
+is @shaped[1;1], 'v', 'a shaped array still stores multidimensionally';
+
+# A `:=`-bound element is written THROUGH its cell, not replaced.
+my $cell = 1;
+my @bound = 0 xx 2;
+@bound[0] := $cell;
+@bound[0] = 5;
+is $cell, 5, 'a :=-bound element writes through to its source';
+is @bound[0], 5, 'and reads back the new value';
+
+# A List is immutable as a container.
+my $list = (1, 2, 3);
+dies-ok { $list[0] = 9 }, 'a List element slot cannot be replaced';
+
+# A `Nil` rvalue restores the container default rather than storing Nil.
+my @nils = 1, 2, 3;
+@nils[1] = Nil;
+nok @nils[1].defined, 'assigning Nil leaves an undefined slot';
+
+# `is default(...)` participates in the store.
+my @defaulted is default(-1) = 1, 2, 3;
+@defaulted[1] = Nil;
+is @defaulted[1], -1, 'Nil restores the declared container default';
+
+# A deleted index is resurrected by a later store.
+my @del = 1, 2, 3;
+@del[1]:delete;
+nok @del[1]:exists, 'the index is gone after :delete';
+@del[1] = 8;
+ok @del[1]:exists, 'and a later store brings it back';
+is @del[1], 8, 'with the stored value';
+
+# A negative index still resolves from the end.
+my @neg = 1, 2, 3;
+@neg[*-1] = 30;
+is @neg[2], 30, 'a *-1 subscript still addresses the last slot';
+
+# A slice subscript distributes rather than storing one value.
+my @slice = 0 xx 4;
+@slice[1, 2] = 'a', 'b';
+is @slice.raku, '[0, "a", "b", 0]', 'a slice subscript still distributes';
+
+# A Range subscript likewise.
+my @range = 0 xx 4;
+@range[1..2] = 'p', 'q';
+is @range.raku, '[0, "p", "q", 0]', 'a Range subscript still distributes';
+
+# A `Whatever` subscript assigns across the whole array.
+my @whatever = 0 xx 3;
+@whatever[*] = 1, 2, 3;
+is @whatever.raku, '[1, 2, 3]', 'a * subscript still assigns across';
+
+# An itemized element ($-wrapped) is written through, not replaced.
+my $held = 3;
+my @items = List.new(1, 2, $held);
+is @items[2], 3, 'an itemized element reads its value';
+
+# A `Proxy` element mediates its own store.
+my $behind = 0;
+my @proxied = 0 xx 2;
+@proxied[0] := Proxy.new(FETCH => -> $ { $behind }, STORE => -> $, $v { $behind = $v * 2 });
+@proxied[0] = 5;
+is $behind, 10, 'a Proxy element fires its STORE';
+
+# The container the array lives in keeps its identity across a store.
+my @ident = 0 xx 2;
+my $before = @ident.WHICH;
+@ident[0] = 1;
+is @ident.WHICH, $before, 'the array keeps its identity across an element store';


### PR DESCRIPTION
Refs #8069 (§2 — the single-threaded half). The issue stays open; §4.1–§4.5 are untouched.

## The problem

`bench-threads` is the only row in `bench-history.tsv` where mutsu is slower than rakudo, and #8069
root-caused it to something that is mostly not about threads: an ordinary indexed element store —
one thread, no `start` anywhere in the program — cost **13,069 instructions, 20 `Symbol::intern`
calls and 6 heap allocations**, against roughly 40 ns of marginal cost in rakudo.

The Associative half of that statement has had a fast path for a long time
(`try_fast_hash_element_assign`). The Positional half had **none**, so every `@a[$i] = $v` went
through `exec_index_assign_expr_named_op_inner`, which re-derives the target's whole *declaration*,
by string key, on each write: is this a sigilless alias, is it shaped, is it `:=`-bound, does it have
a type or key constraint, a default, a readonly flag, a bound index, a `Proxy` element, a lazy tail.
Not one of those is a property of *this store*. They are all properties of *that container*, settled
when the binding was declared.

## The change

`try_fast_array_element_assign` (`src/vm/vm_var_assign_element_fast.rs`) is the Positional twin of
the hash lane. It answers those questions the way the rest of the VM already answers its own hot
probes — from the container's *embedded* metadata (`ArrayData::has_type_meta`, `ArrayKind`, the
element slot's own shape) and from the monotonic `env::*_possible()` latches — so a plain array store
asks no name-keyed env question at all and reaches a `Vec` slot write.

It fires for a positional subscript on an `@`-sigiled name with a plain non-negative **in-range**
`Int` index, a plain rvalue, and a plain mutable untyped `Array`/`ItemArray` target whose destination
slot is not itself a container. Everything else — autovivification past the end, typed and native
arrays, shaped arrays, `:=`-bound and `Proxy` elements, `Nil` rvalues, `is default(...)`, slices,
`Range` and `Whatever` subscripts, `List` targets, `:delete`d indices — returns `None` and the full
store runs unchanged. Like its hash twin the lane never *errors*.

Also adds a `SHAPED_ARRAY_DIMS_SEEN` latch for `__mutsu_shaped_array_dims::*`, joining the six
already in `src/env.rs`. `MetaNs::key` memoizes the key symbol, but the latch skips even that lookup
and the env probe behind it, on a question a program without a single `my @a[2;3]` can never answer
yes to. There is exactly one insert site for the key and it goes through the String-keyed
`Env::insert`, so `note_env_key` catches it and the usual monotonic-over-set argument applies.

## Two decline routes the suites caught

- **A module routine's own `our @arr`.** `env_root_descended_mut_tracked` — the write chokepoint the
  full store funnels through — resolves a name in a strict precedence order: a captured unit lexical,
  then the running routine's package `our` mirror, then env. The bare env key belongs to whatever
  scope *loaded* the module, so reading env without those two probes made the module's
  `@arr[0] = $v` write the loading script's same-named array
  (`t/modules/our-container-bare-name-resolution.t`, 7 failures). Both probes open with their own
  emptiness gate, so a program with no unit lexicals and no `our` variables pays two `is_empty`
  checks.
- **Any program that has spawned a second VM mutator thread.** There the store is routed by the
  name-keyed cross-thread lanes, or excluded by ADR-0068's `ContainerStructGuard` — five documented
  routes whose interaction this lane reproduces none of, and an unguarded `gc_contents_mut` under
  twenty concurrent writers is a `double free or corruption (out)`, which is what
  `t/concurrency/concurrent-lane-decline-routes.t` produced. Taking the guard alone would buy
  exclusion but not the lane's accumulate-instead-of-snapshot semantics, so the lane stands down
  entirely once `multi_mutator_threads_live()` is set: one relaxed atomic load, the same latch the
  guard itself consults.

**So this does not move `bench-threads`** — that row is a concurrent program, and §3 / §4.2–§4.4 are
what address it. What this buys is the single-threaded half: every program that writes an array
element.

## Measured

Before/after on the **same base** (`a8298ea0`), not against #8069's original snapshot — upstream's
`MetaNs` key memoization had already trimmed the before side since the issue was filed, so its
14,053 / 22 / 8.1 are no longer the right comparison.

| per in-range store | before | after |
| --- | ---: | ---: |
| wall clock | 1940 ns | **351 ns** |
| instructions | 13,069 | **2,231** |
| `Symbol::intern` calls | 20.0 | **0** |
| heap allocations | 6.0 | **1.0** |

Wall clock is the best of five in-process rounds differencing the same loop with and without the
store (release, 4 cores): the 400,000-store loop itself goes from **1054 ms to 425 ms**. Instruction
and intern counts are callgrind differences on a `--profile profiling` build; allocation counts come
from the `alloc-stats` feature's per-opcode scope (`op:IndexAssignExprNamed`). The last three are
deterministic and load-independent. The one remaining allocation is ~2 bytes and sits in the
opcode's shared preamble, not in the store itself.

One caveat on the *marginal* number, since it drifts for a reason unrelated to this change: it is a
subtraction, and `2fe3a800` ("decide a plain scalar store's flavour once instead of 2,000 lines")
made the subtrahend — the identical loop with `$s = $i +& 15` in place of the store — drop from
~270 ms to ~185 ms. On the current base the same store therefore measures ~600 ns marginal while its
absolute loop time is unchanged at 425 ms. The loop times and the deterministic counters are the
figures that mean the same thing from one base to the next.

End to end, `benchmarks/bench-index-store.raku` (added by #8086 while this was in flight, which is
why this PR adds no benchmark of its own) goes from **~1.70 s to ~0.95 s**, against rakudo's ~0.73 s
on the same container — a ratio of 2.3 down to 1.3. Re-checked at 0.95 s on the current base.

## Testing

All four gates were run on this exact tree, after the final rebase onto `30491c43`:

- `t/collections/fast-array-element-assign.t` — new, 34 assertions, **all of which also pass under
  rakudo**. Every construct in it either goes through the fast lane and must still be right, or makes
  it decline and must still reach the path that handles it.
- `make lint` — green (all four configurations).
- `make test` — green, 4097 files / 43599 tests.
- `make roast` — the failing set is exactly the three files `docs/agent-environments.md` records as
  this container's own (`6.c/S32-io/file-tests.t` Failed: 4 and `S16-filehandles/filetest.t`
  Failed: 25, both because the container runs as `uid 0`, confirmed with `id -u`; and
  `S32-io/IO-Socket-Async.t` exit 124, the sandboxed network). Nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoRrJgwXv3pryDCnR3aYKS