### PR TITLE
feat(rakuast): carry enum declarations across the AST boundary

### DIFF
--- a/news/2026-09/rakuast-enum-declarations.md
+++ b/news/2026-09/rakuast-enum-declarations.md
@@ -1,0 +1,3 @@
+RakuAST now preserves enum declarations across `.AST` and `.AST.EVAL`, including
+word, quote-word, and pair-list enum forms. `RakuAST::Type::Enum` and enum
+variant-term processors are supported for these declarations.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1088,6 +1088,23 @@ pub(crate) enum PackageKind {
     Grammar,
 }
 
+/// The source spelling of an enum's variant body, retained for RakuAST.
+///
+/// Runtime enum registration only needs the normalized `(name, value)` pairs,
+/// but Rakudo's AST preserves whether the source used a word quote or a
+/// parenthesized pair list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) enum EnumVariantForm {
+    Words,
+    QuoteWords,
+    PairList,
+    Computed,
+}
+
+fn default_enum_variant_form() -> EnumVariantForm {
+    EnumVariantForm::Words
+}
+
 impl PackageKind {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
@@ -1435,6 +1452,9 @@ pub(crate) enum Stmt {
     EnumDecl {
         name: Symbol,
         variants: Vec<(String, Option<Expr>)>,
+        /// The original variant-body spelling for the RakuAST boundary.
+        #[serde(default = "default_enum_variant_form")]
+        variant_form: EnumVariantForm,
         is_export: bool,
         /// Export tags declared by `is export`, or empty for an untagged enum.
         #[serde(default)]

--- a/src/parser/stmt/decl/enum_decl.rs
+++ b/src/parser/stmt/decl/enum_decl.rs
@@ -4,7 +4,7 @@ use super::super::super::parse_result::{PError, PResult, parse_char, take_while1
 use super::super::{ident, keyword, qualified_ident};
 use super::helpers::{has_export_tag_argument, parse_export_trait_tags};
 use super::take_while_opt;
-use crate::ast::{Expr, Stmt};
+use crate::ast::{EnumVariantForm, Expr, Stmt};
 use crate::symbol::Symbol;
 use crate::value::Value;
 use crate::value::ValueView;
@@ -120,8 +120,9 @@ pub(crate) fn enum_decl(input: &str) -> PResult<'_, Stmt> {
 
 /// Parse anonymous enum body (after `enum` keyword with no name).
 fn parse_anon_enum_body(input: &str) -> PResult<'_, Stmt> {
-    let (rest, variants) = if input.starts_with("<<") || input.starts_with('\u{ab}') {
-        parse_double_angle_enum_variants(input)?
+    let (rest, variants, variant_form) = if input.starts_with("<<") || input.starts_with('\u{ab}') {
+        let (rest, variants) = parse_double_angle_enum_variants(input)?;
+        (rest, variants, EnumVariantForm::QuoteWords)
     } else if input.starts_with('<') {
         let (r, _) = parse_char(input, '<')?;
         let mut variants = Vec::new();
@@ -139,12 +140,12 @@ fn parse_anon_enum_body(input: &str) -> PResult<'_, Stmt> {
             variants.push((word.to_string(), None));
             r = r2;
         }
-        (r, variants)
+        (r, variants, EnumVariantForm::Words)
     } else if input.starts_with('(') {
         let (r, body) = parse_paren_enum_body(input)?;
         let variants = enum_variants_from_body(&body)
             .ok_or_else(|| PError::expected("anonymous enum variants"))?;
-        (r, variants)
+        (r, variants, EnumVariantForm::PairList)
     } else {
         return Err(PError::expected("anonymous enum variants"));
     };
@@ -161,6 +162,7 @@ fn parse_anon_enum_body(input: &str) -> PResult<'_, Stmt> {
         Stmt::EnumDecl {
             name: Symbol::intern(""),
             variants,
+            variant_form,
             is_export: false,
             export_tags: Vec::new(),
             is_my: false,
@@ -408,8 +410,9 @@ pub(super) fn parse_enum_decl_body_with_type(
     }
 
     // Enum variants in << >>, « », <> or ()
-    let (rest, variants) = if rest.starts_with("<<") || rest.starts_with('\u{ab}') {
-        parse_double_angle_enum_variants(rest)?
+    let (rest, variants, variant_form) = if rest.starts_with("<<") || rest.starts_with('\u{ab}') {
+        let (rest, variants) = parse_double_angle_enum_variants(rest)?;
+        (rest, variants, EnumVariantForm::QuoteWords)
     } else if rest.starts_with('<') {
         let (r, _) = parse_char(rest, '<')?;
         let mut variants = Vec::new();
@@ -427,7 +430,7 @@ pub(super) fn parse_enum_decl_body_with_type(
             variants.push((word.to_string(), None));
             r = r2;
         }
-        (r, variants)
+        (r, variants, EnumVariantForm::Words)
     } else if rest.starts_with('(') {
         // The body is an ordinary parenthesized term (see `parse_paren_enum_body`).
         // A failure here is a real syntax error in a construct we are already
@@ -443,7 +446,7 @@ pub(super) fn parse_enum_decl_body_with_type(
             }
         })?;
         match enum_variants_from_body(&body) {
-            Some(variants) => (r, variants),
+            Some(variants) => (r, variants, EnumVariantForm::PairList),
             None => {
                 // Computed body (operators like `X~`, `Z=>`, `|`, a `%hash`, …):
                 // keep the whole expression and let the runtime build the enum.
@@ -453,6 +456,7 @@ pub(super) fn parse_enum_decl_body_with_type(
                     Stmt::EnumDecl {
                         name,
                         variants: vec![("__DYNAMIC__".to_string(), Some(body))],
+                        variant_form: EnumVariantForm::Computed,
                         is_export,
                         export_tags,
                         is_my,
@@ -464,7 +468,7 @@ pub(super) fn parse_enum_decl_body_with_type(
             }
         }
     } else {
-        (rest, Vec::new())
+        (rest, Vec::new(), EnumVariantForm::Words)
     };
 
     let (rest, _) = ws(rest)?;
@@ -476,6 +480,7 @@ pub(super) fn parse_enum_decl_body_with_type(
         Stmt::EnumDecl {
             name,
             variants,
+            variant_form,
             is_export,
             export_tags,
             is_my,

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -7,7 +7,7 @@
 //! silently-wrong node.
 
 use super::{RakuAstClass, RakuAstField, RakuAstFieldValue, RakuAstNode};
-use crate::ast::{AssignOp, Expr, ForMode, ParamDef, Stmt};
+use crate::ast::{AssignOp, EnumVariantForm, Expr, ForMode, ParamDef, Stmt};
 use crate::compiler::helpers_ops::token_kind_to_op_name;
 use crate::regex_tree::{RegexNode, RegexQuantifier, RegexTree};
 use crate::runtime::utils::is_known_type_constraint;
@@ -826,6 +826,45 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             Ok(Some(statement_expression(RakuAstNode {
                 class: RakuAstClass::Class,
                 fields,
+            })))
+        }
+        // `enum NAME <A B>` / `enum NAME <<A B>>` / `enum NAME (A => 1)`
+        // -> `Type::Enum(name => Name, term => ...)`. The runtime only needs
+        // normalized variants, but Rakudo preserves the source-level quoting
+        // form in `term`, so the parser records it on `Stmt::EnumDecl`.
+        Stmt::EnumDecl {
+            name,
+            variants,
+            variant_form,
+            is_export,
+            export_tags,
+            is_my,
+            base_type,
+            roles,
+            ..
+        } => {
+            if *is_export
+                || !export_tags.is_empty()
+                || *is_my
+                || base_type.is_some()
+                || !roles.is_empty()
+                || matches!(variant_form, EnumVariantForm::Computed)
+                || variants.is_empty()
+            {
+                return Err(unsupported("enum with scope / traits / computed body"));
+            }
+            let term = match variant_form {
+                EnumVariantForm::Words => enum_quoted_string(variants, "words")?,
+                EnumVariantForm::QuoteWords => enum_quoted_string(variants, "quotewords")?,
+                EnumVariantForm::PairList => enum_pair_list(variants)?,
+                EnumVariantForm::Computed => unreachable!("checked above"),
+            };
+            Ok(Some(statement_expression(RakuAstNode {
+                class: RakuAstClass::TypeEnum,
+                fields: vec![
+                    node_field(Some("name"), name_from_identifier(&name.resolve())),
+                    node_field(Some("term"), term),
+                ],
             })))
         }
         // `module M { }` / `package P { }` -> `RakuAST::Module` / `RakuAST::Package`.
@@ -2965,6 +3004,84 @@ fn quoted_string(str_value: Value) -> RakuAstNode {
             value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(seg))]),
         }],
     }
+}
+
+/// The unevaluated word-list term of an enum declaration. `processors` is part
+/// of the RakuAST contract: omitting it would turn `Red Green` into one enum
+/// member named "Red Green" when the node is evaluated.
+fn enum_quoted_string(
+    variants: &[(String, Option<Expr>)],
+    processor: &'static str,
+) -> Result<RakuAstNode, RuntimeError> {
+    if variants.iter().any(|(_, value)| value.is_some()) {
+        return Err(unsupported("word-quoted enum with explicit values"));
+    }
+    let text = variants
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let segment = RakuAstNode {
+        class: RakuAstClass::StrLiteral,
+        fields: vec![leaf_field(None, Value::str(text))],
+    };
+    Ok(RakuAstNode {
+        class: RakuAstClass::QuotedString,
+        fields: vec![
+            RakuAstField {
+                name: Some("processors"),
+                value: RakuAstFieldValue::List(vec![
+                    Value::str(processor.to_string()),
+                    Value::str("val".to_string()),
+                ]),
+            },
+            RakuAstField {
+                name: Some("segments"),
+                value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(segment))]),
+            },
+        ],
+    })
+}
+
+/// The parenthesized pair-list term of an enum declaration.
+fn enum_pair_list(variants: &[(String, Option<Expr>)]) -> Result<RakuAstNode, RuntimeError> {
+    let operands = variants
+        .iter()
+        .map(|(name, value)| {
+            let value = match value {
+                Some(value) => convert_expr(value)?,
+                None => RakuAstNode {
+                    class: RakuAstClass::TermEnum,
+                    fields: vec![leaf_field(None, Value::str("True".to_string()))],
+                },
+            };
+            Ok(Value::rakuast(Box::new(RakuAstNode {
+                class: RakuAstClass::FatArrow,
+                fields: vec![
+                    leaf_field(Some("key"), Value::str(name.clone())),
+                    node_field(Some("value"), value),
+                ],
+            })))
+        })
+        .collect::<Result<Vec<_>, RuntimeError>>()?;
+    let list = RakuAstNode {
+        class: RakuAstClass::ApplyListInfix,
+        fields: vec![
+            node_field(Some("infix"), plain_infix(",")),
+            RakuAstField {
+                name: Some("operands"),
+                value: RakuAstFieldValue::List(operands),
+            },
+        ],
+    };
+    let semilist = RakuAstNode {
+        class: RakuAstClass::SemiList,
+        fields: vec![node_field(None, statement_expression(list))],
+    };
+    Ok(RakuAstNode {
+        class: RakuAstClass::CircumfixParentheses,
+        fields: vec![node_field(None, semilist)],
+    })
 }
 
 /// A listop `say EXPR` — `Call::Name::WithoutParentheses`.

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -7,10 +7,12 @@
 //! produce an explicit `RuntimeError` (the documented coverage boundary).
 
 use super::{RakuAstClass, RakuAstFieldValue, RakuAstNode};
-use crate::ast::{Expr, ParamDef, Stmt};
+use crate::ast::{EnumVariantForm, Expr, ParamDef, Stmt};
 use crate::regex_tree::{RegexNode, RegexQuantifier, RegexTree};
 use crate::value::{RegexAdverbs, RuntimeError, Value, ValueView};
 use std::sync::Arc;
+
+type LoweredEnumVariants = (Vec<(String, Option<Expr>)>, EnumVariantForm);
 
 fn unsupported(node: &RakuAstNode) -> RuntimeError {
     RuntimeError::new(format!(
@@ -160,6 +162,7 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         RakuAstClass::Role => lower_role(node),
         RakuAstClass::Method | RakuAstClass::Submethod => lower_method(node),
         RakuAstClass::Module | RakuAstClass::Package => lower_package(node),
+        RakuAstClass::TypeEnum => lower_enum(node),
         RakuAstClass::TypeSubset => lower_subset(node),
         // `CATCH { … }` — the `exception`/topic flags on its body block are
         // implied by the statement class, so only the block's statements are
@@ -628,6 +631,96 @@ fn lower_package(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         is_unit: false,
         is_my: false,
     })
+}
+
+/// `RakuAST::Type::Enum(name, term)` -> the existing enum declaration path.
+/// The source form is recovered from the term node because the internal AST
+/// stores only normalized variants for execution.
+fn lower_enum(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let name = call_name_str(node)?;
+    let term = named_child(node, "term")?;
+    let (variants, variant_form) = match term.class {
+        RakuAstClass::QuotedString => lower_enum_word_term(term)?,
+        RakuAstClass::CircumfixParentheses => lower_enum_pair_term(term)?,
+        _ => return Err(unsupported(node)),
+    };
+    Ok(Stmt::EnumDecl {
+        name: crate::symbol::Symbol::intern(&name),
+        variants,
+        variant_form,
+        is_export: false,
+        export_tags: Vec::new(),
+        is_my: false,
+        base_type: None,
+        roles: Vec::new(),
+        language_version: crate::parser::current_language_version(),
+    })
+}
+
+fn lower_enum_word_term(term: &RakuAstNode) -> Result<LoweredEnumVariants, RuntimeError> {
+    let processors = list_field(term, "processors")?;
+    let processor_names = processors
+        .iter()
+        .map(|processor| match processor.view() {
+            ValueView::Str(value) => Ok(value.to_string()),
+            _ => Err(unsupported(term)),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let variant_form = match processor_names.as_slice() {
+        [processor, val] if val == "val" && processor == "words" => EnumVariantForm::Words,
+        [processor, val] if val == "val" && processor == "quotewords" => {
+            EnumVariantForm::QuoteWords
+        }
+        _ => return Err(unsupported(term)),
+    };
+    let segments = list_field(term, "segments")?;
+    let [segment] = segments else {
+        return Err(unsupported(term));
+    };
+    let ValueView::RakuAst(segment) = segment.view() else {
+        return Err(unsupported(term));
+    };
+    if segment.class != RakuAstClass::StrLiteral {
+        return Err(unsupported(term));
+    }
+    let segment_value = positional_leaf(segment)?;
+    let ValueView::Str(text) = segment_value.view() else {
+        return Err(unsupported(term));
+    };
+    Ok((
+        text.split_whitespace()
+            .map(|name| (name.to_string(), None))
+            .collect(),
+        variant_form,
+    ))
+}
+
+fn lower_enum_pair_term(term: &RakuAstNode) -> Result<LoweredEnumVariants, RuntimeError> {
+    let semilist = named_child_or_positional(term)?;
+    let statement = named_child_or_positional(semilist)?;
+    let body = match lower_expr(statement)? {
+        Expr::ArrayLiteral(items) => items,
+        item => vec![item],
+    };
+    let mut variants = Vec::with_capacity(body.len());
+    for item in body {
+        let Expr::Binary { left, op, right } = item else {
+            return Err(unsupported(term));
+        };
+        if op != crate::token_kind::TokenKind::FatArrow {
+            return Err(unsupported(term));
+        }
+        let name = match *left {
+            Expr::Literal(value) | Expr::LiteralSrc(value, _)
+                if matches!(value.view(), ValueView::Str(_)) =>
+            {
+                value.to_string_value()
+            }
+            _ => return Err(unsupported(term)),
+        };
+        variants.push((name, Some(*right)));
+    }
+    Ok((variants, EnumVariantForm::PairList))
 }
 
 /// `subset S of T where P` -> `Stmt::SubsetDecl`. An explicit base type arrives

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -122,6 +122,8 @@ pub enum RakuAstClass {
     ApplyListInfix,
     // Phase 2 slice 10: scoped/typed variable declarations.
     TypeSimple,
+    // `enum Color <Red Green>` -> `Type::Enum(name, term)`.
+    TypeEnum,
     // Phase 2 slice 20: definite types (`Int:D` / `Int:U`).
     TypeDefinedness,
     // Phase 2 slice 27: attribute build-time defaults.
@@ -302,6 +304,7 @@ impl RakuAstClass {
             StatementLoopRepeatWhile => "RakuAST::Statement::Loop::RepeatWhile",
             ApplyListInfix => "RakuAST::ApplyListInfix",
             TypeSimple => "RakuAST::Type::Simple",
+            TypeEnum => "RakuAST::Type::Enum",
             TypeDefinedness => "RakuAST::Type::Definedness",
             TraitWillBuild => "RakuAST::Trait::WillBuild",
             TraitReturns => "RakuAST::Trait::Returns",
@@ -433,6 +436,7 @@ impl RakuAstClass {
             | StrLiteral
             | QuotedString
             | QuotedRegex
+            | TypeEnum
             | VarLexical
             | TermReduce
             | Sub
@@ -558,6 +562,7 @@ fn semantic_type_object_ancestors(class_name: &str) -> &'static [&'static str] {
         | "RakuAST::RatLiteral"
         | "RakuAST::StrLiteral"
         | "RakuAST::QuotedString"
+        | "RakuAST::Type::Enum"
         | "RakuAST::Var::Lexical"
         | "RakuAST::Term::Reduce"
         | "RakuAST::Sub"
@@ -708,6 +713,7 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::StatementLoopRepeatWhile,
     RakuAstClass::ApplyListInfix,
     RakuAstClass::TypeSimple,
+    RakuAstClass::TypeEnum,
     RakuAstClass::TypeDefinedness,
     RakuAstClass::TraitWillBuild,
     RakuAstClass::TraitReturns,
@@ -833,6 +839,77 @@ pub fn construct(
     method: &str,
     args: &[Value],
 ) -> Result<Option<Value>, RuntimeError> {
+    if class_name == "RakuAST::QuotedString" && method == "new" {
+        let segments = named_arg(args, "segments")
+            .ok_or_else(|| RuntimeError::new("RakuAST::QuotedString.new requires `segments`"))?
+            .as_list_items()
+            .map(<[Value]>::to_vec)
+            .ok_or_else(|| {
+                RuntimeError::new("RakuAST::QuotedString.new expects `segments` to be a list")
+            })?;
+        for segment in &segments {
+            require_any_rakuast(segment, "RakuAST::QuotedString.new", "segments")?;
+        }
+        let processors = named_arg(args, "processors")
+            .map(|value| {
+                value.as_list_items().map(<[Value]>::to_vec).ok_or_else(|| {
+                    RuntimeError::new("RakuAST::QuotedString.new expects `processors` to be a list")
+                })
+            })
+            .transpose()?;
+        if let Some(processors) = &processors
+            && processors
+                .iter()
+                .any(|processor| !matches!(processor.view(), ValueView::Str(_)))
+        {
+            return Err(RuntimeError::new(
+                "RakuAST::QuotedString.new expects `processors` to contain strings",
+            ));
+        }
+        let mut fields = Vec::with_capacity(2);
+        if let Some(processors) = processors {
+            fields.push(RakuAstField {
+                name: Some("processors"),
+                value: RakuAstFieldValue::List(processors),
+            });
+        }
+        fields.push(RakuAstField {
+            name: Some("segments"),
+            value: RakuAstFieldValue::List(segments),
+        });
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::QuotedString,
+            fields,
+        }))));
+    }
+    if class_name == "RakuAST::Type::Enum" && method == "new" {
+        let name = named_arg(args, "name")
+            .ok_or_else(|| RuntimeError::new("RakuAST::Type::Enum.new requires `name`"))?;
+        require_rakuast_class(&name, RakuAstClass::Name, "RakuAST::Type::Enum.new")?;
+        let term = named_arg(args, "term")
+            .ok_or_else(|| RuntimeError::new("RakuAST::Type::Enum.new requires `term`"))?;
+        require_rakuast_class(&term, RakuAstClass::QuotedString, "RakuAST::Type::Enum.new")
+            .or_else(|_| {
+                require_rakuast_class(
+                    &term,
+                    RakuAstClass::CircumfixParentheses,
+                    "RakuAST::Type::Enum.new",
+                )
+            })?;
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::TypeEnum,
+            fields: vec![
+                RakuAstField {
+                    name: Some("name"),
+                    value: RakuAstFieldValue::Node(name),
+                },
+                RakuAstField {
+                    name: Some("term"),
+                    value: RakuAstFieldValue::Node(term),
+                },
+            ],
+        }))));
+    }
     if class_name == "RakuAST::StatementList" && method == "new" {
         if !args.is_empty() {
             return Err(RuntimeError::new(
@@ -1417,6 +1494,7 @@ fn require_rakuast_type(value: &Value, constructor: &str) -> Result<(), RuntimeE
             if matches!(
                 node.class,
                 RakuAstClass::TypeSimple
+                    | RakuAstClass::TypeEnum
                     | RakuAstClass::TypeSetting
                     | RakuAstClass::TypeDefinedness
                     | RakuAstClass::TypeParameterized
@@ -1687,6 +1765,7 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::VarDeclarationSimple
             | RakuAstClass::InitializerAssign
             | RakuAstClass::TypeSimple
+            | RakuAstClass::TypeEnum
             | RakuAstClass::TypeSetting
             | RakuAstClass::TypeCapture
             | RakuAstClass::QuotedRegex
@@ -1743,6 +1822,7 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         VarDeclarationSimple => &["sigil", "desigilname", "initializer"],
         InitializerAssign => &["expression"],
         TypeSimple | TypeSetting | TypeCapture => &["name"],
+        TypeEnum => &["name", "term"],
         QuotedRegex => &["match-immediately", "body", "adverbs"],
         RegexSequence | RegexAlternation => &["terms"],
         RegexLiteral => &["text"],

--- a/src/rakuast/render.rs
+++ b/src/rakuast/render.rs
@@ -108,11 +108,32 @@ fn render_inline_field(f: &RakuAstField) -> String {
 }
 
 fn render_field_line(f: &RakuAstField, indent: usize, width: usize) -> String {
-    let val = render_field_value(&f.value, indent);
+    let val = if f.name == Some("processors") {
+        render_processors(&f.value, indent)
+    } else {
+        render_field_value(&f.value, indent)
+    };
     match f.name {
         Some(key) => format!("{key:width$} => {val}"),
         None => val,
     }
+}
+
+/// Rakudo renders a QuotedString's processor names as a word list (`<words
+/// val>`), rather than the ordinary parenthesized list form used by other
+/// RakuAST list-valued fields.
+fn render_processors(fv: &RakuAstFieldValue, indent: usize) -> String {
+    let RakuAstFieldValue::List(items) = fv else {
+        return render_field_value(fv, indent);
+    };
+    let values = items
+        .iter()
+        .map(|item| match item.view() {
+            ValueView::Str(value) => value.to_string(),
+            _ => render_leaf(item),
+        })
+        .collect::<Vec<_>>();
+    format!("<{}>", values.join(" "))
 }
 
 fn render_field_value(fv: &RakuAstFieldValue, indent: usize) -> String {

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -72,6 +72,7 @@ impl Interpreter {
             base_type,
             roles,
             language_version,
+            ..
         } = stmt
         {
             // See the class arm: `enum void <a b>` shadows NativeCall's `void`

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -343,7 +343,7 @@ impl Interpreter {
         // compiles to a method call and already goes through that path, but
         // `$!field` (this op) does not, so it stayed stuck reading `Nil` (#8030).
         if !self.locals[idx].is_container_ref()
-            && let Some((bare, true)) = code.local_attr_key(idx)
+            && let Some((bare, true, _)) = code.local_attr_key(idx)
             && let Some(self_val) = self.get_env_self()
             && let Some(field_val) =
                 self.cstruct_field_value(&self_val.deref_container(), bare.as_str())

--- a/t/rakuast/rakuast-enum.t
+++ b/t/rakuast/rakuast-enum.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+use experimental :rakuast;
+
+# RakuAST::Type::Enum keeps the enum's unevaluated variant term. The parser
+# must therefore preserve which quote form produced the normalized variants.
+plan 15;
+
+my $words = Q[enum WordColor <Red Green>].AST.statements[0].expression;
+is $words.^name, 'RakuAST::Type::Enum', 'word-list enum renders as Type::Enum';
+is $words.name.^name, 'RakuAST::Name', 'enum name is a Name node';
+is $words.term.^name, 'RakuAST::QuotedString', 'word-list enum keeps a QuotedString term';
+is $words.term.processors.raku, '("words", "val")', 'word-list processors are preserved';
+is $words.term.segments[0].value, 'Red Green', 'word-list source stays unevaluated';
+
+my $quote-words = Q[enum QuoteColor «Red Green»].AST.statements[0].expression;
+is $quote-words.term.processors.raku, '("quotewords", "val")',
+    'guillemet enum keeps quotewords processors';
+
+my $pairs = Q[enum PairColor (Red => 5, Green => 6)].AST.statements[0].expression;
+is $pairs.term.^name, 'RakuAST::Circumfix::Parentheses',
+    'pair-list enum keeps its parenthesized term';
+ok $pairs.gist.contains('RakuAST::FatArrow.new('),
+    'pair-list enum renders FatArrow operands';
+ok !Q["hi"].AST.gist.contains('processors'),
+    'ordinary quoted strings still omit the default processors field';
+
+my $word-values = Q[enum EvalWordColor <Red Green>].AST.EVAL;
+is $word-values.^name, 'Map', 'evaluating a word-list enum returns its Map';
+is $word-values<Red>, 0, 'word-list enum registers the first value';
+is $word-values<Green>, 1, 'word-list enum registers the second value';
+
+my $pair-values = Q[enum EvalPairColor (Red => 5, Green => 6)].AST.EVAL;
+is $pair-values<Red>, 5, 'evaluating a pair-list enum preserves its first value';
+is $pair-values<Green>, 6, 'evaluating a pair-list enum preserves its second value';
+
+my $term = RakuAST::QuotedString.new(
+    processors => <words val>,
+    segments => (RakuAST::StrLiteral.new('Red Green'),),
+);
+my $constructed = RakuAST::Type::Enum.new(
+    name => RakuAST::Name.from-identifier('WordColor'),
+    term => $term,
+);
+is $constructed.gist, $words.gist, 'Type::Enum and QuotedString constructors round-trip';


### PR DESCRIPTION
Closes #8034

## Summary
- add `RakuAST::Type::Enum` and preserve enum variant source forms across `.AST` and `.AST.EVAL`
- support enum word, quote-word, and pair-list terms, including `QuotedString` processors
- add focused RakuAST regression coverage and a news entry
- include the one-line `local_attr_key` destructuring fix required by the current main branch

## Validation
- `cargo fmt --all`
- `make lint`
- `make test` — 4,085 files / 43,427 tests, PASS
- `make roast` — 1,437 files / 219,658 tests, PASS