### PR TITLE
fix: carry argument-less pragmas through RakuAST

### DIFF
--- a/news/2026-09/rakuast-pragmas-cross-boundary.md
+++ b/news/2026-09/rakuast-pragmas-cross-boundary.md
@@ -1,0 +1,4 @@
+`use strict`, `use fatal`, and the other argument-less core pragmas now cross
+mutsu's RakuAST boundary as direct `RakuAST::Pragma` nodes. Their constructors,
+accessors, and EVAL lowering are supported while ordinary module imports remain
+separate work.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -218,6 +218,15 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 tree,
             )?)))
         }
+        // Raku keeps an argument-less core pragma as a `Pragma` directly in
+        // the statement list. Ordinary modules use `Statement::Use` instead;
+        // do not reconstruct that distinction from every `Stmt::Use`.
+        Stmt::Use {
+            module,
+            arg: None,
+            tags,
+            condition: None,
+        } if tags.is_empty() && is_pragma_name(module) => Ok(Some(pragma_node(module))),
         // `say 42` / `put`/`print`/`note` as listops (no parens) parse to a
         // dedicated statement; raku models them as a call in WithoutParentheses
         // form.
@@ -1037,6 +1046,36 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             Ok(Some(node))
         }
         other => Err(unsupported(&format!("{other:?}"))),
+    }
+}
+
+/// The argument-less pragmas that Rakudo represents as `RakuAST::Pragma`.
+/// Language-version pragmas and `use lib` have distinct parser contracts, and
+/// ordinary modules remain `RakuAST::Statement::Use`, so neither belongs here.
+fn is_pragma_name(name: &str) -> bool {
+    matches!(
+        name,
+        "strict"
+            | "fatal"
+            | "nqp"
+            | "soft"
+            | "MONKEY"
+            | "MONKEY-GUTS"
+            | "MONKEY-TYPING"
+            | "MONKEY-SEE-NO-EVAL"
+            | "dynamic-scope"
+            | "isms"
+            | "precompilation"
+            | "worries"
+            | "trace"
+            | "internals"
+    )
+}
+
+fn pragma_node(name: &str) -> RakuAstNode {
+    RakuAstNode {
+        class: RakuAstClass::Pragma,
+        fields: vec![leaf_field(Some("name"), Value::str(name.to_string()))],
     }
 }
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -165,6 +165,15 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         // implied by the statement class, so only the block's statements are
         // read back.
         RakuAstClass::StatementCatch => Ok(Stmt::Catch(lower_block(named_child(node, "body")?)?)),
+        // An argument-less `RakuAST::Pragma` is the model form of `use strict`,
+        // `use fatal`, and the other core pragmas handled by the parser and
+        // compiler's existing `Stmt::Use` path.
+        RakuAstClass::Pragma => Ok(Stmt::Use {
+            module: leaf_str(node, "name")?,
+            arg: None,
+            tags: Vec::new(),
+            condition: None,
+        }),
         // A named `sub f { … }` is a declaration; a nameless one (`sub ($x) { … }`,
         // `sub { … }`) is a closure *value*, so it lowers through the expression
         // path instead.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -229,6 +229,8 @@ pub enum RakuAstClass {
     Submethod,
     // `self` — a term with no fields of its own.
     TermSelf,
+    // An argument-less core `use` pragma (`use strict`, `use fatal`, ...).
+    Pragma,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -365,6 +367,7 @@ impl RakuAstClass {
             Package => "RakuAST::Package",
             Submethod => "RakuAST::Submethod",
             TermSelf => "RakuAST::Term::Self",
+            Pragma => "RakuAST::Pragma",
         }
     }
 
@@ -475,6 +478,7 @@ impl RakuAstClass {
                 "RakuAST::Expression",
             ],
             ColonPairTrue => &["RakuAST::Term", "RakuAST::Expression"],
+            Pragma => &["RakuAST::Statement"],
             _ => &[],
         }
     }
@@ -600,6 +604,7 @@ fn semantic_type_object_ancestors(class_name: &str) -> &'static [&'static str] {
             "RakuAST::Regex",
         ],
         "RakuAST::ColonPair::True" => &["RakuAST::Term", "RakuAST::Expression"],
+        "RakuAST::Pragma" => &["RakuAST::Statement"],
         "RakuAST::RegexDeclaration"
         | "RakuAST::TokenDeclaration"
         | "RakuAST::RuleDeclaration" => &[
@@ -771,6 +776,7 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::Package,
     RakuAstClass::Submethod,
     RakuAstClass::TermSelf,
+    RakuAstClass::Pragma,
 ];
 
 /// Entry point for `Str.AST`: parse the source, convert, wrap in `Value::RakuAst`.
@@ -842,6 +848,27 @@ pub fn construct(
         return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
             class: RakuAstClass::StatementList,
             fields: Vec::new(),
+        }))));
+    }
+    if class_name == "RakuAST::Pragma" && method == "new" {
+        let name = named_arg(args, "name")
+            .ok_or_else(|| RuntimeError::new("RakuAST::Pragma.new requires `name`"))?;
+        let ValueView::Str(name) = name.view() else {
+            return Err(RuntimeError::new(
+                "RakuAST::Pragma.new expects `name` to be a Str",
+            ));
+        };
+        if named_arg(args, "argument").is_some() || named_arg(args, "off").is_some() {
+            return Err(RuntimeError::new(
+                "RakuAST::Pragma.new only supports argument-less pragmas",
+            ));
+        }
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::Pragma,
+            fields: vec![RakuAstField {
+                name: Some("name"),
+                value: RakuAstFieldValue::Node(Value::str(name.to_string())),
+            }],
         }))));
     }
     if class_name == "RakuAST::Blockoid" && method == "new" {
@@ -1552,6 +1579,15 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
     if node.class == RakuAstClass::MetaInfixHyper && matches!(method, "dwim-left" | "dwim-right") {
         return Some(Value::truth(false));
     }
+    if node.class == RakuAstClass::Pragma {
+        match method {
+            // Rakudo declares both fields but omits their false/empty values
+            // from `.gist` for the argument-less form.
+            "argument" => return Some(Value::NIL),
+            "off" => return Some(Value::truth(false)),
+            _ => {}
+        }
+    }
     if method == "statements" && matches!(node.class, RakuAstClass::StatementList) {
         let items = node
             .fields
@@ -1706,6 +1742,7 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::TokenDeclaration
             | RakuAstClass::RuleDeclaration
             | RakuAstClass::Grammar
+            | RakuAstClass::Pragma
     )
 }
 
@@ -1751,6 +1788,7 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         RegexQuantifiedAtom => &["atom", "quantifier", "separator", "trailing-separator"],
         RegexDeclaration | TokenDeclaration | RuleDeclaration => &["name", "body"],
         Grammar => &["name", "body"],
+        Pragma => &["name", "argument", "off"],
         _ => &[],
     }
 }

--- a/t/rakuast/rakuast-use-pragma.t
+++ b/t/rakuast/rakuast-use-pragma.t
@@ -1,0 +1,53 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST `use` pragmas (issue #8035). Rakudo keeps an argument-less pragma
+# directly in the StatementList as RakuAST::Pragma, while ordinary modules use
+# a distinct Statement::Use node.
+
+plan 15;
+
+is Q[use strict].AST.gist, q:to/END/.chomp, 'use strict renders as a Pragma';
+RakuAST::StatementList.new(
+  RakuAST::Pragma.new(
+    name => "strict"
+  )
+)
+END
+
+is Q[use fatal].AST.gist, q:to/END/.chomp, 'use fatal renders as a Pragma';
+RakuAST::StatementList.new(
+  RakuAST::Pragma.new(
+    name => "fatal"
+  )
+)
+END
+
+my $pragma = Q[use strict].AST.statements[0];
+is $pragma.^name, 'RakuAST::Pragma', 'pragma is a direct statement node';
+is $pragma.name, 'strict', 'pragma name is a Str field';
+nok $pragma.argument.defined, 'argument is omitted for an argument-less pragma';
+nok $pragma.off, 'off is false for use';
+ok $pragma ~~ RakuAST::Statement, 'pragma retains the Statement hierarchy';
+
+my @methods = RakuAST::Pragma.^methods(:local)>>.name;
+ok 'new' (elem) @methods, 'Pragma exposes a constructor';
+ok 'name' (elem) @methods && 'argument' (elem) @methods && 'off' (elem) @methods,
+    'Pragma exposes its field accessors';
+
+my $constructed = RakuAST::Pragma.new(name => 'strict');
+is $constructed.gist, q:to/END/.chomp, 'Pragma.new constructs the measured shape';
+RakuAST::Pragma.new(
+  name => "strict"
+)
+END
+is $constructed.name, 'strict', 'constructed pragma exposes its name';
+nok $constructed.argument.defined, 'constructed pragma defaults argument to Nil';
+nok $constructed.off, 'constructed pragma defaults off to False';
+
+is EVAL(Q[use strict; 40 + 2].AST), 42,
+    'a parsed pragma AST lowers through the existing compiler';
+dies-ok { EVAL(Q[use fatal; fail "boom"].AST) },
+    'a fatal pragma AST preserves existing failure semantics';


### PR DESCRIPTION
## Summary

- Carry argument-less core `use` pragmas across the RakuAST boundary as direct `RakuAST::Pragma` nodes.
- Support the `Pragma` semantic hierarchy, constructor, accessors, and lowering through the existing `Stmt::Use` compiler path.
- Add Rakudo-oracle regression coverage and a news entry.

## Validation

- `cargo fmt --all`
- `make lint`
- `make test`
- `make roast`

Closes #8035
