### PR TITLE
fix(nativecall): a CArray element write reaches native memory from any expression

### DIFF
--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -183,6 +183,38 @@ impl Interpreter {
             }
         }
 
+        // The accessor returned a `CArray[T]` *native handle*
+        // (`$b.c[1] = 5`, `.c` an attribute accessor): element assignment
+        // writes into native memory, not a throwaway Raku container --
+        // the accessor-lvalue mirror of the computed-target arm in
+        // `vm_var_assign_index_named.rs`'s `exec_index_assign_generic_op`
+        // (#8031). Checked before the ASSIGN-POS/ASSIGN-KEY dispatch below:
+        // a CArray handle never carries a user-defined one.
+        if let ValueView::Instance {
+            attributes,
+            class_name,
+            ..
+        } = current.view()
+            && attributes.contains_key("address")
+            && let Some(elem) = class_name
+                .resolve()
+                .strip_prefix("CArray[")
+                .and_then(|s| s.strip_suffix(']'))
+            && let Ok(pos) = index.to_string_value().parse::<usize>()
+        {
+            let base = attributes
+                .as_map()
+                .get("address")
+                .map(|v| crate::runtime::to_int(v) as usize)
+                .unwrap_or(0);
+            if self
+                .native_carray_element_assign(elem, base, pos, &value)
+                .is_some()
+            {
+                return Ok(value);
+            }
+        }
+
         // The accessor returned an Associative/Positional OBJECT (URI's
         // `$u.query<foo> = v` — `.query` yields a URI::Query instance):
         // dispatch the raku subscript protocol on it instead of treating it

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -4720,6 +4720,41 @@ impl Interpreter {
             _ => (raw_val, None, false),
         };
 
+        // A `CArray[T]` *native handle* produced by an expression -- a sub
+        // call, a method call, an attribute accessor -- rather than bound to
+        // a variable (`get()[2] = 7`, `$b.c[1] = 5`). `target` here is
+        // already the evaluated handle value, so this is the computed-target
+        // mirror of the by-name arm further down this file: element
+        // assignment writes into native memory instead of a throwaway Raku
+        // container the generic auto-vivify path below would otherwise
+        // silently replace the handle with (#8031).
+        if is_positional
+            && let ValueView::Instance {
+                attributes,
+                class_name,
+                ..
+            } = target.descalarize().view()
+            && attributes.contains_key("address")
+            && let Some(elem) = class_name
+                .resolve()
+                .strip_prefix("CArray[")
+                .and_then(|s| s.strip_suffix(']'))
+            && let Some(pos) = Self::index_to_usize(&idx)
+        {
+            let base = attributes
+                .as_map()
+                .get("address")
+                .map(|v| crate::runtime::to_int(v) as usize)
+                .unwrap_or(0);
+            if self
+                .native_carray_element_assign(elem, base, pos, &val)
+                .is_some()
+            {
+                self.stack.push(val);
+                return Ok(());
+            }
+        }
+
         // A positional subscript of a mutable collection producer keeps the
         // producer's element cells alive; assign through the cell (see
         // `try_seq_element_cell_assign`, shared with the named-receiver op).

--- a/t/nativecall/cstruct-carray-expr-index-write.t
+++ b/t/nativecall/cstruct-carray-expr-index-write.t
@@ -1,0 +1,35 @@
+use Test;
+use NativeCall;
+
+# Assigning into an index of a native CArray handle returned by an
+# expression -- a sub call, a method call, an attribute accessor -- used to
+# be a silent no-op (#8031): the write went into a throwaway Raku container
+# instead of native memory. Only a handle already bound to a variable
+# (`my $m = get(); $m[2] = 7;`) reached the write.
+
+plan 4;
+
+sub calloc(size_t, size_t --> Pointer) is native { * }
+sub free(Pointer) is native { * }
+
+my $arr = calloc(4, 4);
+sub get() { nativecast(CArray[int32], $arr) }
+
+get()[2] = 7;
+is get()[2], 7, 'a sub-call-returned CArray handle writes through its index';
+
+class Box { has $.c; }
+my $b = Box.new(c => nativecast(CArray[int32], $arr));
+$b.c[1] = 5;
+is $b.c[1], 5, 'and so does an attribute-accessor-returned CArray handle';
+
+# Binding first already worked before this fix; pin it alongside so a
+# regression in either direction is caught by the same file.
+my $m = get();
+$m[0] = 9;
+is $m[0], 9, 'a CArray handle bound to a variable still writes through';
+
+# The two forms share the same underlying bytes.
+is get()[0], 9, 'the sub-call and the bound-variable form see the same memory';
+
+free($arr);

--- a/t/nativecall/nativecall-has-embedded-struct.t
+++ b/t/nativecall/nativecall-has-embedded-struct.t
@@ -149,11 +149,10 @@ is_run ｢use NativeCall;
     # parameterisation, and what matters is that it is a CArray and not a bare
     # `Pointer` (which cannot be indexed).
     ok $mat.m.^name.ends-with('CArray[int32]'), 'an inline array reads back as a CArray';
-    # Bound to a variable first on purpose: assigning into an index of a
-    # native CArray handle that came straight from a call is a separate
-    # pre-existing no-op (GH #8031).
-    my $m = $mat.m;
-    $m[2] = 7;
+    # Direct form (GH #8031): assigning into an index of the accessor's
+    # result, with no intermediate `my $m = $mat.m;` binding, writes into
+    # the same native memory.
+    $mat.m[2] = 7;
     is nativecast(Flat, $blk).c, 7, 'element 2 is the third word of the struct';
     is $mat.t, 42,                  'the tail sits past the whole array';
     free($blk);


### PR DESCRIPTION
## Summary

Assigning into an index of a native CArray handle silently did nothing
unless the handle was first bound to a variable. Both index-assignment
paths recognized a CArray handle by looking its **variable name** up in
`env`:

- `exec_index_assign_generic_op` (`vm_var_assign_index_named.rs`), for a
  computed target like `get()[2] = 7`, never even reached that lookup —
  its target is already the evaluated stack value, with no name to look
  up, so it fell into the generic Raku-container path and wrote into a
  throwaway array.
- `builtin_index_assign_method_lvalue` (`builtins_multidim_assign.rs`), for
  an accessor-returned handle like `$b.c[1] = 5`, called the accessor to
  get the current value and then dispatched `ASSIGN-POS`/`AT-POS` on it as
  though it were a plain Associative/Positional object.

Both now check the already-evaluated target/accessor-result value directly
for the CArray shape (an `Instance` with an `address` attribute and a
`CArray[...]` class name) and write through `native_carray_element_assign`
when it matches, before falling through to their generic paths.

Closes #8031

(This branch briefly carried a hotfix for an unrelated build breakage on
`main` — two other PRs landed a semantically conflicting change to
`local_attr_key`'s signature. `main` already had its own fix for that
[`0509e19e`] by the time this rebased, so that commit was dropped as
redundant; only the CArray fix below remains.)

## Test plan

- Added `t/nativecall/cstruct-carray-expr-index-write.t` (the issue's
  minimal repro, both the sub-call and accessor forms, plus the
  already-working bound-variable form pinned alongside).
- Restored the direct-form assertion in
  `t/nativecall/nativecall-has-embedded-struct.t` that had been worked
  around with an intermediate `my $m = $mat.m;` binding pending this fix.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run
  locally. `make roast` comes back with only the three environment-only
  failures documented in `docs/agent-environments.md` for a remote
  container (`roast/6.c/S32-io/file-tests.t`,
  `roast/S16-filehandles/filetest.t` — both `uid 0` chmod-based file tests
  — and `roast/S32-io/IO-Socket-Async.t`, sandboxed network); everything
  else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr