### PR TITLE
fix(regex): dereference a container cell in a &lt;@var&gt; array-assertion read

### DIFF
--- a/news/2026-09/array-var-regex-assertion-container-cell-deref.md
+++ b/news/2026-09/array-var-regex-assertion-container-cell-deref.md
@@ -1,0 +1,35 @@
+# A `<@var>` regex assertion no longer collapses a mutated lexical into one literal
+
+A `<@var>` regex assertion (`/ ^ <@alts> $ /`) reads the array's VALUE at the moment the regex
+literal is evaluated, splitting its elements into an alternation. `array_var_alternation_atom`
+(`src/runtime/regex_parse_core.rs`) fetched that value with a bare `self.env.get(env_key)`, with no
+attempt to dereference a `ContainerRef` cell.
+
+The compiler boxes a lexical into such a shared cell when it is reassigned later in the same scope
+(`@alts = <emu>;` after `my @alts = <cat dog>;`), so `@alts` in the earlier repro was a
+`ContainerRef`, not a plain `Array`, by the time its regex literal ran. None of
+`array_var_alternation_atom`'s match arms recognized `ValueView::ContainerRef`, so it fell through
+to the catch-all arm — `crate::value::ArrayData::new(vec![value.clone()])` — treating the *whole
+cell* as a single alternation element. Stringifying it produced the array's rendered form as ONE
+literal pattern (`"cat dog"`) instead of two alternatives (`cat|dog`), so a match against a single
+word like `"cat"` failed even though the array actually held it.
+
+A never-reassigned lexical (`my @only = <cat dog>;`, nothing else touching `@only`) is never boxed,
+so it already worked — which was the one case narrowing this down. A single-element array after
+reassignment (`<emu>`) also happened to stringify identically whether treated as a whole cell or
+correctly split into (one) alternative, which is why only the pre-reassignment match in the
+original repro showed the bug.
+
+The fix mirrors what `<$var>`'s sibling code path a few lines below already does for the same
+reason (`.into_deref()`, following up on the `stored-regex-loses-its-defining-scope-lexicals`
+fix): `.deref_container()` the fetched value before matching on its `ValueView`. Two things were
+worth re-measuring against real rakudo rather than assuming from the issue text alone: a `<@var>`
+assertion, like a bare `$var` interpolation, re-reads the array live on every match (a reassignment
+made after a stored regex's construction but before a later match against it IS visible) — a
+guess to the contrary while writing the regression test was quickly proven wrong by the oracle.
+
+Pinned in `t/regex/regex-subpattern-parse-memo.t` (a match before and after a same-scope
+reassignment) and `t/regex/regex-stored-closure-scope.t` (a stored `rx/.../` reassigned before a
+later match against it).
+
+Fixes #8040.

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -381,9 +381,19 @@ impl Interpreter {
     /// lookahead forms.
     fn array_var_alternation_atom(&self, env_key: &str, mode: RegexParseMode) -> Option<RegexAtom> {
         // Reads the array's VALUE at parse time; the tree is not a function of
-        // the pattern text alone.
+        // the pattern text alone. `.deref_container()` mirrors the `<$var>`
+        // form's `.into_deref()` a few match arms below: a lexical the
+        // compiler boxed into a shared `ContainerRef` cell because it is
+        // reassigned later in the same scope must be dereferenced before its
+        // elements are read, or the whole cell falls through to the `_` arm
+        // below as a single element (issue #8040).
         Self::note_regex_parse_ambient_read();
-        let value = self.env.get(env_key).cloned().unwrap_or(Value::NIL);
+        let value = self
+            .env
+            .get(env_key)
+            .cloned()
+            .unwrap_or(Value::NIL)
+            .deref_container();
         let elements = match value.view() {
             ValueView::Array(arr, _) => arr.as_ref().clone(),
             ValueView::Seq(items) => crate::value::ArrayData::new(items.to_vec()),

--- a/t/regex/regex-stored-closure-scope.t
+++ b/t/regex/regex-stored-closure-scope.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 18;
+plan 20;
 
 # --- Bug 1: a stored regex keeps its defining scope ---------------------------
 
@@ -37,6 +37,18 @@ ok ("xaby" ~~ mk5()).defined, '<$var> assertion form survives the frame';
     $pat = 'zzz';
     nok ("abc" ~~ $re).defined, 'interpolation sees the mutated value, not a snapshot (1)';
     ok  ("zzz" ~~ $re).defined, 'interpolation sees the mutated value, not a snapshot (2)';
+}
+
+# Like bare `$var` interpolation above (and verified against real rakudo,
+# which surprised the author of issue #8040's fix): a stored `<@var>`
+# assertion re-reads the array on every match, so a reassignment made AFTER
+# construction but BEFORE a later match is visible to that match.
+{
+    my @alts = <cat dog>;
+    my $re = rx/ ^ <@alts> $ /;
+    @alts = <emu>;
+    nok ("cat" ~~ $re).defined, '<@var> follows a reassignment made before a match';
+    ok  ("emu" ~~ $re).defined, 'and matches the reassigned value';
 }
 
 # The code-bearing capture must be a live cell, not a stale snapshot (W5/W6).

--- a/t/regex/regex-subpattern-parse-memo.t
+++ b/t/regex/regex-subpattern-parse-memo.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 18;
+plan 20;
 
 # The regex parser is recursive: a group, a lookaround body, an alternation
 # branch, a conjunction part and a `%`-separator atom each re-enter the parse
@@ -59,15 +59,27 @@ plan 18;
     nok 'aa' ~~ / ^ <$var> $ /, 'rather than reusing the first parse';
 }
 
-# `<@var>` reads the array's elements at parse time, the same way. (The
-# matching "follows a reassignment" case is NOT pinned here: a `<@var>` regex
-# literal evaluated before the array is reassigned later in the same scope
-# already sees the later value on `main`, independently of this memo — see
-# issue #8040.)
+# `<@var>` reads the array's elements at parse time, the same way.
 {
     my @alts = <cat dog>;
     ok 'cat' ~~ / ^ <@alts> $ /, 'a <@var> assertion matches an element';
     nok 'emu' ~~ / ^ <@alts> $ /, 'and only an element';
+}
+
+# A `<@var>` match BEFORE a later reassignment in the same scope must see the
+# array's value as it stood at that point, not the array's eventual final
+# content (issue #8040): `self.env.get` returns a lexical the compiler boxed
+# into a shared `ContainerRef` cell because of the later reassignment, and
+# that cell was read without dereferencing it first — so the whole cell
+# stringified as ONE alternation element instead of iterating the array's
+# actual elements. A single-element array happened to stringify the same way
+# either way, which is why only the *first* of a pair of matches around a
+# reassignment ever showed the bug.
+{
+    my @later = <cat dog>;
+    ok 'cat' ~~ / ^ <@later> $ /, 'a <@var> match before a later reassignment sees the current value';
+    @later = <emu>;
+    ok 'emu' ~~ / ^ <@later> $ /, 'and a later match sees the reassigned value';
 }
 
 # --- the current package is part of the key ---------------------------------


### PR DESCRIPTION
## Summary

A `<@var>` regex assertion (`/ ^ <@alts> $ /`) reads the array's value at the point the regex
literal is evaluated, splitting its elements into an alternation. `array_var_alternation_atom`
(`src/runtime/regex_parse_core.rs`) fetched that value with a bare `self.env.get(env_key)`, with
no attempt to dereference a `ContainerRef` cell.

The compiler boxes a lexical into such a shared cell when it is reassigned later in the same scope
(`@alts = <emu>;` after `my @alts = <cat dog>;`), so a match against `<@alts>` that runs *before*
the reassignment still reads the cell wrapper, not the array directly. None of
`array_var_alternation_atom`'s match arms recognized `ValueView::ContainerRef`, so it fell through
to the catch-all arm — `ArrayData::new(vec[value.clone()])` — treating the *whole cell* as a
single alternation element. Stringifying it produced the array's rendered form as ONE literal
pattern (`"cat dog"`) instead of two alternatives (`cat|dog`), so a match against a single word
like `"cat"` failed even though the array actually held it.

## Repro (from #8040)

```raku
my @alts = <cat dog>;
say ('cat' ~~ / ^ <@alts> $ /).Bool;   # rakudo: True, mutsu (before this fix): False
@alts = <emu>;
```

## Fix

Mirrors what `<$var>`'s sibling code path a few lines below already does for the same reason
(`.into_deref()`): `.deref_container()` the fetched value before matching on its `ValueView`.

One assumption made while writing the regression test was disproven by the oracle: a `<@var>`
assertion, like a bare `$var` interpolation, re-reads the array live on every match — a
reassignment made after a stored regex's construction but before a later match against it IS
visible to that later match. Verified against real `raku` before pinning it.

Closes #8040

## Testing

- `t/regex/regex-subpattern-parse-memo.t` — extended with the reassignment-before/after case this
  file's own comment had earmarked for this issue.
- `t/regex/regex-stored-closure-scope.t` — extended with a stored `rx/.../` reassigned before a
  later match against it.
- `cargo fmt --all`, `make lint` — green (all four configurations).
- `make test` — green, `Files=4092, Tests=43537, Result: PASS`.
- `make roast` — the only failures are the documented container-only entries in
  `docs/agent-environments.md` (`6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t` — this
  container runs as `uid 0`); both pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_