### PR TITLE
test: pin mixin native-attribute mutation across calls (#8047 already fixed)

### DIFF
--- a/news/2026-09/mixin-native-attribute-mutation-already-fixed.md
+++ b/news/2026-09/mixin-native-attribute-mutation-already-fixed.md
@@ -1,0 +1,19 @@
+# Mixin role native-attribute mutation was already fixed
+
+[#8047](https://github.com/tokuhirom/mutsu/issues/8047) reported that a
+role mixed in at runtime (`$obj but R`, `@array does R`) whose method
+mutated a native-typed attribute (`has int $.n`) via prefix increment lost
+the write on every call — an object whose iteration state lived in a
+mixin attribute never advanced, turning an exhaustion loop into an
+infinite one.
+
+All three shapes from the issue (a `but`-mixed instance, `does` applied to
+an existing `@array` variable, and the reduced `&each`-cursor role with an
+`INIT` seed) now measure correctly against `raku` on current `main` —
+already fixed, evidently by the ongoing mixin/role attribute-cell work
+(see `t/oo/role/mixin-role-attribute-cell.t`, which pins the general
+mechanism but not this file's native-int / `does`-on-existing-array /
+`INIT`-seed shapes specifically).
+
+Pinned with `t/oo/mixin-typed-int-attr-persists-across-calls.t` so a
+regression here is caught even though no `src/` change was needed.

--- a/t/oo/mixin-typed-int-attr-persists-across-calls.t
+++ b/t/oo/mixin-typed-int-attr-persists-across-calls.t
@@ -1,0 +1,40 @@
+use Test;
+
+# #8047: a role mixed in at runtime (`but`/`does`) whose method mutates a
+# NATIVE-typed attribute (`has int $.n`) via prefix increment used to write
+# against a per-call copy and lose it, turning an exhaustion loop like
+# `&each`'s cursor into an infinite one. Already fixed by the time this was
+# investigated (measured against `t/oo/role/mixin-role-attribute-cell.t`'s
+# non-native-int coverage); pinning the exact shapes from the issue so a
+# regression is caught.
+
+plan 9;
+
+role Bumper { has int $.n; method bump() { ++$!n } }
+
+class C { }
+my $o = C.new but Bumper;
+is $o.bump, 1, '`but` mixin: native int attribute starts at 1 after one bump';
+is $o.bump, 2, 'and advances on a second bump';
+is $o.bump, 3, 'and a third';
+
+my @a = <a b c>;
+@a does Bumper;
+is @a.bump, 1, '`does` on an existing array variable: first bump is 1';
+is @a.bump, 2, 'second bump is 2, not stuck at 1';
+is @a.bump, 3, 'third bump is 3';
+
+# The reduced &each shape: an INIT method writes a negative seed, and each
+# `.each` call both reads and advances the same attribute.
+role EachArray {
+    has int $.index;
+    method INIT() { $!index = -1; self }
+    method each() {
+        ++$!index < self.elems ?? ($!index, self.AT-POS($!index)) !! Empty
+    }
+}
+my @b = <a b c>;
+my $x := (@b does EachArray).INIT;
+is-deeply $x.each, (0, 'a'), 'EachArray: INIT seed is visible to the first .each';
+is-deeply @b.each, (1, 'b'), 'the second .each call advances past the first';
+is-deeply @b.each, (2, 'c'), 'and the third reaches the last element';


### PR DESCRIPTION
## Summary

[#8047](https://github.com/tokuhirom/mutsu/issues/8047) reported that a
role mixed in at runtime (`$obj but R`, `@array does R`) whose method
mutated a native-typed attribute (`has int $.n`) via prefix increment lost
the write on every call — an object whose iteration state lived in a
mixin attribute never advanced, turning an exhaustion loop into an
infinite one.

All three shapes from the issue now measure correctly against `raku` on
current `main`:

- a `but`-mixed plain instance (`C.new but R`)
- `does` applied to an existing `@array` variable (`@a does R`)
- the reduced `&each`-cursor role with an `INIT` seed, from the driving
  `P5each` distribution

This is already fixed — evidently by the ongoing mixin/role
attribute-cell work (`t/oo/role/mixin-role-attribute-cell.t` pins the
general mechanism, but not this issue's native-int /
`does`-on-existing-array / `INIT`-seed shapes specifically). No `src/`
change needed; this PR just pins the exact shapes with a regression test
and closes the issue with that evidence.

Closes #8047

## Test plan

- Added `t/oo/mixin-typed-int-attr-persists-across-calls.t` covering all
  three shapes from the issue.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run
  locally. `make roast` comes back with only the three environment-only
  failures documented in `docs/agent-environments.md` for a remote
  container (`roast/6.c/S32-io/file-tests.t`,
  `roast/S16-filehandles/filetest.t` — both `uid 0` chmod-based file tests
  — and `roast/S32-io/IO-Socket-Async.t`, sandboxed network); everything
  else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_