### PR TITLE
perf(regex): a constant subrule argument needs no interpreter, and the parameterized-rule memo stops refusing itself

### DIFF
--- a/news/2026-09/parameterized-subrule-args-stop-building-interpreters.md
+++ b/news/2026-09/parameterized-subrule-args-stop-building-interpreters.md
@@ -1,0 +1,118 @@
+# A parameterized subrule's arguments stop building an interpreter each
+
+Round 17 of [#7576](https://github.com/tokuhirom/mutsu/issues/7576). Instructions
+retired on the ticket's 60-row YAMLish document go **1,845,742,337 ->
+1,565,835,736 (-15.16%)**, measured with callgrind Ir throughout and the module
+precompilation cache warmed first, per round 14's note.
+
+Round 16 handed off a flat profile — `LocalKey::with` 7.63% across a dozen
+callers, allocator ~19.6%, `memcpy` 4.20%, no mutsu function above ~1.9% — and
+one named item worth ~0.44%. A fresh `callgrind_annotate --tree=both` found
+something else entirely, and not by looking at a self-cost line: two callers of
+`parsed_subrule_candidates` with the same callee and wildly different per-call
+costs. `for_each_atom_candidate` spent 305 instructions per call; the atom path
+spent **5,050**, for 11.59% of the whole program. Everything below follows from
+that one ratio.
+
+## A parameterized subrule's arguments were evaluated by a whole interpreter
+
+`<element($indent, 0)>` evaluates each argument expression before it can resolve
+the rule. `eval_regex_expr_value` has a fast path for a bare `$name` and sends
+everything else — including the literal `0` — through
+`parse_regex_code_cached`, a freshly built scratch `Interpreter`, and
+`eval_block_value`. A scratch interpreter is ~76 heap allocations, five
+multi-kilobyte struct moves and a 13k-instruction drop; evaluating the constant
+`0` cost about **107,000 instructions**, and this document did it **811** times.
+
+A literal is its own value: nothing in it reads the env, the captures or the
+package. `parse_regex_code_cached` wraps the source in `(...)`, so the parse
+comes back as `[SetLine(n), Expr(Grouped(Literal(v)))]` — exactly the shape the
+compiler turns into one `LoadConst`. `constant_stmt_value` recognizes it and
+returns `v`. The list of admitted value kinds is positive rather than an
+exclusion, so a new `Value` kind has to be let in deliberately: the one
+`Expr::Literal` the compiler does *not* treat as a constant is a code-bearing
+regex, which loads as a closure over its enclosing scope.
+
+The bare-`$name` path went with it. It built the whole evaluation env —
+`self.env` cloned, then the positional captures, `/`, the named captures and the
+in-regex lexicals layered on — in order to read one key out of it, 526 times at
+~10,400 instructions each. The guard above it admits only an identifier, which
+can collide with none of the capture key shapes, so the two sources that can
+actually answer are read directly, in the same precedence.
+
+Together: `Interpreter::new` inclusive **63.9M (3.46%) -> 38.7M**, and
+`make_regex_eval_env`, `eval_regex_arg_list` and `eval_regex_expr_value` all
+leave the profile.
+
+## …and then the resolution itself was re-run at every position
+
+What that left was `resolve_token_patterns_with_args_in_pkg` at **9.10%** for
+**692** calls: binding the arguments in a scratch interpreter, evaluating the
+rule body, and running three textual passes over the resulting pattern before
+parsing it — once per `<rule($arg)>` probe, at every position.
+
+`PARSED_TOKEN_ARG_CANDIDATES` exists to memoize exactly that, on
+`(package, rule name, rendered arguments)` plus the token-registry generation.
+It was storing nothing here, because it gated on `pattern_static_modulo_params`:
+a syntactic predicate over the pattern text that required every `$` in it to
+introduce one of the rule's own parameters. `$<sp>`, `$0` and `$(...)` are not
+parameter references at all — they are capture forms the interpolation pass
+provably leaves alone — but the predicate called them dynamic, and they appear
+in most of YAMLish's parameterized rules (`block`, `map`, `sequence`,
+`cuddly-list-entry`, `plain`). Meanwhile it *trusted* the two steps that can
+read anything: the evaluation of the rule body, and the evaluation of the
+argument expressions.
+
+The predicate is gone. The exclusions are raised **at the reads themselves**
+now — round 13's lesson on the sibling `REGEX_SUBPATTERN_PARSE_CACHE`, applied
+one layer up. `regex_arg_purity` records a resolution, and the flag goes up
+when:
+
+* `interpolate_bound_regex_scalars` substitutes a name that is not one of the
+  bound parameters (the value came from the caller's lexical scope, which the
+  key does not carry);
+* `eval_regex_expr_value` needs the general evaluator for an argument (arbitrary
+  code, reads that cannot be attributed);
+* a candidate has a parameter default or a `where` clause (binding evaluates
+  them against the caller's env);
+* a rule body is not a constant;
+* the parse of a resolved candidate raises its own ambient-read flag —
+  `note_regex_parse_ambient_read` raises both, because this memo stores the
+  *parsed* candidates.
+
+Frames nest and the flag OR-restores outward, so an inner impurity is never lost.
+`resolve_token_patterns_with_args_in_pkg` **160.3M (9.10%) -> below the
+threshold**.
+
+The memo is bounded the way the parse cache is, and for the same reason: its key
+carries *rendered arguments*, which are runtime data, so a grammar parameterized
+on the text it is parsing would otherwise mint one entry per distinct value.
+
+## Tests
+
+Two new pins in `t/grammar/`, both verified against rakudo 2026.07:
+
+- `grammar-rule-constant-argument-forms.t` — every literal shape (integer,
+  negative, both string quote forms, rational, boolean) still arrives at the
+  rule with the value it was written with;
+- `grammar-rule-arg-memo-outer-lexical.t` — a rule body that splices an *outer*
+  lexical is not served from the memo after that lexical changes, and a rule
+  that reads only its own parameters keeps matching correctly across repeated
+  resolutions, `$<name>=[...]` captures included.
+
+## Method note
+
+Rounds 11-16 each found their item by resolving a flat profile through caller
+attribution. Round 17's addition is narrower and mechanical: **when one function
+appears under two callers with an order-of-magnitude difference in cost per
+call, that ratio is the finding.** `parsed_subrule_candidates` was not on any
+"top" list — 0.24% self — and its two caller lines sat next to each other in the
+tree output reading 305 and 5,050 instructions per call. Neither number means
+anything alone; the gap between them named the memo that was not storing.
+
+The corollary is about what a memo exclusion may be made of. A syntactic
+predicate is not merely brittle, as round 13 found — it is also *wrong in both
+directions at once*: `pattern_static_modulo_params` refused most of a real
+grammar over capture forms that read nothing, and waved through a body
+evaluation that could read anything. Raising the exclusion where the read
+happens fixed both halves in one change and deleted the predicate.

--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod regex_arg_purity;
 mod regex_call_graph;
 mod regex_casefold;
 pub(crate) mod regex_cursor;

--- a/src/runtime/regex/regex_arg_purity.rs
+++ b/src/runtime/regex/regex_arg_purity.rs
@@ -1,0 +1,110 @@
+//! Purity tracking for the parameterized-subrule memo
+//! ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
+//!
+//! Resolving `<rule($arg)>` binds the arguments into a scratch interpreter,
+//! evaluates the rule body, and runs three textual passes over the resulting
+//! pattern before parsing it. `PARSED_TOKEN_ARG_CANDIDATES` memoizes the whole
+//! chain on `(package, rule name, rendered arguments)` plus the token-registry
+//! generation, so it may only store a result that is a function of exactly
+//! that key.
+//!
+//! The exclusions are raised **at the reads themselves** rather than derived
+//! from a syntactic predicate over the pattern text. That is round 13's lesson
+//! on the sibling `REGEX_SUBPATTERN_PARSE_CACHE` (see
+//! [`crate::runtime::regex_parse::PARSE_CONSULTED_AMBIENT_STATE`]): a list of
+//! "syntax forms that read state", maintained next to the code that reads it,
+//! cannot stay correct as that code grows — the list this replaces
+//! (`pattern_static_modulo_params`) conservatively rejected every `$<capture>`
+//! form, which is most of a real grammar, while silently trusting the
+//! evaluation of the rule body and of the argument expressions, which can read
+//! anything at all.
+//!
+//! Two things raise the flag:
+//!
+//! * a *named* read whose name is not one of the bound parameters — the value
+//!   comes from the caller's lexical scope, which the key does not carry;
+//! * an *opaque* read — a step that runs arbitrary code (a rule body that is
+//!   not a constant, an argument expression that needs the evaluator, a
+//!   parameter default or `where` clause) and whose reads therefore cannot be
+//!   attributed.
+//!
+//! A parse-time ambient read raises this flag too, via
+//! [`crate::runtime::Interpreter::note_regex_parse_ambient_read`]: the memo
+//! stores the *parsed* candidates, so an impure parse makes the entry impure.
+
+use std::cell::{Cell, RefCell};
+
+thread_local! {
+    /// Set when the resolution in progress read state its memo key does not
+    /// carry. Saved/cleared/OR-restored around each resolution exactly the way
+    /// `parse_regex_uncached` handles its own flag, so a nested resolution's
+    /// impurity propagates outward to the enclosing one.
+    static CONSULTED_AMBIENT_STATE: Cell<bool> = const { Cell::new(false) };
+
+    /// The bound parameter names of the resolutions currently in progress,
+    /// innermost last. Empty when no parameterized subrule is being resolved,
+    /// which is what makes every note below a no-op for the ordinary
+    /// (uncached) callers of the same interpolation helpers.
+    static BOUND_PARAMS: RefCell<Vec<Vec<String>>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Raise the flag unconditionally: a step that can read state we cannot name.
+pub(crate) fn note_opaque_read() {
+    CONSULTED_AMBIENT_STATE.with(|f| f.set(true));
+}
+
+/// Raise the flag unless `name` is a bound parameter of every resolution in
+/// progress.
+///
+/// `name` arrives as the pattern spelled it, with or without its sigil, and the
+/// parameter list holds the declared spellings (`$indent`, `:$sep`), so both
+/// sides are compared with sigils and adverb punctuation trimmed.
+pub(crate) fn note_named_read(name: &str) {
+    let ambient = BOUND_PARAMS.with(|p| {
+        let frames = p.borrow();
+        if frames.is_empty() {
+            return false;
+        }
+        let bare = trim_sigils(name);
+        frames
+            .iter()
+            .any(|params| !params.iter().any(|p| trim_sigils(p) == bare))
+    });
+    if ambient {
+        note_opaque_read();
+    }
+}
+
+fn trim_sigils(name: &str) -> &str {
+    name.trim_start_matches([':', '$', '@', '%', '&', '!', '.', '*', '?', '^'])
+}
+
+/// Run `body` as one memoizable resolution of a rule with `params`.
+///
+/// Returns `(value, consulted_ambient_state)`. The enclosing resolution's flag
+/// is restored with this one OR-ed in, so an inner impurity is never lost.
+pub(crate) fn with_resolution<T>(params: Vec<String>, body: impl FnOnce() -> T) -> (T, bool) {
+    BOUND_PARAMS.with(|p| p.borrow_mut().push(params));
+    let outer = CONSULTED_AMBIENT_STATE.with(|f| f.replace(false));
+    let value = body();
+    let consulted = CONSULTED_AMBIENT_STATE.with(|f| f.replace(outer || f.get()));
+    BOUND_PARAMS.with(|p| {
+        p.borrow_mut().pop();
+    });
+    (value, consulted)
+}
+
+/// Run `body` as the window a memo entry would cover, without declaring any
+/// bound parameters of its own.
+///
+/// This is the outer half of [`with_resolution`]: the resolution frames report
+/// the *rule bodies*' reads, and this window additionally covers the steps that
+/// run outside them — notably parsing each resolved candidate, whose own
+/// ambient reads reach here through
+/// [`crate::runtime::Interpreter::note_regex_parse_ambient_read`].
+pub(crate) fn with_memo_window<T>(body: impl FnOnce() -> T) -> (T, bool) {
+    let outer = CONSULTED_AMBIENT_STATE.with(|f| f.replace(false));
+    let value = body();
+    let consulted = CONSULTED_AMBIENT_STATE.with(|f| f.replace(outer || f.get()));
+    (value, consulted)
+}

--- a/src/runtime/regex/regex_interpolate.rs
+++ b/src/runtime/regex/regex_interpolate.rs
@@ -401,6 +401,12 @@ impl Interpreter {
                         .cloned()
                         .or_else(|| self.env.get(&format!("${name}")).cloned())
                     {
+                        // The env this reads is the caller's, with the subrule's
+                        // bound parameters layered on top, so a substitution
+                        // that is not one of them is what makes a
+                        // parameterized-subrule resolution depend on the
+                        // caller's lexical scope rather than on its arguments.
+                        super::regex_arg_purity::note_named_read(&name);
                         // ADR-0046 Decision 2 item 2: a substitution made here is
                         // a *runtime* interpolation, exactly like the general-case
                         // `interpolate_regex_scalars` ones, so it must terminate

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -698,6 +698,56 @@ impl Interpreter {
         v
     }
 
+    /// The value of `stmts` when it is a single constant expression, `None`
+    /// otherwise.
+    ///
+    /// `parse_regex_code_cached` wraps the source in `(...)`, so a literal
+    /// argument arrives as `[SetLine(n), Expr(Grouped(Literal(v)))]`. The
+    /// compiler turns exactly that shape into one `LoadConst` (`Grouped` is a
+    /// transparent wrapper), so returning `v` here is what running it would
+    /// produce — with no env, no package and no interpreter to build.
+    ///
+    /// Deliberately narrow: only the scalar value kinds a literal token can
+    /// produce. The one `Expr::Literal` the compiler does *not* treat as a
+    /// constant is a code-bearing regex, which loads as a closure over its
+    /// enclosing scope ([`crate::opcode::OpCode::LoadRegexClosure`]); keeping
+    /// the list positive means a new `Value` kind has to be admitted here
+    /// explicitly rather than inherited by accident.
+    fn constant_stmt_value(stmts: &[crate::ast::Stmt]) -> Option<Value> {
+        let mut found: Option<&Value> = None;
+        for stmt in stmts {
+            match stmt {
+                crate::ast::Stmt::SetLine(_) => {}
+                crate::ast::Stmt::Expr(expr) if found.is_none() => {
+                    let mut inner = expr;
+                    while let crate::ast::Expr::Grouped(g) = inner {
+                        inner = g;
+                    }
+                    match inner {
+                        crate::ast::Expr::Literal(v) => found = Some(v),
+                        _ => return None,
+                    }
+                }
+                _ => return None,
+            }
+        }
+        let v = found?;
+        matches!(
+            v.view(),
+            ValueView::Int(_)
+                | ValueView::BigInt(_)
+                | ValueView::Num(_)
+                | ValueView::Str(_)
+                | ValueView::Bool(_)
+                | ValueView::Rat(..)
+                | ValueView::FatRat(..)
+                | ValueView::BigRat(..)
+                | ValueView::Complex(..)
+                | ValueView::Nil
+        )
+        .then(|| v.clone())
+    }
+
     pub(in crate::runtime) fn eval_regex_expr_value(
         &mut self,
         expr_src: &str,
@@ -728,15 +778,44 @@ impl Interpreter {
                 ok
             }
         {
-            let env = self.make_regex_eval_env(caps);
-            return env
-                .get(name)
-                .cloned()
-                .or_else(|| env.get(trimmed).cloned())
+            // Read the two candidate keys directly instead of materializing the
+            // whole evaluation env for them. `make_regex_eval_env` clones the
+            // caller's env and then layers the positional captures (all-digit
+            // keys), `/`, the named captures (`<...>`-wrapped keys) and the
+            // in-regex lexicals on top. `name` is an identifier here — the guard
+            // above admits nothing else — so it can collide with none of the
+            // first three shapes, which leaves exactly the two sources this
+            // reads, in the same precedence (`regex_vars` last-inserted, so
+            // first). `trimmed` is `$name`, kept as the second probe because an
+            // in-regex `:my $x` is filed under its sigil-ful spelling.
+            let lookup = |k: &str| {
+                caps.regex_vars()
+                    .get(k)
+                    .or_else(|| self.env.get(k))
+                    .cloned()
+            };
+            super::regex_arg_purity::note_named_read(name);
+            return lookup(name)
+                .or_else(|| lookup(trimmed))
                 .or(Some(Value::NIL));
         }
         let source = format!("({expr_src});");
         let stmts = self.parse_regex_code_cached(&source)?;
+        // A constant argument (`<element($indent, 0)>`'s `0`, an
+        // `<.indent-panic: …, "map">` message) is its own value: nothing in it
+        // can read the env, the captures or the package, so it needs neither an
+        // evaluation env nor a scratch interpreter. Those two together are
+        // ~107k instructions per call, and a YAMLish parse takes this path 811
+        // times for arguments that are all literals
+        // ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
+        if let Some(v) = Self::constant_stmt_value(&stmts) {
+            return Some(v);
+        }
+        // Anything else runs arbitrary Raku against the caller's env and the
+        // live captures; its reads cannot be attributed, so a
+        // parameterized-subrule resolution that reaches here is not a function
+        // of its memo key.
+        super::regex_arg_purity::note_opaque_read();
         let mut interp = Interpreter {
             env: self.make_regex_eval_env(caps),
             current_package: Arc::new(RwLock::new(self.current_package())),

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -31,63 +31,19 @@ thread_local! {
     /// as `<expr(3)>`) re-resolves through a fresh scratch interpreter (bind
     /// args, eval body, bake params) on EVERY match-position probe; nested
     /// precedence-climbing grammars (P47) re-enter that per position and per
-    /// LR-seed iteration, which is exponential without memoization. Cached
-    /// only when every candidate's body references no variables beyond its
-    /// own parameters (the args are part of the key), so a body reading an
-    /// outer runtime lexical is never staled. Same `TOKEN_DEFS_GEN`
-    /// invalidation as above.
+    /// LR-seed iteration, which is exponential without memoization. Same
+    /// `TOKEN_DEFS_GEN` invalidation as above.
+    ///
+    /// An entry is stored only when the resolution read nothing the key does
+    /// not carry, which the resolution reports for itself — see
+    /// [`super::regex_arg_purity`]. That replaced a syntactic predicate over
+    /// the pattern text (`pattern_static_modulo_params`), which rejected every
+    /// `$<capture>` form — most of a real grammar's parameterized rules — while
+    /// trusting the body evaluation and the argument expressions, which can
+    /// read anything.
     static PARSED_TOKEN_ARG_CANDIDATES: std::cell::RefCell<
         rustc_hash::FxHashMap<(String, String, String), CachedCandidates>,
     > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
-}
-
-/// True when `pattern` contains no interpolation the with-args cache key does
-/// not cover: no `@`/`%` refs, no `$<cap>`/`$0`/`$(...)` forms, and every
-/// `$ident` names one of `params` (raku identifier rules: `-` extends a name
-/// only before a letter).
-fn pattern_static_modulo_params(pattern: &str, params: &[String]) -> bool {
-    if pattern.contains(['@', '%']) {
-        return false;
-    }
-    let chars: Vec<char> = pattern.chars().collect();
-    let mut i = 0usize;
-    while i < chars.len() {
-        match chars[i] {
-            '\\' => i += 2,
-            '$' => {
-                let j0 = i + 1;
-                let mut j = j0;
-                if j < chars.len() && (chars[j].is_alphabetic() || chars[j] == '_') {
-                    j += 1;
-                    while j < chars.len() {
-                        let c = chars[j];
-                        let kebab = c == '-'
-                            && chars
-                                .get(j + 1)
-                                .is_some_and(|n| n.is_alphabetic() || *n == '_');
-                        if c.is_alphanumeric() || c == '_' || kebab {
-                            j += 1;
-                        } else {
-                            break;
-                        }
-                    }
-                    let name: String = chars[j0..j].iter().collect();
-                    if !params
-                        .iter()
-                        .any(|p| p.trim_start_matches(['$', '@', '%', '&', ':']) == name)
-                    {
-                        return false;
-                    }
-                    i = j;
-                } else {
-                    // `$<cap>`, `$0`, `$(...)`, bare `$` — dynamic.
-                    return false;
-                }
-            }
-            _ => i += 1,
-        }
-    }
-    true
 }
 
 impl Interpreter {
@@ -212,40 +168,43 @@ impl Interpreter {
             let raw_empty = hit.is_empty();
             return (hit, raw_empty);
         }
-        let raw = self.resolve_named_regex_candidates_in_pkg(spec, pkg, arg_values);
-        let raw_empty = raw.is_empty();
-        let mut parsed_list = Vec::with_capacity(raw.len());
-        for (sub_pat, sub_pkg, sym_key) in raw {
-            if let Some(parsed) = self.parse_candidate_in_pkg(&sub_pat, &sub_pkg) {
-                parsed_list.push((parsed, sub_pkg, sym_key));
-            }
-        }
-        let arc = std::sync::Arc::new(parsed_list);
-        if let Some(fp) = args_fp {
-            // Cache only when every candidate def's body is self-contained
-            // (no variable references beyond its own params).
-            let cacheable = self
-                .resolve_token_defs_in_pkg(&spec.lookup_name, pkg)
-                .iter()
-                .all(|def| {
-                    def.body.iter().all(|stmt| match stmt {
-                        crate::ast::Stmt::Expr(crate::ast::Expr::Literal(v)) => match v.view() {
-                            ValueView::Regex(pat) => {
-                                pattern_static_modulo_params(&pat, &def.params)
-                            }
-                            _ => false,
-                        },
-                        _ => false,
-                    })
-                });
-            if cacheable {
-                PARSED_TOKEN_ARG_CANDIDATES.with(|c| {
-                    c.borrow_mut().insert(
-                        (pkg.to_string(), spec.lookup_name.clone(), fp),
-                        (tok_gen, std::sync::Arc::clone(&arc)),
-                    );
-                });
-            }
+        // Resolve with the purity flag cleared, so it reports only THIS
+        // resolution's reads; `with_memo_window` ORs it back into the enclosing
+        // one on the way out. Everything the entry would have to be a function
+        // of — the rule bodies, the argument expressions, the parameter
+        // binding, and the parse of each resolved candidate — runs inside.
+        let ((raw_empty, arc), consulted_ambient) =
+            super::regex_arg_purity::with_memo_window(|| {
+                let raw = self.resolve_named_regex_candidates_in_pkg(spec, pkg, arg_values);
+                let raw_empty = raw.is_empty();
+                let mut parsed_list = Vec::with_capacity(raw.len());
+                for (sub_pat, sub_pkg, sym_key) in raw {
+                    if let Some(parsed) = self.parse_candidate_in_pkg(&sub_pat, &sub_pkg) {
+                        parsed_list.push((parsed, sub_pkg, sym_key));
+                    }
+                }
+                (raw_empty, std::sync::Arc::new(parsed_list))
+            });
+        if let Some(fp) = args_fp
+            && !consulted_ambient
+        {
+            PARSED_TOKEN_ARG_CANDIDATES.with(|c| {
+                let mut cache = c.borrow_mut();
+                // The key carries the RENDERED arguments, which are runtime
+                // data: a grammar parameterized on the text it is parsing
+                // (`<block($indent)>` over a deep document) mints a fresh key
+                // per distinct value. Bound it the way
+                // `REGEX_SUBPATTERN_PARSE_CACHE` is bounded, for the same
+                // reason and at the same cost — dropping the memo buys back
+                // re-resolutions and nothing else.
+                if cache.len() >= crate::runtime::regex_parse::SUBPATTERN_PARSE_CACHE_MAX {
+                    cache.clear();
+                }
+                cache.insert(
+                    (pkg.to_string(), spec.lookup_name.clone(), fp),
+                    (tok_gen, std::sync::Arc::clone(&arc)),
+                );
+            });
         }
         (arc, raw_empty)
     }
@@ -367,6 +326,58 @@ impl Interpreter {
             literal_matches
         };
         for def in defs {
+            let params: Vec<String> = def
+                .param_defs
+                .iter()
+                .map(|pd| pd.name.clone())
+                .chain(def.params.iter().cloned())
+                .collect();
+            let (resolved, _) = super::regex_arg_purity::with_resolution(params, || {
+                // Binding evaluates a parameter default or a `where` clause in
+                // the scratch env — arbitrary expressions over the caller's
+                // lexical scope, which the memo key does not carry.
+                if def
+                    .param_defs
+                    .iter()
+                    .any(|pd| pd.default.is_some() || pd.where_constraint.is_some())
+                {
+                    super::regex_arg_purity::note_opaque_read();
+                }
+                // Likewise the body: a constant one (the usual `token
+                // t($p) { … }`, whose body is the regex literal itself)
+                // evaluates to itself, anything else runs code.
+                if !Self::body_is_constant(&def.body) {
+                    super::regex_arg_purity::note_opaque_read();
+                }
+                self.resolve_one_token_pattern_with_args(&def, arg_values)
+            });
+            out.extend(resolved);
+        }
+        out
+    }
+
+    /// True when `body` evaluates to a constant — every statement is a line
+    /// marker or a literal, so running it reads nothing. `Expr::Literal` is
+    /// exactly what the compiler turns into a `LoadConst`.
+    fn body_is_constant(body: &[crate::ast::Stmt]) -> bool {
+        body.iter().all(|stmt| {
+            matches!(
+                stmt,
+                crate::ast::Stmt::SetLine(_) | crate::ast::Stmt::Expr(crate::ast::Expr::Literal(_))
+            )
+        })
+    }
+
+    /// One candidate of [`Self::resolve_token_patterns_with_args_in_pkg`]: bind
+    /// the arguments in a scratch interpreter, evaluate the body, and render
+    /// the resulting pattern.
+    fn resolve_one_token_pattern_with_args(
+        &mut self,
+        def: &Arc<FunctionDef>,
+        arg_values: &[Value],
+    ) -> Vec<(String, String, Option<String>)> {
+        let mut out = Vec::new();
+        {
             let mut interp = Interpreter {
                 env: self.env.clone(),
                 current_package: Arc::new(RwLock::new(def.package.resolve())),

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -371,6 +371,9 @@ impl Interpreter {
     /// not a function of its key.
     pub(super) fn note_regex_parse_ambient_read() {
         crate::runtime::regex_parse::PARSE_CONSULTED_AMBIENT_STATE.with(|f| f.set(true));
+        // The parameterized-subrule memo stores PARSED candidates, so a parse
+        // that is not a function of its own key makes that entry impure too.
+        crate::runtime::regex::regex_arg_purity::note_opaque_read();
     }
 
     /// Build the alternation atom for a `<@var>` array-variable subrule: look up

--- a/t/grammar/grammar-rule-arg-memo-outer-lexical.t
+++ b/t/grammar/grammar-rule-arg-memo-outer-lexical.t
@@ -1,0 +1,37 @@
+use Test;
+
+# A parameterized rule (`<rule($arg)>`) is resolved by binding the arguments in
+# a scratch interpreter, evaluating the body and rendering the pattern; the
+# result is memoized on (package, rule name, arguments). An entry may only be
+# stored when that chain read nothing outside the key — so a body that splices
+# an OUTER lexical must not be served from the memo after that lexical changes.
+#
+# Verified against rakudo 2026.07.
+# https://github.com/tokuhirom/mutsu/issues/7576
+
+plan 7;
+
+my $tail = 'a';
+grammar Spliced {
+    token TOP(Int $n) { 'x' ** { $n } $tail }
+}
+
+ok Spliced.parse('xxa', :args(\(2))), 'outer lexical spliced into a parameterized rule';
+$tail = 'b';
+ok Spliced.parse('xxb', :args(\(2))), 'the same rule and arguments see the NEW value';
+nok Spliced.parse('xxa', :args(\(2))), 'and no longer the old one';
+
+# A rule whose body reads nothing but its own parameters IS memoizable, and
+# repeated resolutions must keep producing the same match — including the
+# `$<name>=[...]` capture forms, which the syntactic predicate this replaced
+# rejected outright.
+grammar Rows {
+    token TOP($pad) { <row($pad)>+ % "\n" }
+    token row($pad) { $pad $<val> = [ \w+ ] }
+}
+
+my $m = Rows.parse("  ab\n  cd\n  ef", :args(\('  ')));
+ok $m, 'a parameterized rule with a named capture parses';
+is $m<row>.elems, 3, 'every repetition matched';
+is $m<row>[0]<val>, 'ab', 'first capture';
+is $m<row>[2]<val>, 'ef', 'last capture';

--- a/t/grammar/grammar-rule-constant-argument-forms.t
+++ b/t/grammar/grammar-rule-constant-argument-forms.t
@@ -1,0 +1,43 @@
+use Test;
+
+# A constant subrule argument (`<rule($indent, 0)>`'s `0`) is its own value:
+# nothing in it reads the env, the captures or the package. mutsu returns it
+# straight from the parsed literal instead of building an evaluation env and a
+# scratch interpreter, so this pins that every literal shape still arrives at
+# the rule with the value it was written with.
+#
+# Verified against rakudo 2026.07.
+# https://github.com/tokuhirom/mutsu/issues/7576
+
+plan 6;
+
+grammar Reps {
+    token TOP { <run(3)> }
+    token run(Int $n) { 'x' ** { $n } }
+}
+ok Reps.parse('xxx'), 'an integer literal argument reaches the rule';
+nok Reps.parse('xx'), 'and is not off by one';
+
+grammar Lit {
+    token TOP { <word("hi")> <word('there')> }
+    token word(Str $w) { \s* $w }
+}
+ok Lit.parse('hi there'), 'string literal arguments, both quote forms';
+
+grammar Neg {
+    token TOP { <shifted(-1)> }
+    token shifted(Int $n) { 'y' ** { $n + 3 } }
+}
+ok Neg.parse('yy'), 'a negative integer literal keeps its sign';
+
+grammar Rat {
+    token TOP { <scaled(0.5)> }
+    token scaled($f) { 'z' ** { ($f * 4).Int } }
+}
+ok Rat.parse('zz'), 'a rational literal keeps its value';
+
+grammar Bool {
+    token TOP { <maybe(True)> }
+    token maybe($on) { 'w' ** { $on ?? 2 !! 5 } }
+}
+ok Bool.parse('ww'), 'a boolean literal keeps its truth';


### PR DESCRIPTION
Round 17 of #7576. Instructions retired on the ticket's 60-row YAMLish document go **1,845,742,337 -> 1,565,835,736 (-15.16%)**. Attribution is callgrind Ir throughout (deterministic, load-independent), with the module precompilation cache warmed before each profiled run per round 14's note.

Round 16 handed off a flat profile — `LocalKey::with` 7.63% across a dozen callers, allocator ~19.6%, `memcpy` 4.20%, no mutsu function above ~1.9% — and one named item worth ~0.44%. This round's finding is not a self-cost line at all: `parsed_subrule_candidates` appears in the tree output under two callers, at **305** and **5,050** instructions per call, the second for **11.59% of the whole program**. Everything below follows from that gap.

## (a) The literal `0` was evaluated by a whole interpreter (-4.60%)

`<element($indent, 0)>` evaluates each argument expression before it can resolve the rule. `eval_regex_expr_value` has a fast path for a bare `$name` and sends everything else — the literal `0` included — through `parse_regex_code_cached`, a freshly built scratch `Interpreter` and `eval_block_value`. A scratch interpreter is ~76 heap allocations, five multi-kilobyte struct moves and a 13k-instruction drop: evaluating the constant `0` cost about **107,000 instructions**, and this document did it **811** times.

A literal is its own value. `parse_regex_code_cached` wraps the source in `(...)`, so the parse comes back as `[SetLine(n), Expr(Grouped(Literal(v)))]` — exactly the shape the compiler turns into one `LoadConst`, `Grouped` being a transparent wrapper — and `constant_stmt_value` returns `v`. The admitted value kinds are a positive list rather than an exclusion, so a new `Value` kind has to be let in deliberately: the one `Expr::Literal` the compiler does *not* treat as a constant is a code-bearing regex, which loads as a closure over its enclosing scope.

The bare-`$name` path went with it. It called `make_regex_eval_env` — `self.env` cloned, then the positional captures, `/`, the named captures and the in-regex lexicals layered on top — in order to read **one key** out of the result, 526 times at ~10,400 instructions each. The guard above it admits only an identifier, which can collide with none of those key shapes, so the two sources that can actually answer are read directly, in the same precedence.

`Interpreter::new` inclusive **63.9M (3.46%) -> 38.7M**; `make_regex_eval_env`, `eval_regex_arg_list` and `eval_regex_expr_value` all leave the profile.

## (b) …and the memo that exists to stop the rest was refusing every real grammar (-11.0%)

That left `resolve_token_patterns_with_args_in_pkg` at **9.10% for 692 calls**: binding the arguments in a scratch interpreter, evaluating the rule body, and running three textual passes over the pattern before parsing it — once per `<rule($arg)>` probe, at every position.

`PARSED_TOKEN_ARG_CANDIDATES` exists to memoize exactly that, on `(package, rule name, rendered arguments)` plus the token-registry generation. It was storing **nothing** here, because it gated on `pattern_static_modulo_params` — a syntactic predicate over the pattern text that required every `$` in it to introduce one of the rule's own parameters. That predicate was wrong in *both* directions at once:

- it refused every `$<capture>` / `$0` / `$(...)` form, which the interpolation pass provably leaves alone and which most of YAMLish's parameterized rules contain (`block`, `map`, `sequence`, `cuddly-list-entry`, `plain`);
- and it silently trusted the two steps that can read anything — the evaluation of the rule body, and the evaluation of the argument expressions.

The predicate is deleted. The exclusions are raised **at the reads themselves** now, which is round 13's discipline on the sibling `REGEX_SUBPATTERN_PARSE_CACHE` applied one layer up. The new `regex_arg_purity` records a resolution, and the flag goes up when:

- `interpolate_bound_regex_scalars` substitutes a name that is not one of the bound parameters (the value came from the caller's lexical scope, which the key does not carry);
- `eval_regex_expr_value` needs the general evaluator for an argument (arbitrary code; its reads cannot be attributed);
- a candidate has a parameter default or a `where` clause (binding evaluates them against the caller's env);
- a rule body is not a constant;
- the parse of a resolved candidate raises its own ambient-read flag — `note_regex_parse_ambient_read` raises both, because this memo stores the *parsed* candidates.

Frames nest and the flag OR-restores outward, so an inner impurity is never lost. `resolve_token_patterns_with_args_in_pkg` **160.3M (9.10%) -> below the reporting threshold**.

The memo is now bounded the way `REGEX_SUBPATTERN_PARSE_CACHE` is, and for the same reason: its key carries *rendered arguments*, which are runtime data, so a grammar parameterized on the text it is parsing (`<block($indent)>` over a deep document) would otherwise mint one entry per distinct value. Dropping the memo buys back re-resolutions and nothing else.

## Tests

Two new pins in `t/grammar/`, both verified against rakudo 2026.07:

- `grammar-rule-constant-argument-forms.t` — every literal shape (integer, negative, both string quote forms, rational, boolean) still arrives at the rule with the value it was written with;
- `grammar-rule-arg-memo-outer-lexical.t` — a rule body that splices an *outer* lexical is not served from the memo after that lexical changes (the soundness pin for the widening), and a rule that reads only its own parameters keeps matching correctly across repeated resolutions, `$<name>=[...]` captures included.

`cargo fmt --all`, `make lint`, `make test` (4085 files, 43420 tests) and `make roast` (1437 files, 219635 tests) were all run locally before publishing. roast's only failures are the three documented container-only ones — `roast/6.c/S32-io/file-tests.t` (`Failed: 4`) and `roast/S16-filehandles/filetest.t` (`Failed: 25`), both because the container runs as `uid 0`, and `roast/S32-io/IO-Socket-Async.t` (exit 124, "planned 40 ran 17") on the sandboxed network — each matching `docs/agent-environments.md` exactly, test counts included.

## Method note

Rounds 11-16 each found their item by resolving a flat profile through caller attribution. Round 17 adds a narrower, mechanical tell: **when one function appears under two callers with an order-of-magnitude difference in cost per call, that ratio is the finding.** `parsed_subrule_candidates` was on no "top" list — 0.24% self — and its two caller lines sat next to each other reading 305 and 5,050 instructions per call. Neither number means anything alone; the gap between them named a memo that was not storing.

The corollary is about what a memo exclusion may be made of. A syntactic predicate is not merely brittle, as round 13 found — it is wrong in both directions at once, and the two errors hide each other: the over-refusal costs performance silently, and the over-trust costs correctness silently. Raising the exclusion where the read happens fixed both halves in one change and deleted the predicate.

## What is left

Re-measured on the post-round-17 profile, not carried forward. The profile is flat again: `LocalKey::with` 8.62%, allocator ~18.1%, `memcpy` 2.26%, largest single mutsu function `regex_match_atom_all_with_capture_in_pkg_inner` at 2.33%. `Symbol::intern` is still `LocalKey::with`'s largest caller (417,848 calls, ~3.6% of the run including its TLS probe, of which only 3,568 assign a new id); its own largest caller is round 15's carried item, `resolve_parsed_token_candidates_in_pkg` interning its *package* name on every probe (102,685 of them), which still wants a `Symbol` threaded down through the matcher's `pkg: &str` chain rather than another memo. Behind that, #8095 (the parser re-parsing a module's source for its export list, 209M Ir per `use YAMLish`) is still the largest single identified item and still wants a transitive-invalidation decision before code.

The ticket stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_