### PR TITLE
fix(binding): run an optional parameter's where constraint when the argument is omitted

### DIFF
--- a/news/2026-09/optional-param-where-runs-when-omitted.md
+++ b/news/2026-09/optional-param-where-runs-when-omitted.md
@@ -1,0 +1,70 @@
+# An optional parameter's `where` constraint now runs when the argument is omitted
+
+A `where` post-constraint on an optional parameter was only ever evaluated on the
+branch that had a supplied argument. Omit the argument and mutsu bound the
+parameter unconditionally, so a signature that exists precisely to reject certain
+calls accepted every one of them:
+
+```
+$ mutsu -e 'sub f($x? where { $_ ~~ Int }) { "ran" }; say f()'
+ran
+$ raku  -e 'sub f($x? where { $_ ~~ Int }) { "ran" }; say f()'
+Constraint type check failed in binding to parameter '$x'; expected anonymous
+constraint to be met but got Any (Any)
+```
+
+Rakudo runs the constraint on every binding path. What differs is only the value
+under test: an omitted optional binds its nominal type object (`Any`, or the
+declared type — `Int` for `Int $x?`, and a fresh empty `Array`/`Hash` for `@x?`
+and `%h?`, `Mu` inside a pointy block), and a defaulted parameter binds the
+evaluated default. The constraint is then tested against *that*. Rakudo rejects
+the reverse spelling `$x = 3 where { ... }` at compile time, so a defaulted
+parameter only ever reaches this through `$x where { ... } = 3`.
+
+## Why it mattered beyond the error message
+
+A `where` clause is a multi-dispatch discriminator, so a skipped constraint does
+not merely miss an error — it silently widens candidate selection.
+`Digest::xxHash` is built on exactly that:
+
+```raku
+multi sub build-xxhash(Int @data, Int $seed = 0, $? where { $*KERNEL.bits == 64 } --> Int) { ... }
+```
+
+The trailing anonymous optional never looks at `$_`; it exists only so the
+candidate matches on a 64-bit kernel. With the constraint skipped it matched
+everywhere, on any platform.
+
+## The fix
+
+Both halves of the calling convention had to move, and they had to agree — if the
+multi-candidate matcher and the binder disagree about a `where`, dispatch selects
+a candidate that then dies binding the very call it was selected for.
+
+- `src/runtime/types/binding_signature.rs`: the inline `where` evaluation, which
+  lived only on the supplied-argument path, is now
+  `check_positional_param_where_constraint`, and all three binder paths —
+  supplied, defaulted, omitted-optional — funnel through it. The omitted branch
+  also grew a case it never had: an anonymous optional (`$?`) binds no variable,
+  so it previously fell through every branch and was never checked at all.
+- `src/runtime/types/args_matching.rs`: the matcher already fell back to the
+  evaluated default for an unsupplied parameter that had one, but deliberately
+  skipped the check for a bare optional, on a comment asserting that rakudo
+  defers it to bind time. It does not — `multi g($x, $y? where { $_ ~~ Int })`
+  loses to `multi g($x, $y?)` on `g(1)` in rakudo, and mutsu now agrees. The
+  named-parameter half of the matcher had the fallback right already.
+
+## A leaked internal name, fixed on the way past
+
+The new failures surfaced mutsu's parser placeholders in user-facing messages:
+an anonymous parameter was reported as `'$__ANON_OPTIONAL__'` where rakudo says
+`'<anon>'`. That was not new — a supplied bare `$ where { ... }` had been
+printing `'$__ANON_STATE__'` all along. `param_display_name` now renders every
+anonymous parameter as `<anon>`, sharing one `is_anonymous_param_name` predicate
+with `Signature` gisting rather than keeping two copies of the placeholder list.
+
+Pinned by `t/routines/signature/optional-param-where-runs-when-omitted.t`, which
+covers all four supplied/omitted x passing/failing corners, the type object each
+sigil binds, the anonymous optional and its error text, the defaulted spelling,
+and four multi-dispatch cases holding the matcher and the binder to the same
+answer. It passes under rakudo unchanged.

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -323,10 +323,10 @@ impl Interpreter {
                 // the matcher did not.
                 let mut arg_for_checks = arg_for_checks.map(|v| v.deref_container());
                 // Whether an actual argument was passed for this param (vs. an
-                // unsupplied optional filled with its type object below). An
-                // unsupplied optional's `where` must NOT reject the candidate
-                // during dispatch — raku checks it at bind time against the
-                // default value, not the bare type object.
+                // unsupplied optional filled with its type object below). It
+                // decides which value a `where` post-constraint is tested
+                // against: the argument, the evaluated default, or the nominal
+                // type object an omitted optional binds.
                 let arg_was_supplied = arg_for_checks.is_some();
                 if arg_for_checks.is_none()
                     && !pd.required
@@ -593,13 +593,16 @@ impl Interpreter {
                         return false;
                     }
                 }
-                // An unsupplied parameter that HAS a default is checked
-                // against the *default value* -- raku evaluates the default and
-                // then applies the `where`, which is how a multi can select a
-                // candidate purely on its defaulted parameter
-                // (`multi method message(Str:D $c where { $_ eq 'INTM' } = $.classifier)`).
-                // Skipping the check made every such candidate match, so the
-                // first one declared always won.
+                // An unsupplied parameter is checked against the value it
+                // would actually bind, exactly as the binder does: the
+                // evaluated *default* when it has one -- which is how a multi
+                // can select a candidate purely on its defaulted parameter
+                // (`multi method message(Str:D $c where { $_ eq 'INTM' } = $.classifier)`)
+                // -- and otherwise the nominal type object an omitted optional
+                // binds. Skipping either made every such candidate match, so the
+                // first one declared always won (#8089). Dispatch and binding
+                // have to agree here, or a candidate is selected and then dies
+                // binding the very call it was selected for.
                 let where_default =
                     if !arg_was_supplied && let Some(default_expr) = pd.default.as_ref() {
                         self.eval_block_value(&[Stmt::Expr(default_expr.clone())])
@@ -607,11 +610,7 @@ impl Interpreter {
                     } else {
                         None
                     };
-                if let Some(where_expr) = &pd.where_constraint
-                    && (arg_was_supplied
-                        || where_default.is_some()
-                        || !(pd.default.is_some() || pd.optional_marker))
-                {
+                if let Some(where_expr) = &pd.where_constraint {
                     let Some(arg) = where_default.as_ref().or(arg_for_checks.as_ref()) else {
                         return false;
                     };

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -25,6 +25,13 @@ fn is_multidim_slice_cells(value: &crate::value::Value) -> bool {
 /// no sigil for a scalar (`x` for `$x`), so restore it; a name that already has
 /// one (`@a`, `%h`, `&c`) is left alone.
 fn param_display_name(pd: &crate::ast::ParamDef) -> String {
+    // An anonymous parameter (`$`, `$?`, `@?`, `%?`) carries a synthetic parser
+    // placeholder as its name. Rakudo names it `<anon>` in a binding error, so
+    // leaking `$__ANON_OPTIONAL__` / `$__ANON_STATE__` into the message would
+    // both be wrong and expose an internal spelling.
+    if pd.name.is_empty() || crate::value::signature::is_anonymous_param_name(&pd.name) {
+        return "<anon>".to_string();
+    }
     if pd.name.starts_with(['$', '@', '%', '&']) {
         pd.name.clone()
     } else {
@@ -151,6 +158,80 @@ impl Interpreter {
                 &bound_val,
                 Some(&*self),
             ));
+        }
+        Ok(())
+    }
+
+    /// Evaluate a positional parameter's `where` post-constraint against the
+    /// value the parameter is about to bind.
+    ///
+    /// Rakudo runs the constraint on every binding path, not just the one that
+    /// received an argument: an omitted optional binds its nominal type object
+    /// (`Any`, or the declared type) and a defaulted parameter binds the
+    /// evaluated default, and the constraint is tested against *that*. Skipping
+    /// it for the omitted case let `sub f($x? where { $_ ~~ Int })` accept a
+    /// bare `f()`, and -- because a `where` clause is a multi-dispatch
+    /// discriminator -- silently widened candidate selection (#8089). So all
+    /// three binder paths funnel through here.
+    fn check_positional_param_where_constraint(
+        &mut self,
+        pd: &ParamDef,
+        name_sym: Symbol,
+        value: &Value,
+    ) -> Result<(), RuntimeError> {
+        let Some(where_expr) = &pd.where_constraint else {
+            return Ok(());
+        };
+        let saved_param = if pd.name.is_empty() {
+            None
+        } else {
+            self.env.get(&pd.name).cloned()
+        };
+        if !pd.name.is_empty() {
+            self.bind_param_value_sym(&pd.name, name_sym, value.clone());
+        }
+        let saved_topic = self.env.get("_").cloned();
+        self.env.insert("_".to_string(), value.clone());
+        let ok = match where_expr.as_ref() {
+            Expr::AnonSub { body, .. } => {
+                let ph_keys = self.bind_where_placeholders(body, value);
+                let r = self
+                    .eval_block_value(body)
+                    .map(|v| v.truthy())
+                    .unwrap_or(false);
+                for k in ph_keys {
+                    self.unmark_readonly(&k);
+                    self.env.remove(&k);
+                }
+                r
+            }
+            // Method calls on $_ (topic) in where constraints:
+            // evaluate and check truthiness of the result, not smart-match.
+            // `where .method: args` is equivalent to `where { .method: args }`.
+            Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") => {
+                self.eval_block_value(&[Stmt::Expr(where_expr.as_ref().clone())])
+                    .map(|v| v.truthy())
+                    .unwrap_or(false)
+            }
+            expr => self
+                .eval_block_value(&[Stmt::Expr(expr.clone())])
+                .map(|v| self.smart_match(value, &v))
+                .unwrap_or(false),
+        };
+        if let Some(previous) = saved_topic {
+            self.env.insert("_".to_string(), previous);
+        } else {
+            self.env.remove("_");
+        }
+        if !pd.name.is_empty() {
+            if let Some(previous) = saved_param {
+                self.env.insert(pd.name.clone(), previous);
+            } else {
+                self.env.remove(&pd.name);
+            }
+        }
+        if !ok {
+            return Err(Self::parameter_where_binding_error(pd, value, Some(&*self)));
         }
         Ok(())
     }
@@ -517,14 +598,11 @@ impl Interpreter {
                 // `Type check failed in binding to parameter '$y'; expected
                 // Int but got Str ("s")` -- the same shape the subset branch
                 // just above already spells, with the sigil restored and an
-                // anonymous parameter named `<anon>`. Verified against
-                // `raku -e 'sub f(::T $x, T $y) {}; f(1, "s")'` and its
-                // anonymous-parameter twin.
-                let param_display = if pd.name == "__type_only__" {
-                    "<anon>".to_string()
-                } else {
-                    param_display_name(pd)
-                };
+                // anonymous parameter named `<anon>` (which
+                // `param_display_name` handles for every anonymous spelling).
+                // Verified against `raku -e 'sub f(::T $x, T $y) {}; f(1, "s")'`
+                // and its anonymous-parameter twin.
+                let param_display = param_display_name(pd);
                 return Err(RuntimeError::typecheck_binding_parameter_with_repr(
                     &param_display,
                     &resolved_constraint,
@@ -2601,63 +2679,7 @@ impl Interpreter {
                         )
                         .with_parameter_object(pd, Some(&*self)));
                     }
-                    if let Some(where_expr) = &pd.where_constraint {
-                        let saved_param = if pd.name.is_empty() {
-                            None
-                        } else {
-                            self.env.get(&pd.name).cloned()
-                        };
-                        if !pd.name.is_empty() {
-                            self.bind_param_value_sym(&pd.name, pd_name_sym(), value.clone());
-                        }
-                        let saved_topic = self.env.get("_").cloned();
-                        self.env.insert("_".to_string(), value.clone());
-                        let ok = match where_expr.as_ref() {
-                            Expr::AnonSub { body, .. } => {
-                                let ph_keys = self.bind_where_placeholders(body, &value);
-                                let r = self
-                                    .eval_block_value(body)
-                                    .map(|v| v.truthy())
-                                    .unwrap_or(false);
-                                for k in ph_keys {
-                                    self.unmark_readonly(&k);
-                                    self.env.remove(&k);
-                                }
-                                r
-                            }
-                            // Method calls on $_ (topic) in where constraints:
-                            // evaluate and check truthiness of the result, not smart-match.
-                            // `where .method: args` is equivalent to `where { .method: args }`.
-                            Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") => {
-                                self.eval_block_value(&[Stmt::Expr(where_expr.as_ref().clone())])
-                                    .map(|v| v.truthy())
-                                    .unwrap_or(false)
-                            }
-                            expr => self
-                                .eval_block_value(&[Stmt::Expr(expr.clone())])
-                                .map(|v| self.smart_match(&value, &v))
-                                .unwrap_or(false),
-                        };
-                        if let Some(previous) = saved_topic {
-                            self.env.insert("_".to_string(), previous);
-                        } else {
-                            self.env.remove("_");
-                        }
-                        if !pd.name.is_empty() {
-                            if let Some(previous) = saved_param {
-                                self.env.insert(pd.name.clone(), previous);
-                            } else {
-                                self.env.remove(&pd.name);
-                            }
-                        }
-                        if !ok {
-                            return Err(Self::parameter_where_binding_error(
-                                pd,
-                                &value,
-                                Some(&*self),
-                            ));
-                        }
-                    }
+                    self.check_positional_param_where_constraint(pd, pd_name_sym(), &value)?;
                     // Resolve type capture prefixes (e.g., `::T` → `Int`) so
                     // that the stored variable type constraint uses the
                     // concrete captured type name, not the raw `::T` token.
@@ -2801,6 +2823,10 @@ impl Interpreter {
                 } else if let Some(default_expr) = &pd.default {
                     let value = self.eval_param_default(pd, default_expr)?;
                     let value = self.checked_default_param_value(pd, value)?;
+                    // `sub f($x where { ... } = 3)`: the post-constraint applies
+                    // to the default too (rakudo rejects the reverse spelling,
+                    // `$x = 3 where { ... }`, at compile time).
+                    self.check_positional_param_where_constraint(pd, pd_name_sym(), &value)?;
                     if let Some(captured_name) = pd.captured_type_name() {
                         self.bind_type_capture(captured_name, &value);
                     } else if !pd.name.is_empty() {
@@ -2843,18 +2869,22 @@ impl Interpreter {
                         if total_positional == 1 { "" } else { "s" },
                         positional_arg_count
                     )));
-                } else if !pd.name.is_empty() {
+                } else if pd.optional_marker || !pd.name.is_empty() {
                     // Optional parameters use typed empties/type objects when omitted.
-                    self.bind_param_value_sym(
-                        &pd.name,
-                        pd_name_sym(),
-                        Self::missing_optional_param_value(pd),
-                    );
-                    self.bind_param_type_constraint_sym(
-                        &pd.name,
-                        pd_name_sym(),
-                        pd.type_constraint.clone(),
-                    );
+                    let value = Self::missing_optional_param_value(pd);
+                    // An omitted optional still runs its `where` post-constraint,
+                    // against the type object it would bind (#8089). An anonymous
+                    // optional (`$? where { $*KERNEL.bits == 64 }`) binds nothing
+                    // but is checked all the same -- that is its whole purpose.
+                    self.check_positional_param_where_constraint(pd, pd_name_sym(), &value)?;
+                    if !pd.name.is_empty() {
+                        self.bind_param_value_sym(&pd.name, pd_name_sym(), value);
+                        self.bind_param_type_constraint_sym(
+                            &pd.name,
+                            pd_name_sym(),
+                            pd.type_constraint.clone(),
+                        );
+                    }
                 }
             }
         }

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -249,6 +249,26 @@ fn param_trait_mixin_type(traits: &[String]) -> Option<Symbol> {
     traits.iter().rev().find_map(|t| map.get(t).copied())
 }
 
+/// Whether a parameter name is one of the synthetic placeholders the parser
+/// gives an *anonymous* parameter (`$`, `$?`, `@?`, `%?`, a bare `::T` capture,
+/// a subsignature carrier). The parameter has no user-visible name, so both
+/// `.gist` of a Signature and a binding error message have to render it the way
+/// rakudo does -- as a bare sigil, or as `<anon>` -- never as the placeholder.
+pub fn is_anonymous_param_name(name: &str) -> bool {
+    name == "_capture"
+        || name == "__type_only__"
+        // A bare `::T` / `::T:` capture carries a synthetic parameter name; the
+        // parameter itself is anonymous, and rakudo renders it as a bare `$`.
+        || name.starts_with("__type_capture__")
+        || name.starts_with("__ANON_STATE_")
+        || name == "__ANON_OPTIONAL__"
+        || name == "__subsig__"
+        || name == "__ANON_ARRAY__"
+        || name == "__ANON_HASH__"
+        || name == "@__ANON_ARRAY__"
+        || name == "%__ANON_HASH__"
+}
+
 /// Convert a ParamDef (from the parser) to a SigParam (for runtime).
 pub(crate) fn param_def_to_sig_param(p: &ParamDef) -> SigParam {
     let is_capture = p.slurpy && (p.name == "_capture" || p.sigilless);
@@ -266,19 +286,7 @@ pub(crate) fn param_def_to_sig_param(p: &ParamDef) -> SigParam {
 
     let name = if is_implicit_topic {
         "_".to_string()
-    } else if p.name == "_capture"
-        || p.name == "__type_only__"
-        // A bare `::T` / `::T:` capture carries a synthetic parameter name; the
-        // parameter itself is anonymous, and rakudo renders it as a bare `$`.
-        || p.name.starts_with("__type_capture__")
-        || p.name.starts_with("__ANON_STATE_")
-        || p.name == "__ANON_OPTIONAL__"
-        || p.name == "__subsig__"
-        || p.name == "__ANON_ARRAY__"
-        || p.name == "__ANON_HASH__"
-        || p.name == "@__ANON_ARRAY__"
-        || p.name == "%__ANON_HASH__"
-    {
+    } else if is_anonymous_param_name(&p.name) {
         String::new()
     } else if p.name.starts_with('@') || p.name.starts_with('%') || p.name.starts_with('&') {
         p.name[1..].to_string()

--- a/t/routines/signature/optional-param-where-runs-when-omitted.t
+++ b/t/routines/signature/optional-param-where-runs-when-omitted.t
@@ -1,0 +1,108 @@
+use v6;
+use Test;
+
+plan 20;
+
+# An optional parameter's `where` post-constraint runs even when the argument is
+# omitted: rakudo binds the parameter to the value it would get (the nominal type
+# object, or the evaluated default) and tests the constraint against that. mutsu
+# used to skip the constraint entirely on the omitted-argument path, so
+# `sub f($x? where { $_ ~~ Int }) { }` happily accepted `f()` (#8089).
+
+# --- bare optional, all four supplied/omitted x passing/failing corners --------
+
+{
+    sub f($x? where { $_ ~~ Int }) { 'ran' }
+    is f(3), 'ran', 'supplied value satisfying the constraint binds';
+    dies-ok { f('s') }, 'supplied value failing the constraint dies';
+    dies-ok { f() },    'omitted arg fails the constraint (binds Any, not Int)';
+}
+
+{
+    sub f($x? where { True }) { $x.^name }
+    is f(), 'Any', 'omitted arg passing the constraint binds the Any type object';
+}
+
+# The value under test is the parameter's *declared* type object, not always Any.
+{
+    sub f(Int $x? where { $_.^name eq 'Int' }) { 'ran' }
+    is f(), 'ran', 'typed optional: constraint sees the declared type object';
+}
+{
+    sub f(Int $x? where { $_.^name eq 'Any' }) { 'ran' }
+    dies-ok { f() }, 'typed optional: the type object is Int, not Any';
+}
+
+# `@?`/`%?` bind a fresh empty container rather than a type object.
+{
+    sub f(@x? where { $_.^name eq 'Array' && $_.elems == 0 }) { 'ran' }
+    is f(), 'ran', 'omitted @-optional: constraint sees an empty Array';
+}
+{
+    sub f(%h? where { $_.^name eq 'Hash' && $_.elems == 0 }) { 'ran' }
+    is f(), 'ran', 'omitted %-optional: constraint sees an empty Hash';
+}
+
+# --- the anonymous optional, which binds nothing but is still checked ---------
+
+{
+    sub f($? where { $_ ~~ Int }) { 'ran' }
+    dies-ok { f() }, 'anonymous optional runs its constraint when omitted';
+    is f(1), 'ran', 'anonymous optional accepts a satisfying argument';
+}
+
+# The failure names the parameter the way rakudo does, not by mutsu's internal
+# placeholder for an anonymous parameter.
+{
+    sub f($? where { False }) { 'ran' }
+    my $msg = '';
+    try { f(); CATCH { default { $msg = .message } } };
+    like $msg, /'<anon>'/, 'anonymous parameter is reported as <anon>';
+    unlike $msg, /ANON/, 'the internal placeholder name does not leak';
+}
+
+# --- a parameter whose `where` precedes a default -----------------------------
+# (`$x = 3 where {...}` is a compile-time error in rakudo, so this spelling is
+# the only one, and the constraint applies to the default value.)
+
+{
+    sub f($x where { $_ ~~ Int } = 3) { 'ran' }
+    is f(), 'ran', 'defaulted param: constraint runs against the default and passes';
+}
+
+{
+    sub f($x where { $_ ~~ Str } = 3) { 'ran' }
+    dies-ok { f() }, 'defaulted param: constraint runs against the default and fails';
+}
+
+# --- dispatch must agree with binding ----------------------------------------
+# A `where` clause is a multi-dispatch discriminator, so a skipped constraint
+# silently widens candidate selection. If the matcher and the binder disagree, a
+# candidate is selected and then dies binding the very call it was selected for.
+
+{
+    multi g($x, $y? where { $_ ~~ Int }) { 'constrained' }
+    multi g($x, $y?)                     { 'plain' }
+    is g(1),    'plain',       'omitted arg: constrained candidate is not selected';
+    is g(1, 2), 'constrained', 'supplied Int: constrained candidate wins';
+    is g(1, 'a'), 'plain',     'supplied Str: falls through to the plain candidate';
+}
+
+{
+    multi g($x, $y? where { $_ ~~ Int }) { 'constrained' }
+    dies-ok { g(1) }, 'no candidate remains once the omitted-arg constraint fails';
+}
+
+# The shape that motivated the ticket: a trailing anonymous optional used purely
+# as a platform guard (Digest::xxHash's `$? where { $*KERNEL.bits == 64 }`).
+{
+    multi pick(Int $seed = 0) { 32 }
+    multi pick(Int $seed = 0, $? where { False }) { 64 }
+    is pick(7), 32, 'trailing anonymous where-guard does not match when it is False';
+}
+
+{
+    multi pick(Int $seed = 0) { 32 }
+    multi pick(Int $seed = 0, $? where { True }) { 64 }
+    is pick(7), 64, 'trailing anonymous where-guard matches when it is True';
+}


### PR DESCRIPTION
A `where` post-constraint on an optional parameter was only evaluated on the binder branch that had a supplied argument. Omit the argument and the parameter bound unconditionally, so a signature that exists precisely to reject certain calls accepted every one of them:

```
$ mutsu -e 'sub f($x? where { $_ ~~ Int }) { "ran" }; say f()'
ran
$ raku  -e 'sub f($x? where { $_ ~~ Int }) { "ran" }; say f()'
Constraint type check failed in binding to parameter '$x'; expected anonymous constraint to be met but got Any (Any)
```

Rakudo runs the constraint on every binding path; only the value under test differs. An omitted optional binds its nominal type object (`Any`, or the declared type — `Int` for `Int $x?`, a fresh empty `Array`/`Hash` for `@x?` and `%h?`, `Mu` inside a pointy block), and a defaulted parameter binds the evaluated default. The constraint is tested against that. Rakudo rejects the reverse spelling `$x = 3 where { ... }` at compile time, so a defaulted parameter only ever reaches this through `$x where { ... } = 3`.

## Why it mattered beyond the error message

A `where` clause is a multi-dispatch discriminator, so a skipped constraint does not merely miss an error — it silently widens candidate selection. `Digest::xxHash` is built on exactly that:

```raku
multi sub build-xxhash(Int @data, Int $seed = 0, $? where { $*KERNEL.bits == 64 } --> Int) { ... }
```

The trailing anonymous optional never looks at `$_`; it exists only so the candidate matches on a 64-bit kernel. With the constraint skipped it matched everywhere, on any platform.

## The fix

Both halves of the calling convention had to move, and they had to agree — if the matcher and the binder disagree about a `where`, dispatch selects a candidate that then dies binding the very call it was selected for.

- **`src/runtime/types/binding_signature.rs`** — the inline `where` evaluation is now `check_positional_param_where_constraint`, and all three binder paths (supplied, defaulted, omitted-optional) funnel through it. The omitted branch also grew a case it never had: an anonymous optional (`$?`) binds no variable, so it fell through every branch and was never checked at all.
- **`src/runtime/types/args_matching.rs`** — the matcher already fell back to the evaluated default for an unsupplied parameter that had one, but skipped the check for a bare optional, on a comment asserting that rakudo defers it to bind time. It does not: `multi g($x, $y? where { $_ ~~ Int })` loses to `multi g($x, $y?)` on `g(1)` in rakudo, and mutsu now agrees. The named-parameter half of the matcher had the fallback right already.

## A leaked internal name, fixed on the way past

The new failures surfaced mutsu's parser placeholders in user-facing messages: an anonymous parameter was reported as `'$__ANON_OPTIONAL__'` where rakudo says `'<anon>'`. That was not new — a supplied bare `$ where { ... }` had been printing `'$__ANON_STATE__'` all along. `param_display_name` now renders every anonymous parameter as `<anon>`, sharing one `is_anonymous_param_name` predicate with `Signature` gisting rather than keeping two copies of the placeholder list.

## Testing

New pin `t/routines/signature/optional-param-where-runs-when-omitted.t` (20 tests) covers all four supplied/omitted × passing/failing corners, the type object each sigil binds, the anonymous optional and its error text, the defaulted spelling, and four multi-dispatch cases holding the matcher and the binder to the same answer. **It passes under rakudo unchanged** (`prove -e raku`), so it is a spec pin rather than a mutsu-shaped one.

`.cando` was checked against rakudo too and now agrees on the omitted case (`()` where it used to report the candidate).

Pre-publication gate, all run locally on this branch:

- `cargo fmt --all` + `make lint` — green (all four configurations).
- `make test` — **PASS**, 4079 files / 43402 tests.
- `make roast` — 1437 files / 219635 tests; the only failures are the three documented environment-only files, at exactly their documented shapes (`6.c/S32-io/file-tests.t` Failed: 4, tests 6-8/10; `S16-filehandles/filetest.t` Failed: 25, tests 57-64/69-72/77-80/101-125 odd; `S32-io/IO-Socket-Async.t` exit 124, planned 40 ran 17). `id -u` is `0` here, which is the stated cause of the first two.

Closes #8089

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8)_