### PR TITLE
fix(oo,nativecall): resolve a named-constant has @.a[N] shape at class registration

### DIFF
--- a/docs/adr/0090-has-embedded-cstruct-members.md
+++ b/docs/adr/0090-has-embedded-cstruct-members.md
@@ -74,7 +74,10 @@ Concretely:
    in-progress set catches the cycle), and `HAS T @.x[N]` where `N` is a named
    constant rather than a literal, since only a literal shape survives into the
    compiled declaration. Both make `nativesizeof` fail loudly instead of
-   returning a number that is wrong.
+   returning a number that is wrong. (The `N`-is-a-constant case was resolved by
+   [#8032](https://github.com/tokuhirom/mutsu/issues/8032) — see the third
+   alternative below — leaving only a shape that genuinely cannot be resolved,
+   e.g. one depending on instance state, still refused.)
 
 ## Alternatives considered
 

--- a/news/2026-09/has-array-shape-named-constant-dimension.md
+++ b/news/2026-09/has-array-shape-named-constant-dimension.md
@@ -1,0 +1,29 @@
+# A `has @.a[N]`/`HAS T @.x[N] is CArray` shape survives a named `constant` dimension
+
+`CompiledAttrDecl::declared_shape` (`src/opcode.rs`) is extracted statically from the
+compiler-generated `Array.new(:shape(N))` default that `has @.a[N]` compiles to, and that
+extraction only ever understood a literal integer `N`. A dimension written as a named `constant`
+(`constant N = 5; has @.a[N]`) therefore came back `declared_shape: None`, indistinguishable from a
+plain unshaped `has @.a` — even though the *runtime* shape was always correct (`Array.new` itself
+evaluates `N` at build time, so `.shape` on a built instance already reported right).
+
+Two consumers read the class-level `declared_shape` rather than a built instance's own shape, and
+both saw the gap:
+
+- Constructor coercion of a caller-provided value (`Foo.new(a => [1, 2, 3])`) into the declared
+  shape, which silently left the array unshaped.
+- NativeCall's `cstruct_layout` (ADR-0090), which *refuses* an embedded `HAS T @.x[N] is CArray`
+  member's layout rather than guess a wrong element count — the right behavior for a genuinely
+  unresolvable shape, but a false positive here, since the shape was resolvable, just not
+  statically. `Image::Libexif`'s `ExifData` hits exactly this: `HAS ExifContent @.ifd[EXIF_IFD_COUNT]`
+  with `EXIF_IFD_COUNT` a named constant.
+
+Registration time (`class_body_has_decl` and its `role`/runtime-`has`/`augment class` counterparts)
+has an env the static extraction never did, so `CompiledAttrDecl` now also records whether `default`
+matched the shaped-array pattern at all (`dynamic_shape`) even when the literal extraction failed.
+`Interpreter::resolve_dynamic_attr_shape` uses that flag to evaluate `default` — exactly
+`Array.new(:shape(N))`, evaluated the same way `is default(...)` already is — and read the real
+shape back off the built value, falling back to `None` (the prior, safe behavior) only when the
+dimension genuinely cannot be resolved at registration time (e.g. it depends on instance state).
+
+Fixes #8032.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -420,6 +420,15 @@ pub(crate) struct CompiledAttrDecl {
     /// pattern) — `default` above no longer carries a raw `Expr` a consumer
     /// could re-inspect at construction time.
     pub(crate) declared_shape: Option<Vec<usize>>,
+    /// True when `default` matches the `Array.new(:shape(...))` pattern but
+    /// at least one dimension is not a literal integer (`has @.a[N]` with a
+    /// named `constant N`), so `declared_shape` above came back `None` even
+    /// though this genuinely is a shaped-array declaration (#8032). A
+    /// registration site with `&mut self` available can still resolve it —
+    /// `default` is exactly `Array.new(:shape(N))`, and evaluating N through
+    /// the same `constant`/enum lookup a normal read would use is safe,
+    /// unlike guessing. See `Interpreter::resolve_dynamic_attr_shape`.
+    pub(crate) dynamic_shape: bool,
 }
 
 impl CompiledAttrDecl {
@@ -461,7 +470,8 @@ impl CompiledAttrDecl {
         else {
             unreachable!("CompiledAttrDecl::from_stmt called on a non-HasDecl statement");
         };
-        let declared_shape = attr_declared_shape(default.as_ref());
+        let (declared_shape, has_shape_pattern) = attr_declared_shape(default.as_ref());
+        let dynamic_shape = has_shape_pattern && declared_shape.is_none();
         CompiledAttrDecl {
             name: name.resolve(),
             is_public: *is_public,
@@ -493,6 +503,7 @@ impl CompiledAttrDecl {
             is_built: *is_built,
             unknown_traits: unknown_traits.clone(),
             declared_shape,
+            dynamic_shape,
         }
     }
 }
@@ -2966,20 +2977,27 @@ pub(crate) struct CompiledDeclExpr {
 /// before `default` is lowered to a `DeclTraitArg` and this pattern-match
 /// becomes unreachable — instead of on every instance construction via
 /// `DeclTraitArg::as_expr()` (which panics on a `Compiled` chunk).
-fn attr_declared_shape(default: Option<&Expr>) -> Option<Vec<usize>> {
-    let expr = default?;
+/// Returns `(literal dims if every dimension is a literal integer, whether
+/// `default` matches the shaped-array pattern at all)`. The second element
+/// lets a caller distinguish "not a shaped declaration" from "a shaped
+/// declaration whose dimensions need a runtime lookup" (`dynamic_shape`
+/// above) — both look like `None` if only the first is kept.
+fn attr_declared_shape(default: Option<&Expr>) -> (Option<Vec<usize>>, bool) {
+    let Some(expr) = default else {
+        return (None, false);
+    };
     // Match Array.new(:shape(...)) or Array.new(:shape(...), :data(...))
     let Expr::MethodCall {
         target, name, args, ..
     } = expr
     else {
-        return None;
+        return (None, false);
     };
     if name.resolve() != "new" {
-        return None;
+        return (None, false);
     }
     if !matches!(target.as_ref(), Expr::BareWord(s) if s == "Array") {
-        return None;
+        return (None, false);
     }
     // Find the :shape(...) pair in args
     for arg in args {
@@ -2992,10 +3010,10 @@ fn attr_declared_shape(default: Option<&Expr>) -> Option<Vec<usize>> {
             && let ValueView::Str(key) = lit.view()
             && key.as_str() == "shape"
         {
-            return attr_shape_dims_from_expr(right);
+            return (attr_shape_dims_from_expr(right), true);
         }
     }
-    None
+    (None, false)
 }
 
 fn attr_shape_dims_from_expr(expr: &Expr) -> Option<Vec<usize>> {

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -475,12 +475,15 @@ impl crate::runtime::Interpreter {
                     let (elem_size, elem_align) = self.cstruct_size_align(&field.type_name)?;
                     Some((dims.iter().product::<usize>() * elem_size, elem_align))
                 }
-                // `HAS T @.x[N]` where `N` is a named constant rather than a
-                // literal: only a literal shape survives into the compiled
-                // declaration, so the element count is unknown here. Guessing
-                // would put every later field at a wrong offset, which is a
-                // silent wild read — abort the layout instead, the same way an
-                // unmarshallable field does.
+                // `HAS T @.x[N]` where `N` could not be resolved to a
+                // dimension at all — attribute registration already tried a
+                // literal extraction and, for a named `constant`/enum `N`, a
+                // registration-time evaluation of the shape default too
+                // (#8032); this is left only for a shape that depends on
+                // instance state (`self`) or otherwise fails to evaluate.
+                // Guessing the element count would put every later field at
+                // a wrong offset, which is a silent wild read — abort the
+                // layout instead, the same way an unmarshallable field does.
                 ('@', None) => return None,
                 // `HAS gsl_vector $.vector` — the member struct's own bytes.
                 _ if self.is_cstruct_class(&field.type_name) => {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -572,9 +572,13 @@ impl Interpreter {
                     } else {
                         format!("!{}", attr_name_str)
                     };
-                    // Resolve handles before taking mutable borrow on class_def
+                    // Resolve handles/shape before taking mutable borrow on class_def
                     let resolved =
                         self.resolve_handle_specs_to_names(&decl.handles, &attr_var_name);
+                    let declared_shape = decl
+                        .declared_shape
+                        .clone()
+                        .or_else(|| self.resolve_dynamic_attr_shape(&decl));
                     if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
                         class_def.attributes.push(ClassAttributeDef {
                             name: attr_name_str.clone(),
@@ -585,7 +589,7 @@ impl Interpreter {
                             sigil: decl.sigil,
                             type_constraint: decl.type_constraint.clone(),
                             where_constraint: decl.where_constraint.clone(),
-                            declared_shape: decl.declared_shape.clone(),
+                            declared_shape,
                         });
                         if decl.is_alias {
                             class_def.alias_attributes.insert(attr_name_str.clone());

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -7,6 +7,30 @@ use super::registration_class_body::{ClassBodyCx, ClassBodyFlow};
 use super::*;
 
 impl Interpreter {
+    /// Resolve `has @.a[N]`'s declared shape when `N` is not a literal
+    /// integer (`declared_shape` is `None`, `dynamic_shape` is `true`) — a
+    /// named `constant`, an enum, or any other expression a normal read
+    /// would resolve through the current env (#8032). `default` is exactly
+    /// the compiler-generated `Array.new(:shape(N))`, so evaluating it here
+    /// — at registration time, with the declaring scope's env still current
+    /// — runs nothing beyond what building the attribute's own default value
+    /// already runs, and reads back the shape the same way an instance's own
+    /// `.shape` already does. Returns `None` (same as before this fallback
+    /// existed) when `default` fails to evaluate, e.g. because a dimension
+    /// referenced instance state (`self`) that class-registration time has
+    /// no way to supply.
+    pub(crate) fn resolve_dynamic_attr_shape(
+        &mut self,
+        decl: &crate::opcode::CompiledAttrDecl,
+    ) -> Option<Vec<usize>> {
+        if !decl.dynamic_shape {
+            return None;
+        }
+        let default = decl.default.as_ref()?;
+        let value = self.eval_decl_trait_arg(default).ok()?;
+        crate::runtime::utils::shaped_array_shape(&value)
+    }
+
     /// Register an attribute onto a class whose body is still being defined,
     /// driven by a `has`-declaration that reached the VM at runtime (mainline /
     /// EVAL'd source: `class Foo { BEGIN EVAL q[has $.x] }`). This mirrors the
@@ -51,6 +75,10 @@ impl Interpreter {
             decl.type_smiley.as_deref(),
         )?;
         let effective_is_rw = !decl.is_readonly && decl.is_rw;
+        let declared_shape = decl
+            .declared_shape
+            .clone()
+            .or_else(|| self.resolve_dynamic_attr_shape(decl));
         class_def.attributes.push(ClassAttributeDef {
             name: attr_name.clone(),
             is_public: decl.is_public,
@@ -63,7 +91,7 @@ impl Interpreter {
                 .as_ref()
                 .map(|tc| tc.replace("::?CLASS", class_name)),
             where_constraint: None,
-            declared_shape: decl.declared_shape.clone(),
+            declared_shape,
         });
         if let Some(tc) = &decl.type_constraint {
             let resolved_tc = tc.replace("::?CLASS", class_name);
@@ -234,6 +262,10 @@ impl Interpreter {
         }
         let effective_is_rw =
             !decl.is_readonly && (decl.is_rw || (cx.class_is_rw && decl.is_public));
+        let declared_shape = decl
+            .declared_shape
+            .clone()
+            .or_else(|| self.resolve_dynamic_attr_shape(&decl));
         cx.class_def.attributes.push(ClassAttributeDef {
             name: attr_name_str.clone(),
             is_public: decl.is_public,
@@ -246,7 +278,7 @@ impl Interpreter {
                 .as_ref()
                 .map(|tc| tc.replace("::?CLASS", cx.name)),
             where_constraint: decl.where_constraint.clone(),
-            declared_shape: decl.declared_shape.clone(),
+            declared_shape,
         });
         // Store `is default(...)` trait value for this attribute.
         // When is_default is set, the evaluated value is stored for

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -130,6 +130,10 @@ impl Interpreter {
         // `is readonly` on individual attributes overrides `is rw` on the role
         let effective_is_rw =
             !decl.is_readonly && (decl.is_rw || (cx.role_is_rw && decl.is_public));
+        let declared_shape = decl
+            .declared_shape
+            .clone()
+            .or_else(|| self.resolve_dynamic_attr_shape(&decl));
         cx.role_def.attributes.push(ClassAttributeDef {
             name: attr_name_str.clone(),
             is_public: decl.is_public,
@@ -139,7 +143,7 @@ impl Interpreter {
             sigil: decl.sigil,
             type_constraint: decl.type_constraint.clone(),
             where_constraint: decl.where_constraint.clone(),
-            declared_shape: decl.declared_shape.clone(),
+            declared_shape,
         });
         let attr_var_name = if decl.is_public {
             format!(".{}", attr_name_str)

--- a/t/collections/subscript/shaped-attr-constant-dimension.t
+++ b/t/collections/subscript/shaped-attr-constant-dimension.t
@@ -1,0 +1,38 @@
+use Test;
+
+# `has @.a[N]` where `N` is a named `constant` (not a literal integer) must
+# still be recognized as a shaped-array declaration.
+#
+# `CompiledAttrDecl::declared_shape` (src/opcode.rs) is extracted statically
+# from the compiler-generated `Array.new(:shape(N))` default, and that
+# extraction only ever understood a literal `N` — so a constant-dimension
+# shape came back `declared_shape: None`, indistinguishable from a plain
+# unshaped `has @.a`. The *runtime* shape was always fine (`Array.new` itself
+# evaluates `N` correctly), so `.shape` on a built instance reported right;
+# only consumers reading the class-level `declared_shape` (constructor
+# coercion of a provided value here, NativeCall's CStruct layout in
+# nativecall-has-array-shape-constant.t) saw the gap (GH #8032).
+
+plan 6;
+
+constant N = 3;
+class Row { has @.a[N]; }
+is Row.new.a.shape, (3,), 'a named-constant single-dim shape is recognized on an uninitialized instance';
+
+my $row = Row.new(a => [1, 2, 3]);
+is $row.a.shape, (3,), 'a provided value is coerced into the named-constant shape';
+is $row.a, [1, 2, 3], 'the provided values survive the coercion';
+
+constant M = 2;
+class Grid { has @.a[N, M]; }
+is Grid.new.a.shape, (3, 2), 'a multi-dim shape mixing named constants is recognized';
+
+# A literal dimension keeps working (no regression).
+class Lit { has @.a[4]; }
+is Lit.new.a.shape, (4,), 'a literal-dimension shape is still recognized';
+
+# A role's shaped attribute is resolved at role-registration time and carries
+# through composition.
+role R { has @.a[N]; }
+class FromRole does R { }
+is FromRole.new.a.shape, (3,), 'a role attribute with a named-constant shape survives composition';

--- a/t/nativecall/nativecall-has-array-shape-constant.t
+++ b/t/nativecall/nativecall-has-array-shape-constant.t
@@ -1,0 +1,20 @@
+use NativeCall;
+use Test;
+
+# `HAS T @.x[N] is CArray` where `N` is a named `constant` rather than a
+# literal integer (GH #8032, following on from ADR-0090). `cstruct_layout`
+# refuses the layout when an embedded shaped array's `declared_shape` is
+# `None` (it would otherwise put every later field at a silently wrong
+# offset), and a constant-dimension shape used to read as `None` -- the same
+# gap `nativecall-has-embedded-struct.t` exercises for a literal dimension.
+# `Image::Libexif`'s `ExifData` is exactly this shape, whose `EXIF_IFD_COUNT`
+# dimension is a named constant.
+
+plan 1;
+
+constant N = 5;
+class S is repr('CStruct') {
+    HAS int32 @.a[N] is CArray;
+    has int32 $.t;
+}
+is nativesizeof(S), 24, 'a named-constant CArray shape lays out correctly, matching the literal case';


### PR DESCRIPTION
## Summary

`CompiledAttrDecl::declared_shape` (`src/opcode.rs`) is extracted statically from the
compiler-generated `Array.new(:shape(N))` default that `has @.a[N]` compiles to, and that
extraction only ever understood a literal integer `N`. A dimension written as a named `constant`
(`constant N = 5; has @.a[N]`) came back `declared_shape: None`, indistinguishable from a plain
unshaped `has @.a` — even though the *runtime* shape was always correct (`Array.new` itself
evaluates `N` at build time).

Two consumers read the class-level `declared_shape` rather than a built instance's own shape, and
both saw the gap:

- Constructor coercion of a caller-provided value (`Foo.new(a => [1, 2, 3])`) into the declared
  shape, which silently left the array unshaped.
- NativeCall's `cstruct_layout` (ADR-0090), which refuses an embedded `HAS T @.x[N] is CArray`
  member's layout rather than guess a wrong element count — the right behavior for a genuinely
  unresolvable shape, but a false positive here since the shape *was* resolvable, just not
  statically. `Image::Libexif`'s `ExifData` hits exactly this (`EXIF_IFD_COUNT` is a named
  constant).

## Fix

Class-registration time has an env the static extraction never did, so `CompiledAttrDecl` now also
records whether `default` matched the shaped-array pattern at all (`dynamic_shape`), even when the
literal extraction failed. Each `has`-registration site (class body, role body, runtime `has`,
`augment class`) evaluates `default` — exactly `Array.new(:shape(N))`, evaluated the same way `is
default(...)` already is — to recover the real shape, falling back to `None` (the prior, safe
behavior) only when the dimension genuinely cannot be resolved at registration time (e.g. it
depends on instance state).

Closes #8032

## Testing

- `t/collections/subscript/shaped-attr-constant-dimension.t` — new, covers a single-dim and
  multi-dim named-constant shape, constructor-provided value coercion, a literal-shape regression
  check, and role composition.
- `t/nativecall/nativecall-has-array-shape-constant.t` — new, the NativeCall CArray case from the
  issue (`nativesizeof` matches rakudo).
- `cargo fmt --all`, `make lint` — green (all four configurations).
- `make test` — green, `Files=4086, Tests=43419, Result: PASS`.
- `make roast` — the only failures are the three documented container-only entries in
  `docs/agent-environments.md` (`6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t` — this
  container runs as `uid 0` — and `S32-io/IO-Socket-Async.t`, the sandboxed-network timeout); all
  pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_