### PR TITLE
fix: carry static regex provenance into matching values

### DIFF
--- a/docs/adr/0088-rakuast-regex-boundary-tree.md
+++ b/docs/adr/0088-rakuast-regex-boundary-tree.md
@@ -1,8 +1,8 @@
 # ADR-0088: RakuAST and execution share a source-level regex tree
 
-- Status: Accepted (static source-tree, RakuAST, and execution-lowering slices
-  implemented 2026-09-12; dynamic contents and the complete execution-tree
-  migration remain)
+- Status: Accepted (static source-tree, RakuAST, execution-lowering, and
+  static-value-provenance slices implemented 2026-09-12; dynamic contents and
+  the complete execution-tree migration remain)
 - Date: 2026-09-12
 - Related: [ADR-0011](0011-rakuast-model-layer-and-phasing.md) (the RakuAST
   model layer and its bidirectional conversion),
@@ -354,13 +354,15 @@ classes, and the simple quantifiers directly to `RegexPattern`, carrying the
 whose meaning depends on captures, interpolation, code, or package state keep
 using the established structural parser. The bridge is intentionally a
 fallback-compatible step: the compiled `Value::Regex` still carries its
-execution spelling, so the parser-bound tree must remain the next migration
-target rather than being rediscovered from normalized declaration text.
+execution spelling, while static expression values now carry parser-produced
+tree provenance alongside it. Declaration-normalized values and the remaining
+string-only entry points must still migrate without rediscovering source trees
+from normalized declaration text.
 
 The following remain intentionally open: dynamic assertions and interpolation,
-captures and subrules, adverbs with runtime arguments, and replacing the
-string-carried regex value with parser-produced tree provenance throughout the
-remaining matcher entry points.
+captures and subrules, adverbs with runtime arguments, declaration-normalized
+values, and replacing string-only regex inputs with parser-produced tree
+provenance throughout the remaining matcher entry points.
 
 ## 8. Static execution-lowering slice (2026-09-12)
 
@@ -376,5 +378,30 @@ The regression pin is `t/regex/regex-tree-static-execution.t`: it exercises
 literal and quantified-class `EVAL` results twice, plus a ratcheted token
 declaration twice, and checks rejection cases. The Rust lowering tests pin the
 plan shape and the fallback boundary. This slice establishes only the static
-plan conversion; captures, subrules, dynamic values, and the parser-produced
-tree transport remain separate slices.
+plan conversion; captures, subrules, dynamic values, and the remaining
+string-only execution entry points remain separate slices.
+
+## 9. Static regex-value provenance slice (2026-09-12)
+
+Parser-created static expression regexes now retain their `RegexTree` on the
+regex value as it passes through the compiler and ordinary smartmatch path.
+Plain regex values use the existing transparent `Regex` view, while adverb
+payloads retain their existing execution flags and carry the tree alongside
+them. The captured-scope representation is optional so a source-only value
+does not install a synthetic lexical scope; code-bearing regexes continue to
+use the established closure path.
+
+`Interpreter::parse_regex_value` consumes that provenance for the static
+execution subset and caches the resulting `RegexPattern` with a tree
+fingerprint. It falls back to the established string parser for unsupported,
+dynamic, synthesized, and declaration-normalized values. The matcher and its
+Parser -> Compiler -> VM entry point are otherwise unchanged: this slice
+removes the reparse at the value-aware single-match smartmatch boundary only.
+
+The focused regression is `t/regex/regex-tree-value-provenance.t`, which stores
+plain and adverb-bearing regexes, lowers a constructed `QuotedRegex`, and
+matches each through the ordinary value path. A stale-spelling Rust test pins
+that the execution plan comes from the retained tree rather than the value's
+compatibility string. Other regex entry points that currently accept only a
+pattern string, declaration normalization, captures, subrules, and dynamic
+regex nodes remain follow-up slices.

--- a/news/2026-09/rakuast-regex-value-provenance.md
+++ b/news/2026-09/rakuast-regex-value-provenance.md
@@ -1,0 +1,11 @@
+# Regex values retain their source trees
+
+Static parser-created regex values now keep their shared `RegexTree` through
+the compiler. The ordinary single-match smartmatch path lowers that tree
+directly to the existing `RegexPattern` matcher, while unsupported and
+dynamic values continue through the established parser fallback.
+
+This covers both plain and static adverb-bearing values without changing the
+`Regex` view or the Parser -> Compiler -> VM matcher path. String-only entry
+points, captures, subrules, interpolation, and runtime adverb arguments remain
+open under ADR-0088.

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -100,8 +100,13 @@ impl Compiler {
             Expr::LiteralSrc(v, _) => {
                 self.compile_expr(&Expr::Literal(v.clone()));
             }
-            Expr::RegexLiteral { value, .. } => {
-                self.compile_expr(&Expr::Literal(value.clone()));
+            Expr::RegexLiteral { value, tree } => {
+                // The tree is part of the AST contract, not merely parser
+                // bookkeeping. Reattach it here as well so a serialized AST
+                // whose Value payload predates provenance still reaches the
+                // value-aware execution entry point.
+                let value = value.with_regex_source_tree(tree.clone());
+                self.compile_expr(&Expr::Literal(value));
             }
             Expr::Literal(v) => match v.view() {
                 ValueView::Nil => {
@@ -152,8 +157,9 @@ impl Compiler {
             Expr::MatchRegex(v) => {
                 self.compile_match_regex(v);
             }
-            Expr::MatchRegexTree { value, .. } => {
-                self.compile_match_regex(value);
+            Expr::MatchRegexTree { value, tree } => {
+                let value = value.with_regex_source_tree(tree.clone());
+                self.compile_match_regex(&value);
             }
             Expr::Var(name) => {
                 let name = self.resolve_self_lexical(name);

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -448,8 +448,9 @@ impl Compiler {
                     _ => unreachable!(),
                 }));
             }
-            Expr::RegexLiteral { value, .. } | Expr::MatchRegexTree { value, .. } => {
-                self.compile_match_regex(value);
+            Expr::RegexLiteral { value, tree } | Expr::MatchRegexTree { value, tree } => {
+                let value = value.with_regex_source_tree(tree.clone());
+                self.compile_match_regex(&value);
             }
             other => self.compile_expr(other),
         }

--- a/src/parser/primary/regex/adverbs.rs
+++ b/src/parser/primary/regex/adverbs.rs
@@ -463,5 +463,6 @@ pub(super) fn build_regex_with_adverbs(pattern: String, adverbs: &MatchAdverbs) 
         // Filled in at *load* time by `OpCode::LoadRegexClosure` when the
         // pattern embeds code; a parsed literal never carries a scope.
         captured: None,
+        source_tree: None,
     })
 }

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -39,7 +39,10 @@ use super::trans::{parse_trans_adverbs, process_trans_escapes};
 
 fn static_regex_expr(value: Value, source: &str, declaration: bool) -> Expr {
     match RegexTree::parse_static(source, declaration) {
-        Some(tree) => Expr::RegexLiteral { value, tree },
+        Some(tree) => Expr::RegexLiteral {
+            value: value.with_regex_source_tree(tree.clone()),
+            tree,
+        },
         None => Expr::Literal(value),
     }
 }
@@ -1049,7 +1052,7 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                         return Ok((
                             rest,
                             Expr::MatchRegexTree {
-                                value: regex_val,
+                                value: regex_val.with_regex_source_tree(tree.clone()),
                                 tree,
                             },
                         ));

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1381,7 +1381,7 @@ fn lower_regex_adverb(node: &RakuAstNode) -> Result<crate::regex_tree::RegexAdve
 /// RakuAST and the compiler still emits the existing match opcode.
 fn regex_execution_value(tree: &RegexTree) -> Result<Value, RuntimeError> {
     if tree.adverbs.is_empty() {
-        return Ok(Value::regex(tree.to_source()));
+        return Ok(Value::regex(tree.to_source()).with_regex_source_tree(tree.clone()));
     }
     let mut pattern = tree.to_source();
     let mut value = RegexAdverbs {
@@ -1401,6 +1401,7 @@ fn regex_execution_value(tree: &RegexTree) -> Result<Value, RuntimeError> {
         samecase: false,
         samespace: false,
         captured: None,
+        source_tree: None,
     };
     for adverb in &tree.adverbs {
         if adverb.argument.is_some() {
@@ -1441,7 +1442,7 @@ fn regex_execution_value(tree: &RegexTree) -> Result<Value, RuntimeError> {
         }
     }
     value.pattern = Arc::new(pattern);
-    Ok(Value::regex_with_adverbs(value))
+    Ok(Value::regex_with_adverbs(value).with_regex_source_tree(tree.clone()))
 }
 
 fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -188,6 +188,47 @@ impl Interpreter {
         text: &str,
     ) -> Option<RegexCaptures> {
         let parsed = self.parse_regex(pattern)?;
+        self.regex_match_with_parsed_captures(&parsed, text)
+    }
+
+    /// Match a regex value whose source tree may already have been retained by
+    /// the parser. This is the value-aware counterpart of
+    /// `regex_match_with_captures_core`; it keeps the same matcher and capture
+    /// post-processing while allowing the parse boundary to consume the shared
+    /// tree directly.
+    pub(in crate::runtime) fn regex_match_with_captures_value(
+        &mut self,
+        regex: &Value,
+        text: &str,
+    ) -> Option<RegexCaptures> {
+        let pattern = match regex.view() {
+            ValueView::Regex(pattern) => pattern.to_string(),
+            ValueView::RegexWithAdverbs(adverbs) => adverbs.pattern.to_string(),
+            _ => return None,
+        };
+        // The value-aware path is intentionally only a leaf for the static
+        // tree slice. Declarative prefixes and the anchored single-subrule
+        // ranking path have side effects and package-resolution steps that the
+        // ordinary string entry point owns; preserve those semantics intact.
+        if regex.regex_source_tree().is_none()
+            || Self::parse_anchored_single_subrule(&pattern).is_some()
+            || !Self::parse_regex_declarative_prefix(&pattern).0.is_empty()
+        {
+            return self.regex_match_with_captures(&pattern, text);
+        }
+        let parsed = self.parse_regex_value(regex)?;
+        let result = self.regex_match_with_parsed_captures(&parsed, text);
+        if let Some(caps) = &result {
+            self.persist_embedded_my_decls(caps, &HashSet::new());
+        }
+        result
+    }
+
+    fn regex_match_with_parsed_captures(
+        &mut self,
+        parsed: &RegexPattern,
+        text: &str,
+    ) -> Option<RegexCaptures> {
         let pkg = self.current_package();
         let target = MatchTarget::new(text);
         let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
@@ -199,7 +240,7 @@ impl Interpreter {
         // stripped space so captured text derives from the original subject.
         if parsed.ignore_mark {
             let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
-            let stripped_parsed = strip_marks_pattern(&parsed);
+            let stripped_parsed = strip_marks_pattern(parsed);
             let orig_len = orig_chars.len();
             if stripped_parsed.anchor_start {
                 return self
@@ -238,9 +279,9 @@ impl Interpreter {
         // in folded space that correspond to the start of an original character's
         // fold expansion. This prevents false matches in the middle of a fold
         // (e.g., matching 't' from the expansion of 'ﬆ' -> 'st').
-        if parsed.ignore_case && needs_casefold_expansion(orig_chars, &parsed) {
+        if parsed.ignore_case && needs_casefold_expansion(orig_chars, parsed) {
             let (folded_chars, pos_map) = casefold_text(orig_chars);
-            let folded_parsed = casefold_pattern(&parsed);
+            let folded_parsed = casefold_pattern(parsed);
             let orig_len = orig_chars.len();
 
             // Helper: check if a position in folded space is at a fold boundary
@@ -293,7 +334,7 @@ impl Interpreter {
         let chars = orig_chars;
         if parsed.anchor_start {
             return self
-                .regex_match_end_from_caps_in_pkg(&parsed, chars, 0, &pkg)
+                .regex_match_end_from_caps_in_pkg(parsed, chars, 0, &pkg)
                 .map(|(end, mut caps)| {
                     caps.from = caps.capture_start.unwrap_or(0);
                     caps.to = caps.capture_end.unwrap_or(end);
@@ -303,7 +344,7 @@ impl Interpreter {
         }
         for start in 0..=chars.len() {
             if let Some((end, mut caps)) =
-                self.regex_match_end_from_caps_in_pkg(&parsed, chars, start, &pkg)
+                self.regex_match_end_from_caps_in_pkg(parsed, chars, start, &pkg)
             {
                 caps.from = caps.capture_start.unwrap_or(start);
                 caps.to = caps.capture_end.unwrap_or(end);

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -2,12 +2,13 @@ use super::regex_parse::*;
 use super::*;
 use crate::regex_tree::RegexTree;
 use ::regex::Regex;
+use std::hash::{Hash, Hasher};
 
 /// Lower the static subset of the shared source tree directly to the matcher
 /// plan.  Prefixes are the execution spelling produced by the existing parser;
 /// anything outside this small flag set stays on `parse_regex_structural`,
 /// because it may carry sigspace, captures, interpolation, or package state.
-fn lower_static_execution_pattern(pattern: &str) -> Option<RegexPattern> {
+fn static_execution_policy(pattern: &str) -> Option<(bool, bool, bool, &str)> {
     fn strip_flag<'a>(source: &'a str, flag: &str) -> Option<&'a str> {
         let rest = source.strip_prefix(flag)?;
         if rest.is_empty()
@@ -50,7 +51,20 @@ fn lower_static_execution_pattern(pattern: &str) -> Option<RegexPattern> {
         }
     }
 
+    Some((ratchet, ignore_case, ignore_mark, source))
+}
+
+fn lower_static_execution_pattern(pattern: &str) -> Option<RegexPattern> {
+    let (ratchet, ignore_case, ignore_mark, source) = static_execution_policy(pattern)?;
     let tree = RegexTree::parse_static(source, false)?;
+    tree.lower_execution(ratchet, ignore_case, ignore_mark)
+}
+
+/// Lower a parser-produced tree using the execution policy already encoded in
+/// the regex value. The value's string remains the compatibility spelling, but
+/// the body is no longer reparsed when the tree can provide the static plan.
+fn lower_static_execution_tree(pattern: &str, tree: &RegexTree) -> Option<RegexPattern> {
+    let (ratchet, ignore_case, ignore_mark, _) = static_execution_policy(pattern)?;
     tree.lower_execution(ratchet, ignore_case, ignore_mark)
 }
 
@@ -1512,6 +1526,57 @@ impl Interpreter {
         self.parse_regex_uncached(pattern, RegexParseMode::Match)
             .map(std::sync::Arc::new)
     }
+
+    /// Parse a regex value while retaining parser-produced source provenance.
+    /// Static values use the shared `RegexTree` directly; values synthesized by
+    /// runtime code, and trees outside the current execution subset, retain the
+    /// established string parser path.
+    pub(super) fn parse_regex_value(&self, value: &Value) -> Option<std::sync::Arc<RegexPattern>> {
+        let pattern = match value.view() {
+            ValueView::Regex(pattern) => pattern.to_string(),
+            ValueView::RegexWithAdverbs(adverbs) => adverbs.pattern.to_string(),
+            _ => return None,
+        };
+        let Some(tree) = value.regex_source_tree() else {
+            return self.parse_regex(&pattern);
+        };
+        if !regex_pattern_is_static(&pattern) {
+            return self.parse_regex(&pattern);
+        }
+
+        // Include the tree fingerprint in the existing plan-cache key. This
+        // keeps the cache honest if a future parser creates two source trees
+        // with the same compatibility spelling.
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        tree.hash(&mut hasher);
+        let key = format!(
+            "{}\u{0}{}\u{0}tree:{:016x}",
+            self.current_package(),
+            pattern,
+            hasher.finish()
+        );
+        let tok_gen =
+            crate::runtime::regex_parse::TOKEN_DEFS_GEN.load(std::sync::atomic::Ordering::Relaxed);
+        if let Some(cached) = REGEX_PARSE_CACHE.with(|c| {
+            c.borrow()
+                .get(&key)
+                .filter(|(cached_gen, _)| *cached_gen == tok_gen)
+                .map(|(_, p)| std::sync::Arc::clone(p))
+        }) {
+            return Some(cached);
+        }
+
+        let parsed = lower_static_execution_tree(&pattern, tree)
+            .map(std::sync::Arc::new)
+            .or_else(|| self.parse_regex(&pattern));
+        if let Some(ref p) = parsed {
+            REGEX_PARSE_CACHE.with(|c| {
+                c.borrow_mut()
+                    .insert(key, (tok_gen, std::sync::Arc::clone(p)));
+            });
+        }
+        parsed
+    }
 }
 
 #[cfg(test)]
@@ -1553,5 +1618,22 @@ mod static_execution_tests {
         assert!(lower_static_execution_pattern("(a)").is_none());
         assert!(lower_static_execution_pattern(r#""\x20""#).is_none());
         assert!(lower_static_execution_pattern("\u{1}42\u{1}").is_none());
+    }
+
+    #[test]
+    fn lowers_from_parser_tree_without_using_value_spelling() {
+        let tree = RegexTree::parse_static("tree", false).expect("source tree");
+        let value = Value::regex("stale".to_string()).with_regex_source_tree(tree);
+        let interp = Interpreter::new();
+        let parsed = interp.parse_regex_value(&value).expect("execution plan");
+        let literals: String = parsed
+            .tokens
+            .iter()
+            .filter_map(|token| match token.atom {
+                RegexAtom::Literal(ch) => Some(ch),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(literals, "tree");
     }
 }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -952,16 +952,11 @@ impl Interpreter {
                             if !a.global && !a.exhaustive && !a.overlap && !a.perl5
                     ) =>
             {
-                let pat: String = match right.view() {
-                    ValueView::Regex(p) => p.to_string(),
-                    ValueView::RegexWithAdverbs(a) => a.pattern.to_string(),
-                    _ => unreachable!(),
-                };
                 let text = self.regex_match_text(left);
                 // Set $_ to the match target so $( $_ ) works inside regex
                 let saved_topic = self.env.get("_").cloned();
                 self.env.insert("_".to_string(), Value::str(text.clone()));
-                let match_result = self.regex_match_with_captures(&pat, &text);
+                let match_result = self.regex_match_with_captures_value(right, &text);
                 if let Some(v) = &saved_topic {
                     self.env.insert("_".to_string(), v.clone());
                 } else {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2212,6 +2212,11 @@ pub struct RegexAdverbs {
     /// The defining scope this literal closed over, when its pattern embeds
     /// code — see [`RegexClosure`]. `None` for every ordinary literal.
     pub captured: Option<Arc<HashMap<String, Value>>>,
+    /// Source-level provenance for a parser-created static regex. This is
+    /// separate from the execution spelling in `pattern`: the runtime may
+    /// carry normalized prefixes there, while RakuAST and the execution
+    /// lowerer need the parser's structural tree.
+    pub(crate) source_tree: Option<Box<crate::regex_tree::RegexTree>>,
 }
 
 /// Boxed payload of [`Value::RegexCaptured`]: a code-bearing regex literal
@@ -2228,7 +2233,11 @@ pub struct RegexClosure {
     pub pattern: Arc<String>,
     /// Captured lexicals, keyed the way `env` keys them (`$x` -> `x`,
     /// `@x`/`%x`/`&x` keep their sigil).
-    pub scope: Arc<HashMap<String, Value>>,
+    pub scope: Option<Arc<HashMap<String, Value>>>,
+    /// Source-level provenance for a static regex value. A source-only value
+    /// has no defining lexical scope, so `scope` is `None`; code-bearing
+    /// regexes keep `source_tree` as `None` until dynamic tree nodes exist.
+    pub source_tree: Option<Box<crate::regex_tree::RegexTree>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -259,7 +259,21 @@ impl NanBox {
             return None;
         }
         // SAFETY: kind-checked above; the word is live for this borrow.
-        Some(&unsafe { peek_arc::<crate::value::RegexClosure>(bits) }.scope)
+        unsafe { peek_arc::<crate::value::RegexClosure>(bits) }
+            .scope
+            .as_ref()
+    }
+
+    /// The source-level tree carried by a transparent regex provenance value.
+    #[inline]
+    pub(in crate::value) fn regex_source_tree(&self) -> Option<&crate::regex_tree::RegexTree> {
+        let bits = self.0.get();
+        if !matches!(classify(bits), Classified::Kind(Kind::RegexCaptured)) {
+            return None;
+        }
+        unsafe { peek_arc::<crate::value::RegexClosure>(bits) }
+            .source_tree
+            .as_deref()
     }
 
     /// Whether this word is a `Proxy` — a pure tag probe (same motivation as

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -476,14 +476,16 @@ fn every_variant_roundtrips_losslessly() {
             samecase: false,
             samespace: false,
             captured: None,
+            source_tree: None,
         })),
         ValueRepr::RegexCaptured(Arc::new(crate::value::RegexClosure {
             pattern: Arc::new("a { $x }".to_string()),
-            scope: Arc::new(
+            scope: Some(Arc::new(
                 [("x".to_string(), Value::int(3))]
                     .into_iter()
                     .collect::<std::collections::HashMap<_, _>>(),
-            ),
+            )),
+            source_tree: None,
         })),
         ValueRepr::Sub(sample_sub()),
         ValueRepr::Junction {

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -501,6 +501,7 @@ fn ser_to_value(sv: SerValue) -> Value {
             // A captured defining scope holds live `Value`s; it cannot survive
             // a serialization round-trip and is not part of the wire format.
             captured: None,
+            source_tree: None,
         })),
         SerValue::Junction { kind, values } => {
             let jk = match kind {

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -39,7 +39,33 @@ impl Value {
         pattern: Arc<String>,
         scope: Arc<std::collections::HashMap<String, Value>>,
     ) -> Self {
-        Value::RegexCaptured(Arc::new(crate::value::RegexClosure { pattern, scope }))
+        Value::RegexCaptured(Arc::new(crate::value::RegexClosure {
+            pattern,
+            scope: Some(scope),
+            source_tree: None,
+        }))
+    }
+
+    /// Attach parser-produced source provenance to a regex value while
+    /// preserving its execution spelling and adverb payload. Plain regexes
+    /// use the existing transparent closure-shaped representation; unlike a
+    /// code closure, that representation carries no lexical scope.
+    pub(crate) fn with_regex_source_tree(&self, tree: crate::regex_tree::RegexTree) -> Self {
+        match self.view() {
+            ValueView::Regex(pattern) => {
+                Value::RegexCaptured(Arc::new(crate::value::RegexClosure {
+                    pattern: Arc::new(pattern.to_string()),
+                    scope: None,
+                    source_tree: Some(Box::new(tree)),
+                }))
+            }
+            ValueView::RegexWithAdverbs(adverbs) => {
+                let mut adverbs = adverbs.clone();
+                adverbs.source_tree = Some(Box::new(tree));
+                Value::regex_with_adverbs(adverbs)
+            }
+            _ => self.clone(),
+        }
     }
     /// The defining scope this regex closed over, or `None` for a regex that
     /// captured nothing (and for every non-regex value).
@@ -51,6 +77,18 @@ impl Value {
         }
         match self.view() {
             ValueView::RegexWithAdverbs(a) => a.captured.clone(),
+            _ => None,
+        }
+    }
+
+    /// Source-level provenance carried by a parser-created regex value, or
+    /// `None` for synthesized/legacy values without a structural tree.
+    pub(crate) fn regex_source_tree(&self) -> Option<&crate::regex_tree::RegexTree> {
+        if let Some(tree) = self.0.regex_source_tree() {
+            return Some(tree);
+        }
+        match self.view() {
+            ValueView::RegexWithAdverbs(a) => a.source_tree.as_deref(),
             _ => None,
         }
     }

--- a/t/regex/regex-tree-value-provenance.t
+++ b/t/regex/regex-tree-value-provenance.t
@@ -1,0 +1,32 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# ADR-0088 issue #8033: parser-produced source trees travel with regex values
+# into the ordinary smartmatch entry point. The execution plan is still the
+# existing RegexPattern matcher; dynamic regex contents remain on the fallback
+# path.
+
+plan 7;
+
+my $rx = /test/;
+ok 'test' ~~ $rx, 'a parsed regex value keeps matching after storage';
+nok 'toast' ~~ $rx, 'the stored regex value still rejects a non-match';
+ok 'test' ~~ $rx, 'the same stored tree can be lowered again';
+
+my $case-insensitive = EVAL(RakuAST::QuotedRegex.new(
+    body => RakuAST::Regex::Literal.new("test"),
+    adverbs => (RakuAST::ColonPair::True.new("i"),),
+));
+ok 'TEST' ~~ $case-insensitive, 'an adverb-bearing value uses its source tree';
+nok 'toast' ~~ $case-insensitive, 'an adverb-bearing value keeps its policy';
+
+my $constructed = RakuAST::QuotedRegex.new(
+    body => RakuAST::Regex::Sequence.new(
+        RakuAST::Regex::Literal.new("tree"),
+    ),
+);
+my $constructed-value = EVAL($constructed);
+ok 'tree' ~~ $constructed-value, 'a constructed tree travels through EVAL';
+nok 'stale' ~~ $constructed-value, 'constructed provenance does not alter semantics';


### PR DESCRIPTION
## Summary

- retain parser-created static `RegexTree` provenance on regex values through Parser -> Compiler -> VM
- lower that tree directly at the ordinary single-match smartmatch boundary, while preserving declarative and dynamic fallbacks
- add focused regression coverage and document the next ADR-0088 slice

This is a bounded continuation of #8033. Captures, subrules, dynamic regex contents, runtime adverb arguments, declaration-normalized values, and the remaining string-only entry points stay as follow-up work.

## Validation

- `make lint`
- `make test`
- `make roast`

Part of #8033.