### PR TITLE
fix(oo): a user class `is Version` inherits Version's native constructor

### DIFF
--- a/news/2026-09/version-subclass-native-constructor.md
+++ b/news/2026-09/version-subclass-native-constructor.md
@@ -1,0 +1,37 @@
+# A user class `is Version` now inherits Version's native positional constructor
+
+`class MyVer is Version { }` died with `Default constructor for 'MyVer' only takes named
+arguments` on `MyVer.new("1.2.3")`, because the native-constructor dispatch in
+`methods_object_dispatch_new.rs` matched Version's constructor arm on the **literal** dispatch
+name `"Version"` — a subclass's dispatch name is its own (`"MyVer"`), so the arm never matched and
+fell through to the generic named-arguments-only constructor. This blocked the `Version::Raku` and
+`Version::Nginx` distributions, both `class Version::* is Version { ... }` adding only extra
+methods and relying on inheriting the positional-string constructor.
+
+Unlike `IO::CatHandle`/`IO::Path` (whose MRO-aware subclass check a few lines above already
+handles this), `Version`'s own representation (`ValueView::Version { parts, plus, minus, text }`)
+carries no class-name tag to fall back on — building one the same way `Version.new` always has
+would leave every subclass instance reporting `.^name` as `"Version"`, and would leave a
+subclass's own added methods (`Version::Raku`'s actual reason for existing) unreachable, since
+nothing about a bare `ValueView::Version` value can dispatch through `MyVer`'s method table.
+
+A genuine subclass (MRO includes `Version`, dispatch name isn't the literal `"Version"`, no
+user-defined `new`) is now built as an ordinary tagged `Instance` — the same `__mutsu_*_value`
+native-payload convention `is Int`/`is Str` subclasses already use — carrying the built `Version`
+under `__mutsu_version_value`. This gives the instance a real method table (so `Version::Raku`'s
+own methods resolve, and `~~ MyVer` / `~~ Version` both work via the ordinary class-MRO
+smartmatch, no Version-specific code needed) while `.Str`, `.raku`, `.gist`, and any other method
+the subclass does not implement fall through to the real Version's behavior — the same three
+call sites (`display.rs`, `gist.rs`, `methods_instance_ops.rs`) already wired for `is Int`/`is Str`.
+
+Plain `Version.new(...)` (the overwhelmingly common case) is untouched: the literal-name arm still
+returns a bare `ValueView::Version`, exactly as before.
+
+One gap surfaced but left alone as out of scope, filed as #8134: `@vs.sort` on an array of
+`Version` subclass instances loses the "v" prefix when the *sorted Seq itself* is gisted directly
+(`say @vs.sort` prints `(1.0.0 2.0.0)` instead of `(v1.0.0 v2.0.0)`), even though the same elements
+gist correctly individually, in a `for` loop, or as a plain (unsorted) `Array`. This points at
+`sort`'s own internal handling rather than at construction or display, and is unrelated to the
+reported symptom.
+
+Fixes #8070.

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -204,6 +204,13 @@ impl Interpreter {
         if let Some(payload) = attributes.as_map().get("__mutsu_int_value").cloned() {
             return Some(self.call_method_with_values(payload, method, vec![]));
         }
+        // An `is Version` subclass (#8070) delegates any method it does not
+        // define itself to its native Version payload -- `.raku`, `.Str`, and
+        // any other Version method a real `Version::Raku`/`Version::Nginx`
+        // caller reaches without overriding.
+        if let Some(payload) = attributes.as_map().get("__mutsu_version_value").cloned() {
+            return Some(self.call_method_with_values(payload, method, vec![]));
+        }
         if let Some(storage) = attributes.as_map().get("__mutsu_array_storage").cloned() {
             return Some(self.call_method_with_values(storage, method, vec![]));
         }

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -815,6 +815,36 @@ impl Interpreter {
             if is_cathandle_like && !self.has_user_method(class_key, "new") {
                 return Ok(self.build_io_cathandle(*class_name, &args));
             }
+            // A user subclass of Version (`class MyVer is Version {}`) inherits
+            // the native positional-string constructor. `Version`'s own
+            // `ValueView::Version` representation carries no class-name tag (#8070),
+            // so unlike the constructor_dispatch_name-matched exact-"Version" arm
+            // below, a genuine subclass is built as an ordinary tagged Instance —
+            // the same `__mutsu_*_value` native-payload convention `is Int`/`is Str`
+            // subclasses already use (`seed_native_subclass_payloads`,
+            // `display.rs`/`gist.rs`/`methods_instance_ops.rs`) — carrying the
+            // built Version under `__mutsu_version_value`. This gives the instance
+            // its own method table (so `Version::Raku`'s/`Version::Nginx`'s own
+            // added methods resolve normally) while `.Str`/`.raku`/`.gist` and any
+            // other unimplemented-on-the-subclass method fall through to the real
+            // Version's behavior via the same native-payload delegation.
+            let is_version_like = base_class_name == "Version"
+                || self
+                    .class_mro(class_key)
+                    .iter()
+                    .any(|name| name == "Version");
+            if is_version_like
+                && cn_resolved != "Version"
+                && !self.has_user_method(class_key, "new")
+            {
+                let arg = args.first().cloned().unwrap_or(Value::NIL);
+                let mut attrs = HashMap::new();
+                attrs.insert(
+                    "__mutsu_version_value".to_string(),
+                    Self::version_from_value(arg),
+                );
+                return Ok(Value::make_instance(*class_name, attrs));
+            }
             match constructor_dispatch_name {
                 "IO::CatHandle" if !self.has_user_method(class_key, "new") => {
                     return Ok(self.build_io_cathandle(*class_name, &args));

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -497,6 +497,17 @@ pub(crate) fn gist_value(value: &Value) -> String {
                 .map(crate::value::Value::to_string_value)
                 .unwrap_or_default()
         }
+        // An `is Version` subclass gists as its Version payload, just like
+        // Version (#8070).
+        ValueView::Instance { attributes, .. }
+            if attributes.contains_key("__mutsu_version_value") =>
+        {
+            attributes
+                .as_map()
+                .get("__mutsu_version_value")
+                .map(crate::value::Value::to_string_value)
+                .unwrap_or_default()
+        }
         // An `is Array` subclass instance gists as its backing array elements
         // (`Vector.new(1,2,3).gist` → `[1 2 3]`), not the generic `Class.new`.
         ValueView::Instance { attributes, .. }

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -1064,6 +1064,18 @@ impl Value {
                     .map(Value::to_string_value)
                     .unwrap_or_default()
             }
+            // A subclass of native `Version` (`class Foo is Version {}`) carries
+            // its built `Version` in `__mutsu_version_value` (#8070); stringify
+            // as that Version, e.g. `v1.2.3`.
+            ValueView::Instance { attributes, .. }
+                if attributes.contains_key("__mutsu_version_value") =>
+            {
+                attributes
+                    .as_map()
+                    .get("__mutsu_version_value")
+                    .map(Value::to_string_value)
+                    .unwrap_or_default()
+            }
             ValueView::Instance { class_name, .. } => format!("{}()", class_name),
             ValueView::Junction { kind, values } => {
                 let kind_str = match kind {

--- a/t/oo/construct/version-subclass-constructor.t
+++ b/t/oo/construct/version-subclass-constructor.t
@@ -1,0 +1,35 @@
+use Test;
+
+# A user class `is Version` must inherit Version's native positional-string
+# constructor (GH #8070). `constructor_dispatch_name` in
+# `methods_object_dispatch_new.rs` matched the LITERAL name "Version", so a
+# subclass (whose dispatch name is its own, e.g. "MyVer") fell through to the
+# default named-arguments-only constructor and died with
+# "Default constructor for 'MyVer' only takes named arguments" -- exactly the
+# symptom that blocked the `Version::Raku` and `Version::Nginx` distributions,
+# both of which are `class Version::* is Version { ... }` adding only extra
+# methods.
+
+plan 8;
+
+class MyVer is Version {
+    method shout() { "I AM " ~ self.Str.uc }
+}
+
+my $v = MyVer.new("1.2.3");
+is $v.gist, 'v1.2.3', 'a Version subclass constructs from a positional string';
+is $v.Str, '1.2.3', 'and stringifies like a plain Version';
+is $v.^name, 'MyVer', 'the built instance is tagged as the actual subclass';
+ok $v ~~ MyVer, 'it matches its own subclass';
+ok $v ~~ Version, 'and still matches Version';
+is $v.shout, 'I AM 1.2.3', "the subclass's own added method resolves";
+
+# Plain `Version.new` is unaffected by the subclass-aware dispatch.
+is Version.new("1.2.3").^name, 'Version', 'a plain Version.new is not tagged as a subclass';
+
+# A subclass that defines its own `new` keeps it -- the native positional
+# constructor only fills in for a subclass that does not override `new`.
+class MyVerCustom is Version {
+    method new(|c) { callsame }
+}
+is MyVerCustom.new("4.5.6").gist, 'v4.5.6', "a subclass's own new(|c) still reaches the native constructor via callsame";


### PR DESCRIPTION
## Summary

`class MyVer is Version { }` died with `Default constructor for 'MyVer' only takes named
arguments` on `MyVer.new("1.2.3")`, because `constructor_dispatch_name` matched Version's
constructor arm on the **literal** name `"Version"` — a subclass's own dispatch name (`"MyVer"`)
never matched, so dispatch fell through to the generic named-arguments-only constructor. This
blocked the `Version::Raku` and `Version::Nginx` distributions, both `class Version::* is Version
{ ... }` relying on inheriting the positional-string constructor.

## Repro

```raku
class MyVer is Version { }
say MyVer.new("1.2.3");
```
| | rakudo | mutsu (before) |
|---|---|---|
| output | `v1.2.3` | `Default constructor for 'MyVer' only takes named arguments` |

## Why not just an MRO check like `IO::CatHandle`/`IO::Path`

`Version`'s own representation (`ValueView::Version { parts, plus, minus, text }`) carries no
class-name tag to fall back on. Just relaxing the dispatch match to also catch a subclass via MRO
(the existing `is_cathandle_like`/`is_io_path_like` pattern) while still returning a bare
`ValueView::Version` would leave the built value reporting `.^name` as `"Version"`, and — more
importantly — leave a subclass's own added methods (`Version::Raku`'s actual reason for existing)
unreachable, since nothing about a bare `ValueView::Version` can dispatch through `MyVer`'s method
table.

## Fix

A genuine subclass (MRO includes `Version`, dispatch name isn't the literal `"Version"`, no
user-defined `new`) is built as an ordinary tagged `Instance` — the same `__mutsu_*_value`
native-payload convention `is Int`/`is Str` subclasses already use — carrying the built `Version`
under `__mutsu_version_value`. This gives the instance a real method table (so a subclass's own
methods resolve, and `~~ MyVer` / `~~ Version` both work via ordinary class-MRO smartmatch, no
Version-specific code needed) while `.Str`/`.raku`/`.gist` and anything else the subclass doesn't
implement fall through to the real Version's behavior, via the same three call sites already wired
for `is Int`/`is Str` (`display.rs`, `gist.rs`, `methods_instance_ops.rs`).

Plain `Version.new(...)` is untouched — the literal-name arm still returns a bare
`ValueView::Version`, exactly as before.

Closes #8070

## A separate finding, filed rather than chased here

Testing surfaced an unrelated pre-existing gap: `@vs.sort` on an array of `Version` subclass
instances loses the `v` prefix when the *sorted Seq itself* is gisted directly, even though the
same elements gist correctly individually, in a `for` loop, or as a plain unsorted `Array`. Points
at `sort`'s own internal handling, not at construction/display — filed as #8134.

## Testing

- `t/oo/construct/version-subclass-constructor.t` — new: the reported repro, `.^name`, both
  smartmatch directions, a subclass's own added method, plain `Version.new` unaffected, and a
  subclass's own `new(|c)` override still reaching the native constructor via `callsame`.
- `cargo fmt --all`, `make lint` — green (all four configurations).
- `make test` — green, `Files=4101, Tests=43627, Result: PASS`.
- `make roast` — the only failures are the documented container-only entries in
  `docs/agent-environments.md` (`6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t` — this
  container runs as `uid 0`); both pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_