### PR TITLE
perf(vm): decide a plain scalar store's flavour once instead of 2,000 lines

### DIFF
--- a/news/2026-09/plain-scalar-store-decides-its-flavour-once.md
+++ b/news/2026-09/plain-scalar-store-decides-its-flavour-once.md
@@ -1,0 +1,91 @@
+# A plain scalar store decides its flavour once, instead of falling through 2,000 lines
+
+`exec_set_local_op_inner` is the VM's whole-variable store. It is also one long
+cascade of store-*flavour* tests — is this a `:=` bind, a rebind, a `constant`, a
+declaration, an array share, a `%`/`@` container assignment, an attribute write,
+a `Proxy`, a shared cell, a typed lexical, an `is default(...)` variable, an
+atomic, a sigilless alias — and `$i = $i + 1` fell through every one of them.
+[#8094](https://github.com/tokuhirom/mutsu/issues/8094) measured what that cost:
+**746 instructions of self cost per store**, 21.6% of a `while` loop that does
+nothing but compare, add and store.
+
+The interesting part of that number is that it is not a hot spot. Nothing in the
+cascade is expensive on its own; it is a dozen inert helpers at 20-60
+instructions each, and the list reads like a catalogue of questions the store
+could have answered without asking:
+
+| per store | what it asked | why the answer was already known |
+| --- | --- | --- |
+| 58 | `scalar_attr_type_constraint` | the name has no `!`/`.` twigil |
+| 36 | `maybe_tied_store_reassign` | the name has no `@`/`%` sigil |
+| 27 | `reset_nil_untyped_scalar` | the value is not `Nil` |
+| 25 | `update_bound_decont_marker` | no `:=`-bound decont marker exists |
+| 20 | `reset_atomic_var_key` | the program has no atomic variable |
+| 20 | `mirror_attr_local_to_cell` | the name is not an attribute |
+| 20 | `normalize_scalar_assignment_value` | the value is not a 1-element `Seq` |
+| 19 | `resolve_pending_alias_binds` | nothing is pending |
+| 18 | `term_symbol_from_name`, twice | the name is not `term:<…>` |
+
+Each is individually too small to be worth a local fix, and a local fix would
+not help anyway: the cost is the *shape*, not any one line. So the fix is a
+single decision taken up front, split in two halves.
+
+The **compile-time half** is a new per-slot bitmap, `CompiledCode::simple_scalar_locals`
+— a strict subset of the existing `plain_locals`, adding "not a `term:<…>`
+definition" and "not a `__ANON` container slot". A slot in it is an ordinary user
+scalar (`my $i` is stored as `"i"`), and its *name* settles every sigil, twigil,
+attribute, topic, term and anon branch of the cascade, at the point where the
+name is already in hand.
+
+The **runtime half** is `exec_set_local_scalar_fast`, a guard block at the top of
+`exec_set_local_op` in which every guard stands in for exactly one branch below
+it: the packed mark word is clear (so there is no bind/decl/constant flavour —
+and nothing to consume either), none of the monotonic metadata latches is armed
+(`bound_array_slice_possible`, `sigilless_readonly_keys_possible`,
+`closure_meta_keys_possible`, `atomic_var_seen_anywhere`,
+`env_type_constraint_seen`), no collection that would have to be walked is
+non-empty (`pending_alias_bind_names`, `local_bind_pairs`, `var_defaults`,
+`thread_decl_in_flight`, `our_locals`), and two new pure tag probes say the
+incoming value is an ordinary scalar and the slot holds one rather than a cell,
+`Proxy` or phantom hash entry. The one env probe that survives is the one the
+full path would have run anyway. A guard that fails is never wrong — it just
+takes the unchanged slow path, so the cascade remains the single definition of
+what a store means.
+
+What the fast path then *does* is three things: itemize the value into its `$`
+container (`itemize_scalar_store_value`, minus the name half that the bitmap
+settled), write the slot, and take the same `(B)` per-store env-mirror decision
+the full path takes.
+
+## Measured
+
+Callgrind, release, `MUTSU_JIT=off MUTSU_GC=off`, the ticket's own control loop
+(20,000 iterations of `$i = $i + 1`):
+
+| | before | after |
+| --- | --- | --- |
+| `SetLocal`, inclusive per store | 1,161 Ir | **312 Ir** (-73%) |
+| whole program | 77,867,825 Ir | **60,746,320 Ir** (-22.0%) |
+
+`exec_set_local_op_inner` drops out of the profile entirely for this program —
+only the one `my $i = 0;` declaration still reaches it.
+
+## Pin
+
+`t/vm/binding/assign-plain-scalar-store-fast-path.t` drives a plain scalar store
+through each branch the guards stand in for — itemization of an Array/Hash/Range/Seq
+into a `$`, the `Nil` reset for both an untyped and a typed scalar, a typed
+lexical's check, `is default(...)`, a `:=` alias in both directions, a
+write-through to an element-bound scalar, a `Proxy`'s `STORE`, an atomic
+variable, the topic, an attribute, an `our` mirror, a closure capture, a `state`
+accumulator, a `use fatal` `Failure`, and a named sub writing an outer scalar —
+and pins that every answer is what it was when every store fell through the whole
+cascade. All 28 assertions were verified against the rakudo oracle first.
+
+## Still open
+
+The ticket's second row — a *closure-creation* store at 1,110 instructions — is
+narrowed but not closed by this: `my $c = * + 1;` is a declaration, so its
+`VARDECL` mark keeps it on the slow path by construction. Hoisting the
+declaration flavours the same way is the natural follow-on, and a bigger job,
+because a declaration really does have per-slot work to do.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1914,6 +1914,9 @@ impl Compiler {
         self.code
             .plain_locals
             .push(Self::is_plain_lexical_name(name));
+        self.code
+            .simple_scalar_locals
+            .push(Self::is_simple_scalar_store_name(name));
         self.local_map.insert(name.to_string(), slot);
         slot
     }
@@ -1928,6 +1931,18 @@ impl Compiler {
             && !name.contains("::")
             && !name.starts_with("__mutsu_")
             && !name.starts_with("__ANON")
+    }
+
+    /// See [`CompiledCode::simple_scalar_locals`]. A plain lexical name, minus
+    /// the two shapes that still reach a name-derived branch of the store
+    /// cascade: a `term:<...>` definition (mirrored into its own and its
+    /// package-qualified env keys on every store) and a compiler-synthesised
+    /// anonymous container slot (`__ANON_HASH__`, which `is_plain_lexical_name`
+    /// only rejects as a *prefix*).
+    pub(crate) fn is_simple_scalar_store_name(name: &str) -> bool {
+        Self::is_plain_lexical_name(name)
+            && !crate::runtime::utils::has_anon_marker(name)
+            && crate::runtime::Interpreter::term_symbol_from_name(name).is_none()
     }
 
     /// Store a finalized closure body in this frame's `closure_compiled_codes`,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4364,6 +4364,23 @@ pub(crate) struct CompiledCode {
     /// rather than on every store (`flush_local_to_env` runs on each `my $x =
     /// ...`).
     pub(crate) plain_locals: Vec<bool>,
+    /// Bitmap: true if a store into `local[i]` can take the plain-scalar fast
+    /// path in `exec_set_local_op` — i.e. the slot's *name* alone makes every
+    /// name-derived branch of the store cascade inert.
+    ///
+    /// A strict subset of [`CompiledCode::plain_locals`]: on top of "no sigil,
+    /// twigil, qualifier, attribute marker, topic or compiler-internal name" it
+    /// also rules out a `term:<...>` definition (which mirrors itself into two
+    /// extra env keys) and any `__ANON` container slot. What remains is the
+    /// ordinary user scalar (`my $i` -> `"i"`, a scalar parameter `$n` -> `"n"`)
+    /// whose store has no container identity to preserve, no attribute cell to
+    /// mirror, no `is default` / atomic / alias lane keyed on its name, and no
+    /// `@`/`%` coercion to run — see the fast path's own doc comment for the
+    /// full list and for the runtime half of the decision.
+    ///
+    /// Like `plain_locals` this is a scan of the name's bytes, so it is settled
+    /// once per slot at compile time instead of on every store.
+    pub(crate) simple_scalar_locals: Vec<bool>,
     /// Maps local slot indices to persistent state keys for `state` variables.
     pub(crate) state_locals: Vec<(usize, Symbol)>,
     /// Maps local slot indices to qualified package names for `our` variables.
@@ -5494,6 +5511,7 @@ impl CompiledCode {
             locals_bound_slice_sym: Vec::new(),
             locals_scalar_no_container_sym: Vec::new(),
             plain_locals: Vec::new(),
+            simple_scalar_locals: Vec::new(),
             state_locals: Vec::new(),
             our_locals: Vec::new(),
             param_bind_names: Vec::new(),

--- a/src/runtime/mark_context.rs
+++ b/src/runtime/mark_context.rs
@@ -92,6 +92,18 @@ impl MarkContextState {
         | bit::EXPLICIT_INITIALIZER
         | bit::VARDECL;
 
+    /// Whether *no* store-flavour mark is pending: the next store is a plain
+    /// `=` into an already-declared variable, with no bind, rebind, `constant`,
+    /// declaration, initializer or array-share flavour to apply.
+    ///
+    /// One load and one test, and — because there is then nothing to clear —
+    /// it leaves the word alone, which is what lets the plain-scalar store fast
+    /// path decide its whole flavour question before it touches the stack.
+    #[inline]
+    pub(crate) fn store_flags_clear(&self) -> bool {
+        self.flags.get() & Self::CONSUMED_BY_STORE == 0
+    }
+
     /// Snapshot the flag word and clear everything a store consumes, in one
     /// load and one store. See [`MarkFlags`].
     #[inline]

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -528,6 +528,15 @@ impl Interpreter {
         self.var_defaults.insert(name.to_string(), value);
     }
 
+    /// Whether any variable in this program carries an `is default(...)` trait.
+    /// When false, no store has a default to substitute for a `Nil` and no
+    /// declaration has a stale one to clear — the gate the plain-scalar store
+    /// fast path asks before committing.
+    #[inline(always)]
+    pub(crate) fn has_var_defaults(&self) -> bool {
+        !self.var_defaults.is_empty()
+    }
+
     /// Get the default value for a variable, if one was set with `is default(...)`.
     pub(crate) fn var_default(&self, name: &str) -> Option<&Value> {
         if self.var_defaults.is_empty() {

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -366,6 +366,57 @@ impl NanBox {
         matches!(classify(self.0.get()), Classified::Kind(Kind::LazyList))
     }
 
+    /// Whether this word is a value that a plain `$x = ...` scalar store can
+    /// take through the narrow path in `exec_set_local_op_inner` — i.e. it is
+    /// NOT one of the kinds that store has to unwrap, reshape or record on the
+    /// way in (a `:=` source wrapper, a Proxy to FETCH through, a lazy sequence
+    /// to itemize, a shared cell to decontainerize, a thunk that marks the
+    /// variable readonly, or the `Nil` that resets an untyped scalar to `Any`).
+    ///
+    /// A pure tag probe, for the same reason as
+    /// [`Self::needs_element_itemization`]: it runs before anything else on the
+    /// hottest write path in the VM, and `view()` on a lazy `Match` would force
+    /// the match (ADR-0016 P5).
+    #[inline]
+    pub(in crate::value) fn is_plain_scalar_store_payload(&self) -> bool {
+        !matches!(
+            classify(self.0.get()),
+            Classified::Kind(
+                Kind::VarRef
+                    | Kind::Proxy
+                    | Kind::Seq
+                    | Kind::Slip
+                    | Kind::LazyList
+                    | Kind::ContainerRef
+                    | Kind::ContainerRefItemized
+                    | Kind::ContainerView
+                    | Kind::HashEntryRef
+                    | Kind::LazyThunk
+                    | Kind::Scalar
+                    | Kind::Nil
+            )
+        )
+    }
+
+    /// Whether a local slot holding this word can be overwritten outright by a
+    /// plain scalar store. The three write-through holders cannot: a
+    /// `ContainerRef` stores into its shared cell, a `Proxy` runs its `STORE`,
+    /// and a `HashEntryRef` materializes its phantom entry. A pure tag probe,
+    /// for the same reason as [`Self::is_plain_scalar_store_payload`].
+    #[inline]
+    pub(in crate::value) fn is_plain_scalar_store_slot(&self) -> bool {
+        !matches!(
+            classify(self.0.get()),
+            Classified::Kind(
+                Kind::ContainerRef
+                    | Kind::ContainerRefItemized
+                    | Kind::ContainerView
+                    | Kind::Proxy
+                    | Kind::HashEntryRef
+            )
+        )
+    }
+
     /// Whether this word is one of the kinds ADR-0040's element store itemizes
     /// (`Value::needs_element_itemization`) — a pure tag probe.
     ///

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -706,6 +706,22 @@ impl Value {
         self.0.is_lazy_thunk()
     }
 
+    /// Whether a plain `$x = ...` scalar store can take this value through its
+    /// narrow path (`Interpreter::exec_set_local_scalar_fast`). A pure tag
+    /// probe (see [`Self::is_junction_value`]).
+    #[inline]
+    pub(crate) fn is_plain_scalar_store_payload(&self) -> bool {
+        self.0.is_plain_scalar_store_payload()
+    }
+
+    /// Whether a local slot holding this value can be overwritten outright by a
+    /// plain scalar store, rather than written *through*. A pure tag probe (see
+    /// [`Self::is_junction_value`]).
+    #[inline]
+    pub(crate) fn is_plain_scalar_store_slot(&self) -> bool {
+        self.0.is_plain_scalar_store_slot()
+    }
+
     /// Whether this is a `Package` type object. A pure tag probe (see
     /// [`Self::is_junction_value`]).
     #[inline]

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -292,11 +292,140 @@ impl Interpreter {
         })
     }
 
+    /// The plain `$x = <ordinary scalar>` store: an already-declared user
+    /// scalar, no store-flavour mark pending, and none of the rare metadata
+    /// lanes the full cascade exists to serve in play. Returns `false` without
+    /// touching the stack or any flag when a guard fails, so the caller falls
+    /// through to [`Interpreter::exec_set_local_op`]'s full path unchanged.
+    ///
+    /// `exec_set_local_op_inner` is ~2,000 lines of store-*flavour* cascade, and
+    /// a plain scalar store fell through all of it: 746 instructions of self
+    /// cost per store, 21.6% of a `while` loop that does nothing but compare,
+    /// add and store ([#8094](https://github.com/tokuhirom/mutsu/issues/8094)).
+    /// None of it applied. The cost was not one hot spot but a dozen inert
+    /// helpers at 20-60 instructions each — `maybe_tied_store_reassign` on a
+    /// name with no `@`/`%` sigil, `scalar_attr_type_constraint` on a name with
+    /// no twigil, `reset_atomic_var_key` with no atomic variable in the program,
+    /// and so on — which is exactly the shape that a single up-front decision
+    /// removes and no local fix does.
+    ///
+    /// The decision splits in two. The **compile-time** half is
+    /// [`CompiledCode::simple_scalar_locals`]: the slot's name settles every
+    /// sigil / twigil / attribute / topic / term / anon branch at compile time,
+    /// where it is already known. The **runtime** half is the guards below, each
+    /// of which names the branch of the full path it stands in for; every one is
+    /// a flag load, a tag probe or an `is_empty`, and the single env probe is the
+    /// one the full path would run anyway. A guard that fails is never wrong —
+    /// it just takes the (unchanged) slow path.
+    #[inline]
+    fn exec_set_local_scalar_fast(&mut self, code: &CompiledCode, idx: u32) -> bool {
+        let idx = idx as usize;
+        // The slot's name makes every name-derived branch inert (see the
+        // bitmap's doc), and there is no `@`/`%`/`&`/attribute slot in play for
+        // the wrapper's tied-store, `our`-sync and attribute-mirror steps either.
+        if !code.simple_scalar_locals.get(idx).copied().unwrap_or(false) {
+            return false;
+        }
+        // A plain `=` into an existing variable: no bind, rebind, `constant`,
+        // declaration, explicit initializer or array-share flavour is pending,
+        // so every `is_bind` / `is_vardecl` / `is_constant` branch is inert —
+        // and, since nothing is set, nothing needs consuming either. The
+        // declaration flag also being clear is what makes the wrapper's
+        // `box_decl` / `stamp_decl_name` / `our`-sync steps inert.
+        if !self.mark_ctx.store_flags_clear() || self.shaped_decl_context {
+            return false;
+        }
+        // Every metadata lane the store would otherwise consult, in the order
+        // the full path consults them. All are monotonic "has this program ever
+        // done X" latches or empty-collection tests, so the common program
+        // answers the whole block with a handful of loads:
+        //   - a sigilless multi-dim slice bind to distribute through
+        //     (`distribute_bound_multidim_slice`),
+        //   - a `:=`-bound decont marker to clear (`update_bound_decont_marker`),
+        //   - a pending alias bind to resolve, or a recorded bind pair to
+        //     propagate the write to,
+        //   - an `is default(...)` value to substitute for a stored `Nil`,
+        //   - a typed lexical whose constraint has to be checked and coerced,
+        //   - a sigilless-readonly marker that would reject the write,
+        //   - an atomic-variable cell to detach the name from,
+        //   - a `:=` alias chain to walk forward,
+        //   - a `Failure` to turn fatal, or a declaration still in flight on
+        //     another thread.
+        if crate::env::bound_array_slice_possible()
+            || self.bound_decont_active().get()
+            || !self.pending_alias_bind_names.is_empty()
+            || !self.local_bind_pairs.is_empty()
+            || self.has_var_defaults()
+            || Self::env_type_constraint_seen()
+            || crate::env::sigilless_readonly_keys_possible()
+            || Self::atomic_var_seen_anywhere()
+            || crate::env::closure_meta_keys_possible()
+            || self.fatal_mode
+            || !self.thread_decl_in_flight.is_empty()
+            || !code.our_locals.is_empty()
+        {
+            return false;
+        }
+        // The incoming value is an ordinary scalar — nothing to unwrap, reify,
+        // decontainerize or record — and the slot holds one too, so the store
+        // replaces it rather than writing *through* a cell, Proxy or phantom
+        // hash entry. Both are pure tag probes: a `view()` here would force a
+        // lazy `Match`.
+        if !self
+            .stack
+            .last()
+            .is_some_and(Value::is_plain_scalar_store_payload)
+            || !self.locals[idx].is_plain_scalar_store_slot()
+        {
+            return false;
+        }
+        // The one probe the full path would run anyway: a shared cell or Proxy
+        // parked in env under this name, which the slot adopts and then writes
+        // through. Rare, but not latched by any flag, so it is asked for real.
+        let name = &code.locals[idx];
+        let name_sym = code.locals_sym.get(idx).copied();
+        if self
+            .env()
+            .get_for(name, name_sym)
+            .is_some_and(|v| v.is_container_ref() || v.is_proxy_value())
+        {
+            return false;
+        }
+        // -- committed: from here the store cannot fall back --
+        let v = self.stack.pop().unwrap_or(Value::NIL);
+        // The two value-shaping steps that survive: a re-store of the same
+        // backing array keeps its kind (the hyper-func-op writeback), everything
+        // else gets the `$` container's itemization. The name half of
+        // `itemize_scalar_store` is settled by `simple_scalar_locals`.
+        let val = if Self::is_identity_scalar_restore(&self.locals[idx], &v) {
+            v
+        } else {
+            Self::itemize_scalar_store_value(v)
+        };
+        self.locals[idx] = val.clone();
+        // `(B)` per-store env-write, verbatim from the full path: a
+        // slot-authoritative plain lexical skips its env mirror. The `is_bind` /
+        // `is_constant` / term-symbol terms of that condition are all settled
+        // above, so only the two live tests remain.
+        if code.needs_env_sync.get(idx).copied().unwrap_or(true)
+            || crate::opcode::reflective_name_access_possible()
+        {
+            let name = code.locals[idx].clone();
+            self.set_env_plain_lexical(&name, name_sym, val);
+        }
+        true
+    }
+
     pub(super) fn exec_set_local_op(
         &mut self,
         code: &CompiledCode,
         idx: u32,
     ) -> Result<(), RuntimeError> {
+        // The hot `$x = <scalar>` store, decided up front so it pays for none of
+        // the cascade below or in `exec_set_local_op_inner`. See its doc comment.
+        if self.exec_set_local_scalar_fast(code, idx) {
+            return Ok(());
+        }
         // A re-assignment to a tied container (`my %h is Foo; %h = ...`, Foo
         // `does Associative`/`Positional`) routes through the class's `STORE`,
         // preserving the tied instance, instead of overwriting the slot with a

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -509,7 +509,7 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn term_symbol_from_name(name: &str) -> Option<&str> {
+    pub(crate) fn term_symbol_from_name(name: &str) -> Option<&str> {
         let bytes = name.as_bytes();
         if bytes.is_empty() {
             return None;

--- a/t/vm/binding/assign-plain-scalar-store-fast-path.t
+++ b/t/vm/binding/assign-plain-scalar-store-fast-path.t
@@ -1,0 +1,182 @@
+use v6;
+use Test;
+
+# `$x = <ordinary scalar>` takes a narrow path in `exec_set_local_op`
+# (#8094) instead of the ~2,000-line store-flavour cascade. Every guard that
+# path asks stands in for one branch of the cascade, so this file drives a
+# plain scalar store through each of those branches and pins that the answer is
+# the same as it was when every store fell through the whole thing.
+
+plan 28;
+
+# -- the fast path itself: a plain reassignment of an already-declared scalar --
+{
+    my $i = 0;
+    $i = $i + 1;
+    $i = $i + 1;
+    is $i, 2, 'plain scalar reassignment accumulates';
+    my $s = 'a';
+    $s = $s ~ 'b';
+    is $s, 'ab', 'plain string reassignment accumulates';
+}
+
+# -- itemization still happens on the way in --
+{
+    my $a;
+    $a = [1, 2];
+    is $a.raku, '$[1, 2]', 'an Array stored into a scalar is itemized';
+    my $h;
+    $h = {:k(1)};
+    is $h.raku, '${:k(1)}', 'a Hash stored into a scalar is itemized';
+    my $r;
+    $r = 1..3;
+    my @flat = $r;
+    is @flat.elems, 1, 'a Range stored into a scalar is one element in list context';
+    my $q;
+    $q = (1, 2, 3).Seq;
+    is $q.raku, '$((1, 2, 3).Seq)', 'a Seq stored into a scalar is itemized';
+}
+
+# -- Nil resets an untyped scalar to Any, a typed one to its type object --
+{
+    my $x = 5;
+    $x = Nil;
+    ok $x === Any, 'Nil assigned to an untyped scalar resets it to Any';
+    my Str $t = 'a';
+    $t = Nil;
+    ok $t === Str, 'Nil assigned to a typed scalar resets it to its type object';
+}
+
+# -- a typed lexical is still type-checked and coerced --
+{
+    my Int $n = 1;
+    $n = 2;
+    is $n, 2, 'a typed scalar takes a conforming store';
+    dies-ok { $n = 'x' }, 'a typed scalar rejects a non-conforming store';
+    my Num $f = 1e0;
+    $f = 2e0;
+    is $f, 2e0, 'a typed Num scalar takes a conforming store';
+}
+
+# -- `is default(...)` survives a Nil store --
+{
+    my $d is default('N/A') = 'v';
+    $d = Nil;
+    is $d, 'N/A', 'a scalar with is default() keeps its default over a Nil store';
+}
+
+# -- `:=` aliases still see the write, in both directions --
+{
+    my $src = 1;
+    my $alias := $src;
+    $src = 9;
+    is $alias, 9, 'a := alias observes a write to its source';
+    $alias = 11;
+    is $src, 11, 'the source observes a write through the := alias';
+}
+
+# -- a scalar bound to a shared cell is written THROUGH, not replaced --
+{
+    my @a = 1, 2;
+    my $e := @a[0];
+    $e = 7;
+    is @a[0], 7, 'a store through an element-bound scalar reaches the array';
+}
+
+# -- a Proxy in the slot still runs its STORE --
+{
+    my $seen;
+    my $p := Proxy.new(FETCH => sub ($) { 42 }, STORE => sub ($, $v) { $seen = $v });
+    $p = 5;
+    is $seen, 5, 'a store into a Proxy-bound scalar runs STORE';
+    is $p, 42, 'the Proxy still FETCHes';
+}
+
+# -- an atomic variable's cell is detached by a plain reassignment --
+{
+    my atomicint $c = 0;
+    $c⚛++;
+    is $c, 1, 'atomic increment reaches the variable';
+    $c = 5;
+    is $c, 5, 'a plain store to an atomic variable takes effect';
+}
+
+# -- a `term:<...>` definition mirrors itself, and is not a plain scalar slot --
+{
+    my \unused = 1;
+    is unused, 1, 'a sigilless binding reads back';
+}
+
+# -- the topic is not a plain scalar slot: writing it reaches its source --
+{
+    my $t = 1;
+    given $t { $_ = 4 }
+    is $t, 4, 'assigning the topic writes back through its source variable';
+}
+
+# -- an attribute write still mirrors into self's cell --
+{
+    class C {
+        has $.v is rw;
+        method bump() { $!v = $!v + 1; self }
+    }
+    my $o = C.new(v => 1);
+    $o.bump;
+    is $o.v, 2, 'a private-attribute store mirrors into the instance';
+}
+
+# -- `our` in the same chunk keeps its package mirror in sync --
+{
+    our $g = 1;
+    $g = 3;
+    is $GLOBAL::g, 3, 'a store to an our-variable reaches its package slot';
+}
+
+# -- a closure capturing the variable sees later writes --
+{
+    my $n = 1;
+    my $get = { $n };
+    $n = 8;
+    is $get(), 8, 'a closure reads the latest value of a captured scalar';
+}
+
+# -- a state variable accumulates across calls --
+{
+    sub counter() { state $s = 0; $s = $s + 1; $s }
+    counter();
+    counter();
+    is counter(), 3, 'a state scalar accumulates across calls';
+}
+
+# -- a re-store of the same backing array keeps its identity --
+{
+    my @a = 1, 2;
+    my $v = @a;
+    $v = $v;
+    is $v.raku, '$[1, 2]', 'restoring a scalar-held array preserves its shape';
+}
+
+# -- a Failure stored under `use fatal` still throws --
+{
+    my $ok = 0;
+    {
+        use fatal;
+        try {
+            my $f = Nil;
+            $f = (die 'boom');
+            CATCH { default { $ok = 1 } }
+        }
+    }
+    is $ok, 1, 'a die on the RHS of a scalar store propagates under use fatal';
+}
+
+# -- writes from a nested named sub reach the owner's slot --
+{
+    my $acc = 0;
+    sub via() { $acc = $acc + 1 }
+    via();
+    via();
+    is $acc, 2, 'a named sub writing an outer scalar accumulates in the owner';
+}
+
+done-testing;


### PR DESCRIPTION
`exec_set_local_op_inner` is one long cascade of store-*flavour* tests — is this a `:=` bind, a rebind, a `constant`, a declaration, an array share, a `%`/`@` container assignment, an attribute write, a `Proxy`, a shared cell, a typed lexical, an `is default(...)` variable, an atomic, a sigilless alias — and `$i = $i + 1` fell through every one of them: **746 instructions of self cost per store**, 21.6% of a `while` loop that does nothing but compare, add and store.

## Why no local fix helps

The cost is the *shape*, not any one line. It is a dozen inert helpers at 20-60 instructions each, and the list reads like a catalogue of questions the store could have answered without asking:

| per store | what it asked | why the answer was already known |
| --- | --- | --- |
| 58 | `scalar_attr_type_constraint` | the name has no `!`/`.` twigil |
| 36 | `maybe_tied_store_reassign` | the name has no `@`/`%` sigil |
| 27 | `reset_nil_untyped_scalar` | the value is not `Nil` |
| 25 | `update_bound_decont_marker` | no `:=`-bound decont marker exists |
| 20 | `reset_atomic_var_key` | the program has no atomic variable |
| 20 | `mirror_attr_local_to_cell` | the name is not an attribute |
| 20 | `normalize_scalar_assignment_value` | the value is not a 1-element `Seq` |
| 19 | `resolve_pending_alias_binds` | nothing is pending |
| 18 | `term_symbol_from_name`, twice | the name is not `term:<…>` |

## The change

One decision taken up front, split in two halves.

**Compile-time half** — `CompiledCode::simple_scalar_locals`, a per-slot bitmap and a strict subset of the existing `plain_locals` (adding "not a `term:<…>` definition" and "not a `__ANON` container slot"). A slot in it is an ordinary user scalar (`my $i` is stored as `"i"`), and its *name* settles every sigil / twigil / attribute / topic / term / anon branch of the cascade, at the point where the name is already in hand.

**Runtime half** — `exec_set_local_scalar_fast`, a guard block at the top of `exec_set_local_op` in which **every guard stands in for exactly one branch below it**:

- the packed mark word is clear, so there is no bind / rebind / `constant` / declaration / initializer / array-share flavour to apply — and, since nothing is set, nothing needs consuming either;
- none of the monotonic metadata latches is armed (`bound_array_slice_possible`, `sigilless_readonly_keys_possible`, `closure_meta_keys_possible`, `atomic_var_seen_anywhere`, `env_type_constraint_seen`, `bound_decont_active`);
- no collection that would have to be walked is non-empty (`pending_alias_bind_names`, `local_bind_pairs`, `var_defaults`, `thread_decl_in_flight`, `our_locals`);
- two new **pure tag probes** say the incoming value is an ordinary scalar and the slot holds one rather than a cell, `Proxy` or phantom hash entry (tag probes, not `view()` matches: a `view()` here would force a lazy `Match`);
- the one env probe that survives is the one the full path would have run anyway.

A guard that fails is never wrong — it just takes the **unchanged** slow path, so the cascade remains the single definition of what a store means. What the fast path then *does* is three things: itemize the value into its `$` container, write the slot, and take the same `(B)` per-store env-mirror decision the full path takes.

## Measured

Callgrind, release, `MUTSU_JIT=off MUTSU_GC=off`, the issue's own control loop (20,000 iterations of `$i = $i + 1`):

| | before | after |
| --- | --- | --- |
| `SetLocal`, inclusive per store | 1,161 Ir | **312 Ir** (−73%) |
| whole program | 77,867,825 Ir | **60,746,320 Ir** (−22.0%) |

`exec_set_local_op_inner` drops out of the profile entirely for that program — only the one `my $i = 0;` declaration still reaches it. (Instruction counts, not wall clock: they are load-independent, so they are what a change like this should be iterated against. The authoritative wall-clock comes from the bench CI.)

## Pin

`t/vm/binding/assign-plain-scalar-store-fast-path.t` drives a plain scalar store through each branch the guards stand in for — itemization of an Array/Hash/Range/Seq into a `$`, the `Nil` reset for both an untyped and a typed scalar, a typed lexical's check, `is default(...)`, a `:=` alias in both directions, a write-through to an element-bound scalar, a `Proxy`'s `STORE`, an atomic variable, the topic, an attribute, an `our` mirror, a closure capture, a `state` accumulator, a `use fatal` `Failure`, and a named sub writing an outer scalar. All 28 assertions were verified against the rakudo oracle before being run against mutsu.

## Verification

- `make test` — PASS (4069 files, 43333 tests)
- `make roast` — the only failures are the three documented container-environment ones (`roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` from running as `uid 0`, `roast/S32-io/IO-Socket-Async.t` from the sandboxed network), each with exactly the shape [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) records
- `make lint` — all four configurations clean (default clippy, `jit` off, wasm32, rustdoc)

## Not in scope

The issue's second row — a *closure-creation* store at 1,110 instructions — is narrowed but not closed: `my $c = * + 1;` is a declaration, so its `VARDECL` mark keeps it on the slow path by construction. Hoisting the declaration flavours the same way is the natural follow-on, and a bigger job, because a declaration really does have per-slot work to do (`bench-mandelbrot`'s `my $t` in its inner loop is where its remaining `SetLocal` cost now sits).

Closes #8094

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rtFLuDLNqD45pfCwgPYpJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016rtFLuDLNqD45pfCwgPYpJ)_