### PR TITLE
fix(oo): qualify a compound-name role declaration by its package, and expose Awaitable

### DIFF
--- a/news/2026-09/my-role-compound-name-installs-into-its-package.md
+++ b/news/2026-09/my-role-compound-name-installs-into-its-package.md
@@ -1,0 +1,53 @@
+# A compound-name role declaration installs into its package, and `Awaitable` is a role again
+
+Two small core-surface gaps, both found by the `invalid-typename` ecosystem cluster
+([#7993](https://github.com/tokuhirom/mutsu/issues/7993)) and both blocking `TAP` — and through
+it `App::Mi6` and `Mi6::Helper` — at load time.
+
+## A `role` declared with a compound name was not qualified by its package
+
+`exec_register_class_op` has qualified a nested declared name by the enclosing package for a while:
+`module M { my class A::B { } }` declares `M::A::B`, which is what rakudo does for `my`, `our` and
+a bare declarator alike. The *role* arm of the same op still carried the older rule — any name
+containing `::` was taken to be already fully qualified and registered verbatim — so
+`module M { my role A::B { } }` registered a global `A::B` instead of `M::A::B`.
+
+The visible symptom was `X::InvalidType` on the module's own code. `TAP.rakumod` is exactly this
+shape:
+
+```raku
+unit module TAP:ver<0.3.15>;
+role Entry { }                                    # TAP::Entry
+my role Entry::Handler { ... }                    # installs Handler into TAP::Entry
+my class State does TAP::Entry::Handler { ... }   # line 654
+```
+
+Line 654 died with `Invalid typename 'TAP::Entry::Handler'`, because nothing was registered under
+that name: the role had gone in as a bare `Entry::Handler`. The fix is to give the role arm the
+class arm's rule — qualify unless the name is already prefixed with the current package — after
+which the qualified spelling, the relative spelling (`Entry::Handler`) and the package walk
+(`TT::Entry.WHO<Handler>`) all name one role, and `.^name`, `===` and `.HOW` agree with rakudo for
+every scope declarator.
+
+## `Awaitable` was not in the core role list
+
+With the name resolving, `TAP`'s next line was `class Parser does Awaitable`, which failed the same
+way. `Awaitable` is a core role — `raku -e 'say Awaitable.^name'` resolves it with no `use`, and
+mutsu's own builtin type catalog already lists it as a role of `Promise` and `Channel` — but it was
+missing from `BUILTIN_ROLE_NAMES`, the list every `does`-validation and `.HOW` consumer ORs against
+the registry. So the name decayed to a bareword `Str` and the composition was rejected.
+
+Adding it makes a user class compose `Awaitable` the way rakudo allows, with `~~`, `.^roles` and
+`.HOW` matching. Two related gaps stay open and are filed separately: `Promise ~~ Awaitable` still
+answers `False` because the catalog's `roles` column is not yet read by anything
+([#8118](https://github.com/tokuhirom/mutsu/issues/8118)), and `await` on a user class does not
+consult its `get-await-handle`.
+
+## Effect on the corpus
+
+`TAP` moves off `blocked_load`: `use TAP` now succeeds, and `t/string.rakutest` runs 17 of its 61
+assertions instead of dying on the first line of the module. What it stops on next is unrelated to
+typenames — a role's `::?CLASS:U:` multi candidate is dropped when the role is composed
+([#8119](https://github.com/tokuhirom/mutsu/issues/8119)), and TAP's own subtest entries come back
+as `TAP::Unknown`. The cluster's own re-measure ([#7993](https://github.com/tokuhirom/mutsu/issues/7993))
+will re-group the rest.

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -39,6 +39,7 @@ pub(crate) const BUILTIN_ROLE_NAMES: &[&str] = &[
     "Sequence",
     "PositionalBindFailover",
     "Systemic",
+    "Awaitable",
 ];
 
 /// Is `name` one of [`BUILTIN_ROLE_NAMES`]?

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -818,12 +818,19 @@ impl Interpreter {
             let current_package = self.current_package().to_string();
             let qualified_name = if let Some(stripped) = name_str.strip_prefix("GLOBAL::") {
                 stripped.to_string()
-            } else if name_str.contains("::")
-                || current_package == "GLOBAL"
+            } else if current_package == "GLOBAL"
                 || name_str == current_package
+                || name_str.starts_with(&format!("{current_package}::"))
             {
                 name_str.clone()
             } else {
+                // A *nested* declared name is qualified by the enclosing package
+                // like any other, exactly as `exec_register_class_op` does it:
+                // `module M { my role A::B { } }` declares `M::A::B`, so
+                // `M::A::B` (and the relative `A::B`) both resolve. Leaving a
+                // compound name bare registered `TAP.rakumod`'s `my role
+                // Entry::Handler` as a global `Entry::Handler`, so its own
+                // `my class State does TAP::Entry::Handler` found no such role.
                 format!("{current_package}::{name_str}")
             };
             // If the short name was suppressed by an earlier lexical type with

--- a/t/concurrency/promise/awaitable-role-composition.t
+++ b/t/concurrency/promise/awaitable-role-composition.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 6;
+
+# `Awaitable` is a core role — `raku -e 'say Awaitable.^name'` resolves it with
+# no `use` — and real code composes it onto its own classes (`TAP.rakumod`:
+# `class Parser does Awaitable`, delegating `get-await-handle` to a Promise
+# attribute). It was missing from mutsu's core role list, so the name decayed
+# to a bareword and the composition died with `Invalid typename 'Awaitable'`.
+is Awaitable.^name, 'Awaitable', 'Awaitable names itself';
+is Awaitable.HOW.^name, 'Perl6::Metamodel::ParametricRoleGroupHOW',
+    'and it is a role, not a class';
+
+class Handler does Awaitable {
+    has Promise $.promise = Promise.kept(42);
+    method get-await-handle() { $!promise.get-await-handle }
+}
+
+ok Handler ~~ Awaitable, 'a class that composes it does it';
+ok Handler.new ~~ Awaitable, 'and so does an instance';
+is Handler.^roles.map(*.^name).sort.join(','), 'Awaitable', 'it shows up in .^roles';
+nok Int ~~ Awaitable, 'an unrelated type does not do it';

--- a/t/lib/CompoundNameRole.rakumod
+++ b/t/lib/CompoundNameRole.rakumod
@@ -1,0 +1,14 @@
+unit module CompoundNameRole;
+
+# TAP.rakumod's exact shape: a `role` establishes the package, a `my role` with
+# a compound name installs its last component into that package, and a class in
+# the same file composes it through the fully qualified name.
+role Entry { }
+
+my role Entry::Handler {
+    method handle-entry() { 'handled' }
+}
+
+my class State does CompoundNameRole::Entry::Handler { }
+
+sub make-state() is export { State.new }

--- a/t/oo/role/my-role-compound-name-qualification.t
+++ b/t/oo/role/my-role-compound-name-qualification.t
@@ -1,0 +1,51 @@
+use Test;
+use lib 't/lib';
+use CompoundNameRole;
+
+plan 12;
+
+# A declaration written with a COMPOUND name installs its last component into
+# the package named by the preceding components, and is itself qualified by the
+# enclosing package - `module TT { my role Entry::Handler { } }` declares
+# `TT::Entry::Handler`, exactly as `my class Entry::Handler` already did. The
+# role path registered a compound name bare instead, so `TT::Entry::Handler`
+# named nothing and `does TT::Entry::Handler` died as `X::InvalidType`. The
+# scope declarator does not change this: `my`, `our` and none behave alike.
+
+module TT {
+    role Entry { }
+    my role Entry::Handler { method handle-entry() { 'handled' } }
+    my class Composer does TT::Entry::Handler { }
+    my class Relative does Entry::Handler { }
+
+    is TT::Entry::Handler.^name, 'TT::Entry::Handler', 'the qualified name resolves';
+    is Entry::Handler.^name, 'TT::Entry::Handler', 'the relative name names the same role';
+    ok Entry::Handler === TT::Entry::Handler, 'both spellings are one role, not two';
+    is Composer.new.handle-entry, 'handled', 'a class composes it through the qualified name';
+    is Relative.new.handle-entry, 'handled', 'and through the relative name';
+    ok Composer ~~ TT::Entry::Handler, 'the composer does the role';
+    is TT::Entry.WHO<Handler>.^name, 'TT::Entry::Handler',
+        'Handler is installed into the Entry package';
+}
+
+module TU {
+    class Entry { }
+    our role Entry::Handler { method h() { 'our' } }
+    is TU::Entry::Handler.^name, 'TU::Entry::Handler', 'an our-scoped compound name qualifies too';
+}
+
+module TV {
+    class Entry { }
+    role Entry::Handler { method h() { 'plain' } }
+    is TV::Entry::Handler.^name, 'TV::Entry::Handler', 'and so does one with no scope declarator';
+}
+
+# The name must not leak into GLOBAL: the bare compound spelling is not a type
+# of its own outside the declaring package.
+nok (try ::('Entry::Handler').defined), 'the bare compound name is not global';
+
+# The cross-file `unit module` form is what TAP.rakumod actually does, and the
+# composing class lives in the module itself.
+is make-state().handle-entry, 'handled', 'the same shape works across a file boundary';
+is CompoundNameRole::Entry::Handler.^name, 'CompoundNameRole::Entry::Handler',
+    'and the role is reachable through its package from the importer';


### PR DESCRIPTION
Closes #8061 — the `my role A::B` half of the `invalid-typename` ecosystem cluster (#7993).

## The gap

`exec_register_class_op` already qualifies a nested declared name by the enclosing package: `module M { my class A::B { } }` declares `M::A::B`, for `my`, `our` and a bare declarator alike. The **role** arm of the same op still carried the older rule — any name containing `::` was taken to be already fully qualified and registered verbatim — so `module M { my role A::B { } }` went into the registry as a global `A::B`.

The symptom was `X::InvalidType` on the declaring module's own code. `TAP.rakumod` is exactly this shape:

```raku
unit module TAP:ver<0.3.15>;
role Entry { }                                    # TAP::Entry
my role Entry::Handler { ... }                    # installs Handler into TAP::Entry
my class State does TAP::Entry::Handler { ... }   # line 654 -> Invalid typename
```

The fix gives the role arm the class arm's rule (qualify unless the name already carries the current package as a prefix). After it, the qualified spelling, the relative spelling (`Entry::Handler`) and the package walk (`TT::Entry.WHO<Handler>`) all name **one** role, and `.^name`, `===` and `.HOW` match rakudo for every scope declarator — measured, not assumed:

| | mutsu before | mutsu after | raku |
|---|---|---|---|
| `TT::Entry::Handler.^name` | *(a distinct ClassHOW thing)* | `TT::Entry::Handler` | `TT::Entry::Handler` |
| `Entry::Handler.^name` | `Entry::Handler` | `TT::Entry::Handler` | `TT::Entry::Handler` |
| `Entry::Handler === TT::Entry::Handler` | `False` | `True` | `True` |
| `class C does TT::Entry::Handler` | `X::InvalidType` | composes | composes |

## Awaitable

With the name resolving, TAP's next line is `class Parser does Awaitable`, which failed the same way. `Awaitable` is a core role — `raku -e 'say Awaitable.^name'` resolves it with no `use`, and mutsu's own builtin type catalog already lists it as a role of `Promise`/`Channel` — but it was missing from `BUILTIN_ROLE_NAMES`, the list every `does`-validation and `.HOW` consumer ORs against the registry. So the name decayed to a bareword `Str` and the composition was rejected. One word added; `~~`, `.^roles` and `.HOW` on the composing class now match rakudo.

## Effect on the corpus

`TAP` moves off `blocked_load`: `use TAP` succeeds, and `t/string.rakutest` runs 17 of its 61 assertions instead of dying on the module's first lines. `App::Mi6` and `Mi6::Helper` fail on `TAP` and are behind the same two gaps.

The `ecosystem/` ledger is deliberately **not** touched here: #7993's own sweep re-measure is claimed by another session and covers all 21 records in the cluster, so editing TAP's record from this branch would only conflict with it.

## Three separate gaps found on the way, filed not bundled

- #8118 — `Promise ~~ Awaitable` answers `False` and `Promise.^roles` is empty (the catalog's `roles` column is `#[allow(dead_code)]`; the real fix is ADR-0051 P2's cutover, not another legacy table); `await` also ignores a user class's `get-await-handle`.
- #8119 — a role's `::?CLASS:U:` multi candidate is dropped when the role is composed. This is what TAP's `t/source-file.rakutest` now stops on.
- #8120 — an imported module's `my class` shadows the importer's own same-named class. Pre-existing (reproduced on `main`) and unrelated to roles; it is why the regression test names its composer `Composer` rather than `State`.

One dead end is worth recording: a first attempt also guarded `resolve_declared_type_name` so a registered qualified name would win over its bare-suffix fallbacks. `rust-gdb` on `compose_class_parent_roles` showed resolution was already handing back the right name in both cases — the wrong role came from #8120's class shadowing — so that guard was reverted rather than shipped on a wrong hypothesis.

## Tests

- `t/oo/role/my-role-compound-name-qualification.t` (12 assertions) — the qualified/relative/`WHO` identity, all three scope declarators, the bare compound name staying out of GLOBAL, and the cross-file `unit module` shape via `t/lib/CompoundNameRole.rakumod` (TAP's exact structure).
- `t/concurrency/promise/awaitable-role-composition.t` (6 assertions) — `Awaitable`'s name/HOW and composition by a user class.

Both files were validated against `raku` first, and both fail with the source change reverted (12 → aborts at the `does`; the Awaitable one on `Invalid typename`).

## Pre-publication gates

- `cargo fmt --all`, `make check-t-layout`: clean (both test files were moved/renamed to the paths the layout rules require).
- `make lint`: all four configurations green.
- `make test`: **PASS** — 4086 files, 43430 tests.
- `make roast`: three failures, all three exactly the container-specific known reds documented in `docs/agent-environments.md` (`roast/6.c/S32-io/file-tests.t` `Failed: 4` tests 6-8/10 and `roast/S16-filehandles/filetest.t` `Failed: 25` tests 57-64/69-72/77-80/101/103/105/107 — both from running as `uid 0`; `roast/S32-io/IO-Socket-Async.t` exit 124 "planned 40 ran 17" — sandboxed network). Nothing else in the whitelist failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK)_