### PR TITLE
fix(seq): preserve deferred iterators through Seq.iterator

### DIFF
--- a/news/2026-09/seq-iterator-returns-deferred-source.md
+++ b/news/2026-09/seq-iterator-returns-deferred-source.md
@@ -1,0 +1,2 @@
+`Seq.new($iterator).iterator` now returns the original deferred iterator without
+draining it to `IterationEnd`, so unbounded user-defined iterators remain lazy.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -280,6 +280,16 @@ impl Interpreter {
         } else {
             (target, true)
         };
+        // A deferred `Seq.new($iterator).iterator` hands its original user
+        // iterator directly to the caller. It is already the result of the
+        // requested method; dispatching `iterator` on it again would treat the
+        // user iterator as an ordinary one-element value. Materialized Seq
+        // iterators also arrive here as an `Iterator` instance, so the same
+        // short-circuit preserves both forms.
+        if pre_reify && method == "iterator" && matches!(target.view(), ValueView::Instance { .. })
+        {
+            return Ok(target);
+        }
         match self.call_method_with_values_inner(target.clone(), method, args, reify_seq) {
             Err(err) if Self::is_method_not_found_for(&err, method) => {
                 self.call_method_with_values_inner(target, method, positional, reify_seq)
@@ -295,6 +305,7 @@ impl Interpreter {
         args: Vec<Value>,
         reify_seq: bool,
     ) -> Result<Value, RuntimeError> {
+        let target_was_seq = target.is_seq_value();
         // ADR-0064: a `.VAR` reflection descriptor is a CONTAINER, and a
         // container is transparent for ordinary method dispatch -- everything
         // that is not a property of the container itself is answered by the
@@ -921,6 +932,12 @@ impl Interpreter {
         } else {
             target
         };
+        if target_was_seq
+            && method == "iterator"
+            && matches!(target.view(), ValueView::Instance { .. })
+        {
+            return Ok(target);
+        }
         if is_seq_sink {
             return Ok(Value::NIL);
         }

--- a/src/value/seq_body.rs
+++ b/src/value/seq_body.rs
@@ -475,6 +475,29 @@ impl SeqBody {
         Ok((items, SeqTaken::Taken))
     }
 
+    /// Hand the original deferred iterator to `.iterator` without pulling it.
+    /// Rakudo's `Seq.new($iterator).iterator` returns the stored iterator
+    /// object itself, so an unbounded user iterator must remain lazy. Other
+    /// deferred sources still use the materialized iterator path, and a
+    /// cached/retained body must iterate its retained elements instead.
+    pub(crate) fn take_iterator_source(&self) -> Result<Option<Value>, RuntimeError> {
+        let mut state = self.core.state.lock().unwrap();
+        if state.cache_requested || state.retained {
+            return Ok(None);
+        }
+        if matches!(state.source, SeqSource::Taken) {
+            return Err(super::seq_consumed_error());
+        }
+        if !matches!(state.source, SeqSource::Iterator(_)) {
+            return Ok(None);
+        }
+        let SeqSource::Iterator(iterator) = std::mem::replace(&mut state.source, SeqSource::Taken)
+        else {
+            unreachable!("matched Iterator above")
+        };
+        Ok(Some(iterator))
+    }
+
     /// Store elements a [`SeqBody::take`] just pulled back into this body's
     /// generation graveyard WITHOUT reviving its (now `Taken`) source.
     ///

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -717,6 +717,9 @@ impl Interpreter {
             return Ok(target);
         }
         if method == "iterator" {
+            if let Some(iterator) = body.take_iterator_source()? {
+                return Ok(iterator);
+            }
             // `.iterator` builds its FINAL result (an `Iterator` instance)
             // here, in place of returning a still-`ValueView::Seq` target
             // for a LATER dispatch layer to call `.iterator` on again. Two

--- a/t/collections/lazy-seq/seq-new-user-iterator.t
+++ b/t/collections/lazy-seq/seq-new-user-iterator.t
@@ -5,7 +5,7 @@ use Test;
 # `pull-one` (deferred reification), not read an empty backing vec or wrap the
 # iterator as a single element.
 
-plan 16;
+plan 19;
 
 class Counter does Iterator {
     has $.n = 0;
@@ -50,6 +50,19 @@ is Seq.new(Doubler.new(src => (1, 2, 3))).List, (2, 4, 6),
 
 # The built-in `.iterator` still reifies correctly (no infinite pull loop).
 is Seq.new((1, 2, 3).iterator).List, (1, 2, 3), 'Seq.new(built-in iterator).List';
+
+# `.iterator` on a deferred Seq hands the original user iterator back without
+# draining it first. This keeps an unbounded iterator usable and lazy.
+class Unbounded does Iterator {
+    has $.n = 5;
+    method pull-one() { $!n++ }
+}
+my $unbounded = Unbounded.new;
+my $unbounded-seq = Seq.new($unbounded);
+my $handed-back = $unbounded-seq.iterator;
+ok $handed-back === $unbounded, 'Seq.iterator returns the stored user iterator';
+is $handed-back.pull-one, 5, 'handed-back iterator remains lazy';
+is $handed-back.pull-one, 6, 'handed-back iterator can continue pulling';
 
 # `.sort`/`.reverse` (comparator-capable methods) also reify: chained (a rvalue
 # receiver -> CallMethod) and via a variable (an lvalue receiver -> CallMethodMut).


### PR DESCRIPTION
Closes #8046

## Summary

- return the original deferred user iterator from `Seq.new($iterator).iterator`
- keep cached, retained, and other deferred `Seq` sources on their existing materialized paths
- add an unbounded iterator regression test and news entry

## Validation

- `cargo fmt --all`
- `make lint`
- `make test` — 4090 files / 43529 tests, PASS
- `make roast` — 1437 files / 219658 tests, PASS
