### PR TITLE
perf(parser): cache the module export scan on disk

### DIFF
--- a/news/2026-09/module-export-scan-is-cached-on-disk.md
+++ b/news/2026-09/module-export-scan-is-cached-on-disk.md
@@ -1,0 +1,71 @@
+# The parser's module export scan is cached on disk
+
+A `use Foo;` made mutsu read `Foo`'s source twice. The run-time half consults
+the precompilation cache and skips its parse on a hit; the parser half — which
+scans the module to learn what it exports, so the importing unit can parse calls
+to those exports — had no cache at all and re-parsed from source in every
+process. On a warm `use YAMLish; say "ok"` it was the larger half:
+`find_and_scan_module` alone accounted for 209 M of the 334 M instructions the
+run cost ([#8095](https://github.com/tokuhirom/mutsu/issues/8095)).
+
+The scan now persists to `~/.cache/mutsu/modscan/`, next to the precompilation
+cache and keyed the same way (canonical source path, mtime + content hash, and
+the interpreter version stamp that embeds the executable's mtime, so a rebuilt
+mutsu never reuses an older build's entries).
+
+Measured with callgrind on `use YAMLish; say "ok"`, release build, precompilation
+cache warm in both rows:
+
+| module scan cache | Ir |
+| --- | --- |
+| cold (previous behaviour) | 271,924,883 |
+| warm | 124,158,716 |
+
+## The invalidation question the precompilation cache does not have
+
+A scan result deliberately carries **transitive** names: the qualified type
+names, enum values and sigilless constant terms that reached the module from the
+modules *it* `use`s, because an importer can see those too. So the result is a
+function of the dependency sources as well, and a content hash of the module's
+own source would happily serve a stale answer after a dependency was edited.
+
+Each entry therefore records every module its scan resolved, as a `ScanDep`: the
+module name as written, the file it resolved to (or `None` when it resolved to
+nothing the parser could scan — a name that resolves to nothing today and to a
+file tomorrow changes the answer too), and that file's mtime + hash. The list is
+the transitive closure — a child scan's deps are merged into its parent's — so
+validating one entry validates the whole subtree without loading the children's
+entries. Validation also **re-resolves** each dependency's module name through
+the parser's current search path and requires it to land on the same file, which
+is what keeps the cache honest across a changed `-I` or `use lib`.
+
+## What a hit has to replay, and what it may drop
+
+A hit runs no nested parse, so anything the scan used to leave behind as a side
+effect had to become part of the entry. One such effect was found and captured:
+inline `module Foo { ... is export }` tables. The nested parse registers those in
+the process-wide inline-export table, which the scan does not restore, so an
+`import Foo;` in the importing file finds them purely because the scan ran. They
+are now recorded in the entry and replayed on every importer.
+
+Parse warnings are deliberately *not* persisted. They are re-raised — and
+deduplicated by `(file, message)` — when the runtime actually loads the module,
+which always happens for a `use`; the in-process scan memo has behaved this way
+for every `use` after the first since it was added.
+
+Two situations skip the disk cache entirely rather than risk an unsound entry:
+a module whose source says `no precompilation;`, and a scan running underneath
+an EVAL that has preseeded the parser with names from its calling unit (the
+result is then not the pure function of the module sources that the key assumes).
+`MUTSU_PRECOMP=0` and `--no-precomp` turn it off with the rest of the caching.
+
+## Tests
+
+`src/scan_cache.rs` unit-tests the invalidation rules directly: an edited
+module, an edited dependency, a dependency that now resolves to a different
+file, and a dependency that was absent and is now present must all miss.
+`t/modules/compunit/module-scan-precomp-cache.t` pins the end-to-end behaviour
+across separate processes — which is the only place the disk cache exists, since
+within one process the scan is memoized in a thread-local and the bug class
+cannot appear. It probes with an *exported operator*, so a lost or stale export
+list is a hard compile failure rather than a subtle difference.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub(crate) mod regex_tree;
 pub mod repl;
 pub(crate) mod repl_core;
 mod runtime;
+pub(crate) mod scan_cache;
 pub mod symbol;
 mod token_kind;
 mod trace;

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -175,7 +175,7 @@ struct LexicalScope {
     anon_states: Vec<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 struct InlineModuleExport {
     name: String,
     precedence: Option<i32>,
@@ -260,6 +260,23 @@ thread_local! {
     /// Used by `import` to register exported operators at parse time.
     static INLINE_MODULE_EXPORTS: RefCell<HashMap<String, Vec<InlineModuleExport>>> =
         RefCell::new(HashMap::new());
+}
+
+/// Whether an EVAL is seeding the next `reset_user_subs` with names (or a
+/// language revision) from its calling unit.
+///
+/// A module scan nested inside such a parse sees those seeded names, so its
+/// result is not a pure function of the module sources — which is exactly what
+/// the on-disk scan cache ([`crate::scan_cache`]) keys on. The cache steps
+/// aside while any preseed is live rather than risk storing, or serving, a
+/// result that belongs to one particular EVAL.
+pub(crate) fn eval_preseed_active() -> bool {
+    EVAL_OPERATOR_PRESEED.with(|p| !p.borrow().is_empty())
+        || EVAL_OPERATOR_ASSOC_PRESEED.with(|p| !p.borrow().is_empty())
+        || EVAL_USER_SUB_PRESEED.with(|p| !p.borrow().is_empty())
+        || EVAL_USER_TYPE_PRESEED.with(|p| !p.borrow().is_empty())
+        || EVAL_USER_VALUE_TERM_PRESEED.with(|p| !p.borrow().is_empty())
+        || EVAL_LANGUAGE_VERSION_PRESEED.with(|p| p.borrow().is_some())
 }
 
 pub(in crate::parser) static TMP_INDEX_COUNTER: AtomicUsize = AtomicUsize::new(0);

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::ast::CallArg;
+use crate::scan_cache::{self, FileStamp, ScanDep};
 use std::cell::Cell;
 use std::rc::Rc;
 
@@ -15,6 +16,7 @@ use export_hook::{
 /// each module file is scan-parsed at most once per process — without the
 /// cache a diamond-heavy dependency graph re-parses the same file once per
 /// reachable `use` mention (Template::HAML re-read its `X.rakumod` 222 times).
+#[derive(serde::Serialize, serde::Deserialize)]
 struct ModuleScanResult {
     exports: Vec<InlineModuleExport>,
     type_names: Vec<String>,
@@ -45,6 +47,24 @@ struct ModuleScanResult {
     /// module must execute it at parse time so its slang registration can
     /// switch parser modes for the rest of the importing unit.
     uses_slangify: bool,
+    /// `module Foo { sub bar is export }` blocks declared *inside* the scanned
+    /// module. The nested parse registers these in the process-wide inline
+    /// export table, which — unlike the scopes — the scan does not restore, so
+    /// an `import Foo;` in the importing file finds them today purely as a
+    /// side effect of the scan having run. Captured here and replayed on every
+    /// importer so a cache hit, which runs no nested parse, behaves the same.
+    inline_module_exports: Vec<(String, Vec<InlineModuleExport>)>,
+    /// Every module this scan resolved, transitively — the invalidation input
+    /// the on-disk cache needs because the fields above carry names that came
+    /// from those modules. Not part of the serialized payload: the cache
+    /// stores it in its own metadata, where it can be checked before the
+    /// payload is decoded. See [`crate::scan_cache`].
+    #[serde(skip)]
+    deps: Vec<crate::scan_cache::ScanDep>,
+    /// This module file's own stamp, so an importer can record it as a
+    /// dependency without re-reading the file.
+    #[serde(skip)]
+    stamp: Option<crate::scan_cache::FileStamp>,
 }
 
 thread_local! {
@@ -78,6 +98,40 @@ thread_local! {
     /// installed repository, a `require`, a module absent from this
     /// environment).
     static TYPE_INDEX_INCOMPLETE: Cell<bool> = const { Cell::new(false) };
+    /// One frame per module scan currently in progress; each collects the
+    /// modules that scan resolved, so the finished scan can be cached on disk
+    /// with the dependency list its validity depends on (see
+    /// [`crate::scan_cache`]). Empty while the top-level unit is parsed —
+    /// nothing caches that, so nothing needs to record it.
+    static SCAN_DEP_FRAMES: RefCell<Vec<Vec<ScanDep>>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Record that the scan currently in progress resolved `module` to `path`.
+/// A module that resolved to nothing is recorded too: it becoming resolvable
+/// later changes what the scan would find.
+fn record_scan_dep(module: &str, path: Option<&str>, stamp: Option<FileStamp>) {
+    push_scan_deps(std::iter::once(ScanDep {
+        module: module.to_string(),
+        path: path.map(str::to_string),
+        stamp,
+    }));
+}
+
+/// Merge a finished sub-scan's own dependency list into the enclosing frame,
+/// so each entry's list is the transitive closure and validating it validates
+/// the whole subtree without loading the children's entries.
+fn push_scan_deps(deps: impl IntoIterator<Item = ScanDep>) {
+    SCAN_DEP_FRAMES.with(|frames| {
+        let mut frames = frames.borrow_mut();
+        let Some(frame) = frames.last_mut() else {
+            return;
+        };
+        for dep in deps {
+            if !frame.contains(&dep) {
+                frame.push(dep);
+            }
+        }
+    });
 }
 
 /// Record that a `use`/`need`/`require` could not be resolved and scanned, so
@@ -201,6 +255,17 @@ pub(crate) fn register_module_exports(module: &str) {
 
 /// Replay a scan's declared type/enum names into the importer's current scope.
 fn apply_scan_types(scan: &ModuleScanResult) {
+    // Replay the scanned module's inline `module Foo { ... is export }` tables
+    // so a later `import Foo;` resolves them on a cache hit exactly as it does
+    // after a fresh scan.
+    if !scan.inline_module_exports.is_empty() {
+        INLINE_MODULE_EXPORTS.with(|m| {
+            let mut map = m.borrow_mut();
+            for (name, exports) in &scan.inline_module_exports {
+                map.entry(name.clone()).or_insert_with(|| exports.clone());
+            }
+        });
+    }
     // A dependency whose own type index was incomplete makes the importer's
     // incomplete too. Replayed here (not only at scan time) so a cache hit,
     // which skips the nested parse entirely, still propagates it.
@@ -372,24 +437,89 @@ pub(crate) fn register_module_type_names(module: &str) {
 }
 
 /// Resolve a module name to its source file and scan it, memoized per file
-/// path. A cache hit performs no I/O and no parse — the callers replay the
-/// stored registrations into their own scope instead.
+/// path in this process and — since GH-8095 — on disk across processes. Either
+/// cache hit performs no parse: the callers replay the stored registrations
+/// into their own scope instead.
 fn find_and_scan_module(module: &str) -> Option<Rc<ModuleScanResult>> {
-    let path = find_module_file(module)?;
+    let Some(path) = find_module_file(module) else {
+        record_scan_dep(module, None, None);
+        return None;
+    };
     if let Some(hit) = MODULE_SCAN_CACHE.with(|c| c.borrow().get(&path).cloned()) {
+        record_scan_result_as_dep(module, &path, &hit);
+        return Some(hit);
+    }
+    if let Some(hit) = load_scan_from_disk(&path) {
+        MODULE_SCAN_CACHE.with(|c| {
+            c.borrow_mut().insert(path.clone(), Rc::clone(&hit));
+        });
+        record_scan_result_as_dep(module, &path, &hit);
         return Some(hit);
     }
     let source = std::fs::read_to_string(&path).ok()?;
     let skips_before = SCAN_GUARD_SKIPS.with(|c| c.get());
-    let result = Rc::new(scan_module_source(&source, &path));
+    SCAN_DEP_FRAMES.with(|frames| frames.borrow_mut().push(Vec::new()));
+    let mut result = scan_module_source(&source, &path);
+    result.deps = SCAN_DEP_FRAMES
+        .with(|frames| frames.borrow_mut().pop())
+        .unwrap_or_default();
+    result.stamp = FileStamp::of_source(std::path::Path::new(&path), &source);
+    let result = Rc::new(result);
     // Only a scan the recursion guard never truncated is complete enough to
     // cache (see SCAN_GUARD_SKIPS).
     if SCAN_GUARD_SKIPS.with(|c| c.get()) == skips_before {
         MODULE_SCAN_CACHE.with(|c| {
-            c.borrow_mut().insert(path, Rc::clone(&result));
+            c.borrow_mut().insert(path.clone(), Rc::clone(&result));
         });
+        save_scan_to_disk(&path, &source, &result);
     }
+    record_scan_result_as_dep(module, &path, &result);
     Some(result)
+}
+
+/// Record a resolved module, and everything its own scan resolved, into the
+/// enclosing scan's dependency frame.
+fn record_scan_result_as_dep(module: &str, path: &str, result: &ModuleScanResult) {
+    record_scan_dep(module, Some(path), result.stamp.clone());
+    push_scan_deps(result.deps.iter().cloned());
+}
+
+/// Whether the on-disk scan cache may be consulted for the parse in progress.
+///
+/// An EVAL preseeds the parser with names from its calling unit, and a module
+/// scanned under those names can parse differently — so its result is not the
+/// pure function of the module sources that the cache key assumes.
+fn disk_scan_cache_usable() -> bool {
+    !super::eval_preseed_active()
+}
+
+fn load_scan_from_disk(path: &str) -> Option<Rc<ModuleScanResult>> {
+    if !disk_scan_cache_usable() {
+        return None;
+    }
+    let loaded = scan_cache::load::<ModuleScanResult>(std::path::Path::new(path), &|module| {
+        find_module_file(module)
+    })?;
+    let mut result = loaded.payload;
+    result.deps = loaded.deps;
+    result.stamp = Some(loaded.stamp);
+    Some(Rc::new(result))
+}
+
+fn save_scan_to_disk(path: &str, source: &str, result: &ModuleScanResult) {
+    if !disk_scan_cache_usable() {
+        return;
+    }
+    // `no precompilation;` opts a module out of the run-time AST cache; honour
+    // it for the parse-time scan too, rather than leaving half of the caching
+    // on for a module that asked for none.
+    if crate::runtime::Interpreter::source_has_no_precompilation(source) {
+        return;
+    }
+    let Some(stamp) = result.stamp.as_ref() else {
+        return;
+    };
+    scan_cache::save(std::path::Path::new(path), result, &result.deps, stamp);
 }
 
 /// Search lib_paths and program directory for a `.rakumod` / `.pm6` / `.pm` file
@@ -496,6 +626,11 @@ fn scan_module_source(source: &str, path: &str) -> ModuleScanResult {
     // through `ModuleScanResult` so `apply_scan_types` replays it on every
     // importer — cache hits included.
     let saved_type_index_incomplete = take_type_index_incomplete();
+    // The inline-export table is process-wide and deliberately not restored
+    // (see `ModuleScanResult::inline_module_exports`); note what was already
+    // there so the scan's own additions can be told apart and replayed.
+    let inline_exports_before: Vec<String> =
+        INLINE_MODULE_EXPORTS.with(|m| m.borrow().keys().cloned().collect());
     let skips_before = super::super::partial_parse_skips();
     let (stmts, _) = crate::parser::parse_program_partial(source);
     // A best-effort parse silently drops every statement it cannot parse — a
@@ -615,6 +750,14 @@ fn scan_module_source(source: &str, path: &str) -> ModuleScanResult {
     // parsed AST for that method call. This deliberately operates on AST
     // nodes rather than source text: a comment mentioning `define_slang` must
     // not cause an arbitrary module to execute in the parse-time interpreter.
+    let inline_module_exports: Vec<(String, Vec<InlineModuleExport>)> =
+        INLINE_MODULE_EXPORTS.with(|m| {
+            m.borrow()
+                .iter()
+                .filter(|(name, _)| !inline_exports_before.contains(name))
+                .map(|(name, exports)| (name.clone(), exports.clone()))
+                .collect()
+        });
     let defines_slang = contains_define_slang(&stmts);
     let uses_slangify = defines_slang
         || stmts.iter().any(|s| {
@@ -629,6 +772,11 @@ fn scan_module_source(source: &str, path: &str) -> ModuleScanResult {
         declare_keywords,
         type_index_incomplete,
         uses_slangify,
+        inline_module_exports,
+        // Filled in by `find_and_scan_module`, which owns the dependency frame
+        // and the file stamp.
+        deps: Vec::new(),
+        stamp: None,
     }
 }
 

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -25,7 +25,10 @@
 //! `ParseEffects` too, or it becomes the next cache-state-dependent bug. A
 //! deliberate non-entry: inline `module Foo { ... is export }` registrations
 //! (`INLINE_MODULE_EXPORTS`) were measured to behave identically cold and warm,
-//! because the importer's own uncached parse-time export scan registers them.
+//! because the importer's own parse-time export scan registers them. That scan
+//! now has a disk cache of its own ([`crate::scan_cache`]), so it carries the
+//! registrations in its entry and replays them on a hit — the guarantee holds,
+//! but it is no longer free.
 //!
 //! ## Cache layout
 //!
@@ -91,7 +94,7 @@ const CACHE_MAGIC: &[u8; 4] = b"MTS2";
 /// AST could survive the prelude-injection fix and resurface as an undeclared
 /// `Pointer`. Stamping the exe mtime invalidates the cache on every rebuild,
 /// removing the need to manually `rm` the cache after parser/compiler changes.
-fn interpreter_version() -> String {
+pub(crate) fn interpreter_version() -> String {
     // Bump CACHE_FORMAT_VERSION when Stmt/Expr/Value enum variants change,
     // or when `CacheMetadata` / `ParseEffects` gain or lose a field.
     // 9: `Value` gained `BufStorage` (ADR-0015 P2), which also shifted the
@@ -156,8 +159,14 @@ pub(crate) fn enabled_by_default() -> bool {
 
 /// Compute a deterministic hash of a canonical file path for use as cache filename.
 fn path_hash(path: &Path) -> String {
+    path_hash_hex(&path.to_string_lossy())
+}
+
+/// The same path hash, for callers holding the path as a string (the module
+/// scan cache, which names its entries exactly the way this one does).
+pub(crate) fn path_hash_hex(path: &str) -> String {
     let mut hasher = DefaultHasher::new();
-    path.to_string_lossy().hash(&mut hasher);
+    path.hash(&mut hasher);
     format!("{:016x}", hasher.finish())
 }
 
@@ -183,6 +192,45 @@ fn cache_dir() -> io::Result<PathBuf> {
     let dir = base.join("mutsu").join("precomp");
     fs::create_dir_all(&dir)?;
     Ok(dir)
+}
+
+/// A cache directory next to the precompilation cache, for the other caches
+/// keyed the same way (currently [`crate::scan_cache`]). Sharing the root
+/// means one `~/.cache/mutsu` to clear and one test override to set.
+pub(crate) fn sibling_cache_dir(name: &str) -> io::Result<PathBuf> {
+    let precomp_dir = cache_dir()?;
+    let root = precomp_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or(precomp_dir);
+    let dir = root.join(name);
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Set (or clear) the cache root used by tests, so a test never writes into
+/// the developer's real `~/.cache/mutsu`.
+#[cfg(test)]
+pub(crate) fn set_test_cache_dir(dir: Option<PathBuf>) {
+    TEST_CACHE_DIR.with(|cell| *cell.borrow_mut() = dir);
+}
+
+/// Cleared by `--no-precomp` (via `Interpreter::set_precomp_enabled`), which
+/// otherwise only reaches the interpreter it was passed to. The parser's
+/// module export scan runs with no interpreter in scope, so its cache needs a
+/// process-wide switch of its own to read.
+static PROCESS_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
+
+/// Mirror an interpreter's precompilation setting into the process-wide switch
+/// the parser-side caches read.
+pub(crate) fn set_process_enabled(enabled: bool) {
+    PROCESS_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether on-disk caching is permitted at all in this process — the
+/// `MUTSU_PRECOMP=0` environment switch and the `--no-precomp` flag combined.
+pub(crate) fn enabled_for_process() -> bool {
+    PROCESS_ENABLED.load(std::sync::atomic::Ordering::Relaxed) && enabled_by_default()
 }
 
 fn warn_cache_unavailable(err: &dyn std::fmt::Display) {
@@ -253,7 +301,7 @@ fn temp_cache_path(cache_file: &Path) -> PathBuf {
 /// itself imposes.
 const MAX_DECODE_ALLOC: usize = 256 * 1024 * 1024;
 
-fn decode_config() -> impl bincode::config::Config {
+pub(crate) fn decode_config() -> impl bincode::config::Config {
     bincode::config::standard().with_limit::<MAX_DECODE_ALLOC>()
 }
 
@@ -361,7 +409,8 @@ pub(crate) fn save_cached_unit(source_path: &Path, stmts: &[Stmt], effects: &Par
     let Some(source_mtime) = source_mtime_nanos(source_path) else {
         return;
     };
-    prune_cache_once(&dir);
+    static PRUNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    prune_cache_once(&dir, &PRUNED);
 
     let hash = path_hash(&canonical);
     let cache_file = dir.join(format!("{}.bin", hash));
@@ -431,10 +480,10 @@ const MAX_CACHE_ENTRIES: usize = 4096;
 /// dropped once they are old enough that no live writer could still own them.
 ///
 /// Runs at most once per process, and only from the save path, so a warm run
-/// that never writes never pays for the scan.
-fn prune_cache_once(dir: &Path) {
-    static PRUNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-    if PRUNED.set(()).is_err() {
+/// that never writes never pays for the scan. The `once` guard is the caller's,
+/// so each cache directory (this one and the module scan cache's) gets its own.
+pub(crate) fn prune_cache_once(dir: &Path, once: &std::sync::OnceLock<()>) {
+    if once.set(()).is_err() {
         return;
     }
     let Ok(entries) = fs::read_dir(dir) else {
@@ -477,21 +526,21 @@ fn prune_cache_once(dir: &Path) {
 }
 
 /// Get the modification time of a file as seconds since UNIX epoch.
-fn source_mtime_nanos(path: &Path) -> Option<u128> {
+pub(crate) fn source_mtime_nanos(path: &Path) -> Option<u128> {
     let metadata = fs::metadata(path).ok()?;
     let modified = metadata.modified().ok()?;
     let duration = modified.duration_since(SystemTime::UNIX_EPOCH).ok()?;
     Some(duration.as_nanos())
 }
 
-fn source_content_hash(path: &Path) -> Option<u64> {
+pub(crate) fn source_content_hash(path: &Path) -> Option<u64> {
     let bytes = fs::read(path).ok()?;
     Some(content_hash(&bytes))
 }
 
 /// Hash source bytes the same way `source_content_hash` does, so an in-memory
 /// hash validates against an entry written from a disk read (and vice versa).
-fn content_hash(bytes: &[u8]) -> u64 {
+pub(crate) fn content_hash(bytes: &[u8]) -> u64 {
     let mut hasher = DefaultHasher::new();
     bytes.hash(&mut hasher);
     hasher.finish()

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -285,7 +285,7 @@ impl Interpreter {
         *stmts = combined;
     }
 
-    pub(super) fn source_has_no_precompilation(code: &str) -> bool {
+    pub(crate) fn source_has_no_precompilation(code: &str) -> bool {
         code.lines().any(|line| {
             let trimmed = line.trim();
             trimmed == "no precompilation;"

--- a/src/runtime/runtime_output.rs
+++ b/src/runtime/runtime_output.rs
@@ -101,6 +101,10 @@ impl Interpreter {
     /// Enable or disable module precompilation cache.
     pub fn set_precomp_enabled(&mut self, val: bool) {
         self.precomp_enabled = val;
+        // The parser's module export scan cache runs before this interpreter
+        // is reachable, so it reads a process-wide mirror of this switch —
+        // otherwise `--no-precomp` would silently leave half the caching on.
+        crate::precomp::set_process_enabled(val);
     }
 
     /// Check if MONKEY-TYPING pragma is active.

--- a/src/scan_cache.rs
+++ b/src/scan_cache.rs
@@ -1,0 +1,404 @@
+//! On-disk cache for the parser's module *export scan*.
+//!
+//! A `use Foo;` makes mutsu read `Foo`'s source twice: the parser scans it to
+//! learn what it exports (so the importing unit can parse calls to those
+//! exports), and the runtime loads it to execute it. The runtime half has had a
+//! precompilation cache for a long time ([`crate::precomp`]); the parser half
+//! had none, so every process re-parsed every `use`d module's source from
+//! scratch. That scan was measured at 209 M instructions — 63% of a warm
+//! `use YAMLish; say "ok"` run (GH-8095).
+//!
+//! This module gives the scan the same treatment, with one extra validation
+//! obligation the precompilation cache does not have.
+//!
+//! ## Why the module's own source hash is not a sufficient key
+//!
+//! A scan result deliberately carries **transitive** names: the type names,
+//! enum values and constant terms that reached the module from the modules *it*
+//! `use`s, because an importer can see those too. So the result is a function
+//! of the dependency sources as well, and validating only the module's own
+//! source would serve a stale answer after a dependency is edited.
+//!
+//! Each entry therefore records every module the scan resolved, as a
+//! [`ScanDep`]: the module name as written, the file it resolved to (or `None`
+//! when it resolved to nothing the parser could scan), and that file's stamp.
+//! The list is the *transitive* closure — a child scan's deps are merged into
+//! its parent's — so validating one entry validates the whole subtree without
+//! loading the children's entries.
+//!
+//! Validation re-resolves each dependency's module name through the parser's
+//! current search path and requires it to land on the same file, which is what
+//! makes the cache safe across a changed `-I` / `use lib`: a module that now
+//! resolves elsewhere invalidates the entry rather than silently keeping the
+//! old file's names.
+//!
+//! ## What is deliberately not persisted
+//!
+//! The parse warnings the scan raises. They are re-raised (and deduplicated by
+//! `(file, message)`) when the runtime actually loads the module, which always
+//! happens for a `use`, so a hit loses nothing the user sees. The in-process
+//! scan memo has behaved this way for every `use` after the first since it was
+//! added.
+
+use std::path::{Path, PathBuf};
+
+use crate::precomp;
+
+/// Identity of a source file at scan time: both halves of the precompilation
+/// cache's own validity test, so a dependency is judged exactly as strictly as
+/// the unit it belongs to.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct FileStamp {
+    pub(crate) mtime_nanos: u128,
+    pub(crate) hash: u64,
+}
+
+impl FileStamp {
+    /// Stamp a file whose content the caller already has in memory.
+    pub(crate) fn of_source(path: &Path, source: &str) -> Option<Self> {
+        Some(FileStamp {
+            mtime_nanos: precomp::source_mtime_nanos(path)?,
+            hash: precomp::content_hash(source.as_bytes()),
+        })
+    }
+
+    /// Stamp a file by reading it.
+    fn of_path(path: &Path) -> Option<Self> {
+        Some(FileStamp {
+            mtime_nanos: precomp::source_mtime_nanos(path)?,
+            hash: precomp::source_content_hash(path)?,
+        })
+    }
+}
+
+/// One module the scan resolved, recorded so the entry can be invalidated when
+/// that module changes — or when the same name now resolves to a different
+/// file.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ScanDep {
+    /// Module name exactly as the `use`/`need` wrote it.
+    pub(crate) module: String,
+    /// The file it resolved to, or `None` when it resolved to no scannable
+    /// file (a pragma, a native provider, an installed repository the parser
+    /// cannot walk). Recorded either way: a name that resolves to nothing
+    /// today and to a file tomorrow changes the scan's answer.
+    pub(crate) path: Option<String>,
+    /// Stamp of `path`, when there is one.
+    pub(crate) stamp: Option<FileStamp>,
+}
+
+/// Metadata stored ahead of the serialized scan payload.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct ScanMetadata {
+    /// Canonical path of the module this entry describes. The cache file name
+    /// is only a hash of it, so storing it lets the entry name itself rather
+    /// than be assumed to belong to the file being loaded.
+    source_path: String,
+    /// Stamp of that module's own source.
+    stamp: FileStamp,
+    /// Interpreter version stamp (embeds the executable's mtime, so a rebuilt
+    /// mutsu with different scan logic never reuses an older build's entries).
+    version: String,
+    /// Every module the scan resolved, transitively. See the module docs.
+    deps: Vec<ScanDep>,
+}
+
+/// Magic bytes for the scan-cache format. `MSC1` marks version 1; bump the
+/// trailing byte whenever the framing changes so stale files are rejected by
+/// the magic check rather than mis-decoded.
+const CACHE_MAGIC: &[u8; 4] = b"MSC1";
+
+fn cache_dir() -> std::io::Result<PathBuf> {
+    precomp::sibling_cache_dir("modscan")
+}
+
+/// A validated cache entry.
+pub(crate) struct LoadedScan<T> {
+    pub(crate) payload: T,
+    pub(crate) deps: Vec<ScanDep>,
+    pub(crate) stamp: FileStamp,
+}
+
+/// Whether a dependency record still describes the world the scan saw.
+fn dep_is_valid(dep: &ScanDep, resolve: &dyn Fn(&str) -> Option<String>) -> bool {
+    let resolved = resolve(&dep.module);
+    if resolved != dep.path {
+        return false;
+    }
+    match (&dep.path, &dep.stamp) {
+        (None, _) => true,
+        (Some(path), Some(stamp)) => FileStamp::of_path(Path::new(path)).as_ref() == Some(stamp),
+        // A resolved path with no stamp means the scan could not read the file;
+        // never treat that as a reusable observation.
+        (Some(_), None) => false,
+    }
+}
+
+/// Load the cached scan for `source_path`, if one is valid.
+///
+/// `resolve` maps a module name to the file the parser would resolve it to
+/// right now; it is how a changed search path invalidates the entry.
+pub(crate) fn load<T: serde::de::DeserializeOwned>(
+    source_path: &Path,
+    resolve: &dyn Fn(&str) -> Option<String>,
+) -> Option<LoadedScan<T>> {
+    if !precomp::enabled_for_process() {
+        return None;
+    }
+    let canonical = source_path.canonicalize().ok()?;
+    let cache_file = cache_dir().ok()?.join(format!(
+        "{}.bin",
+        precomp::path_hash_hex(&canonical.to_string_lossy())
+    ));
+    let data = std::fs::read(&cache_file).ok()?;
+    if data.len() < 8 || &data[0..4] != CACHE_MAGIC {
+        return None;
+    }
+    let meta_len = u32::from_le_bytes([data[4], data[5], data[6], data[7]]) as usize;
+    let rest = &data[8..];
+    if rest.len() < meta_len {
+        return None;
+    }
+    let (meta, _): (ScanMetadata, usize) =
+        bincode::serde::decode_from_slice(&rest[..meta_len], precomp::decode_config()).ok()?;
+
+    if meta.source_path != canonical.to_string_lossy() {
+        return None;
+    }
+    if meta.version != precomp::interpreter_version() {
+        let _ = std::fs::remove_file(&cache_file);
+        return None;
+    }
+    if FileStamp::of_path(source_path).as_ref() != Some(&meta.stamp) {
+        let _ = std::fs::remove_file(&cache_file);
+        return None;
+    }
+    // A dependency change does not invalidate this file's *own* identity, so
+    // the entry is merely unusable now, not garbage — leave it on disk; the
+    // re-scan that follows overwrites it.
+    if !meta.deps.iter().all(|dep| dep_is_valid(dep, resolve)) {
+        return None;
+    }
+
+    let (payload, _): (T, usize) =
+        bincode::serde::decode_from_slice(&rest[meta_len..], precomp::decode_config()).ok()?;
+    Some(LoadedScan {
+        payload,
+        deps: meta.deps,
+        stamp: meta.stamp,
+    })
+}
+
+/// Store a scan result for `source_path`. Best effort: every failure is a
+/// silent no-op, since the only consequence is a re-scan next time.
+pub(crate) fn save<T: serde::Serialize>(
+    source_path: &Path,
+    payload: &T,
+    deps: &[ScanDep],
+    stamp: &FileStamp,
+) {
+    if !precomp::enabled_for_process() {
+        return;
+    }
+    let Ok(canonical) = source_path.canonicalize() else {
+        return;
+    };
+    let Ok(dir) = cache_dir() else {
+        return;
+    };
+    static PRUNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    precomp::prune_cache_once(&dir, &PRUNED);
+    let meta = ScanMetadata {
+        source_path: canonical.to_string_lossy().into_owned(),
+        stamp: stamp.clone(),
+        version: precomp::interpreter_version(),
+        deps: deps.to_vec(),
+    };
+    let Ok(meta_bytes) = bincode::serde::encode_to_vec(&meta, bincode::config::standard()) else {
+        return;
+    };
+    let Ok(payload_bytes) = bincode::serde::encode_to_vec(payload, bincode::config::standard())
+    else {
+        return;
+    };
+    let mut data = Vec::with_capacity(8 + meta_bytes.len() + payload_bytes.len());
+    data.extend_from_slice(CACHE_MAGIC);
+    data.extend_from_slice(&(meta_bytes.len() as u32).to_le_bytes());
+    data.extend_from_slice(&meta_bytes);
+    data.extend_from_slice(&payload_bytes);
+
+    let cache_file = dir.join(format!(
+        "{}.bin",
+        precomp::path_hash_hex(&canonical.to_string_lossy())
+    ));
+    // Same atomicity rule as the precompilation cache: the scratch name is
+    // per-writer, because two `prove -j` processes scanning the same module
+    // would otherwise interleave their non-atomic writes into one buffer and
+    // rename the mixture into place.
+    let tmp_file = cache_file.with_extension(format!("{}.tmp", std::process::id()));
+    if std::fs::write(&tmp_file, &data).is_ok() {
+        if std::fs::rename(&tmp_file, &cache_file).is_err() {
+            let _ = std::fs::remove_file(&tmp_file);
+        }
+    } else {
+        let _ = std::fs::remove_file(&tmp_file);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+    struct Payload {
+        names: Vec<String>,
+    }
+
+    fn tempdir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "mutsu-scan-cache-{}-{}-{:?}",
+            std::process::id(),
+            tag,
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Point both caches at a scratch directory so the test never touches the
+    /// developer's real `~/.cache/mutsu`.
+    fn with_scratch_cache<R>(tag: &str, f: impl FnOnce(&Path) -> R) -> R {
+        let dir = tempdir(tag);
+        precomp::set_test_cache_dir(Some(dir.join("precomp")));
+        let out = f(&dir);
+        precomp::set_test_cache_dir(None);
+        let _ = std::fs::remove_dir_all(&dir);
+        out
+    }
+
+    fn write(path: &Path, content: &str) {
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn round_trips_a_payload() {
+        with_scratch_cache("roundtrip", |dir| {
+            let module = dir.join("Mod.rakumod");
+            write(&module, "sub a is export {}\n");
+            let stamp = FileStamp::of_source(&module, "sub a is export {}\n").unwrap();
+            let payload = Payload {
+                names: vec!["a".to_string()],
+            };
+            save(&module, &payload, &[], &stamp);
+            let loaded: LoadedScan<Payload> = load(&module, &|_| None).expect("cache hit");
+            assert_eq!(loaded.payload, payload);
+        });
+    }
+
+    #[test]
+    fn edited_source_misses() {
+        with_scratch_cache("edited", |dir| {
+            let module = dir.join("Mod.rakumod");
+            write(&module, "sub a is export {}\n");
+            let stamp = FileStamp::of_source(&module, "sub a is export {}\n").unwrap();
+            save(
+                &module,
+                &Payload {
+                    names: vec!["a".to_string()],
+                },
+                &[],
+                &stamp,
+            );
+            write(&module, "sub b is export {}\n");
+            let loaded: Option<LoadedScan<Payload>> = load(&module, &|_| None);
+            assert!(loaded.is_none(), "an edited module must not hit");
+        });
+    }
+
+    /// The invalidation obligation this cache has and the precompilation cache
+    /// does not: a scan carries names that came from its dependencies, so
+    /// editing a dependency must invalidate the importer's entry.
+    #[test]
+    fn edited_dependency_misses() {
+        with_scratch_cache("dep", |dir| {
+            let module = dir.join("Mod.rakumod");
+            let dep = dir.join("Dep.rakumod");
+            write(&module, "use Dep;\n");
+            write(&dep, "class Dep::Thing {}\n");
+            let stamp = FileStamp::of_source(&module, "use Dep;\n").unwrap();
+            let deps = vec![ScanDep {
+                module: "Dep".to_string(),
+                path: Some(dep.to_string_lossy().into_owned()),
+                stamp: FileStamp::of_path(&dep),
+            }];
+            let payload = Payload {
+                names: vec!["Dep::Thing".to_string()],
+            };
+            save(&module, &payload, &deps, &stamp);
+            let resolve = |name: &str| (name == "Dep").then(|| dep.to_string_lossy().into_owned());
+            let hit: Option<LoadedScan<Payload>> = load(&module, &resolve);
+            assert!(hit.is_some(), "an untouched dependency must still hit");
+
+            write(&dep, "class Dep::Other {}\n");
+            let miss: Option<LoadedScan<Payload>> = load(&module, &resolve);
+            assert!(miss.is_none(), "an edited dependency must invalidate");
+        });
+    }
+
+    /// A dependency that now resolves to a different file (a changed `-I`)
+    /// invalidates too, even when neither file was edited.
+    #[test]
+    fn re_resolved_dependency_misses() {
+        with_scratch_cache("resolve", |dir| {
+            let module = dir.join("Mod.rakumod");
+            let dep = dir.join("Dep.rakumod");
+            let other = dir.join("Other.rakumod");
+            write(&module, "use Dep;\n");
+            write(&dep, "class Dep::Thing {}\n");
+            write(&other, "class Other::Thing {}\n");
+            let stamp = FileStamp::of_source(&module, "use Dep;\n").unwrap();
+            let deps = vec![ScanDep {
+                module: "Dep".to_string(),
+                path: Some(dep.to_string_lossy().into_owned()),
+                stamp: FileStamp::of_path(&dep),
+            }];
+            save(
+                &module,
+                &Payload {
+                    names: vec!["Dep::Thing".to_string()],
+                },
+                &deps,
+                &stamp,
+            );
+            let miss: Option<LoadedScan<Payload>> =
+                load(&module, &|_| Some(other.to_string_lossy().into_owned()));
+            assert!(miss.is_none(), "a re-resolved dependency must invalidate");
+        });
+    }
+
+    /// A dependency that resolved to nothing is recorded too: it becoming
+    /// resolvable changes the scan's answer.
+    #[test]
+    fn newly_resolvable_dependency_misses() {
+        with_scratch_cache("unresolved", |dir| {
+            let module = dir.join("Mod.rakumod");
+            write(&module, "use Absent;\n");
+            let stamp = FileStamp::of_source(&module, "use Absent;\n").unwrap();
+            let deps = vec![ScanDep {
+                module: "Absent".to_string(),
+                path: None,
+                stamp: None,
+            }];
+            save(&module, &Payload { names: vec![] }, &deps, &stamp);
+            let hit: Option<LoadedScan<Payload>> = load(&module, &|_| None);
+            assert!(hit.is_some(), "still-absent dependency must hit");
+            let miss: Option<LoadedScan<Payload>> =
+                load(&module, &|_| Some("/nowhere/Absent.rakumod".to_string()));
+            assert!(
+                miss.is_none(),
+                "a now-resolvable dependency must invalidate"
+            );
+        });
+    }
+}

--- a/t/modules/compunit/module-scan-precomp-cache.t
+++ b/t/modules/compunit/module-scan-precomp-cache.t
@@ -1,0 +1,105 @@
+use Test;
+
+# The parser scans a `use`d module's source to learn what it exports, and since
+# GH-8095 that scan is cached on disk (`src/scan_cache.rs`) the way the run-time
+# AST already was. A scan hit performs no parse at all, so whatever the scan
+# used to register as a side effect must now be replayed from the entry -- and
+# whatever the entry depends on must invalidate it.
+#
+# Both halves are pinned here end to end, across separate processes, because
+# that is the only place the disk cache exists: within one process the scan is
+# memoized in a thread-local and the bug class cannot appear.
+#
+# An *exported operator* is the probe throughout: `1 topadd 2` only parses when
+# the parser already knows `infix:<topadd>` was imported, so a lost or stale
+# export list is a hard compile failure rather than a subtle difference.
+
+plan 6;
+
+my $dir = $*TMPDIR.add("mutsu-scan-cache-{$*PID}");
+my $lib = $dir.add('lib');
+$lib.mkdir;
+
+# Give the run its own cache root so the first run really is cold, whatever the
+# developer's ~/.cache happens to hold.
+%*ENV<XDG_CACHE_HOME> = $dir.add('cache').Str;
+
+my $leaf = $lib.add('ScanCacheLeaf.rakumod');
+my $top = $lib.add('ScanCacheTop.rakumod');
+my $script = $dir.add('prog.raku');
+
+sub write-leaf($tag) {
+    $leaf.spurt: qq:to/LEAF/;
+        unit module ScanCacheLeaf;
+        constant SCAN_CACHE_LEAF_TAG is export = '$tag';
+        sub leaf-tag() is export \{ SCAN_CACHE_LEAF_TAG }
+        LEAF
+}
+
+sub write-top($op) {
+    $top.spurt: qq:to/TOP/;
+        unit module ScanCacheTop;
+        use ScanCacheLeaf;
+        class ScanCacheTop::Marker is export \{ }
+        sub infix:<$op>(\$a, \$b) is export \{ \$a + \$b }
+        sub top-leaf-tag() is export \{ leaf-tag() }
+        TOP
+}
+
+sub write-script($op) {
+    $script.spurt: qq:to/PROG/;
+        use ScanCacheTop;
+        say 1 $op 2;
+        say top-leaf-tag();
+        say ScanCacheTop::Marker.new.defined;
+        PROG
+}
+
+sub run-script() {
+    my $proc = run($*EXECUTABLE, '-I', $lib.Str, $script.Str, :out, :err);
+    my $out = $proc.out.slurp;
+    my $err = $proc.err.slurp;
+    %( :$out, :$err, exit => $proc.exitcode )
+}
+
+write-leaf('one');
+write-top('topadd');
+write-script('topadd');
+
+my %cold = run-script();
+is %cold<exit>, 0, 'cold run compiles and runs';
+is %cold<out>, "3\none\nTrue\n", 'cold run sees the imported operator and sub';
+
+my %warm = run-script();
+is %warm<out>, %cold<out>,
+    'a warm module-scan cache replays the export registrations identically';
+
+# The module's own source changing must invalidate its entry. A stale entry
+# would still list `topadd` and know nothing of `topmul`, so the new program
+# would fail to parse rather than quietly compute the old answer.
+write-top('topmul');
+write-script('topmul');
+my %edited = run-script();
+is %edited<exit>, 0, 'an edited module is re-scanned, not served from the entry';
+is %edited<out>, "3\none\nTrue\n", 'the renamed operator is imported';
+
+# A scan result carries names that reached the module from its *dependencies*,
+# so editing one must re-validate the importer's entry too (the precise
+# invalidation rules are unit-tested in `src/scan_cache.rs`; what matters here
+# is that a dependency edit still produces a correct, consistent run).
+write-leaf('two');
+my %dep-edited = run-script();
+is %dep-edited<out>, "3\ntwo\nTrue\n",
+    'an edited dependency is picked up through the importer';
+
+END {
+    # `run` may still hold the directory; ignore a failed cleanup.
+    try rmtree($dir) if $dir.e;
+}
+
+sub rmtree(IO::Path $d) {
+    for $d.dir -> $e {
+        $e.d ?? rmtree($e) !! $e.unlink;
+    }
+    $d.rmdir;
+}


### PR DESCRIPTION
A `use Foo;` read `Foo`'s source twice. The run-time half consults the precompilation cache and skips its parse on a hit; the parser half — which scans the module for its `is export` subs, type names, enum values and constant terms so the importing unit can parse calls to them — had no cache and re-parsed from source in every process. It was the larger half: on a warm `use YAMLish; say "ok"`, `find_and_scan_module` alone accounted for 209 M of the run's 334 M instructions.

The scan now persists to `~/.cache/mutsu/modscan/`, next to the precompilation cache and keyed the same way (canonical source path, mtime + content hash, and the interpreter version stamp that embeds the executable's mtime, so a rebuilt mutsu never reuses an older build's entries).

## Measurement

callgrind, `use YAMLish; say "ok"`, release build, precompilation cache warm in both rows:

| module scan cache | Ir |
| --- | --- |
| cold (previous behaviour) | 271,924,883 |
| warm | 124,158,716 |

`find_and_scan_module` no longer appears in the warm profile at all.

## The invalidation question the precompilation cache does not have

A scan result deliberately carries **transitive** names — the qualified type names, enum values and sigilless constant terms that reached the module from the modules *it* `use`s, because an importer can see those too. So the result is a function of the dependency sources as well, and a content hash of the module's own source alone would serve a stale answer after a dependency was edited. This is the reason #8095 was filed rather than fixed inline.

Each entry therefore records every module its scan resolved, as a `ScanDep`: the module name as written, the file it resolved to (or `None` when it resolved to nothing the parser could scan — a name that resolves to nothing today and to a file tomorrow changes the answer too), and that file's mtime + hash. The list is the transitive closure — a child scan's deps merge into its parent's — so validating one entry validates the whole subtree without loading the children's entries. Validation also **re-resolves** each dependency's module name through the parser's current search path and requires it to land on the same file, which is what keeps the cache honest across a changed `-I` or `use lib`.

That is option 1 of the three the issue listed. Option 2 (derive the scan from the precompiled unit's `stmts`) is still not a drop-in — the nested parse's scope-stack side effects remain the only record of constants and `imported_value_terms` — and option 3 does nothing for the ~3,000 short-lived processes of a test run, which is where the cost actually lands.

## What a hit has to replay, and what it may drop

A hit runs no nested parse, so anything the scan used to leave behind as a side effect had to become part of the entry. One such effect was found and captured: inline `module Foo { ... is export }` tables. The nested parse registers those in the process-wide inline-export table, which the scan does not restore, so an `import Foo;` in the importing file finds them purely because the scan ran. They are now recorded in the entry and replayed on every importer. (`precomp.rs`'s module docs, which cited that side effect as the reason inline exports are a deliberate non-entry there, are updated: the guarantee holds, but it is no longer free.)

Parse warnings are deliberately *not* persisted. They are re-raised — and deduplicated by `(file, message)` — when the runtime actually loads the module, which always happens for a `use`; the in-process scan memo has behaved this way for every `use` after the first since it was added.

Two situations skip the disk cache entirely rather than risk an unsound entry:

- a module whose source says `no precompilation;`, which already opts out of the run-time cache;
- a scan running underneath an EVAL that has preseeded the parser with names from its calling unit, where the result is not the pure function of the module sources that the key assumes.

`MUTSU_PRECOMP=0` and `--no-precomp` turn it off with the rest of the caching — the latter needed a process-wide mirror of the interpreter's switch, since the parser's scan runs with no interpreter in scope.

## Tests

- `src/scan_cache.rs` unit-tests the invalidation rules directly: an edited module, an edited dependency, a dependency that now resolves to a different file, and a dependency that was absent and is now present must all miss.
- `t/modules/compunit/module-scan-precomp-cache.t` pins the end-to-end behaviour across separate processes — the only place the disk cache exists, since within one process the scan is memoized in a thread-local and the bug class cannot appear. It probes with an *exported operator*, so a lost or stale export list is a hard compile failure rather than a subtle difference.

## Verification

`cargo fmt --all`, `make lint`, `make test` and `make roast` all run locally and green. `make roast` shows only `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8/10) and `roast/S16-filehandles/filetest.t` (`Failed: 25`) — the two documented `uid 0` container failures in [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md), with exactly the documented test numbers.

Closes #8095

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rtFLuDLNqD45pfCwgPYpJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016rtFLuDLNqD45pfCwgPYpJ)_