### PR TITLE
feat(rakuast): carry the with/without statement modifier across the boundary

### DIFF
--- a/news/2026-09/with-without-statement-modifier-crosses-the-rakuast-boundary.md
+++ b/news/2026-09/with-without-statement-modifier-crosses-the-rakuast-boundary.md
@@ -1,0 +1,74 @@
+# The `with` / `without` statement modifiers cross the RakuAST boundary
+
+`EXPR with X` and `EXPR without X` executed correctly, but the parser rewrote
+them into a `given` whose body is an `if $_.defined`, so by the time anything
+downstream looked at the AST the modifier keyword was gone. `.AST` could only
+report a boundary error:
+
+```
+$ mutsu -e 'say Q["found" with "hello"].AST.gist'
+RakuAST: `.AST` does not yet support this construct: DoStmt(Given { topic: ... })
+```
+
+raku keeps both as a `condition-modifier` on the statement, exactly as it does
+for `if` / `unless`:
+
+```
+RakuAST::Statement::Expression.new(
+  expression         => RakuAST::QuotedString.new(...),
+  condition-modifier => RakuAST::StatementModifier::With.new(...)
+)
+```
+
+## Why the converter could not just recognise the shape
+
+The desugar is genuinely lossy. `STMT with X` becomes
+`given X { if $_.defined { STMT } }`, and a hand-written
+`(STMT if $_.defined) given X` produces the identical internal statement — same
+`Given`, same `is_statement_modifier`, same `.defined` test. A converter that
+matched on the shape would have to guess, and would render one of the two
+wrongly. The information has to survive the parse instead.
+
+So `Stmt::Given` grew a `with_kind: Option<GivenWithKind>` marker, recording
+which source keyword desugared into it. This is the same trick `Stmt::If`
+already uses for `unless` (a negated condition plus an `is_unless` flag, with
+the converter stripping the parser's `!` back off) and `Stmt::While` for
+`until`. Execution ignores the marker entirely; only the RakuAST converter reads
+it.
+
+## Both directions
+
+- `src/rakuast/convert.rs` renders `StatementModifier::With` / `::Without` as a
+  `condition-modifier`, unwrapping the topicalizer and its `.defined` test back
+  to the two pieces raku's node actually holds. The expression-statement
+  spelling arrives wrapped in a `DoStmt` (that is how the parser keeps
+  expression semantics), which has no RakuAST counterpart, so `Stmt::Expr` now
+  unwraps it when it carries a marked `Given`.
+- `src/rakuast/lower.rs` accepts the hand-built node and rebuilds the same
+  `given`/`if` shape the parser produces, marker included, so the round trip is
+  stable.
+- `src/rakuast/mod.rs` registers the two classes.
+
+Output is byte-identical to rakudo 2026.07 for `"found" with "hello"`,
+`"nf" without Nil`, `say 1 with 2` and `say 1 without Nil`, and
+`EVAL(Q[...].AST)` agrees on all of them — including the empty `Slip` both
+produce when the topic fails the test.
+
+Critically, `(say 1 if $_.defined) given 2` still renders as a
+`loop-modifier => StatementModifier::Given`, which is the whole point of the
+marker.
+
+## The block forms are a separate slice
+
+`with X { … }` / `without X { … }` were measured at the same time, as the ticket
+asked. They have the same problem but a much larger desugar — mutsu produces
+`If { cond: <a `__with_tmp_N` declaration>.defined, then_branch: [Given { … }] }`
+rather than a marked `Given` — and raku models them as `Statement::With`
+(fields `condition` / `then` / `else`) and `Statement::Without` (fields
+`condition` / `body`), with `orwith`/`else` chaining on top. That is filed
+separately rather than widened into this change.
+
+Pinned by `t/rakuast/rakuast-with-without-modifier.t` (20 tests: node classes,
+which modifier slot is filled, the `given` ambiguity case, `EVAL` of the
+round-tripped AST, and the source-level semantics). It passes under rakudo
+unchanged.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1143,6 +1143,21 @@ pub(crate) enum ReadonlyKind {
     ImmutableValue,
 }
 
+/// Which `with`-family keyword the parser desugared into a [`Stmt::Given`].
+///
+/// The desugar is lossy on its own: `STMT with X` becomes
+/// `given X { if $_.defined { STMT } }`, which a hand-written
+/// `(STMT if $_.defined) given X` also produces. `Stmt::Given`'s `with_kind`
+/// carries the distinction so the RakuAST converter can render
+/// `StatementModifier::With` / `::Without` instead of guessing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) enum GivenWithKind {
+    /// `STMT with EXPR` -- run `STMT` when the topic is defined.
+    With,
+    /// `STMT without EXPR` -- run `STMT` when the topic is NOT defined.
+    Without,
+}
+
 #[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum Stmt {
     VarDecl {
@@ -1420,6 +1435,15 @@ pub(crate) enum Stmt {
         /// True for postfix statement-modifier `STMT given EXPR`. Unlike the
         /// block form, a modifier does not introduce a lexical scope.
         is_statement_modifier: bool,
+        /// Which source keyword produced this `Given`, when it was not `given`
+        /// itself. `STMT with X` and `STMT without X` desugar to
+        /// `given X { if $_.defined { STMT } }` (negated for `without`), which
+        /// is exactly the shape a hand-written `(STMT if $_.defined) given X`
+        /// produces -- so without this marker the source keyword is
+        /// unrecoverable. Only the RakuAST converter reads it; execution
+        /// treats every `Given` alike. Mirrors `Stmt::If`'s `is_unless` and
+        /// `Stmt::While`'s `is_until`.
+        with_kind: Option<GivenWithKind>,
     },
     When {
         cond: Expr,

--- a/src/compiler/helpers_phasers.rs
+++ b/src/compiler/helpers_phasers.rs
@@ -697,6 +697,7 @@ impl Compiler {
                 topic: post_topic,
                 body: post_body,
                 is_statement_modifier: false,
+                with_kind: None,
             });
         }
         // KEEP/UNDO runs before LEAVE on normal (uninterrupted) completion,
@@ -744,6 +745,7 @@ impl Compiler {
                 topic: Expr::Var(last_topic_var),
                 body: last_ph,
                 is_statement_modifier: false,
+                with_kind: None,
             };
             vec![Stmt::If {
                 cond: Expr::Var(ran_var),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2793,6 +2793,9 @@ impl Compiler {
                 topic,
                 body,
                 is_statement_modifier,
+                // `with_kind` records which source keyword desugared into this
+                // `Given`; it changes nothing about how one executes.
+                with_kind: _,
             } => {
                 // A pointy `-> $_ is copy` block starts with a parser-generated
                 // lexical declaration carrying the `__pointy_copy` marker: the

--- a/src/parser/primary/ident/supply.rs
+++ b/src/parser/primary/ident/supply.rs
@@ -254,10 +254,12 @@ fn rewrite_supply_stmt(stmt: Stmt, emitter_name: &str) -> Stmt {
             topic,
             body,
             is_statement_modifier,
+            with_kind,
         } => Stmt::Given {
             topic,
             body: rewrite_supply_body(body, emitter_name),
             is_statement_modifier,
+            with_kind,
         },
         Stmt::When {
             cond,

--- a/src/parser/stmt/control/conditionals.rs
+++ b/src/parser/stmt/control/conditionals.rs
@@ -138,6 +138,7 @@ fn lower_if_clause_binding(
                     topic: source_expr,
                     body: then_branch,
                     is_statement_modifier: false,
+                    with_kind: None,
                 }],
             );
         }
@@ -207,6 +208,7 @@ fn lower_else_binding(source_binding: &str, else_clause: ElseClause) -> Vec<Stmt
                 topic: Expr::Var(source_binding.trim_start_matches('$').to_string()),
                 body: else_clause.body,
                 is_statement_modifier: false,
+                with_kind: None,
             }];
         }
         let mut body = Vec::with_capacity(else_clause.body.len() + 1);
@@ -342,6 +344,7 @@ pub(crate) fn parse_elsif_chain(
                 topic: orwith_cond_expr.clone(),
                 body: orwith_given_body,
                 is_statement_modifier: false,
+                with_kind: None,
             }];
             // orwith uses .defined as the condition
             last_orwith_cond = Some(orwith_cond_expr.clone());
@@ -410,6 +413,7 @@ pub(crate) fn parse_elsif_chain(
                 topic: orwith_expr.clone(),
                 body: given_body,
                 is_statement_modifier: false,
+                with_kind: None,
             }];
         }
         return Ok((

--- a/src/parser/stmt/control/given_when.rs
+++ b/src/parser/stmt/control/given_when.rs
@@ -25,6 +25,7 @@ pub(crate) fn given_stmt(input: &str) -> PResult<'_, Stmt> {
             topic,
             body,
             is_statement_modifier: false,
+            with_kind: None,
         },
     ))
 }

--- a/src/parser/stmt/control/with_stmt.rs
+++ b/src/parser/stmt/control/with_stmt.rs
@@ -256,18 +256,21 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
             topic: cond_expr.clone(),
             body: given_body,
             is_statement_modifier: false,
+            with_kind: None,
         }];
     } else if route_through_given_tmp || pointy_is_topic {
         with_body = vec![Stmt::Given {
             topic: tmp_var.clone(),
             body,
             is_statement_modifier: false,
+            with_kind: None,
         }];
     } else if route_literal_through_given {
         with_body = vec![Stmt::Given {
             topic: cond_expr.clone(),
             body,
             is_statement_modifier: false,
+            with_kind: None,
         }];
     } else {
         with_body.extend(body);
@@ -380,6 +383,7 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
                 topic: tmp_var.clone(),
                 body: else_given_body,
                 is_statement_modifier: false,
+                with_kind: None,
             }];
             (r, else_with_topic)
         } else {

--- a/src/parser/stmt/decl/mod.rs
+++ b/src/parser/stmt/decl/mod.rs
@@ -97,6 +97,7 @@ fn wrap_with_will_leave(
             topic: topic_expr,
             body,
             is_statement_modifier: false,
+            with_kind: None,
         }];
         stmts.push(Stmt::Phaser {
             kind,

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -2,7 +2,7 @@ use super::super::expr::expression;
 use super::super::helpers::{ws, ws1};
 use super::super::parse_result::{PError, PResult, merge_expected_messages};
 
-use crate::ast::{CallArg, Expr, ParamDef, Stmt};
+use crate::ast::{CallArg, Expr, GivenWithKind, ParamDef, Stmt};
 use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
 use crate::value::Value;
@@ -771,6 +771,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 topic,
                 body: vec![given_stmt],
                 is_statement_modifier: true,
+                with_kind: None,
             },
         )));
     }
@@ -802,6 +803,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                     is_statement_modifier: true,
                 }],
                 is_statement_modifier: true,
+                with_kind: None,
             },
         )));
     }
@@ -864,6 +866,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 topic: cond,
                 body: vec![Stmt::Expr(Expr::DoStmt(Box::new(if_stmt)))],
                 is_statement_modifier: true,
+                with_kind: Some(GivenWithKind::With),
             };
             return Ok(Some((
                 r_tail,
@@ -887,6 +890,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 is_unless: false,
             }],
             is_statement_modifier: true,
+            with_kind: Some(GivenWithKind::With),
         };
         return Ok(Some((r_tail, given_stmt)));
     }
@@ -945,6 +949,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 topic: cond,
                 body: vec![Stmt::Expr(Expr::DoStmt(Box::new(if_stmt)))],
                 is_statement_modifier: true,
+                with_kind: Some(GivenWithKind::Without),
             };
             return Ok(Some((
                 r_tail,
@@ -962,6 +967,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 is_unless: false,
             }],
             is_statement_modifier: true,
+            with_kind: Some(GivenWithKind::Without),
         };
         return Ok(Some((r_tail, given_stmt)));
     }

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -7,7 +7,7 @@
 //! silently-wrong node.
 
 use super::{RakuAstClass, RakuAstField, RakuAstFieldValue, RakuAstNode};
-use crate::ast::{AssignOp, EnumVariantForm, Expr, ForMode, ParamDef, Stmt};
+use crate::ast::{AssignOp, EnumVariantForm, Expr, ForMode, GivenWithKind, ParamDef, Stmt};
 use crate::compiler::helpers_ops::token_kind_to_op_name;
 use crate::regex_tree::{RegexNode, RegexQuantifier, RegexTree};
 use crate::runtime::utils::is_known_type_constraint;
@@ -149,6 +149,21 @@ fn collect_declared_names(
 fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
     match stmt {
         Stmt::SetLine(_) => Ok(None),
+        // An expression statement modified by `with`/`without` is wrapped in a
+        // `DoStmt` so it keeps expression semantics. The wrapper has no RakuAST
+        // counterpart, so convert the `Given` it carries instead of rendering a
+        // `Statement::Expression` around it.
+        Stmt::Expr(Expr::DoStmt(inner))
+            if matches!(
+                inner.as_ref(),
+                Stmt::Given {
+                    with_kind: Some(_),
+                    ..
+                }
+            ) =>
+        {
+            convert_stmt(inner)
+        }
         Stmt::Expr(e) => Ok(Some(statement_expression(convert_expr(e)?))),
         Stmt::TokenDecl {
             name,
@@ -585,7 +600,17 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             topic,
             body,
             is_statement_modifier,
+            with_kind,
         } => {
+            // `STMT with X` / `STMT without X` reach here as the `given` the
+            // parser desugared them into; `with_kind` is what says which
+            // keyword the source actually used (the desugared shape alone is
+            // ambiguous with a hand-written `(STMT if $_.defined) given X`).
+            // raku keeps them as a `condition-modifier`, like `if`/`unless`,
+            // not as the `loop-modifier` a real `given` gets.
+            if let Some(kind) = with_kind {
+                return with_modifier_node(*kind, topic, body).map(Some);
+            }
             if *is_statement_modifier {
                 let [modified] = body.as_slice() else {
                     return Err(unsupported("multi-statement given modifier body"));
@@ -1995,6 +2020,62 @@ fn single_if_stmt(stmts: &[Stmt]) -> Option<&Stmt> {
         return None;
     }
     matches!(first, Stmt::If { .. }).then_some(first)
+}
+
+/// `STMT with X` / `STMT without X` -> the modified statement carrying a
+/// `condition-modifier` of `StatementModifier::With` / `::Without`.
+///
+/// The parser desugars both into `given X { if $_.defined { STMT } }` (with the
+/// condition negated for `without`), optionally wrapped in a `DoStmt` when the
+/// modified statement is an expression statement. Everything but `STMT` and `X`
+/// is scaffolding raku does not model, so this unwraps back to the two pieces
+/// raku's node actually holds. Measured against rakudo 2026.07:
+/// `Q["found" with "hello"].AST`.
+fn with_modifier_node(
+    kind: GivenWithKind,
+    topic: &Expr,
+    body: &[Stmt],
+) -> Result<RakuAstNode, RuntimeError> {
+    let [wrapper] = body else {
+        return Err(unsupported("multi-statement with/without modifier body"));
+    };
+    // The expression-statement spelling carries the `if` inside a `DoStmt`.
+    let wrapper = match wrapper {
+        Stmt::Expr(Expr::DoStmt(inner)) => inner.as_ref(),
+        other => other,
+    };
+    let Stmt::If {
+        then_branch,
+        else_branch,
+        ..
+    } = wrapper
+    else {
+        return Err(unsupported(
+            "with/without modifier body is not a conditional",
+        ));
+    };
+    if !else_branch.is_empty() {
+        return Err(unsupported("with/without modifier with an else branch"));
+    }
+    let mut real = then_branch
+        .iter()
+        .filter(|s| !matches!(s, Stmt::SetLine(_)));
+    let (Some(modified), None) = (real.next(), real.next()) else {
+        return Err(unsupported("multi-statement with/without modifier body"));
+    };
+    let mut statement =
+        convert_stmt(modified)?.ok_or_else(|| unsupported("empty with/without modifier body"))?;
+    statement.fields.push(node_field(
+        Some("condition-modifier"),
+        RakuAstNode {
+            class: match kind {
+                GivenWithKind::With => RakuAstClass::StatementModifierWith,
+                GivenWithKind::Without => RakuAstClass::StatementModifierWithout,
+            },
+            fields: vec![node_field(None, convert_expr(topic)?)],
+        },
+    ));
+    Ok(statement)
 }
 
 /// One `elsif` clause -> `Statement::Elsif(condition, then => Block)`.

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -7,7 +7,7 @@
 //! produce an explicit `RuntimeError` (the documented coverage boundary).
 
 use super::{RakuAstClass, RakuAstFieldValue, RakuAstNode};
-use crate::ast::{EnumVariantForm, Expr, ParamDef, Stmt};
+use crate::ast::{EnumVariantForm, Expr, GivenWithKind, ParamDef, Stmt};
 use crate::regex_tree::{RegexNode, RegexQuantifier, RegexTree};
 use crate::value::{RegexAdverbs, RuntimeError, Value, ValueView};
 use std::sync::Arc;
@@ -65,6 +65,7 @@ fn lower_stmt(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
                         topic: lower_expr(named_child_or_positional(modifier)?)?,
                         body: vec![statement],
                         is_statement_modifier: true,
+                        with_kind: None,
                     });
                 }
                 return Err(unsupported(modifier));
@@ -80,6 +81,21 @@ fn lower_stmt(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
                 .find(|f| f.name == Some("condition-modifier"))
             {
                 let modifier = child_node(&modifier.value)?;
+                // `with`/`without` are condition modifiers too, but they
+                // topicalize: mutsu spells them as the `given` desugar the
+                // parser builds, tagged with `with_kind` so the converter can
+                // read the keyword back out.
+                if let Some(kind) = match modifier.class {
+                    RakuAstClass::StatementModifierWith => Some(GivenWithKind::With),
+                    RakuAstClass::StatementModifierWithout => Some(GivenWithKind::Without),
+                    _ => None,
+                } {
+                    return Ok(lower_with_modifier(
+                        kind,
+                        lower_expr(named_child_or_positional(modifier)?)?,
+                        statement,
+                    ));
+                }
                 let is_unless = match modifier.class {
                     RakuAstClass::StatementModifierIf => false,
                     RakuAstClass::StatementModifierUnless => true,
@@ -98,6 +114,40 @@ fn lower_stmt(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
             Ok(statement)
         }
         _ => lower_stmt_inner(node),
+    }
+}
+
+/// Rebuild the `given TOPIC { if $_.defined { STMT } }` shape that mutsu's
+/// parser produces for `STMT with TOPIC` (condition negated for `without`),
+/// carrying the `with_kind` tag the converter reads back. Keeping the lowered
+/// form identical to the parsed one is what makes the round trip stable.
+fn lower_with_modifier(kind: GivenWithKind, topic: Expr, statement: Stmt) -> Stmt {
+    let defined = Expr::MethodCall {
+        target: Box::new(Expr::Var("_".to_string())),
+        name: crate::symbol::Symbol::intern("defined"),
+        args: Vec::new(),
+        modifier: None,
+        quoted: false,
+    };
+    let cond = match kind {
+        GivenWithKind::With => defined,
+        GivenWithKind::Without => Expr::Unary {
+            op: crate::token_kind::TokenKind::Bang,
+            expr: Box::new(defined),
+        },
+    };
+    Stmt::Given {
+        topic,
+        body: vec![Stmt::If {
+            cond,
+            then_branch: vec![statement],
+            else_branch: Vec::new(),
+            binding_var: None,
+            is_statement_modifier: true,
+            is_unless: false,
+        }],
+        is_statement_modifier: true,
+        with_kind: Some(kind),
     }
 }
 
@@ -188,6 +238,7 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
             topic: lower_expr(named_child(node, "source")?)?,
             body: lower_block(named_child(node, "body")?)?,
             is_statement_modifier: false,
+            with_kind: None,
         }),
         RakuAstClass::StatementWhen => Ok(Stmt::When {
             cond: lower_expr(named_child(node, "condition")?)?,

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -152,6 +152,8 @@ pub enum RakuAstClass {
     StatementModifierGiven,
     StatementModifierIf,
     StatementModifierUnless,
+    StatementModifierWith,
+    StatementModifierWithout,
     // Phase 2 slice 19: ternary.
     Ternary,
     // Phase 2 slice 22: positional subscripts.
@@ -325,6 +327,8 @@ impl RakuAstClass {
             StatementModifierGiven => "RakuAST::StatementModifier::Given",
             StatementModifierIf => "RakuAST::StatementModifier::If",
             StatementModifierUnless => "RakuAST::StatementModifier::Unless",
+            StatementModifierWith => "RakuAST::StatementModifier::With",
+            StatementModifierWithout => "RakuAST::StatementModifier::Without",
             Ternary => "RakuAST::Ternary",
             SemiList => "RakuAST::SemiList",
             PostcircumfixArrayIndex => "RakuAST::Postcircumfix::ArrayIndex",
@@ -737,6 +741,8 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::StatementModifierGiven,
     RakuAstClass::StatementModifierIf,
     RakuAstClass::StatementModifierUnless,
+    RakuAstClass::StatementModifierWith,
+    RakuAstClass::StatementModifierWithout,
     RakuAstClass::Ternary,
     RakuAstClass::SemiList,
     RakuAstClass::PostcircumfixArrayIndex,

--- a/t/rakuast/rakuast-with-without-modifier.t
+++ b/t/rakuast/rakuast-with-without-modifier.t
@@ -1,0 +1,87 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# The `with` / `without` statement modifiers across the RakuAST boundary.
+#
+# raku hangs both off the modified statement as a `condition-modifier`, exactly
+# like `if` / `unless` — NOT as the `loop-modifier` a real `given` gets, even
+# though mutsu's parser desugars them into `given X { if $_.defined { STMT } }`.
+# That desugar is ambiguous on its own: a hand-written
+# `(STMT if $_.defined) given X` produces the identical internal shape, so the
+# internal AST carries a marker recording which keyword the source used.
+# Measured against Rakudo; every assertion below passes under BOTH mutsu and raku.
+
+plan 20;
+
+# --- read direction: the node class ----------------------------------------
+
+is Q["found" with "hello"].AST.statements[0].condition-modifier.^name,
+    'RakuAST::StatementModifier::With',
+    'with modifier renders as StatementModifier::With';
+is Q["nf" without Nil].AST.statements[0].condition-modifier.^name,
+    'RakuAST::StatementModifier::Without',
+    'without modifier renders as StatementModifier::Without';
+
+# It is a *condition* modifier, not a loop modifier: `loop-modifier` is the
+# field a real `given` fills, and `with` must leave it out entirely.
+unlike Q[say 1 with 2].AST.gist, /'loop-modifier'/,
+    'with modifier does not occupy the loop-modifier slot';
+unlike Q[say 1 without Nil].AST.gist, /'loop-modifier'/,
+    'without modifier does not occupy the loop-modifier slot';
+
+# The modified statement survives as the statement's own expression, with the
+# scaffolding of the desugar (the topicalizer and its `.defined` test) gone.
+is Q[say 1 with 2].AST.statements[0].expression.^name,
+    'RakuAST::Call::Name::WithoutParentheses',
+    'the modified statement is the statement expression, not the desugar';
+
+# --- the ambiguity the marker exists to resolve -----------------------------
+# Same internal shape, different source keyword: this one really is a `given`.
+
+is Q[(say 1 if $_.defined) given 2].AST.statements[0].loop-modifier.^name,
+    'RakuAST::StatementModifier::Given',
+    'an explicit given modifier is still a Given, not mistaken for a with';
+like Q[(say 1 if $_.defined) given 2].AST.gist, /'loop-modifier'/,
+    'an explicit given modifier fills the loop-modifier slot instead';
+
+# A real `given` block is unaffected too.
+is Q[given 2 { say 1 }].AST.statements[0].^name,
+    'RakuAST::Statement::Given',
+    'the given block form still renders as Statement::Given';
+
+# --- write direction: EVAL of the round-tripped AST -------------------------
+
+is EVAL(Q["found" with "hello"].AST), 'found',
+    'with: a defined topic runs the statement and yields its value';
+is EVAL(Q["found" with Nil].AST).gist, '()',
+    'with: an undefined topic yields the empty Slip';
+is EVAL(Q["nf" without Nil].AST), 'nf',
+    'without: an undefined topic runs the statement';
+is EVAL(Q["nf" without 3].AST).gist, '()',
+    'without: a defined topic yields the empty Slip';
+
+# The modifier topicalizes, so the modified statement sees `$_`.
+is EVAL(Q[my $seen; $seen = $_ with 42; $seen].AST), 42,
+    'with: the modified statement sees the topic as $_';
+is EVAL(Q[my $seen = 0; $seen = 1 without Nil; $seen].AST), 1,
+    'without: the modified statement runs when the topic is undefined';
+
+# Like the `given` modifier, it introduces no lexical block of its own.
+is EVAL(Q[(my $m = 9) with 2; $m].AST), 9,
+    'with modifier round-trips without introducing a lexical scope';
+
+# --- semantics, from source, unchanged by the marker ------------------------
+
+is ("found" with "hello"), 'found', 'source: with runs on a defined topic';
+is ("found" with Nil).gist, '()',    'source: with skips an undefined topic';
+is ("nf" without Nil),     'nf',     'source: without runs on an undefined topic';
+is ("nf" without 3).gist,  '()',     'source: without skips a defined topic';
+
+# A `with` modifier still composes with the topic it binds.
+{
+    my $out;
+    $out = "got: $_" with 42;
+    is $out, 'got: 42', 'source: the with modifier topicalizes for the statement';
+}


### PR DESCRIPTION
`EXPR with X` and `EXPR without X` executed correctly, but the parser rewrote them into a `given` whose body is an `if $_.defined`, so by the time anything downstream looked at the AST the modifier keyword was gone and `.AST` could only report a boundary error.

raku keeps both as a `condition-modifier` on the statement, exactly as it does for `if` / `unless`:

```
RakuAST::Statement::Expression.new(
  expression         => RakuAST::QuotedString.new(...),
  condition-modifier => RakuAST::StatementModifier::With.new(...)
)
```

## Why the converter could not just recognise the shape

The desugar is genuinely lossy. `STMT with X` becomes `given X { if $_.defined { STMT } }`, and a hand-written `(STMT if $_.defined) given X` produces the **identical** internal statement — same `Given`, same `is_statement_modifier`, same `.defined` test. Matching on shape would mean guessing, and rendering one of the two wrongly. The information has to survive the parse instead.

So `Stmt::Given` grows a `with_kind: Option<GivenWithKind>` marker recording which source keyword desugared into it. This is the trick `Stmt::If` already uses for `unless` (a negated condition plus `is_unless`, with the converter stripping the parser's `!` back off) and `Stmt::While` for `until`. Execution ignores the marker entirely; only the RakuAST converter reads it.

## Both directions

- **`src/rakuast/convert.rs`** renders `StatementModifier::With` / `::Without` as a `condition-modifier`, unwrapping the topicalizer and its `.defined` test back to the two pieces raku's node actually holds. The expression-statement spelling arrives wrapped in a `DoStmt` (that is how the parser keeps expression semantics), which has no RakuAST counterpart, so `Stmt::Expr` now unwraps it when it carries a marked `Given`.
- **`src/rakuast/lower.rs`** accepts the hand-built node and rebuilds the same `given`/`if` shape the parser produces, marker included, so the round trip is stable.
- **`src/rakuast/mod.rs`** registers the two classes.

Output is byte-identical to rakudo 2026.07 for `"found" with "hello"`, `"nf" without Nil`, `say 1 with 2` and `say 1 without Nil`, and `EVAL(Q[...].AST)` agrees on all of them — including the empty `Slip` both produce when the topic fails the test.

Critically, `(say 1 if $_.defined) given 2` still renders as a `loop-modifier => StatementModifier::Given`, which is the whole point of the marker.

## The block forms are a separate slice

`with X { … }` / `without X { … }` were measured at the same time, as the ticket asked. They have the same problem but a much larger desugar — mutsu produces `If { cond: <a __with_tmp_N declaration>.defined, then_branch: [Given { … }] }` rather than a marked `Given` — and raku models them as `Statement::With` (fields `condition` / `then` / `else`) and `Statement::Without` (fields `condition` / `body`), with `orwith`/`else` chaining and an `implicit-topic` / `required-topic` block shape on top. Filed as #8123 rather than widened into this change.

Two accessor gaps found while measuring are filed as #8124 (an absent optional field throws instead of returning a falsy value; `StatementModifier::*` exposes no `.expression` — both pre-existing and uniform across `If`/`Unless`/`Given`) and #8125 (a parenthesized listop call renders as `Call::Name` instead of `Call::Name::WithoutParentheses`). #8124 is why the test's negative assertions use a `.gist` match rather than `.loop-modifier.defined`.

## Testing

New pin `t/rakuast/rakuast-with-without-modifier.t` (20 tests): node classes, which modifier slot is filled, the `given` ambiguity case, `EVAL` of the round-tripped AST, and the source-level semantics. **It passes under rakudo unchanged** (`prove -e raku`), so it is a spec pin rather than a mutsu-shaped one.

Pre-publication gate, all run locally on this branch:

- `cargo fmt --all` + `make lint` — green (all four configurations).
- `make test` — **PASS**, 4086 files / 43452 tests.
- `make roast` — 1437 files / 219635 tests; the only failures are the three documented environment-only files, at exactly their documented shapes (`6.c/S32-io/file-tests.t` Failed: 4, tests 6-8/10; `S16-filehandles/filetest.t` Failed: 25, tests 57-64/69-72/77-80/101-125 odd; `S32-io/IO-Socket-Async.t` exit 124, planned 40 ran 17). This container runs as `id -u` `0`, the stated cause of the first two.
- `t/rakuast` + `t/control` together: 278 files / 2613 tests PASS.

Closes #8036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8)_