### PR TITLE
fix: preserve rebound hash aliases for return-rw

### DIFF
--- a/news/2026-09/return-rw-rebound-hash-alias.md
+++ b/news/2026-09/return-rw-rebound-hash-alias.md
@@ -1,0 +1,3 @@
+`return-rw` now preserves a live hash-element container when a routine
+rebinds a name onto one of its own nested elements. Plain assignment through
+the rebound name is writable as well.

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -941,6 +941,16 @@ impl Interpreter {
             return false;
         };
         if let ValueView::ContainerRef(cell) = slot.view() {
+            // A whole-container `:=` bind installs the target cell in the
+            // unit-lexical store separately (`unit_scope_lexical_bind`). Do
+            // not treat that cell as a value to store through the old cell:
+            // when both are the same cell this would make it contain itself,
+            // and the next definedness/read-through would deadlock while
+            // recursively locking the same Mutex (todo:ticket #8048).
+            if matches!(val.view(), ValueView::ContainerRef(new_cell) if crate::gc::Gc::ptr_eq(&cell, &new_cell))
+            {
+                return true;
+            }
             Self::cell_store_preserving_container_identity(name, &cell, val);
             return true;
         }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1754,9 +1754,17 @@ impl Interpreter {
             loan_env!(self, reset_atomic_var_key(name));
         }
         // When rebinding a variable (`$x := expr`), remove any existing
-        // bind pairs where this slot was the source.  Rebinding replaces
-        // the container, so previously bound targets must stop tracking.
+        // bind pairs where this slot was the source. Rebinding replaces the
+        // binding, so previously derived readonly state must stop tracking it
+        // too; the new source's readonly state is installed below.
         if is_rebind {
+            if !self.no_readonly_vars() {
+                self.unmark_readonly(name);
+            }
+            if crate::env::sigilless_readonly_keys_possible() {
+                let readonly_key = runtime::sigilless_readonly_key(name);
+                self.env_mut().remove(&readonly_key);
+            }
             self.local_bind_pairs.retain(|&(source, _)| source != idx);
             // Also remove env-based aliases that point TO this variable,
             // so GetLocal alias-following doesn't read the new value.

--- a/t/collections/rebound-return-rw-hash-element.t
+++ b/t/collections/rebound-return-rw-hash-element.t
@@ -1,0 +1,62 @@
+use Test;
+
+plan 4;
+
+# Rebinding a name onto one of its own hash elements must preserve the
+# deferred element location across a routine boundary. This is the shape used
+# by Text::Markov's graph walk.
+my %graph;
+sub slot() {
+    my $p := %graph;
+    $p := $p{'x'};
+    return-rw $p;
+}
+
+my $s := slot();
+$s //= BagHash.new;
+$s{'foo'}++;
+is %graph.raku, '{:x(("foo"=>1).BagHash)}',
+    'return-rw of a rebound hash element keeps the live container';
+
+# The same rebind must remain an ordinary writable scalar assignment when the
+# returned element is not involved.
+sub assign-through-rebound() {
+    my %g;
+    my $p := %g;
+    $p := $p{'x'};
+    $p = 42;
+    %g.raku;
+}
+is assign-through-rebound(), '{:x(42)}',
+    'plain assignment through a rebound hash element remains writable';
+
+class C {
+    has %!graph;
+
+    method !slot() {
+        my $p := %!graph;
+        $p := $p{'x'};
+        return-rw $p;
+    }
+
+    method put() {
+        my $s := self!slot();
+        $s //= BagHash.new;
+        $s{'foo'}++;
+    }
+
+    method dump() { %!graph.raku }
+}
+
+my $c = C.new;
+$c.put;
+is $c.dump, '{:x(("foo"=>1).BagHash)}',
+    'the method form writes through the rebound hash element';
+
+my %inline;
+my $inline := %inline;
+$inline := $inline{'x'};
+$inline //= BagHash.new;
+$inline{'bar'}++;
+is %inline.raku, '{:x(("bar"=>1).BagHash)}',
+    'the inline rebound hash-element walk remains writable';


### PR DESCRIPTION
Summary:
- preserve unit-scope container identity when a bind reuses the same cell
- clear stale readonly state when a name is rebound to a writable hash element
- add regression coverage for sub and method return-rw paths

Validation:
- cargo fmt --all
- cargo clippy -- -D warnings
- make check-t-layout
- make test
- make roast

Closes #8048
