### PR TITLE
fix: an uppercase `is Trait` is still a trait, and a natively-modelled core type is still a parent

### DIFF
--- a/news/2026-09/an-uppercase-is-trait-is-still-a-trait.md
+++ b/news/2026-09/an-uppercase-is-trait-is-still-a-trait.md
@@ -1,0 +1,149 @@
+# An uppercase `is Trait` is still a trait, and a natively-modelled core type is still a parent
+
+The ecosystem parity ledger grouped 20 distributions under one cluster,
+[#7996](https://github.com/tokuhirom/mutsu/issues/7996) — "a class cannot
+inherit from a type declared in the same or an imported unit". The census the
+ticket asked for turned out to be the whole job: those 20 failures are **five
+different root causes**, not one, and they do not need the same fix. Three of
+them are closed here; one had already been closed on `main` after the sweep
+measured; the fifth is the real content of the cluster and is re-filed narrowly
+with its own minimised repros.
+
+## 1. `class Foo is Static { }` never reached `trait_mod:<is>`
+
+Raku spells a class-level trait `is Foo`, and decides what that means from
+whether `Foo` names a known type. When it does not, `is Foo` is not inheritance
+at all — it desugars to the **named** argument `trait_mod:<is>($type, :Foo)`.
+That is the entire public interface of the `Staticish` distribution:
+
+```raku
+use Staticish;
+class Foo is Static { has Str $.bar is rw; }   # multi trait_mod:<is>(Mu:U, :$Static!)
+```
+
+`validate_class_parents` did defer an unknown parent to that dispatch, but only
+when the name began with an **ASCII lowercase letter**. Trait names written the
+way Raku programs actually write them — capitalised — fell straight through to
+`X::Inheritance::UnknownParent`. The restriction is gone: any unknown `is`
+parent is deferred whenever the program defines a `trait_mod:<is>` at all. That
+is safe because the dispatch site already converts a no-matching-candidate
+verdict back into `unknown_parent_error` (`vm_typedecl_ops.rs`), so a genuine
+typo still raises `X::Inheritance::UnknownParent` — `t/oo/trait/
+user-trait-mod-does-not-consume-every-trait.t` pins exactly that and still
+passes unchanged.
+
+One ordering change came with it. The `package A {}; class B is A {}` →
+`X::Inheritance::Unsupported` check now runs **before** the deferral rather than
+after. A declared package is not an unknown name, so rakudo hands it to
+`trait_mod:<is>` positionally, as the package object — never as the `:Name`
+named argument the deferral synthesises.
+
+## 2. The deferred name was still becoming a parent
+
+Widening the deferral exposed a second bug that had been sitting on the
+lowercase path all along: the trait name stayed in the class's inheritance
+parent list. `class Alpha is Marked { }` gave mutsu
+
+```
+Alpha.^parents   (Marked,)          # rakudo: ()
+Alpha.^mro       Alpha,Marked,Any,Mu # rakudo: Alpha,Any,Mu
+```
+
+— a phantom ancestor for every class that uses a class-level trait. A deferred
+name is a trait, never a parent, so it now joins the `does`-role-sharing-the-
+class's-own-name case in the set `validate_class_parents` returns for
+`begin_class_def` to filter out of the C3 parents. That set was called
+`self_named_does_roles`; it now holds both kinds and is called
+`non_inheritance_parents`.
+
+## 3. A core type mutsu models natively could not be a parent
+
+`class ValueClass::Attribute is Attribute { }` died as an unknown parent, and
+with it the `ValueClass` distribution and `Functional::Queue` /
+`Functional::Stack`, which depend on it. `Attribute` is a perfectly real type in
+mutsu — `::('Attribute')` yields the type object and
+`Interpreter::is_builtin_type` knows it — it simply has no `ClassDef` in
+`registry.classes`, and the existence check vouched for a parent only through
+`registry.classes`, `BUILTIN_PARENT_TYPES`, the core-role oracle,
+`registry.roles` and `registry.enum_types`.
+
+`BUILTIN_INHERITABLE_TYPES` fills that hole with the 26 names in the same
+position, each checked against rakudo 2026.07 with `class Zz is <Name> { }`
+(rakudo compiles all of them): `Attribute`, `CallFrame`, `CompUnit`,
+`CX::Return`, `CX::Warn`, `Cursor`, `Deprecation`, `Duration`, `Instant`,
+`Label`, `NFC`/`NFD`/`NFKC`/`NFKD`, `ObjAt`, `Scalar`, `StrDistance`,
+`Submethod`, `Uni`, and the seven metamodel HOWs that were not already listed.
+Two more distributions come off the same hook: `Timezones::ZoneInfo`
+(`class CX::Warn::Timezones::UnknownID is CX::Warn { }`) and `Protocol`
+(`class MetamodelX::Protocol is Metamodel::SubsetHOW { }`).
+
+The list is deliberately **separate** from `BUILTIN_PARENT_TYPES` rather than
+folded into it. That table also decides whether a `does` target is composable,
+and whether a `but`-mixin may take the class-declaration path instead of the
+wrapper one — `types::role_mixin_class`'s own comment names `Attribute` as the
+example that must keep the wrapper. Only the `is`-parent existence check
+consults the new list, so `class Nope does Attribute { }` is rejected exactly as
+before and `Holder.^attributes[0] but Tag` still takes the wrapper path.
+
+## 4. Already fixed, ledger stale
+
+`Test::Async::Metamodel::BundleHOW is Metamodel::ParametricRoleHOW` and
+`OO::Plugin::Metamodel::PlugRoleHOW is Metamodel::ParametricRoleHOW`
+(`Test::Async`, `OO::Plugin`, `Config::BINDish`) are not a gap:
+`Metamodel::ParametricRoleHOW` was added to `BUILTIN_PARENT_TYPES` by `5926cbbc`
+at 2026-09-11 23:58 UTC, minutes after the sweep that produced the cluster
+measured `7807eb5`. Both declarations compile on `main` today.
+
+## 5. What is left: `also is` is applied too early
+
+The remaining members are one root cause with a different shape, and it is
+**not** the inheritance check — it is *when* mutsu applies `also is Parent`.
+Rakudo executes that statement at its position in the class body; mutsu's parser
+hoists it into the class header (`stmt_also_is_parent` /
+`push_also_is_parent`), so the parent is validated before any of the body has
+run. Everything the body would have established first is therefore invisible:
+
+```raku
+class Kid {
+    use Parentish;          # the parent arrives HERE
+    also is Parentish;
+}                           # mutsu: 'Kid' cannot inherit from 'Parentish' because it is unknown.
+```
+
+```raku
+unit class UC;
+class Inner is Positional { }   # a nested class of UC
+also is Inner;                  # mutsu: 'UC' cannot inherit from 'Inner' because it is unknown.
+```
+
+The first shape is every one of `Font::AFM`'s 14 `Font::Metrics::*` compunits;
+the second is `Intl::CLDR`'s five `CLDR::*` types. Filed as
+[#8099](https://github.com/tokuhirom/mutsu/issues/8099) with both repros, since
+the fix is a different change in a different layer (mark the `also is` parents
+through the declaration plan, defer their validation until after the body walk,
+and add them before `finalize_class_registration` computes the MRO) from
+anything in this one.
+
+The rest of the cluster's 20 are cascades: the named parent's own compunit fails
+to load for an unrelated reason (`PDF::Content::Font::Enc`'s missing
+`NativeCall::Types`, `CSS::Grammar::AST`, `Parse::Paths`'s `BasePaths`), so the
+parent genuinely does not exist and the inheritance error is the symptom, not
+the disease.
+
+## Pins
+
+- `t/oo/trait/uppercase-is-trait-reaches-trait-mod.t` — 9 assertions: the
+  uppercase trait fires its handler, the name reaches neither `^parents` nor
+  `^mro`, the lowercase spelling still works and is likewise absent from the
+  MRO, a name no candidate claims is still `X::Inheritance::UnknownParent`, an
+  error from inside a matching handler still propagates, and a known uppercase
+  parent is still ordinary inheritance. Passes verbatim under rakudo. The
+  role-side mirror (`role R is Marked { }`) is still broken and is
+  [#8100](https://github.com/tokuhirom/mutsu/issues/8100): `RoleParentOp` does
+  not record `is` vs `does`, so widening the deferral there would change the
+  error for a `does` typo too.
+- `t/oo/class/builtin-inheritable-parent-types.t` — all 26 new names as an `is`
+  parent, plus the three things that must NOT move: an unknown parent is still
+  `X::Inheritance::UnknownParent`, `does Attribute` is still rejected, and a
+  `but`-mixin on an `Attribute` still keeps the wrapper path. Also passes
+  verbatim under rakudo.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -791,7 +791,7 @@ mod registration_class_compose;
 mod registration_class_compose_body;
 pub(crate) mod registration_class_compose_record;
 mod registration_class_decl;
-mod registration_class_validate;
+pub(crate) mod registration_class_validate;
 mod registration_role;
 mod registration_role_body;
 mod registration_role_decl;
@@ -2073,6 +2073,21 @@ pub struct Interpreter {
     /// package than the caller). See
     /// `news/2026-08/class-decl-expr-is-not-a-name-lookup.md`.
     pub(crate) last_registered_class_key: Option<String>,
+    /// Registry state from just before the class `register_class_decl` last
+    /// registered WITH a parent deferred to `trait_mod:<is>` dispatch, keyed
+    /// by that class's storage name. Set only on that path, and consumed by
+    /// `exec_register_class_op`: if the dispatch then reports that no
+    /// candidate claims the trait, the name really was an unknown parent, the
+    /// declaration must fail, and — because the class shell was already
+    /// published so the trait handler could see the type object — it has to be
+    /// rolled back here rather than by `register_class_decl`'s own snapshot,
+    /// which has already gone out of scope. Without it a failed `class B is
+    /// NoSuchParent { }` left `B` registered and the next real `class B`
+    /// declaration died as a redeclaration.
+    pub(crate) deferred_trait_class_rollback: Option<(
+        String,
+        crate::runtime::registration_class_validate::ClassRegSnapshot,
+    )>,
     /// The qualified registry key most recently installed by
     /// `exec_register_role_op`. Consumed immediately by
     /// `PushLastRegisteredRole` for a named role declaration expression.

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -111,6 +111,60 @@ pub(crate) const BUILTIN_PARENT_TYPES: &[&str] = &[
     "Perl6::Metamodel::ParametricRoleHOW",
 ];
 
+/// Core types a user class may name as an `is` parent, but which mutsu models
+/// natively rather than as an entry in `registry.classes`. They answer to
+/// [`Interpreter::is_builtin_type`], most of them resolve as a type object
+/// through `::('Name')`, and every one of them was checked against rakudo with
+/// `class Zz is <Name> { }` — which compiles for all of them. Without this
+/// list, `class ValueClass::Attribute is Attribute { }` (the `ValueClass`
+/// distribution, and `Functional::Queue` / `Functional::Stack` through it),
+/// `class CX::Warn::Timezones::UnknownID is CX::Warn { }` (`Timezones::
+/// ZoneInfo`) and `class MetamodelX::Protocol is Metamodel::SubsetHOW { }`
+/// (`Protocol`) all died as X::Inheritance::UnknownParent.
+///
+/// Deliberately SEPARATE from [`BUILTIN_PARENT_TYPES`] rather than folded
+/// into it: that table also decides whether a `does` target is composable
+/// (`registration_class_validate.rs`) and whether a `but`-mixin may take the
+/// class-declaration path instead of the wrapper one
+/// (`types::role_mixin_class`, whose own comment names `Attribute` as the
+/// example that must keep the wrapper). Only the `is`-parent existence check
+/// consults this list, so neither of those decisions moves.
+pub(crate) const BUILTIN_INHERITABLE_TYPES: &[&str] = &[
+    "Attribute",
+    "CallFrame",
+    "CompUnit",
+    "CX::Return",
+    "CX::Warn",
+    "Cursor",
+    "Deprecation",
+    "Duration",
+    "Instant",
+    "Label",
+    "NFC",
+    "NFD",
+    "NFKC",
+    "NFKD",
+    "ObjAt",
+    "Scalar",
+    "StrDistance",
+    "Submethod",
+    "Uni",
+    // The rest of the metamodel HOW family. `Metamodel::ClassHOW`,
+    // `::GrammarHOW` and `::ParametricRoleHOW` are in `BUILTIN_PARENT_TYPES`
+    // above because a subclass of those three also needs the metamodel
+    // dispatch frame (`Interpreter::is_metamodel_class_name`); the ones here
+    // have no native metamethods to inherit yet, so naming one as a parent
+    // yields an ordinary class — but that is still much closer to rakudo than
+    // refusing the declaration outright.
+    "Metamodel::ConcreteRoleHOW",
+    "Metamodel::CurriedRoleHOW",
+    "Metamodel::EnumHOW",
+    "Metamodel::ModuleHOW",
+    "Metamodel::PackageHOW",
+    "Metamodel::ParametricRoleGroupHOW",
+    "Metamodel::SubsetHOW",
+];
+
 impl Interpreter {
     pub(crate) fn register_class_decl(
         &mut self,
@@ -191,12 +245,12 @@ impl Interpreter {
         }
         self.note_compound_declared_type(name);
 
-        let (self_named_does_roles, deferred_custom_traits) =
+        let (non_inheritance_parents, deferred_custom_traits) =
             self.validate_class_parents(name, parents, does_parents, hidden_parents)?;
         let mut class_def = self.begin_class_def(
             name,
             parents,
-            &self_named_does_roles,
+            &non_inheritance_parents,
             is_hidden,
             hidden_parents,
         );
@@ -252,6 +306,15 @@ impl Interpreter {
             &composed_roles_list,
             &direct_composed_roles,
         );
+        // A parent deferred to `trait_mod:<is>` may still turn out to be a
+        // genuine unknown parent, and the dispatch that decides that runs in
+        // `exec_register_class_op`, AFTER this function has published the
+        // class shell (the trait handler has to be able to see the type
+        // object). Hand `snapshot` on so that site can undo the declaration;
+        // see `Interpreter::deferred_trait_class_rollback`.
+        if !deferred_custom_traits.is_empty() {
+            self.deferred_trait_class_rollback = Some((name.to_string(), snapshot.clone()));
+        }
         if self.publish_class_shell(
             name,
             trusts,

--- a/src/runtime/registration_class_validate.rs
+++ b/src/runtime/registration_class_validate.rs
@@ -4,7 +4,7 @@
 //! `registration_class_decl.rs` — no behavior change.
 
 use super::registration_class::is_non_composable_builtin;
-use super::registration_class_decl::BUILTIN_PARENT_TYPES;
+use super::registration_class_decl::{BUILTIN_INHERITABLE_TYPES, BUILTIN_PARENT_TYPES};
 use super::*;
 
 /// Short (unqualified) name of the class being declared, for detecting a
@@ -16,7 +16,8 @@ fn short_of(s: &str) -> &str {
 /// Snapshot of the previous registry state for this class, taken under a
 /// single read guard (all values are owned/cloned, no re-entry) so a
 /// redefinition can be rolled back if the new body fails.
-pub(super) struct ClassRegSnapshot {
+#[derive(Clone)]
+pub(crate) struct ClassRegSnapshot {
     prev_class: Option<ClassDef>,
     prev_hidden: bool,
     prev_lexical: bool,
@@ -46,9 +47,17 @@ impl ClassRegSnapshot {
         }
     }
 
+    /// Whether this class already existed when the snapshot was taken. A
+    /// rollback of a declaration that created the class from scratch has more
+    /// to undo than one that merely replaced an earlier definition — see
+    /// `Interpreter::rollback_deferred_trait_class_decl`.
+    pub(crate) fn had_previous_class(&self) -> bool {
+        self.prev_class.is_some()
+    }
+
     /// Rollback writes are purely registry mutations with no user-code
     /// re-entry, so they take a single write guard for the whole block.
-    pub(super) fn restore(&self, this: &mut Interpreter, name: &str) {
+    pub(crate) fn restore(&self, this: &mut Interpreter, name: &str) {
         let mut reg = this.registry_mut();
         if let Some(class_def) = self.prev_class.clone() {
             reg.classes.insert(name.to_string(), class_def);
@@ -121,8 +130,8 @@ impl Interpreter {
     /// `X::Inheritance::UnknownParent`: `name` (the class being declared)
     /// gave `parent_name` as an `is` parent that names no known class, role,
     /// enum, or builtin type. Shared by the immediate check below and by the
-    /// deferred-custom-trait dispatch (`vm_typedecl_ops.rs`) for when a
-    /// lowercase parent name was optimistically deferred to a user
+    /// deferred-custom-trait dispatch (`vm_typedecl_ops.rs`) for when an
+    /// unknown parent name was optimistically deferred to a user
     /// `trait_mod:<is>` candidate that turns out not to match this call's
     /// shape after all (mirrors the sibling variable-/attribute-trait
     /// no-candidate fallback).
@@ -163,14 +172,22 @@ impl Interpreter {
 
     /// Validate that all parent classes exist.
     /// Allow inheriting from built-in types that may not be in the classes HashMap.
-    /// Returns the parents that must NOT enter the C3 inheritance MRO because
-    /// they are a `does`-role whose (short) name collides with the class's own
-    /// name — e.g. `class Iterator does Iterator` (Rakudo composes the CORE
-    /// `Iterator` role, not the class itself). Such a parent is still composed
-    /// as a role by the role-composition loop; keeping it in the inheritance
-    /// parent list would make the class its own C3 ancestor (self-cycle /
-    /// self-inherit). Also returns the unknown lowercase parents deferred to
-    /// custom `trait_mod:<is>` dispatch.
+    /// Returns the parents that must NOT enter the C3 inheritance MRO, which
+    /// are of two kinds:
+    ///
+    /// - a `does`-role whose (short) name collides with the class's own name —
+    ///   e.g. `class Iterator does Iterator` (Rakudo composes the CORE
+    ///   `Iterator` role, not the class itself). Such a parent is still
+    ///   composed as a role by the role-composition loop; keeping it in the
+    ///   inheritance parent list would make the class its own C3 ancestor
+    ///   (self-cycle / self-inherit);
+    /// - an unknown name deferred to custom `trait_mod:<is>` dispatch. `is
+    ///   Marked` there is a TRAIT, not a parent, so rakudo reports
+    ///   `Alpha.^parents` as empty and `Alpha.^mro` as `Alpha, Any, Mu`;
+    ///   leaving the trait name in gave mutsu a phantom `Marked` ancestor.
+    ///
+    /// Also returns those deferred names, in source order, for the dispatch
+    /// site in `vm_typedecl_ops.rs` to call `trait_mod:<is>` with.
     pub(super) fn validate_class_parents(
         &mut self,
         name: &str,
@@ -189,7 +206,7 @@ impl Interpreter {
         // supposed to collide with.
         let name = crate::value::user_facing_type_name(name);
         let self_short = short_of(&name);
-        let mut self_named_does_roles: HashSet<String> = HashSet::new();
+        let mut non_inheritance_parents: HashSet<String> = HashSet::new();
         let mut deferred_custom_traits: Vec<String> = Vec::new();
         for parent in parents {
             let resolved_parent_name = self.resolve_declared_type_name(parent);
@@ -213,7 +230,7 @@ impl Interpreter {
                     || resolved_parent_name == name.as_ref())
                 && self.registry().roles.contains_key(resolved_parent);
             if is_self_named_does_role {
-                self_named_does_roles.insert(parent.clone());
+                non_inheritance_parents.insert(parent.clone());
                 continue;
             }
             if resolved_parent == name.as_ref() {
@@ -244,20 +261,22 @@ impl Interpreter {
                         resolved_parent_name
                     )));
                 }
-                // If trait_mod:<is> is defined, defer unknown lowercase parents
-                // to custom trait dispatch instead of erroring.
-                if (self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>"))
-                    && resolved_parent
-                        .chars()
-                        .next()
-                        .is_some_and(|c| c.is_ascii_lowercase())
-                {
-                    deferred_custom_traits.push(resolved_parent_name.to_string());
+                // A plain `is` parent may also name a core type mutsu models
+                // natively instead of registering a `ClassDef` for it
+                // (`Attribute`, `CX::Warn`, `Metamodel::SubsetHOW`, ...).
+                // Consulted only here, on the `is` path, so it moves neither
+                // the `does`-composability verdict below nor the `but`-mixin
+                // fast path — see `BUILTIN_INHERITABLE_TYPES`'s own comment.
+                if BUILTIN_INHERITABLE_TYPES.contains(&base_parent) {
                     continue;
                 }
                 // A name that is declared as a `package` (or module) exists but
                 // does not support inheritance: `package A {}; class B is A {}`
                 // is X::Inheritance::Unsupported, not an unknown-parent error.
+                // Checked BEFORE the custom-trait deferral below: a declared
+                // package is not an unknown name, so rakudo passes it to
+                // `trait_mod:<is>` positionally (as the package object) rather
+                // than as the `:Name` named argument the deferral synthesises.
                 if self.chain_declared_packages.contains(base_parent)
                     || self
                         .chain_declared_packages
@@ -277,6 +296,27 @@ impl Interpreter {
                     );
                     attrs.insert("message".to_string(), Value::str(msg));
                     return Err(RuntimeError::typed("X::Inheritance::Unsupported", attrs));
+                }
+                // `is Foo` on a name that is NOT a known type is rakudo's
+                // spelling of the named trait argument `trait_mod:<is>($type,
+                // :Foo)` — that is how `class Foo is Static { }` reaches the
+                // `Staticish` distribution's
+                // `multi trait_mod:<is>(Mu:U $doee, :$Static!)`. Defer any such
+                // parent to custom trait dispatch whenever the program defines
+                // a `trait_mod:<is>` at all; the dispatch site
+                // (`vm_typedecl_ops.rs`) turns a no-matching-candidate result
+                // back into `unknown_parent_error`, so a genuine typo still
+                // raises X::Inheritance::UnknownParent. This used to be
+                // restricted to lowercase names, which made every uppercase
+                // trait name (the overwhelmingly common spelling) an
+                // unknown-parent error instead.
+                if self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>") {
+                    deferred_custom_traits.push(resolved_parent_name.to_string());
+                    // `is Marked` is then a trait, not inheritance: keep the
+                    // name out of the C3 parents (keyed by the source spelling,
+                    // which is what `begin_class_def` filters on).
+                    non_inheritance_parents.insert(parent.clone());
+                    continue;
                 }
                 return Err(self.unknown_parent_error(name.as_ref(), resolved_parent_name.as_str()));
             }
@@ -359,7 +399,7 @@ impl Interpreter {
                 return Err(err);
             }
         }
-        Ok((self_named_does_roles, deferred_custom_traits))
+        Ok((non_inheritance_parents, deferred_custom_traits))
     }
 
     /// Build the initial `ClassDef` for the declaration and record the
@@ -368,19 +408,21 @@ impl Interpreter {
         &mut self,
         name: &str,
         parents: &[String],
-        self_named_does_roles: &HashSet<String>,
+        non_inheritance_parents: &HashSet<String>,
         is_hidden: bool,
         hidden_parents: &[String],
     ) -> ClassDef {
-        // Drop any `does`-role that shares the class's own name from the C3
-        // inheritance parents (it is composed as a role below; leaving it here
-        // would make the class its own ancestor — see `self_named_does_roles`).
-        let inheritance_parents: Vec<String> = if self_named_does_roles.is_empty() {
+        // Drop the parents `validate_class_parents` classified as
+        // non-inheritance: a `does`-role sharing the class's own name (composed
+        // as a role below; leaving it here would make the class its own
+        // ancestor) and a name deferred to `trait_mod:<is>` (a trait, never a
+        // parent) — see `non_inheritance_parents`.
+        let inheritance_parents: Vec<String> = if non_inheritance_parents.is_empty() {
             parents.to_vec()
         } else {
             parents
                 .iter()
-                .filter(|p| !self_named_does_roles.contains(*p))
+                .filter(|p| !non_inheritance_parents.contains(*p))
                 .cloned()
                 .collect()
         };

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3060,6 +3060,7 @@ impl Interpreter {
             method_class_stack: Vec::new(),
             constructing_class: None,
             last_registered_class_key: None,
+            deferred_trait_class_rollback: None,
             last_registered_role_key: None,
             build_attr_writes: std::cell::RefCell::new(Vec::new()),
             defining_class: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -611,6 +611,7 @@ impl Interpreter {
             method_class_stack: Vec::new(),
             constructing_class: None,
             last_registered_class_key: None,
+            deferred_trait_class_rollback: None,
             last_registered_role_key: None,
             build_attr_writes: std::cell::RefCell::new(Vec::new()),
             defining_class: None,

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -602,12 +602,17 @@ impl Interpreter {
                     {
                         Ok(_) => {}
                         Err(err) if Self::is_trait_mod_no_candidate(&err) => {
+                            self.rollback_deferred_trait_class_decl();
                             return Err(self.unknown_parent_error(&storage_name, trait_name));
                         }
                         Err(err) => return Err(err),
                     }
                 }
             }
+            // The deferral paid off (or there was none): the class stands, so
+            // drop the rollback snapshot rather than leaving it for whichever
+            // declaration runs next.
+            self.deferred_trait_class_rollback = None;
             // Raku desugars `is Parent` to `trait_mod:<is>($type, Parent)`; when a
             // KNOWN-class parent matches a *typed* user candidate
             // (`multi trait_mod:<is>(Mu:U, SomeType:U)`, more specific than the
@@ -688,6 +693,31 @@ impl Interpreter {
             None => Value::NIL,
         };
         self.stack.push(val);
+    }
+
+    /// Undo the class declaration `register_class_decl` published before this
+    /// op dispatched its deferred `is` traits, for when that dispatch reports
+    /// that no candidate claims the trait after all — the name really was an
+    /// unknown parent, so the declaration failed and must leave no trace.
+    /// Without this a failed `class B is NoSuchParent { }` (in any scope that
+    /// declares a `trait_mod:<is>` at all, which merely importing `Test` does)
+    /// left `B` half-registered, and the next genuine `class B` died as a
+    /// redeclaration instead.
+    fn rollback_deferred_trait_class_decl(&mut self) {
+        let Some((name, snapshot)) = self.deferred_trait_class_rollback.take() else {
+            return;
+        };
+        snapshot.restore(self, &name);
+        // `restore` is shared with the body-failure path and deliberately only
+        // rewinds the registry columns that path owns. A declaration that
+        // created the class from nothing also wrote the two "this name is a
+        // user-declared type" markers, and leaving those behind is what still
+        // made `B.^name` answer `B` instead of falling through to the bareword
+        // path after the failed declaration.
+        if !snapshot.had_previous_class() {
+            crate::runtime::cow_table_mut(&mut self.user_declared_classes).remove(&name);
+            self.registry_mut().compound_declared_types.remove(&name);
+        }
     }
 
     /// Whether a *typed* user `trait_mod:<is>` candidate matches `call_args`

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -358,6 +358,13 @@ impl Interpreter {
                     },
                 )
             )?;
+            // Take the rollback snapshot `register_class_decl` leaves behind
+            // for a deferred `is` trait IMMEDIATELY, into a local: a nested
+            // declaration in this class's own body runs its own
+            // `RegisterClass` op before the dispatch below and would otherwise
+            // overwrite the field with its own snapshot. See
+            // `Interpreter::deferred_trait_class_rollback`.
+            let deferred_trait_rollback = self.deferred_trait_class_rollback.take();
             // ADR-0019 Phase F box F5 shadow check: confirm this successful
             // registration bumped `Registry::method_generation` (see
             // `record_class_reg_gen_shadow_check`'s doc comment). Shadow-only
@@ -602,17 +609,13 @@ impl Interpreter {
                     {
                         Ok(_) => {}
                         Err(err) if Self::is_trait_mod_no_candidate(&err) => {
-                            self.rollback_deferred_trait_class_decl();
+                            self.rollback_deferred_trait_class_decl(deferred_trait_rollback);
                             return Err(self.unknown_parent_error(&storage_name, trait_name));
                         }
                         Err(err) => return Err(err),
                     }
                 }
             }
-            // The deferral paid off (or there was none): the class stands, so
-            // drop the rollback snapshot rather than leaving it for whichever
-            // declaration runs next.
-            self.deferred_trait_class_rollback = None;
             // Raku desugars `is Parent` to `trait_mod:<is>($type, Parent)`; when a
             // KNOWN-class parent matches a *typed* user candidate
             // (`multi trait_mod:<is>(Mu:U, SomeType:U)`, more specific than the
@@ -702,9 +705,17 @@ impl Interpreter {
     /// Without this a failed `class B is NoSuchParent { }` (in any scope that
     /// declares a `trait_mod:<is>` at all, which merely importing `Test` does)
     /// left `B` half-registered, and the next genuine `class B` died as a
-    /// redeclaration instead.
-    fn rollback_deferred_trait_class_decl(&mut self) {
-        let Some((name, snapshot)) = self.deferred_trait_class_rollback.take() else {
+    /// redeclaration instead. `rollback` is the snapshot the caller took off
+    /// `Interpreter::deferred_trait_class_rollback` right after registering,
+    /// not a fresh read of that field — see the take site for why.
+    fn rollback_deferred_trait_class_decl(
+        &mut self,
+        rollback: Option<(
+            String,
+            crate::runtime::registration_class_validate::ClassRegSnapshot,
+        )>,
+    ) {
+        let Some((name, snapshot)) = rollback else {
             return;
         };
         snapshot.restore(self, &name);

--- a/t/oo/class/builtin-inheritable-parent-types.t
+++ b/t/oo/class/builtin-inheritable-parent-types.t
@@ -1,0 +1,61 @@
+use Test;
+
+# `class C is <CoreType> { }` for the core types mutsu models natively instead
+# of registering a `ClassDef` for them. `validate_class_parents` vouched for a
+# parent only through `registry.classes`, `BUILTIN_PARENT_TYPES`, the core-role
+# oracle, `registry.roles` or `registry.enum_types` — so every core type absent
+# from all five died as X::Inheritance::UnknownParent even though rakudo
+# compiles the same declaration. `class ValueClass::Attribute is Attribute { }`
+# is the shape that blocked the `ValueClass` distribution (and `Functional::
+# Queue` / `Functional::Stack`, which depend on it) from loading at all;
+# `is CX::Warn` blocked `Timezones::ZoneInfo` and `is Metamodel::SubsetHOW`
+# blocked `Protocol`.
+#
+# Every name below was checked against rakudo 2026.07 with exactly this
+# declaration; all of them compile there.
+
+my @inheritable =
+    'Attribute', 'CallFrame', 'CompUnit', 'CX::Return', 'CX::Warn', 'Cursor',
+    'Deprecation', 'Duration', 'Instant', 'Label', 'NFC', 'NFD', 'NFKC',
+    'NFKD', 'ObjAt', 'Scalar', 'StrDistance', 'Submethod', 'Uni',
+    'Metamodel::ConcreteRoleHOW', 'Metamodel::CurriedRoleHOW',
+    'Metamodel::EnumHOW', 'Metamodel::ModuleHOW', 'Metamodel::PackageHOW',
+    'Metamodel::ParametricRoleGroupHOW', 'Metamodel::SubsetHOW';
+
+plan @inheritable.elems + 5;
+
+use MONKEY-SEE-NO-EVAL;
+
+for @inheritable -> $parent {
+    my $child = 'Child' ~ $++;
+    lives-ok { EVAL "class $child is $parent \{ \}" },
+        "class $child is $parent is a legal declaration";
+}
+
+# The declaration really produces a usable class, not just a silenced error.
+class MyAttr is Attribute {
+    method describe { 'described' }
+}
+is MyAttr.describe, 'described', 'a class inheriting a natively-modelled core type still works';
+ok MyAttr.^name eq 'MyAttr', 'and keeps its own name';
+
+# A genuine typo is still an unknown parent — the new list vouches for the
+# names on it, nothing more.
+throws-like 'class Oops is NoSuchParentType { }', X::Inheritance::UnknownParent,
+    'an unknown parent is still X::Inheritance::UnknownParent';
+
+# `does` is untouched: these are classes, not composable roles, so composing
+# one is still rejected rather than silently accepted.
+dies-ok { EVAL 'class Nope does Attribute { }' },
+    'does Attribute is still rejected';
+
+# And a `but`-mixin on an Attribute instance still takes the wrapper path
+# (`types::role_mixin_class` keys that decision off BUILTIN_PARENT_TYPES,
+# which this change deliberately left alone).
+{
+    role Tag { method tag { 'tagged' } }
+    class Holder { has $.x }
+    my $mixed = Holder.^attributes[0] but Tag;
+    is $mixed.tag ~ ' ' ~ $mixed.name, 'tagged $!x',
+        'mixing a role into an Attribute still keeps both halves';
+}

--- a/t/oo/trait/uppercase-is-trait-reaches-trait-mod.t
+++ b/t/oo/trait/uppercase-is-trait-reaches-trait-mod.t
@@ -1,0 +1,57 @@
+use Test;
+
+# Raku spells a class-level trait `is Foo`, and decides what that means from
+# whether `Foo` names a known type: if it does, this is inheritance; if it does
+# not, it desugars to the NAMED argument `trait_mod:<is>($type, :Foo)`. mutsu
+# only ever deferred an unknown parent to that dispatch when the name began
+# with a LOWERCASE letter, so the overwhelmingly common spelling — a
+# capitalised trait name — became X::Inheritance::UnknownParent instead of
+# reaching the user's handler. That is what made the `Staticish`
+# distribution's documented usage,
+#
+#     use Staticish;
+#     class Foo is Static { ... }        # multi trait_mod:<is>(Mu:U, :$Static!)
+#
+# die on the class declaration.
+#
+# A deferred name is a TRAIT, not a parent, so it must also stay out of the
+# class's C3 parents: rakudo reports `Alpha.^parents` as empty and
+# `Alpha.^mro` as `Alpha, Any, Mu`. mutsu left the name in the parent list on
+# BOTH paths, giving every such class a phantom ancestor.
+
+plan 9;
+
+use MONKEY-SEE-NO-EVAL;
+
+my %fired;
+multi sub trait_mod:<is>(Mu:U $doee, :$Marked!) { %fired{'Marked'} = $doee.^name }
+multi sub trait_mod:<is>(Mu:U $doee, :$lowered!) { %fired{'lowered'} = $doee.^name }
+multi sub trait_mod:<is>(Mu:U $doee, :$Explodes!) { die "boom from handler" }
+
+class Alpha is Marked { method hi { 'hi' } }
+class Gamma is lowered { }
+
+is %fired{'Marked'}, 'Alpha', 'an uppercase `is Trait` reaches the user trait_mod:<is>';
+is Alpha.new.hi, 'hi', 'and the class is otherwise a normal class';
+is Alpha.^parents.elems, 0, 'the uppercase trait name did not become a parent';
+is Alpha.^mro.map(*.^name).join(','), 'Alpha,Any,Mu', 'nor an MRO entry';
+
+is %fired{'lowered'}, 'Gamma', 'a lowercase trait name still reaches its handler';
+is Gamma.^mro.map(*.^name).join(','), 'Gamma,Any,Mu',
+    'and it is likewise absent from the MRO';
+
+# The trait argument is the named one, so a name no candidate claims is still
+# an unknown parent rather than a silently-accepted trait.
+throws-like 'class Beta is AlsoNotATrait { }', X::Inheritance::UnknownParent,
+    'an uppercase name no candidate claims is still X::Inheritance::UnknownParent';
+
+# An error raised from inside a matching handler still propagates as itself.
+throws-like 'class Delta is Explodes { }', X::AdHoc,
+    'an error from inside a matching uppercase handler still propagates';
+
+# A real parent that happens to sit alongside the traits is still inheritance.
+{
+    class Base { method who { 'base' } }
+    class Derived is Base { }
+    is Derived.new.who, 'base', 'a known uppercase parent is still ordinary inheritance';
+}

--- a/t/oo/trait/uppercase-is-trait-reaches-trait-mod.t
+++ b/t/oo/trait/uppercase-is-trait-reaches-trait-mod.t
@@ -19,7 +19,7 @@ use Test;
 # `Alpha.^mro` as `Alpha, Any, Mu`. mutsu left the name in the parent list on
 # BOTH paths, giving every such class a phantom ancestor.
 
-plan 9;
+plan 12;
 
 use MONKEY-SEE-NO-EVAL;
 
@@ -54,4 +54,28 @@ throws-like 'class Delta is Explodes { }', X::AdHoc,
     class Base { method who { 'base' } }
     class Derived is Base { }
     is Derived.new.who, 'base', 'a known uppercase parent is still ordinary inheritance';
+}
+
+# A declaration that dies because no candidate claimed its trait must leave no
+# trace: the class shell is published BEFORE the dispatch runs (the handler has
+# to see the type object), so the name stayed registered and the next genuine
+# declaration of it died as a redeclaration. Merely `use Test` is enough to put
+# a `trait_mod:<is>` in scope, so this reached ordinary test files.
+{
+    try { EVAL 'class Reused is NotAnyTraitAtAll { }' };
+    lives-ok { EVAL 'class Reused { method m { 1 } }' },
+        'a failed trait declaration frees its name again';
+}
+
+# A class whose own trait is deferred may still declare nested types in its
+# body — those run their own registration before the outer dispatch, so the
+# outer rollback snapshot must not be the nested one's.
+{
+    multi sub trait_mod:<is>(Mu:U $doee, :$Outerish!) { %fired{'Outerish'} = $doee.^name }
+    class Outer is Outerish {
+        class Inner { method v { 7 } }
+        method use-inner { Inner.new.v }
+    }
+    is %fired{'Outerish'}, 'Outer', 'the enclosing class trait fired';
+    is Outer.new.use-inner, 7, 'and its nested class still resolves';
 }


### PR DESCRIPTION
Closes #7996.

The ecosystem parity ledger grouped 20 distributions under one cluster, "a class cannot inherit from a type declared in the same or an imported unit". The census the ticket asked for turned out to be the whole job: those 20 failures are **five different root causes**, not one, and they do not want the same fix. Three are fixed here, one was already fixed on `main` after the sweep measured, and the fifth — the real content of the cluster — is re-filed narrowly as #8099 with its own minimised repros.

The long-form write-up is `news/2026-09/an-uppercase-is-trait-is-still-a-trait.md`.

## 1. `class Foo is Static { }` never reached `trait_mod:<is>`

Raku decides what `is Foo` means from whether `Foo` names a known type, not from its capitalisation: an unknown name desugars to the **named** argument `trait_mod:<is>($type, :Foo)`. That is the entire public interface of the `Staticish` distribution.

`validate_class_parents` did defer an unknown parent to that dispatch — but only when the name began with an ASCII lowercase letter, so the spelling Raku programs actually use fell straight through to `X::Inheritance::UnknownParent`. The restriction is gone. It is safe because the dispatch site already turns a no-matching-candidate verdict back into `unknown_parent_error`, which `t/oo/trait/user-trait-mod-does-not-consume-every-trait.t` pins and which still passes unchanged.

One ordering change came with it: the `package A {}; class B is A {}` → `X::Inheritance::Unsupported` check now runs **before** the deferral. A declared package is not an unknown name, so rakudo hands it to `trait_mod:<is>` positionally, as the package object, never as the `:Name` named argument the deferral synthesises.

## 2. The deferred name was still becoming a parent

Widening the deferral exposed a second bug that had been sitting on the lowercase path all along — the trait name stayed in the class's C3 parents:

```
class Alpha is Marked { }
Alpha.^parents   mutsu: (Marked,)            rakudo: ()
Alpha.^mro       mutsu: Alpha,Marked,Any,Mu  rakudo: Alpha,Any,Mu
```

a phantom ancestor for every class that uses a class-level trait. Such a name now joins the `does`-role-sharing-the-class's-own-name case in the set `begin_class_def` filters out (`self_named_does_roles` → `non_inheritance_parents`).

And a deferral that turns out to have been wrong must leave no trace. The class shell is published *before* the dispatch runs — the handler has to be able to see the type object — so `register_class_decl` now hands its rollback snapshot on for the no-candidate case. Without it, a failed `class B is NoSuchParent { }` in any scope that declares a `trait_mod:<is>` at all (merely importing `Test` does) left `B` registered, and the next genuine `class B` died as a redeclaration. That is not hypothetical: it is what `t/oo/class/inheritance-unsupported.t` hit on the first run of this branch.

The snapshot is taken into a local immediately after registration rather than read off the field later, because a nested declaration in the class's own body runs its own `RegisterClass` op before the outer dispatch and would otherwise overwrite it.

## 3. A core type mutsu models natively could not be a parent

`class ValueClass::Attribute is Attribute { }` died as an unknown parent, blocking the `ValueClass` distribution and, through it, `Functional::Queue` and `Functional::Stack`. `Attribute` is a real type in mutsu — `::('Attribute')` yields the type object and `Interpreter::is_builtin_type` knows it — it simply has no `ClassDef` in `registry.classes`, and the existence check consulted no oracle that does.

`BUILTIN_INHERITABLE_TYPES` lists the 26 core types in that position, each checked against rakudo 2026.07 with `class Zz is <Name> { }` (rakudo compiles all of them). Two more distributions come off the same hook: `Timezones::ZoneInfo` (`is CX::Warn`) and `Protocol` (`is Metamodel::SubsetHOW`).

It is deliberately **separate** from `BUILTIN_PARENT_TYPES`, which also decides whether a `does` target is composable and whether a `but`-mixin may take the class-declaration path instead of the wrapper one — `types::role_mixin_class`'s own comment names `Attribute` as the example that must keep the wrapper. Only the `is`-parent existence check reads the new list, so `class Nope does Attribute { }` is rejected exactly as before and an `Attribute` mixin still wraps. Both are asserted.

## 4. Already fixed, ledger stale

`Test::Async::Metamodel::BundleHOW` / `OO::Plugin::Metamodel::PlugRoleHOW` `is Metamodel::ParametricRoleHOW` (`Test::Async`, `OO::Plugin`, `Config::BINDish`) are not a gap: `5926cbbc` added that name to `BUILTIN_PARENT_TYPES` at 2026-09-11 23:58 UTC, minutes after the sweep that produced the cluster measured `7807eb5`. Both compile on `main` today.

## 5. Re-filed

- **#8099** — `also is Parent` is applied at the class header instead of at its position in the body, so anything the body establishes first (a `use`, a nested class) is invisible to it. `Font::AFM`'s 14 `Font::Metrics::*` compunits and `Intl::CLDR`'s five `CLDR::*` types, with both shapes minimised. A different change in a different layer from anything here.
- **#8100** — the role-side mirror of §1 (`role R is Marked { }`). `RoleParentOp` records no `is`-vs-`does` flag, so widening the deferral there would also change the error for a `does` typo; it needs the flag first.

The rest of the cluster's 20 are cascades — the named parent's own compunit fails to load for an unrelated reason (`PDF::Content::Font::Enc`'s missing `NativeCall::Types`, `CSS::Grammar::AST`, `Parse::Paths`'s `BasePaths`), so the parent genuinely does not exist and the inheritance error is the symptom, not the disease.

## Tests

- `t/oo/trait/uppercase-is-trait-reaches-trait-mod.t` (12 assertions) — the uppercase trait fires its handler; the name reaches neither `^parents` nor `^mro`; the lowercase spelling still works and is likewise absent from the MRO; a name no candidate claims is still `X::Inheritance::UnknownParent`; an error from inside a matching handler still propagates; a known uppercase parent is still ordinary inheritance; a failed trait declaration frees its name again; a deferred-trait class may still declare nested types.
- `t/oo/class/builtin-inheritable-parent-types.t` (31 assertions) — all 26 names as an `is` parent, plus the three things that must NOT move.

Both files pass **verbatim under rakudo 2026.07** as well as under mutsu.

Ran locally before publishing: `cargo fmt --all`, `make lint` (all four configurations) green; `make test` green (4073 files, 43359 tests); `make roast` red only on the three files `docs/agent-environments.md` documents for this container — `6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` (`id -u` is 0 here, so the `chmod`-based assertions cannot pass) and `S32-io/IO-Socket-Async.t` (exit 124 under the network sandbox) — each with exactly the documented subtest range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pz6URmTWmqMP41wKgpjkRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pz6URmTWmqMP41wKgpjkRo)_