### PR TITLE
docs(news): backfill entries for #8024, #8030, #8031

### DIFF
--- a/news/2026-09/carray-expression-index-write-reaches-native-memory.md
+++ b/news/2026-09/carray-expression-index-write-reaches-native-memory.md
@@ -1,0 +1,29 @@
+# A CArray element write reaches native memory from any expression
+
+Assigning into an index of a native CArray handle silently did nothing
+unless the handle was first bound to a variable. Both index-assignment
+paths recognized a CArray handle by looking its **variable name** up in
+`env`:
+
+- `exec_index_assign_generic_op` (`vm_var_assign_index_named.rs`), for a
+  computed target like `get()[2] = 7`, never even reached that lookup —
+  its target is already the evaluated stack value, with no name to look
+  up, so it fell into the generic Raku-container path and wrote into a
+  throwaway array.
+- `builtin_index_assign_method_lvalue` (`builtins_multidim_assign.rs`), for
+  an accessor-returned handle like `$b.c[1] = 5`, called the accessor to
+  get the current value and then dispatched `ASSIGN-POS`/`AT-POS` on it as
+  though it were a plain Associative/Positional object.
+
+Both now check the already-evaluated target/accessor-result value
+directly for the CArray shape (an `Instance` with an `address` attribute
+and a `CArray[...]` class name) and write through
+`native_carray_element_assign` when it matches, before falling through to
+their generic paths.
+
+This matters because a `has CArray[T] $.x` CStruct field, and an inline
+`HAS T @.x[N] is CArray` member, both read back as a proper `CArray[T]`
+handle, so `$s.x[1] = 5` is a shape users reasonably write directly.
+
+See [#8031](https://github.com/tokuhirom/mutsu/issues/8031) and the
+regression test `t/nativecall/cstruct-carray-expr-index-write.t`.

--- a/news/2026-09/cstruct-private-attribute-reads-native-memory.md
+++ b/news/2026-09/cstruct-private-attribute-reads-native-memory.md
@@ -1,0 +1,22 @@
+# A private $!field on a CStruct handle reads native memory
+
+`has int32 $!a` on an `is repr('CStruct')` handle read `Nil` instead of the
+C struct's own bytes. The public accessor (`$obj.field`) compiles to a
+method call and already went through `cstruct_field_value` (all five of
+its call sites are method dispatch), but `$!field` — the private-twigil
+form — compiles to a direct local-slot read (`GetLocal`) with no CStruct
+fallback, so it always found the instance's empty Raku attribute map.
+
+`exec_get_local_op_inner` (`src/vm/vm_var_assign_local_get.rs`) now tries
+`cstruct_field_value` for a private-attribute local once the ordinary
+self-cell lookup comes back empty — the same lookup the public accessor's
+method-dispatch path already uses. This covers both a plain `has $!a` and
+a `HAS`-declared embedded member read back through a method.
+
+The write half (`$!a = 42` inside a method) stays a separate, wider touch:
+`write_attr_cell_by_key` and its callers are `&self`, not `&mut self`, all
+the way up through several files, so threading `&mut self` through for a
+`cstruct_field_assign` fallback is left for a follow-up.
+
+See [#8030](https://github.com/tokuhirom/mutsu/issues/8030) and the
+regression test `t/nativecall/cstruct-private-attr-read.t`.

--- a/news/2026-09/nqp-defined-isconcrete-list-unshift-ops.md
+++ b/news/2026-09/nqp-defined-isconcrete-list-unshift-ops.md
@@ -1,0 +1,27 @@
+# nqp::defined, nqp::isconcrete, nqp::list, and nqp::unshift
+
+Four `nqp::` value ops that ordinary Raku modules reach for were
+unimplemented, failing loudly with "Unsupported nqp:: op" instead of
+silently aliasing to a different-semantics Raku builtin: `nqp::defined`,
+`nqp::isconcrete`, `nqp::list`, and `nqp::unshift`. `nqp::unless` — the
+fifth op the driving repro used — was already a compiled special form
+(`compiler/nqp_forms.rs`); the real blocker was `nqp::isconcrete`.
+
+- `nqp::defined` / `nqp::isconcrete` both collapse to the existing
+  `runtime::types::value_is_defined` check: 0 for a type object or the VM
+  null, 1 otherwise.
+- `nqp::list` is the untyped VM list, using the same representation as the
+  existing typed `list_s`/`list_i`/`list_n` (an ordinary array).
+- `nqp::unshift` is the positional peer of `push_s`/`push_i`/`push_n`,
+  inserting at the front of an nqp list / native array in place.
+
+This unblocks Test::Async 0.1.17's `HubHOW` bundle registry, which builds
+and reads a raw nqp list with exactly this idiom:
+
+```raku
+nqp::unless(nqp::isconcrete($bundle-typeobjs), ($bundle-typeobjs := nqp::list()));
+nqp::unshift($bundle-typeobjs, bundle-typeobj);
+```
+
+See [#8024](https://github.com/tokuhirom/mutsu/issues/8024) and the
+regression test `t/vm/nqp-defined-list-unshift-ops.t`.


### PR DESCRIPTION
## Summary

Three tickets merged (#8092, #8103, #8111) without their `news/` writeups
being added at the time. This adds the three missing entries:

- `news/2026-09/nqp-defined-isconcrete-list-unshift-ops.md` (#8024)
- `news/2026-09/cstruct-private-attribute-reads-native-memory.md` (#8030)
- `news/2026-09/carray-expression-index-write-reaches-native-memory.md` (#8031)

Documentation-only change (`news/` is on the CI docs-only allowlist), no
code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_