### PR TITLE
test: pin Attribute inheritance in a role body (#8062 already fixed)

### DIFF
--- a/news/2026-09/attribute-inheritance-in-role-body-already-fixed.md
+++ b/news/2026-09/attribute-inheritance-in-role-body-already-fixed.md
@@ -1,0 +1,20 @@
+# A class in a role body inheriting Attribute was already fixed
+
+[#8062](https://github.com/tokuhirom/mutsu/issues/8062) reported that
+`class MyAttr is Attribute { }` died as `X::Inheritance::UnknownParent`,
+blocking the PDF distribution family (`PDF`, `PDF::Class`,
+`PDF::Content`, `PDF::Font::Loader`, `FDF`, `Pod::To::PDF::Lite`) via
+`PDF::COS::Tie`'s attribute-trait helper classes, declared inside a role
+body.
+
+`Attribute` was added to `BUILTIN_INHERITABLE_TYPES` by an unrelated,
+broader fix (`af7e5ab3`, "an uppercase `is Trait` is still a trait, and a
+natively-modelled core type is still a parent", closing
+[#7996](https://github.com/tokuhirom/mutsu/issues/7996)) shortly before
+this ticket was picked up — both the top-level case and the role-body
+case measure correctly against `raku` now.
+
+Extended `t/oo/class/builtin-inheritable-parent-types.t` with the
+role-body shape specifically (a `my class ... is Attribute` declared
+inside a `role`, composed into a consumer class to make it reachable) so
+that this coverage is not left implicit in the top-level case alone.

--- a/t/oo/class/builtin-inheritable-parent-types.t
+++ b/t/oo/class/builtin-inheritable-parent-types.t
@@ -22,7 +22,7 @@ my @inheritable =
     'Metamodel::EnumHOW', 'Metamodel::ModuleHOW', 'Metamodel::PackageHOW',
     'Metamodel::ParametricRoleGroupHOW', 'Metamodel::SubsetHOW';
 
-plan @inheritable.elems + 5;
+plan @inheritable.elems + 6;
 
 use MONKEY-SEE-NO-EVAL;
 
@@ -58,4 +58,26 @@ dies-ok { EVAL 'class Nope does Attribute { }' },
     my $mixed = Holder.^attributes[0] but Tag;
     is $mixed.tag ~ ' ' ~ $mixed.name, 'tagged $!x',
         'mixing a role into an Attribute still keeps both halves';
+}
+
+# GH #8062: PDF::COS::Tie declares an attribute-trait helper class INSIDE a
+# role body (`my class COSAttr is Attribute { ... }` within `role Tie { }`,
+# further nested as `COSAttr::CosOfAttr`). The role-body scope reaches the
+# same `validate_class_parents` path as a top-level declaration, so this was
+# never a separate code path -- but it is the shape the issue's own repro
+# names, so pin it directly rather than trusting the top-level case above to
+# stand in for it. (A role's own top-level statements run only once it is
+# composed into a class, and a role body may only declare a `my`-scoped
+# class -- both true in rakudo too -- so the role below is composed into a
+# throwaway consumer to make `COSAttr` reachable.)
+{
+    role Tie {
+        my class COSAttr is Attribute {
+            method label { 'cos-attr' }
+        }
+        method describe-attr { COSAttr.label }
+    }
+    class Consumer does Tie { }
+    is Consumer.new.describe-attr, 'cos-attr',
+        'a `my class` nested in a role body may inherit Attribute and be used';
 }


### PR DESCRIPTION
## Summary

[#8062](https://github.com/tokuhirom/mutsu/issues/8062) reported that
`class MyAttr is Attribute { }` died as `X::Inheritance::UnknownParent`,
blocking the PDF distribution family (`PDF`, `PDF::Class`,
`PDF::Content`, `PDF::Font::Loader`, `FDF`, `Pod::To::PDF::Lite`) via
`PDF::COS::Tie`'s attribute-trait helper classes, declared inside a role
body.

`Attribute` was added to `BUILTIN_INHERITABLE_TYPES` by an unrelated,
broader fix (`af7e5ab3`, "an uppercase `is Trait` is still a trait, and a
natively-modelled core type is still a parent", closing
[#7996](https://github.com/tokuhirom/mutsu/issues/7996)) shortly before
this ticket was picked up. Both the top-level case (already covered by
`t/oo/class/builtin-inheritable-parent-types.t`) and the issue's specific
role-body case now measure correctly against `raku`. No `src/` change
needed; this PR extends that existing test with the role-body shape
specifically and closes the issue with this evidence.

Closes #8062

## Test plan

- Extended `t/oo/class/builtin-inheritable-parent-types.t` with a `my
  class ... is Attribute` declared inside a `role`, composed into a
  consumer class to make it reachable and exercised through a method
  call — verified byte-identical behavior against `raku` directly (both
  pass the extended file verbatim).
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run
  locally. `make roast` comes back with only the three environment-only
  failures documented in `docs/agent-environments.md` for a remote
  container (`roast/6.c/S32-io/file-tests.t`,
  `roast/S16-filehandles/filetest.t` — both `uid 0` chmod-based file tests
  — and `roast/S32-io/IO-Socket-Async.t`, sandboxed network); everything
  else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_