### PR TITLE
feat(rakuast): carry the with/without block forms across the boundary

### DIFF
--- a/news/2026-09/with-without-block-forms-cross-the-rakuast-boundary.md
+++ b/news/2026-09/with-without-block-forms-cross-the-rakuast-boundary.md
@@ -1,0 +1,89 @@
+# The `with` / `without` block forms cross the RakuAST boundary
+
+`with X { … }`, `without X { … }` and the `orwith` / `else` clauses that
+continue them executed correctly but could not be rendered as RakuAST at all:
+`.AST` reported the parser's desugar back as an unsupported construct
+(`DoStmt(VarDecl { name: "__with_tmp_0", … })`). They now render as
+`RakuAST::Statement::With` / `::Without` / `::Orwith`, byte-identical to rakudo
+2026.07, and a hand-built node of any of those lowers back to the same
+executable shape.
+
+This is the block half of the slice whose statement-modifier half shipped as
+[#8036](https://github.com/tokuhirom/mutsu/issues/8036); it closes
+[#8123](https://github.com/tokuhirom/mutsu/issues/8123).
+
+## The desugar, and why the shape could not simply be recognised
+
+mutsu has no runtime representation of `with`. The parser rewrites the block
+form into a conditional over a once-evaluated temp:
+
+```
+with X { BODY }   ->   if (my $__with_tmp_N = X).defined { given <topic> { BODY } }
+```
+
+with the condition negated for `without`, an `orwith` clause becoming a nested
+`if EXPR.defined { given EXPR { … } }` in the else branch, and a trailing `else`
+wrapped in a `given` of its own so it topicalizes on the last tested value.
+
+Nothing of the source keyword survives that: a hand-written
+`if (my $t = 1).defined { given 1 { … } }` produces the same statement, and the
+synthetic temp's *name* is not a discriminator either — a program may declare
+`__with_tmp_0` itself, and a converter that keyed off it would be guessing. So,
+as for `unless` (`is_unless`) and `until` (`is_until`) before it, the
+distinction is kept rather than reconstructed:
+
+- `Stmt::If` grows `with_kind: Option<WithBlockKind>` (`With` / `Without` /
+  `Orwith`), set by `parser::stmt::control::with_stmt` and by the `orwith` arm
+  of `parse_elsif_chain`;
+- `Stmt::Given`'s existing `with_kind` grows a `BlockTopic` variant marking the
+  scaffold `given` a block body runs under — which raku does not model as a
+  `given` at all, but as the `implicit-topic => True` / `required-topic => 1`
+  flags on the `Block` itself.
+
+Execution ignores both markers; only the RakuAST converter reads them.
+
+Only the *parameterless* spelling is marked. A pointy body (`with X -> $a { … }`)
+binds its parameter inside the same scaffold `given`, which raku spells as a
+`PointyBlock` rather than an implicit-topic `Block`, so it is deliberately left
+unmarked and `.AST` reports the boundary instead of silently dropping the
+parameter.
+
+## Both directions
+
+- `src/with_desugar.rs` (new) holds the pieces the parser and the RakuAST
+  lowerer both need — the temp-name counter, the `(my $tmp = X).defined`
+  condition, the topic-routing rule (an lvalue or literal condition topicalizes
+  on the source, anything else on the temp), and the two conditional builders —
+  so the desugar is spelled once instead of twice.
+- `convert.rs` renders the node, recovering the written condition from the
+  `.defined` test and the block body from the scaffold `given`. The `elsifs` /
+  `else` walk is now shared with `Statement::If`, which gained `orwith` clauses
+  for free: `if 1 { } orwith 2 { } else { }` is legal Raku and renders correctly
+  too. An `else` topicalizes exactly when the clause it continues does, matching
+  rakudo (after `orwith`: yes; after `elsif`: no).
+- `lower.rs` accepts hand-built `Statement::With` / `::Without` / `::Orwith`
+  nodes and rebuilds the parser's shape, so the round trip is stable and
+  `EVAL(Q[…].AST)` runs on the existing compiler and VM path.
+
+A `with` block written *inside* an `else` stays a statement rather than being
+absorbed as a continuation clause, which the shared chain walk checks for
+explicitly.
+
+## Verification
+
+`.AST.gist` is byte-identical to rakudo 2026.07 for `with 1 { say 2 }`,
+`without Nil { say 2 }`, `with … else`, `with … orwith … else`,
+`with … elsif … else`, `with … orwith … orwith …`, `if … orwith … else`, and a
+`with` nested in an `else`; `EVAL(Q[…].AST)` agrees with rakudo on all of them,
+including the single evaluation of the condition and the write-back through an
+lvalue topic.
+
+Pinned by `t/rakuast/rakuast-with-without-block.t` (25 tests: node classes, the
+`then` / `body` naming asymmetry, the topic flags, the `elsifs` chain, which
+`else` topicalizes, `EVAL` of the round-tripped AST, and the source-level
+semantics). It passes under rakudo unchanged.
+
+One assertion there is spelled against `.gist` rather than `.elsifs`, because an
+absent optional field still throws on mutsu instead of returning an empty list —
+that gap is [#8124](https://github.com/tokuhirom/mutsu/issues/8124), unchanged
+by this work.

--- a/news/2026-09/with-without-block-forms-cross-the-rakuast-boundary.md
+++ b/news/2026-09/with-without-block-forms-cross-the-rakuast-boundary.md
@@ -35,18 +35,19 @@ distinction is kept rather than reconstructed:
 - `Stmt::If` grows `with_kind: Option<WithBlockKind>` (`With` / `Without` /
   `Orwith`), set by `parser::stmt::control::with_stmt` and by the `orwith` arm
   of `parse_elsif_chain`;
-- `Stmt::Given`'s existing `with_kind` grows a `BlockTopic` variant marking the
-  scaffold `given` a block body runs under — which raku does not model as a
-  `given` at all, but as the `implicit-topic => True` / `required-topic => 1`
-  flags on the `Block` itself.
+- `Stmt::Given`'s existing `with_kind` grows `BlockTopic` / `BlockTopicPointy`,
+  marking the scaffold `given` a block body runs under — which raku does not
+  model as a `given` at all, but as the `implicit-topic => True` /
+  `required-topic => 1` flags on the `Block` itself.
 
 Execution ignores both markers; only the RakuAST converter reads them.
 
-Only the *parameterless* spelling is marked. A pointy body (`with X -> $a { … }`)
-binds its parameter inside the same scaffold `given`, which raku spells as a
-`PointyBlock` rather than an implicit-topic `Block`, so it is deliberately left
-unmarked and `.AST` reports the boundary instead of silently dropping the
-parameter.
+The pointy spellings (`with X -> $a { … }`, `else -> $p { … }`,
+`orwith X -> $q { … }`) bind their parameter inside that same scaffold, which
+raku spells as a `PointyBlock` rather than an implicit-topic `Block`. They carry
+the distinct tag, so `.AST` reports the boundary instead of rendering a block
+that has swallowed the binding — which is what an untagged scaffold would have
+produced for a pointy `else` after an `orwith`.
 
 ## Both directions
 
@@ -68,6 +69,11 @@ parameter.
 A `with` block written *inside* an `else` stays a statement rather than being
 absorbed as a continuation clause, which the shared chain walk checks for
 explicitly.
+
+`t/rakuast/rakuast-desugar-boundary.t` is updated too: `with` was listed there
+as a construct that throws rather than leak its `__with_tmp_N` temporary, and
+that point survives as the stronger assertion — it renders, and the temporary
+does not appear anywhere in the output — alongside the two pointy boundaries.
 
 ## Verification
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1143,7 +1143,7 @@ pub(crate) enum ReadonlyKind {
     ImmutableValue,
 }
 
-/// Which `with`-family keyword the parser desugared into a [`Stmt::Given`].
+/// What role a [`Stmt::Given`] plays in a `with`-family desugar.
 ///
 /// The desugar is lossy on its own: `STMT with X` becomes
 /// `given X { if $_.defined { STMT } }`, which a hand-written
@@ -1156,6 +1156,34 @@ pub(crate) enum GivenWithKind {
     With,
     /// `STMT without EXPR` -- run `STMT` when the topic is NOT defined.
     Without,
+    /// Not a keyword: the topicalizing `given` the `with`-family BLOCK forms
+    /// wrap a `{ ... }` body in, so `$_` is established by the `given` opcode.
+    /// raku does not model it as a `given` at all -- it is the
+    /// `implicit-topic` `Block` of `Statement::With` / `::Without` /
+    /// `::Orwith`.
+    BlockTopic,
+    /// The same scaffold, for a body written with an explicit signature
+    /// (`with X -> $a { }`), which additionally binds the parameter inside the
+    /// `given`. raku spells that as a `PointyBlock`, a shape the converter does
+    /// not build yet -- so it is tagged distinctly, to report the boundary
+    /// rather than render an implicit-topic block that has swallowed the
+    /// binding.
+    BlockTopicPointy,
+}
+
+/// Which `with`-family BLOCK keyword the parser desugared into a [`Stmt::If`].
+///
+/// Like [`GivenWithKind`] this exists because the desugar cannot be read back
+/// off the resulting shape -- see `Stmt::If`'s `with_kind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) enum WithBlockKind {
+    /// `with EXPR { ... }` -- run the block, topicalized, when `EXPR` is defined.
+    With,
+    /// `without EXPR { ... }` -- run the block when `EXPR` is NOT defined.
+    Without,
+    /// `orwith EXPR { ... }` -- a `with` continuation clause, nested in the
+    /// preceding conditional's else branch.
+    Orwith,
 }
 
 #[derive(Debug, Clone, Hash, serde::Serialize, serde::Deserialize)]
@@ -1367,6 +1395,17 @@ pub(crate) enum Stmt {
         /// (`RakuAST::Statement::Unless` vs `::If`), so the RakuAST converter
         /// needs the source keyword back. Mirrors `Stmt::While::is_until`.
         is_unless: bool,
+        /// Set when this `If` is the lowering of a `with` / `without` /
+        /// `orwith` BLOCK form rather than a source `if`. The desugar is lossy:
+        /// `with X { BODY }` becomes
+        /// `if (my $tmp = X).defined { given X { BODY } }`, which a
+        /// hand-written conditional of the same shape also produces, and the
+        /// synthetic temp's *name* is not a sound discriminator (a program may
+        /// declare one). Carries no execution meaning; only the RakuAST
+        /// converter reads it, to render `Statement::With` / `::Without` /
+        /// `::Orwith`. Sibling of `is_unless`.
+        #[serde(default)]
+        with_kind: Option<WithBlockKind>,
     },
     While {
         cond: Expr,
@@ -3640,6 +3679,7 @@ mod env_only_decl_tests {
             binding_var: None,
             is_statement_modifier: false,
             is_unless: false,
+            with_kind: None,
         };
         // Wrapped in a gather-shaped Block([While { body: [...] }]).
         let body = vec![Stmt::Block(vec![Stmt::While {

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -1597,6 +1597,7 @@ impl Compiler {
                             binding_var: None,
                             is_statement_modifier: false,
                             is_unless: false,
+                            with_kind: None,
                         },
                         Stmt::Expr(Expr::Var(seen_name)),
                     ]);

--- a/src/compiler/helpers_phasers.rs
+++ b/src/compiler/helpers_phasers.rs
@@ -194,9 +194,11 @@ impl Compiler {
                 binding_var,
                 is_statement_modifier,
                 is_unless,
+                with_kind,
             } => Stmt::If {
                 is_statement_modifier: *is_statement_modifier,
                 is_unless: *is_unless,
+                with_kind: *with_kind,
                 cond: cond.clone(),
                 then_branch: Self::rewrite_next_targets_in_stmts(
                     then_branch,
@@ -600,6 +602,7 @@ impl Compiler {
                 binding_var: None,
                 is_statement_modifier: false,
                 is_unless: false,
+                with_kind: None,
             });
         }
         // Declare temp variables for extracted ENTER phaser expressions
@@ -715,6 +718,7 @@ impl Compiler {
                 binding_var: None,
                 is_statement_modifier: false,
                 is_unless: false,
+                with_kind: None,
             });
         }
         loop_body.extend(leave_ph);
@@ -754,6 +758,7 @@ impl Compiler {
                 binding_var: None,
                 is_statement_modifier: false,
                 is_unless: false,
+                with_kind: None,
             }]
         } else {
             vec![Stmt::If {
@@ -763,6 +768,7 @@ impl Compiler {
                 binding_var: None,
                 is_statement_modifier: false,
                 is_unless: false,
+                with_kind: None,
             }]
         };
 
@@ -862,9 +868,11 @@ impl Compiler {
                 binding_var,
                 is_statement_modifier,
                 is_unless,
+                with_kind,
             } => Stmt::If {
                 is_statement_modifier: *is_statement_modifier,
                 is_unless: *is_unless,
+                with_kind: *with_kind,
                 cond: Self::rewrite_enter_phaser_expr(cond, extracted, counter),
                 then_branch: Self::rewrite_enter_phaser_stmts(then_branch, extracted, counter),
                 else_branch: Self::rewrite_enter_phaser_stmts(else_branch, extracted, counter),

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -3244,6 +3244,7 @@ impl Compiler {
                     binding_var: None,
                     is_statement_modifier: false,
                     is_unless: false,
+                    with_kind: None,
                 });
             }
         }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -606,6 +606,7 @@ impl Compiler {
             binding_var: None,
             is_statement_modifier: false,
             is_unless: false,
+            with_kind: None,
         };
 
         Some(vec![decl, for_stmt, writeback])
@@ -783,6 +784,7 @@ impl Compiler {
             binding_var: None,
             is_statement_modifier: false,
             is_unless: false,
+            with_kind: None,
         };
 
         Some(vec![idx_decl, slice_decl, src_decl, for_stmt, writeback])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub(crate) mod type_id;
 mod value;
 mod vm;
 pub(crate) mod whatever_curry;
+pub(crate) mod with_desugar;
 
 pub use interpreter::Interpreter;
 pub use value::{HashKey, RuntimeError, RuntimeErrorCode, Value};

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -685,6 +685,7 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                         binding_var: None,
                         is_statement_modifier: false,
                         is_unless: false,
+                        with_kind: None,
                     })),
                 ));
             }

--- a/src/parser/primary/ident/supply.rs
+++ b/src/parser/primary/ident/supply.rs
@@ -185,9 +185,11 @@ fn rewrite_supply_stmt(stmt: Stmt, emitter_name: &str) -> Stmt {
             binding_var,
             is_statement_modifier,
             is_unless,
+            with_kind,
         } => Stmt::If {
             is_statement_modifier,
             is_unless,
+            with_kind,
             cond,
             then_branch: rewrite_supply_body(then_branch, emitter_name),
             else_branch: rewrite_supply_body(else_branch, emitter_name),

--- a/src/parser/stmt/assign/compound_expr.rs
+++ b/src/parser/stmt/assign/compound_expr.rs
@@ -433,6 +433,7 @@ pub(crate) fn build_compound_assign_expr(
                 binding_var,
                 is_statement_modifier: false,
                 is_unless: false,
+                with_kind: None,
             }))
         }
         // `(cond ?? A !! B) op= rhs`: the ternary is an lvalue selecting one

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -3,7 +3,10 @@ use super::super::helpers::{ws, ws1};
 use super::super::parse_result::{PError, PResult, opt_char, parse_char};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::ast::{AssignOp, Expr, ParamDef, ReadonlyKind, Stmt, collect_placeholders_shallow};
+use crate::ast::{
+    AssignOp, Expr, GivenWithKind, ParamDef, ReadonlyKind, Stmt, WithBlockKind,
+    collect_placeholders_shallow,
+};
 use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
 use crate::value::Value;

--- a/src/parser/stmt/control/conditionals.rs
+++ b/src/parser/stmt/control/conditionals.rs
@@ -7,6 +7,10 @@ pub(crate) struct IfChainClause {
     cond: Expr,
     then_branch: Vec<Stmt>,
     binding_var: Option<String>,
+    /// `Some(WithBlockKind::Orwith)` for an `orwith` clause, which desugars
+    /// into the same `.defined` conditional an `elsif` would but which raku
+    /// models as its own `Statement::Orwith`. See `Stmt::If`'s `with_kind`.
+    with_kind: Option<WithBlockKind>,
 }
 
 pub(crate) struct ElseClause {
@@ -45,6 +49,7 @@ pub(crate) fn if_stmt(input: &str) -> PResult<'_, Stmt> {
         cond,
         then_branch,
         binding_var,
+        with_kind: None,
     }];
     let (rest, (mut elsif_clauses, else_clause)) = parse_elsif_chain(rest)?;
     clauses.append(&mut elsif_clauses);
@@ -284,6 +289,7 @@ pub(crate) fn parse_elsif_chain(
                 cond,
                 then_branch,
                 binding_var,
+                with_kind: None,
             });
             last_orwith_cond = None;
             rest = r;
@@ -344,7 +350,13 @@ pub(crate) fn parse_elsif_chain(
                 topic: orwith_cond_expr.clone(),
                 body: orwith_given_body,
                 is_statement_modifier: false,
-                with_kind: None,
+                // Tagged distinctly for the pointy spelling, as in
+                // `with_stmt`: a pointy body is a `PointyBlock` in raku.
+                with_kind: Some(if orwith_param_name.is_none() {
+                    GivenWithKind::BlockTopic
+                } else {
+                    GivenWithKind::BlockTopicPointy
+                }),
             }];
             // orwith uses .defined as the condition
             last_orwith_cond = Some(orwith_cond_expr.clone());
@@ -360,6 +372,7 @@ pub(crate) fn parse_elsif_chain(
                 cond: orwith_cond,
                 then_branch: orwith_then,
                 binding_var: None,
+                with_kind: Some(WithBlockKind::Orwith),
             });
             rest = r;
             continue;
@@ -388,6 +401,9 @@ pub(crate) fn parse_elsif_chain(
             // pointy param explicitly to the orwith value and drop `binding_params`
             // so `lower_else_clause` does not re-bind it to the Bool.
             let mut given_body = Vec::new();
+            // Whether this `else` binds anything of its own decides the tag
+            // below, so record it before `binding_params` is consumed.
+            let had_binding = binding_params.is_some();
             if let Some(ref params) = binding_params {
                 for pd in params {
                     if pd.name.is_empty() {
@@ -413,7 +429,13 @@ pub(crate) fn parse_elsif_chain(
                 topic: orwith_expr.clone(),
                 body: given_body,
                 is_statement_modifier: false,
-                with_kind: None,
+                // As above: a pointy `else -> $p` prepends its own binding to
+                // this block, so raku spells it as a `PointyBlock`.
+                with_kind: Some(if had_binding {
+                    GivenWithKind::BlockTopicPointy
+                } else {
+                    GivenWithKind::BlockTopic
+                }),
             }];
         }
         return Ok((
@@ -455,6 +477,7 @@ pub(crate) fn lower_if_chain(
             binding_var: clause.binding_var,
             is_statement_modifier: false,
             is_unless: false,
+            with_kind: clause.with_kind,
         }];
     }
 
@@ -506,6 +529,7 @@ pub(crate) fn unless_stmt(input: &str) -> PResult<'_, Stmt> {
             cond,
             then_branch: Vec::new(),
             binding_var: None,
+            with_kind: None,
         }];
         let else_clause = ElseClause {
             binding_params: Some(params),
@@ -525,6 +549,7 @@ pub(crate) fn unless_stmt(input: &str) -> PResult<'_, Stmt> {
             binding_var: None,
             is_statement_modifier: false,
             is_unless: true,
+            with_kind: None,
         },
     ))
 }

--- a/src/parser/stmt/control/with_stmt.rs
+++ b/src/parser/stmt/control/with_stmt.rs
@@ -26,9 +26,7 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     // This is important for expressions like `Failure.new` where evaluating
     // twice would create two distinct objects, and the `.defined` call on the
     // condition would not mark the same instance that `$_` receives.
-    static WITH_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-    let with_id = WITH_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let tmp_name = format!("__with_tmp_{}", with_id);
+    let tmp_name = crate::with_desugar::next_tmp_name();
     let tmp_var = Expr::Var(tmp_name.clone());
 
     // The body uses $_ which was set in the condition block.
@@ -239,6 +237,16 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
             });
         }
     }
+    // Tag the scaffold `given` so the RakuAST converter can tell it from a
+    // source-level one. A pointy body prepends its own binding to the same
+    // `given`, a shape raku spells as a `PointyBlock` rather than an
+    // implicit-topic `Block`, so it gets the distinct tag that makes the
+    // converter report the boundary instead of swallowing the parameter.
+    let block_topic = Some(if param_name.is_none() {
+        GivenWithKind::BlockTopic
+    } else {
+        GivenWithKind::BlockTopicPointy
+    });
     if use_given_alias {
         let mut given_body = body;
         // For a container/scalar pointy param, prepend the alias/copy bind
@@ -256,21 +264,21 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
             topic: cond_expr.clone(),
             body: given_body,
             is_statement_modifier: false,
-            with_kind: None,
+            with_kind: block_topic,
         }];
     } else if route_through_given_tmp || pointy_is_topic {
         with_body = vec![Stmt::Given {
             topic: tmp_var.clone(),
             body,
             is_statement_modifier: false,
-            with_kind: None,
+            with_kind: block_topic,
         }];
     } else if route_literal_through_given {
         with_body = vec![Stmt::Given {
             topic: cond_expr.clone(),
             body,
             is_statement_modifier: false,
-            with_kind: None,
+            with_kind: block_topic,
         }];
     } else {
         with_body.extend(body);
@@ -281,33 +289,7 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     // evaluates cond_expr once, declares $tmp in the current scope, and
     // returns the value. Then .defined() checks it. The body uses $tmp
     // for topicalization instead of re-evaluating cond_expr.
-    let var_decl_expr = Expr::DoStmt(Box::new(Stmt::VarDecl {
-        name: tmp_name.clone(),
-        expr: cond_expr.clone(),
-        type_constraint: None,
-        is_state: false,
-        is_our: false,
-        is_dynamic: false,
-        is_export: false,
-        export_tags: Vec::new(),
-        custom_traits: Vec::new(),
-        where_constraint: None,
-    }));
-    let defined_check = Expr::MethodCall {
-        target: Box::new(var_decl_expr),
-        name: Symbol::intern("defined"),
-        args: Vec::new(),
-        modifier: None,
-        quoted: false,
-    };
-    let cond = if is_without {
-        Expr::Unary {
-            op: TokenKind::Bang,
-            expr: Box::new(defined_check),
-        }
-    } else {
-        defined_check
-    };
+    let cond = crate::with_desugar::defined_condition(is_without, &tmp_name, cond_expr.clone());
     // Parse orwith / else chains
     let rest_before_ws = rest;
     let (rest, _) = ws(rest)?;
@@ -383,7 +365,11 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
                 topic: tmp_var.clone(),
                 body: else_given_body,
                 is_statement_modifier: false,
-                with_kind: None,
+                with_kind: Some(if else_param.is_none() {
+                    GivenWithKind::BlockTopic
+                } else {
+                    GivenWithKind::BlockTopicPointy
+                }),
             }];
             (r, else_with_topic)
         } else {
@@ -402,6 +388,11 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
             binding_var: None,
             is_statement_modifier: false,
             is_unless: false,
+            with_kind: Some(if is_without {
+                WithBlockKind::Without
+            } else {
+                WithBlockKind::With
+            }),
         },
     ))
 }

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -134,6 +134,7 @@ fn try_split_decl_modifier(stmt: &Stmt, effective_cond: &Expr) -> Option<Stmt> {
         binding_var: None,
         is_statement_modifier: true,
         is_unless: false,
+        with_kind: None,
     };
     Some(Stmt::SyntheticBlock(vec![decl, init]))
 }
@@ -489,6 +490,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 binding_var: None,
                 is_statement_modifier: true,
                 is_unless: false,
+                with_kind: None,
             },
         )));
     }
@@ -524,6 +526,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 binding_var: None,
                 is_statement_modifier: true,
                 is_unless: true,
+                with_kind: None,
             },
         )));
     }
@@ -861,6 +864,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 binding_var: None,
                 is_statement_modifier: true,
                 is_unless: false,
+                with_kind: None,
             };
             let given_stmt = Stmt::Given {
                 topic: cond,
@@ -888,6 +892,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 binding_var: None,
                 is_statement_modifier: true,
                 is_unless: false,
+                with_kind: None,
             }],
             is_statement_modifier: true,
             with_kind: Some(GivenWithKind::With),
@@ -944,6 +949,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 binding_var: None,
                 is_statement_modifier: true,
                 is_unless: false,
+                with_kind: None,
             };
             let given_stmt = Stmt::Given {
                 topic: cond,
@@ -965,6 +971,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 binding_var: None,
                 is_statement_modifier: true,
                 is_unless: false,
+                with_kind: None,
             }],
             is_statement_modifier: true,
             with_kind: Some(GivenWithKind::Without),

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -7,7 +7,9 @@
 //! silently-wrong node.
 
 use super::{RakuAstClass, RakuAstField, RakuAstFieldValue, RakuAstNode};
-use crate::ast::{AssignOp, EnumVariantForm, Expr, ForMode, GivenWithKind, ParamDef, Stmt};
+use crate::ast::{
+    AssignOp, EnumVariantForm, Expr, ForMode, GivenWithKind, ParamDef, Stmt, WithBlockKind,
+};
 use crate::compiler::helpers_ops::token_kind_to_op_name;
 use crate::regex_tree::{RegexNode, RegexQuantifier, RegexTree};
 use crate::runtime::utils::is_known_type_constraint;
@@ -363,9 +365,17 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             binding_var,
             is_statement_modifier,
             is_unless,
+            with_kind,
         } => {
             if binding_var.is_some() {
                 return Err(unsupported("`if EXPR -> $var` topic binding"));
+            }
+            // `with X { }` / `without X { }` reach here as the conditional the
+            // parser desugared them into; `with_kind` records which keyword the
+            // source wrote, because neither the shape nor the synthetic temp's
+            // name can be trusted to say so (see `Stmt::If`'s `with_kind`).
+            if let Some(kind) = with_kind {
+                return with_block_node(*kind, cond, then_branch, else_branch).map(Some);
             }
             // mutsu stores `unless X` as `if !X` PLUS an `is_unless` flag, so the
             // source keyword is recoverable: raku has `Statement::Unless` (and
@@ -422,34 +432,7 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 node_field(Some("condition"), convert_expr(cond)?),
                 node_field(Some("then"), block_node(then_branch)?),
             ];
-            // mutsu nests each `elsif` as a single `if` inside the else-branch.
-            // Flatten that chain into raku's `elsifs` list; whatever remains
-            // after the last `elsif` is the final `else` block.
-            let mut elsifs: Vec<Value> = Vec::new();
-            let mut tail: &[Stmt] = else_branch;
-            while let Some(Stmt::If {
-                cond,
-                then_branch,
-                else_branch,
-                binding_var,
-                ..
-            }) = single_if_stmt(tail)
-            {
-                if binding_var.is_some() {
-                    return Err(unsupported("`elsif EXPR -> $var` topic binding"));
-                }
-                elsifs.push(Value::rakuast(Box::new(elsif_node(cond, then_branch)?)));
-                tail = else_branch;
-            }
-            if !elsifs.is_empty() {
-                fields.push(RakuAstField {
-                    name: Some("elsifs"),
-                    value: RakuAstFieldValue::List(elsifs),
-                });
-            }
-            if tail.iter().any(|s| !matches!(s, Stmt::SetLine(_))) {
-                fields.push(node_field(Some("else"), block_node(tail)?));
-            }
+            fields.extend(conditional_chain_fields(else_branch)?);
             Ok(Some(RakuAstNode {
                 class: RakuAstClass::StatementIf,
                 fields,
@@ -608,8 +591,18 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             // ambiguous with a hand-written `(STMT if $_.defined) given X`).
             // raku keeps them as a `condition-modifier`, like `if`/`unless`,
             // not as the `loop-modifier` a real `given` gets.
-            if let Some(kind) = with_kind {
-                return with_modifier_node(*kind, topic, body).map(Some);
+            match with_kind {
+                Some(kind @ (GivenWithKind::With | GivenWithKind::Without)) => {
+                    return with_modifier_node(*kind, topic, body).map(Some);
+                }
+                // The scaffold of a block form, reached on its own: the
+                // conditional that owns it renders the parameterless spelling
+                // itself, so arriving here means the block had a signature raku
+                // would spell as a `PointyBlock`.
+                Some(GivenWithKind::BlockTopic | GivenWithKind::BlockTopicPointy) => {
+                    return Err(unsupported("with/without block with an explicit signature"));
+                }
+                None => {}
             }
             if *is_statement_modifier {
                 let [modified] = body.as_slice() else {
@@ -2071,11 +2064,190 @@ fn with_modifier_node(
             class: match kind {
                 GivenWithKind::With => RakuAstClass::StatementModifierWith,
                 GivenWithKind::Without => RakuAstClass::StatementModifierWithout,
+                // The block scaffold never reaches the modifier path: the
+                // conditional that owns it is handled by `with_block_node`, and
+                // the `Given` arm rejects a stray one before calling this.
+                GivenWithKind::BlockTopic | GivenWithKind::BlockTopicPointy => {
+                    return Err(unsupported("with/without block scaffold"));
+                }
             },
             fields: vec![node_field(None, convert_expr(topic)?)],
         },
     ));
     Ok(statement)
+}
+
+/// `with X { ... }` / `without X { ... }` -> `Statement::With` / `::Without`.
+///
+/// The parser desugars the block forms into
+/// `if (my $tmp = X).defined { given X { ... } }` (condition negated for
+/// `without`), so everything raku models is wrapped in scaffolding: the once-
+/// evaluated temp around the condition, and the topicalizing `given` around the
+/// body, which raku spells as the block's own `implicit-topic` flag. `kind`
+/// says which keyword the source wrote -- see `Stmt::If`'s `with_kind`.
+/// Measured against rakudo 2026.07: `Q[with 1 { say 2 }].AST`.
+fn with_block_node(
+    kind: WithBlockKind,
+    cond: &Expr,
+    then_branch: &[Stmt],
+    else_branch: &[Stmt],
+) -> Result<RakuAstNode, RuntimeError> {
+    let condition = node_field(
+        Some("condition"),
+        convert_expr(with_block_condition(kind, cond)?)?,
+    );
+    let Some(body) = topic_given_body(then_branch) else {
+        // A pointy body (`with X -> $a { }`) binds its parameter inside the same
+        // `given`, which raku spells as a `PointyBlock` rather than an
+        // implicit-topic `Block`; report the boundary rather than drop it.
+        return Err(unsupported("with/without block with an explicit signature"));
+    };
+    match kind {
+        // `without` takes no `else`/`orwith`/`elsif` (rakudo rejects them at
+        // compile time), so its node is condition + `body` -- the same naming
+        // difference `Statement::Unless` has against `::If`.
+        WithBlockKind::Without => {
+            if !else_branch.is_empty() {
+                return Err(unsupported("`without` with an else branch"));
+            }
+            Ok(RakuAstNode {
+                class: RakuAstClass::StatementWithout,
+                fields: vec![condition, node_field(Some("body"), topic_block_node(body)?)],
+            })
+        }
+        WithBlockKind::With => {
+            let mut fields = vec![condition, node_field(Some("then"), topic_block_node(body)?)];
+            fields.extend(conditional_chain_fields(else_branch)?);
+            Ok(RakuAstNode {
+                class: RakuAstClass::StatementWith,
+                fields,
+            })
+        }
+        // An `orwith` clause is only ever reached through the chain walk of the
+        // conditional it continues.
+        WithBlockKind::Orwith => Err(unsupported("`orwith` outside a conditional chain")),
+    }
+}
+
+/// One `orwith` clause -> `Statement::Orwith(condition, then => topic Block)`.
+fn orwith_node(cond: &Expr, then_branch: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
+    let Some(body) = topic_given_body(then_branch) else {
+        return Err(unsupported("`orwith` block with an explicit signature"));
+    };
+    Ok(RakuAstNode {
+        class: RakuAstClass::StatementOrwith,
+        fields: vec![
+            node_field(
+                Some("condition"),
+                convert_expr(with_block_condition(WithBlockKind::Orwith, cond)?)?,
+            ),
+            node_field(Some("then"), topic_block_node(body)?),
+        ],
+    })
+}
+
+/// The condition a `with`-family conditional was written with, recovered from
+/// the `.defined` test the parser built around it.
+fn with_block_condition(kind: WithBlockKind, cond: &Expr) -> Result<&Expr, RuntimeError> {
+    let tested = match kind {
+        WithBlockKind::Without => match cond {
+            Expr::Unary {
+                op: crate::token_kind::TokenKind::Bang,
+                expr,
+            } => expr.as_ref(),
+            _ => return Err(unsupported("`without` condition")),
+        },
+        WithBlockKind::With | WithBlockKind::Orwith => cond,
+    };
+    let Expr::MethodCall { target, name, .. } = tested else {
+        return Err(unsupported("with/without condition"));
+    };
+    if name.as_str() != "defined" {
+        return Err(unsupported("with/without condition"));
+    }
+    Ok(match target.as_ref() {
+        // The block forms evaluate the condition once into a hidden temp; an
+        // `orwith` clause tests its expression directly.
+        Expr::DoStmt(inner) => match inner.as_ref() {
+            Stmt::VarDecl { expr, .. } => expr,
+            _ => return Err(unsupported("with/without condition")),
+        },
+        other => other,
+    })
+}
+
+/// The body of the topicalizing `given` the `with`-family block forms wrap a
+/// `{ ... }` in, when `stmts` is exactly that scaffold. `None` for anything
+/// else, including the untagged `given` a pointy body produces and a
+/// hand-written `given` that happens to sit in the same position.
+fn topic_given_body(stmts: &[Stmt]) -> Option<&[Stmt]> {
+    let mut real = stmts.iter().filter(|s| !matches!(s, Stmt::SetLine(_)));
+    let (Some(first), None) = (real.next(), real.next()) else {
+        return None;
+    };
+    match first {
+        Stmt::Given {
+            body,
+            with_kind: Some(GivenWithKind::BlockTopic),
+            ..
+        } => Some(body),
+        _ => None,
+    }
+}
+
+/// The `elsifs` and `else` fields of a conditional chain. mutsu nests every
+/// continuation clause as a single `if` inside the else branch; raku flattens
+/// them into one `elsifs` list, with whatever remains as the `else` block.
+/// Shared by `Statement::If` and `Statement::With`, both of which accept
+/// `elsif` and `orwith` clauses.
+fn conditional_chain_fields(else_branch: &[Stmt]) -> Result<Vec<RakuAstField>, RuntimeError> {
+    let mut fields = Vec::new();
+    let mut elsifs: Vec<Value> = Vec::new();
+    let mut tail: &[Stmt] = else_branch;
+    while let Some(Stmt::If {
+        cond,
+        then_branch,
+        else_branch,
+        binding_var,
+        with_kind,
+        ..
+    }) = single_if_stmt(tail)
+    {
+        // A `with`/`without` BLOCK statement written inside an `else` is a
+        // statement of its own, not a continuation clause: stop and let it be
+        // converted as part of the else block.
+        if matches!(
+            with_kind,
+            Some(WithBlockKind::With | WithBlockKind::Without)
+        ) {
+            break;
+        }
+        if binding_var.is_some() {
+            return Err(unsupported("`elsif EXPR -> $var` topic binding"));
+        }
+        let node = match with_kind {
+            Some(WithBlockKind::Orwith) => orwith_node(cond, then_branch)?,
+            _ => elsif_node(cond, then_branch)?,
+        };
+        elsifs.push(Value::rakuast(Box::new(node)));
+        tail = else_branch;
+    }
+    if !elsifs.is_empty() {
+        fields.push(RakuAstField {
+            name: Some("elsifs"),
+            value: RakuAstFieldValue::List(elsifs),
+        });
+    }
+    if tail.iter().any(|s| !matches!(s, Stmt::SetLine(_))) {
+        // An `else` continuing a `with`/`orwith` topicalizes on the last tested
+        // value, which raku records on the block itself.
+        let block = match topic_given_body(tail) {
+            Some(body) => topic_block_node(body)?,
+            None => block_node(tail)?,
+        };
+        fields.push(node_field(Some("else"), block));
+    }
+    Ok(fields)
 }
 
 /// One `elsif` clause -> `Statement::Elsif(condition, then => Block)`.

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -7,7 +7,7 @@
 //! produce an explicit `RuntimeError` (the documented coverage boundary).
 
 use super::{RakuAstClass, RakuAstFieldValue, RakuAstNode};
-use crate::ast::{EnumVariantForm, Expr, GivenWithKind, ParamDef, Stmt};
+use crate::ast::{EnumVariantForm, Expr, GivenWithKind, ParamDef, Stmt, WithBlockKind};
 use crate::regex_tree::{RegexNode, RegexQuantifier, RegexTree};
 use crate::value::{RegexAdverbs, RuntimeError, Value, ValueView};
 use std::sync::Arc;
@@ -109,6 +109,7 @@ fn lower_stmt(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
                     binding_var: None,
                     is_statement_modifier: true,
                     is_unless,
+                    with_kind: None,
                 });
             }
             Ok(statement)
@@ -129,12 +130,13 @@ fn lower_with_modifier(kind: GivenWithKind, topic: Expr, statement: Stmt) -> Stm
         modifier: None,
         quoted: false,
     };
-    let cond = match kind {
-        GivenWithKind::With => defined,
-        GivenWithKind::Without => Expr::Unary {
+    let cond = if matches!(kind, GivenWithKind::Without) {
+        Expr::Unary {
             op: crate::token_kind::TokenKind::Bang,
             expr: Box::new(defined),
-        },
+        }
+    } else {
+        defined
     };
     Stmt::Given {
         topic,
@@ -145,6 +147,7 @@ fn lower_with_modifier(kind: GivenWithKind, topic: Expr, statement: Stmt) -> Stm
             binding_var: None,
             is_statement_modifier: true,
             is_unless: false,
+            with_kind: None,
         }],
         is_statement_modifier: true,
         with_kind: Some(kind),
@@ -156,6 +159,12 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         RakuAstClass::VarDeclarationSimple => lower_var_decl(node),
         RakuAstClass::VarDeclarationConstant => lower_constant(node),
         RakuAstClass::StatementIf => lower_if(node),
+        // `with X { … }` / `without X { … }`. Both rebuild the conditional the
+        // parser desugars them into, tagged so a round trip renders the same
+        // node again. `without` names its block `body`, not `then`, and takes
+        // no continuation clauses.
+        RakuAstClass::StatementWith => lower_with_block(node, WithBlockKind::With),
+        RakuAstClass::StatementWithout => lower_with_block(node, WithBlockKind::Without),
         // `unless C { … }`. mutsu stores it as a negated condition plus the
         // `is_unless` flag, which is what the converter reads back, so the
         // lowerer has to re-plant both. raku's node names the block `body`
@@ -167,6 +176,7 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
             binding_var: None,
             is_statement_modifier: false,
             is_unless: true,
+            with_kind: None,
         }),
         RakuAstClass::StatementLoopWhile | RakuAstClass::StatementLoopUntil => lower_while(node),
         RakuAstClass::StatementLoop => lower_cstyle_loop(node),
@@ -298,39 +308,116 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 fn lower_if(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let cond = lower_expr(named_child(node, "condition")?)?;
     let then_branch = lower_block(named_child(node, "then")?)?;
-    // The base `else` (the outer `else { … }` block, or empty).
+    Ok(Stmt::If {
+        cond,
+        then_branch,
+        else_branch: lower_conditional_chain(node, None)?,
+        binding_var: None,
+        is_statement_modifier: false,
+        is_unless: false,
+        with_kind: None,
+    })
+}
+
+/// Lower `with COND { … }` / `without COND { … }` to the conditional mutsu's
+/// parser desugars them into (`with_desugar`), so execution reuses the existing
+/// path and the converter renders the same node back.
+fn lower_with_block(node: &RakuAstNode, kind: WithBlockKind) -> Result<Stmt, RuntimeError> {
+    let cond_expr = lower_expr(named_child(node, "condition")?)?;
+    let tmp_name = crate::with_desugar::next_tmp_name();
+    let (body_field, else_branch) = if matches!(kind, WithBlockKind::Without) {
+        // rakudo rejects `without … else` at compile time, so a node carrying
+        // one is not a shape it could have produced.
+        if node
+            .fields
+            .iter()
+            .any(|f| f.name == Some("else") || f.name == Some("elsifs"))
+        {
+            return Err(unsupported(node));
+        }
+        ("body", Vec::new())
+    } else {
+        // The `else` of a `with` continues a topicalizing clause, so it runs
+        // under the last tested value -- the hidden temp when no `orwith`
+        // intervened.
+        (
+            "then",
+            lower_conditional_chain(node, Some(Expr::Var(tmp_name.clone())))?,
+        )
+    };
+    let body = lower_block(named_child(node, body_field)?)?;
+    Ok(crate::with_desugar::with_conditional(
+        kind,
+        &tmp_name,
+        cond_expr,
+        body,
+        else_branch,
+    ))
+}
+
+/// The `else` branch of a conditional: its `elsifs` clauses folded
+/// innermost-last into nested `if`s, with the `else` block at the bottom.
+///
+/// `topic` is the value the head clause tested when that clause topicalizes
+/// (`with`), because a trailing `else` runs under the *last* tested value --
+/// which an intervening `orwith` replaces and a plain `elsif` clears.
+fn lower_conditional_chain(
+    node: &RakuAstNode,
+    topic: Option<Expr>,
+) -> Result<Vec<Stmt>, RuntimeError> {
+    let clauses = match node.fields.iter().find(|f| f.name == Some("elsifs")) {
+        Some(field) => match &field.value {
+            RakuAstFieldValue::List(items) => items.as_slice(),
+            _ => return Err(unsupported(node)),
+        },
+        None => &[],
+    };
+    let mut lowered = Vec::with_capacity(clauses.len());
+    let mut else_topic = topic;
+    for item in clauses {
+        let ValueView::RakuAst(clause) = item.view() else {
+            return Err(unsupported(node));
+        };
+        let cond = lower_expr(named_child(clause, "condition")?)?;
+        let body = lower_block(named_child(clause, "then")?)?;
+        match clause.class {
+            RakuAstClass::StatementElsif => else_topic = None,
+            RakuAstClass::StatementOrwith => else_topic = Some(cond.clone()),
+            _ => return Err(unsupported(clause)),
+        }
+        lowered.push((clause.class, cond, body));
+    }
+
     let mut else_branch = match node.fields.iter().find(|f| f.name == Some("else")) {
-        Some(_) => lower_block(named_child(node, "else")?)?,
+        Some(_) => {
+            let body = lower_block(named_child(node, "else")?)?;
+            match else_topic {
+                Some(topic) => vec![crate::with_desugar::topic_given(topic, body)],
+                None => body,
+            }
+        }
         None => Vec::new(),
     };
-    // Fold the `elsif` clauses in reverse into nested `if`s in the `else`.
-    if let Some(field) = node.fields.iter().find(|f| f.name == Some("elsifs"))
-        && let RakuAstFieldValue::List(items) = &field.value
-    {
-        for item in items.iter().rev() {
-            let ValueView::RakuAst(clause) = item.view() else {
-                return Err(unsupported(node));
-            };
-            let econd = lower_expr(named_child(clause, "condition")?)?;
-            let ethen = lower_block(named_child(clause, "then")?)?;
-            else_branch = vec![Stmt::If {
-                cond: econd,
-                then_branch: ethen,
+    for (class, cond, body) in lowered.into_iter().rev() {
+        else_branch = if class == RakuAstClass::StatementOrwith {
+            vec![crate::with_desugar::orwith_conditional(
+                cond,
+                body,
+                else_branch,
+            )]
+        } else {
+            vec![Stmt::If {
+                cond,
+                then_branch: body,
                 else_branch,
                 binding_var: None,
                 is_statement_modifier: false,
                 is_unless: false,
-            }];
-        }
+                with_kind: None,
+            }]
+        };
     }
-    Ok(Stmt::If {
-        cond,
-        then_branch,
-        else_branch,
-        binding_var: None,
-        is_statement_modifier: false,
-        is_unless: false,
-    })
+    Ok(else_branch)
 }
 
 /// Lower `for SOURCE -> $x { … }` to `Stmt::For`. Only a single-parameter pointy

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -154,6 +154,10 @@ pub enum RakuAstClass {
     StatementModifierUnless,
     StatementModifierWith,
     StatementModifierWithout,
+    // The `with`/`without`/`orwith` BLOCK forms.
+    StatementWith,
+    StatementWithout,
+    StatementOrwith,
     // Phase 2 slice 19: ternary.
     Ternary,
     // Phase 2 slice 22: positional subscripts.
@@ -329,6 +333,9 @@ impl RakuAstClass {
             StatementModifierUnless => "RakuAST::StatementModifier::Unless",
             StatementModifierWith => "RakuAST::StatementModifier::With",
             StatementModifierWithout => "RakuAST::StatementModifier::Without",
+            StatementWith => "RakuAST::Statement::With",
+            StatementWithout => "RakuAST::Statement::Without",
+            StatementOrwith => "RakuAST::Statement::Orwith",
             Ternary => "RakuAST::Ternary",
             SemiList => "RakuAST::SemiList",
             PostcircumfixArrayIndex => "RakuAST::Postcircumfix::ArrayIndex",
@@ -743,6 +750,9 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::StatementModifierUnless,
     RakuAstClass::StatementModifierWith,
     RakuAstClass::StatementModifierWithout,
+    RakuAstClass::StatementWith,
+    RakuAstClass::StatementWithout,
+    RakuAstClass::StatementOrwith,
     RakuAstClass::Ternary,
     RakuAstClass::SemiList,
     RakuAstClass::PostcircumfixArrayIndex,

--- a/src/runtime/dispatch_proto_rewrite.rs
+++ b/src/runtime/dispatch_proto_rewrite.rs
@@ -61,9 +61,11 @@ impl Interpreter {
                 binding_var,
                 is_statement_modifier,
                 is_unless,
+                with_kind,
             } => Stmt::If {
                 is_statement_modifier: *is_statement_modifier,
                 is_unless: *is_unless,
+                with_kind: *with_kind,
                 cond: Self::rewrite_proto_dispatch_expr(cond),
                 then_branch: Self::rewrite_proto_dispatch_stmts(then_branch),
                 else_branch: Self::rewrite_proto_dispatch_stmts(else_branch),

--- a/src/with_desugar.rs
+++ b/src/with_desugar.rs
@@ -1,0 +1,153 @@
+//! The shared pieces of the `with` / `without` / `orwith` BLOCK desugar.
+//!
+//! `with X { BODY }` has no dedicated runtime representation: the parser lowers
+//! it to the conditional
+//!
+//! ```text
+//! if (my $__with_tmp_N = X).defined { given <topic> { BODY } }
+//! ```
+//!
+//! (the condition negated for `without`), tagging both halves so the source
+//! keyword survives -- see `Stmt::If`'s and `Stmt::Given`'s `with_kind`.
+//!
+//! The RakuAST lowerer has to rebuild exactly that shape when it is handed a
+//! hand-written `RakuAST::Statement::With`, so the parts both sides need live
+//! here rather than being spelled twice and drifting apart.
+
+use crate::ast::{Expr, GivenWithKind, Stmt, WithBlockKind};
+use crate::symbol::Symbol;
+use crate::token_kind::TokenKind;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static WITH_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+/// A fresh name for the hidden temp holding the once-evaluated condition.
+///
+/// The condition must be evaluated exactly once: for `with Failure.new { }`,
+/// evaluating it twice would `.defined`-test a different object than the one
+/// `$_` receives.
+pub(crate) fn next_tmp_name() -> String {
+    format!(
+        "__with_tmp_{}",
+        WITH_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+/// `(my $tmp = COND).defined`, negated for `without`.
+///
+/// The `DoStmt(VarDecl)` declares the temp in the current scope and evaluates
+/// to the condition's value, so the body can topicalize on the temp instead of
+/// re-evaluating the source expression.
+pub(crate) fn defined_condition(negated: bool, tmp_name: &str, cond_expr: Expr) -> Expr {
+    let init = Expr::DoStmt(Box::new(Stmt::VarDecl {
+        name: tmp_name.to_string(),
+        expr: cond_expr,
+        type_constraint: None,
+        is_state: false,
+        is_our: false,
+        is_dynamic: false,
+        is_export: false,
+        export_tags: Vec::new(),
+        custom_traits: Vec::new(),
+        where_constraint: None,
+    }));
+    let defined = Expr::MethodCall {
+        target: Box::new(init),
+        name: Symbol::intern("defined"),
+        args: Vec::new(),
+        modifier: None,
+        quoted: false,
+    };
+    if negated {
+        Expr::Unary {
+            op: TokenKind::Bang,
+            expr: Box::new(defined),
+        }
+    } else {
+        defined
+    }
+}
+
+/// The topic the parameterless block form's scaffold `given` runs on.
+///
+/// An lvalue condition topicalizes on the *source* so mutations through `$_`
+/// write back to it, and a literal topicalizes on the literal so `$_` keeps
+/// `given`'s read-only semantics; anything else uses the once-evaluated temp.
+/// Mirrors the routing in `parser::stmt::control::with_stmt` for the case with
+/// no pointy parameter -- keep the two in step.
+pub(crate) fn body_topic(cond_expr: &Expr, tmp_var: &Expr) -> Expr {
+    let is_element_lvalue = matches!(
+        cond_expr,
+        Expr::Index { target, .. }
+            if matches!(
+                target.as_ref(),
+                Expr::Var(_) | Expr::ArrayVar(_) | Expr::HashVar(_)
+            )
+    );
+    let is_lvalue = matches!(
+        cond_expr,
+        Expr::Var(_) | Expr::ArrayVar(_) | Expr::HashVar(_)
+    ) || is_element_lvalue;
+    if is_lvalue || matches!(cond_expr, Expr::Literal(_)) {
+        cond_expr.clone()
+    } else {
+        tmp_var.clone()
+    }
+}
+
+/// The topicalizing `given` a `with`-family block body runs under, tagged so
+/// the RakuAST converter can render it as the block's `implicit-topic` flag
+/// rather than as a source-level `given`.
+pub(crate) fn topic_given(topic: Expr, body: Vec<Stmt>) -> Stmt {
+    Stmt::Given {
+        topic,
+        body,
+        is_statement_modifier: false,
+        with_kind: Some(GivenWithKind::BlockTopic),
+    }
+}
+
+/// The conditional a `with` / `without` block form lowers to, given an already
+/// built `else` branch (an `orwith`/`elsif` chain, a topicalized `else` block,
+/// or nothing).
+pub(crate) fn with_conditional(
+    kind: WithBlockKind,
+    tmp_name: &str,
+    cond_expr: Expr,
+    body: Vec<Stmt>,
+    else_branch: Vec<Stmt>,
+) -> Stmt {
+    let tmp_var = Expr::Var(tmp_name.to_string());
+    let topic = body_topic(&cond_expr, &tmp_var);
+    Stmt::If {
+        cond: defined_condition(kind == WithBlockKind::Without, tmp_name, cond_expr),
+        then_branch: vec![topic_given(topic, body)],
+        else_branch,
+        binding_var: None,
+        is_statement_modifier: false,
+        is_unless: false,
+        with_kind: Some(kind),
+    }
+}
+
+/// The conditional one `orwith` clause lowers to: like `with`, but the
+/// condition is tested directly (the preceding clause already evaluated it into
+/// its own temp, and an `orwith` expression is evaluated only when reached).
+pub(crate) fn orwith_conditional(cond_expr: Expr, body: Vec<Stmt>, else_branch: Vec<Stmt>) -> Stmt {
+    let cond = Expr::MethodCall {
+        target: Box::new(cond_expr.clone()),
+        name: Symbol::intern("defined"),
+        args: Vec::new(),
+        modifier: None,
+        quoted: false,
+    };
+    Stmt::If {
+        cond,
+        then_branch: vec![topic_given(cond_expr, body)],
+        else_branch,
+        binding_var: None,
+        is_statement_modifier: false,
+        is_unless: false,
+        with_kind: Some(WithBlockKind::Orwith),
+    }
+}

--- a/t/rakuast/rakuast-desugar-boundary.t
+++ b/t/rakuast/rakuast-desugar-boundary.t
@@ -20,7 +20,7 @@ use Test;
 # does NOT assert what the right node would be — that needs measuring against
 # raku first.
 
-plan 6;
+plan 9;
 
 # --- a desugared construct throws rather than rendering a fake node ---------
 throws-like { Q[-<<@a].AST }, Exception,
@@ -29,8 +29,22 @@ throws-like { Q[-<<@a].AST }, Exception,
 throws-like { Q[my @a; @a Z= @a].AST }, Exception,
     'zip assignment does not render an internal __mutsu_zip_assign call';
 
-throws-like { Q[with 1 { say $_ }].AST }, Exception,
+# `with` used to be on that list: it threw rather than rendering its temp. It
+# now renders as raku's own `Statement::With`, and the point of the assertion
+# survives as the stronger one -- the temporary must not appear in the output.
+ok Q[with 1 { say $_ }].AST.gist.contains('RakuAST::Statement::With.new('),
+    '`with` renders as Statement::With';
+nok Q[with 1 { say $_ }].AST.gist.contains('__with_tmp'),
     '`with` does not render its __with_tmp_N temporary';
+
+# The pointy spellings are still boundaries: such a body binds its parameter
+# inside the same scaffold, which raku spells as a PointyBlock -- a shape the
+# converter does not build yet, so it must not render an implicit-topic block
+# that has swallowed the binding.
+throws-like { Q[with 1 -> $a { say $a }].AST }, Exception,
+    '`with` with an explicit signature is still an explicit boundary';
+throws-like { Q[with 1 { say 2 } else -> $p { say $p }].AST }, Exception,
+    'a pointy `else` on a with chain is an explicit boundary too';
 
 # --- constructs that are NOT desugared still render -------------------------
 ok Q[say 42].AST.gist.contains('RakuAST::Call::Name::WithoutParentheses.new('),

--- a/t/rakuast/rakuast-with-without-block.t
+++ b/t/rakuast/rakuast-with-without-block.t
@@ -1,0 +1,109 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# The `with` / `without` / `orwith` BLOCK forms across the RakuAST boundary.
+#
+# raku models them as `Statement::With` / `::Without` / `::Orwith`, with the
+# block carrying `implicit-topic` / `required-topic` — it is the *block* that
+# topicalizes, not an enclosing `given`. mutsu's parser desugars the whole thing
+# into `if (my $tmp = X).defined { given X { BODY } }`, which a hand-written
+# conditional of the same shape also produces, so the internal AST carries a
+# marker recording which keyword the source used rather than guessing from the
+# shape (or from the synthetic temp's name, which a program may declare itself).
+# Measured against Rakudo; every assertion below passes under BOTH mutsu and raku.
+
+plan 25;
+
+# --- read direction: the node classes ---------------------------------------
+
+is Q[with 1 { say 2 }].AST.statements[0].^name, 'RakuAST::Statement::With',
+    'the with block form renders as Statement::With';
+is Q[without Nil { say 2 }].AST.statements[0].^name, 'RakuAST::Statement::Without',
+    'the without block form renders as Statement::Without';
+is Q[with 1 { say 2 }].AST.statements[0].condition.^name, 'RakuAST::IntLiteral',
+    'the condition is the written expression, not the .defined test';
+is Q[without Nil { say 2 }].AST.statements[0].condition.^name, 'RakuAST::Type::Simple',
+    'without: the condition is the written expression too';
+
+# `With` names its block `then`; `Without` names it `body` — the same asymmetry
+# `Statement::If` and `Statement::Unless` have.
+is Q[with 1 { say 2 }].AST.statements[0].then.^name, 'RakuAST::Block',
+    'with: the block is the `then` slot';
+is Q[without Nil { say 2 }].AST.statements[0].body.^name, 'RakuAST::Block',
+    'without: the block is the `body` slot';
+
+# The block itself topicalizes, with a *required* topic.
+like Q[with 1 { say 2 }].AST.gist, /'implicit-topic => True'/,
+    'the with block is marked implicit-topic';
+like Q[with 1 { say 2 }].AST.gist, /'required-topic => 1'/,
+    'the with block takes a required topic';
+
+# No `given` survives the boundary: the topicalizer of the desugar is the
+# block's own flag in raku, not a statement.
+unlike Q[with 1 { say 2 }].AST.gist, /'Statement::Given'/,
+    'the desugared topicalizer does not leak out as a given';
+
+# --- else / orwith chains ---------------------------------------------------
+
+is Q[with 1 { say 2 } else { say 3 }].AST.statements[0].else.^name, 'RakuAST::Block',
+    'with: a trailing else fills the `else` slot';
+is Q[with 1 { say 2 } orwith 2 { say 3 }].AST.statements[0].elsifs[0].^name,
+    'RakuAST::Statement::Orwith',
+    'an orwith clause renders as Statement::Orwith in `elsifs`';
+is Q[with 1 { say 2 } elsif 0 { say 3 }].AST.statements[0].elsifs[0].^name,
+    'RakuAST::Statement::Elsif',
+    'an elsif clause after with is still an Elsif';
+is Q[if 1 { say 1 } orwith 2 { say 2 }].AST.statements[0].elsifs[0].^name,
+    'RakuAST::Statement::Orwith',
+    'an orwith clause continuing a plain if is an Orwith too';
+
+# An `else` continuing a topicalizing clause topicalizes; one continuing an
+# `elsif` does not.
+like Q[with 1 { say 2 } orwith 2 { say 3 } else { say 4 }].AST.gist,
+    /'else' .* 'implicit-topic => True'/,
+    'the else after an orwith topicalizes';
+unlike Q[with 1 { say 2 } elsif 0 { say 3 } else { say 4 }].AST.statements[0].else.gist,
+    /'implicit-topic'/,
+    'the else after an elsif does not topicalize';
+
+# --- a nested `with` statement is not a continuation clause ------------------
+
+# (spelled against `.gist` rather than `.elsifs`, which throws on mutsu when the
+# field is absent instead of returning an empty list -- see #8124)
+unlike Q[if 1 { say 1 } else { with 2 { say 2 } }].AST.statements[0].gist, /'elsifs'/,
+    'a with block inside an else is a statement, not an elsif clause';
+like Q[if 1 { say 1 } else { with 2 { say 2 } }].AST.statements[0].else.gist,
+    /'Statement::With'/,
+    'that nested with block is converted inside the else block';
+
+# --- write direction: EVAL of the round-tripped AST -------------------------
+
+is EVAL(Q[with 42 { $_ }].AST), 42,
+    'with: the block runs, topicalized, on a defined condition';
+is EVAL(Q[my $n = 0; with Nil { $n = 1 }; $n].AST), 0,
+    'with: the block is skipped on an undefined condition';
+is EVAL(Q[without Nil { 7 }].AST), 7,
+    'without: the block runs on an undefined condition';
+is EVAL(Q[with Nil { 1 } else { $_.defined ?? 2 !! 3 }].AST), 3,
+    'with: the else branch runs, topicalized on the tested value';
+is EVAL(Q[with Nil { 1 } orwith 5 { $_ } else { 9 }].AST), 5,
+    'with: an orwith clause runs, topicalized on its own condition';
+
+# The condition is evaluated exactly once, and an lvalue condition stays
+# writable through the topic.
+is EVAL(Q[my $c = 0; sub bump() { $c++; 1 }; with bump() { }; $c].AST), 1,
+    'with: the condition is evaluated exactly once';
+is EVAL(Q[my $x = 5; with $x { $_++ }; $x].AST), 6,
+    'with: a variable condition aliases the topic back to the source';
+
+# --- semantics, from source, unchanged by the marker ------------------------
+
+{
+    my @seen;
+    with Nil { @seen.push: 'with' }
+    orwith 3 { @seen.push: "orwith:$_" }
+    else     { @seen.push: 'else' }
+    is @seen.join(','), 'orwith:3', 'source: the with/orwith/else chain picks the orwith clause';
+}


### PR DESCRIPTION
`with X { … }`, `without X { … }` and the `orwith` / `else` clauses that continue them executed correctly but could not be rendered as RakuAST at all — `.AST` reported the parser's own desugar back as an unsupported construct:

```
$ mutsu -e 'say Q[with 1 { say 2 }].AST.gist'
RakuAST: `.AST` does not yet support this construct: DoStmt(VarDecl { name: "__with_tmp_0", … })
```

They now render as `RakuAST::Statement::With` / `::Without` / `::Orwith`, and a hand-built node of any of those lowers back to the same executable shape.

This is the block half of #8036, which fixed the statement modifier and measured these forms at the same time, as that ticket asked.

## Why the converter could not just recognise the shape

mutsu has no runtime representation of `with`. The parser rewrites the block form into a conditional over a once-evaluated temp:

```
with X { BODY }  ->  if (my $__with_tmp_N = X).defined { given <topic> { BODY } }
```

(negated for `without`), with an `orwith` clause becoming a nested `if EXPR.defined { given EXPR { … } }` in the else branch and a trailing `else` wrapped in a `given` of its own so it topicalizes on the last tested value.

Nothing of the source keyword survives that. A hand-written `if (my $t = 1).defined { given 1 { … } }` produces the same statement, and the synthetic temp's **name** is not a discriminator either — a program may declare `__with_tmp_0` itself, so keying off it would be exactly the guess #8036 established must be avoided. As for `unless` (`is_unless`) and `until` (`is_until`) before it, the distinction is kept rather than reconstructed:

- `Stmt::If` grows `with_kind: Option<WithBlockKind>` (`With` / `Without` / `Orwith`), set by `with_stmt` and by the `orwith` arm of `parse_elsif_chain`;
- `Stmt::Given`'s `with_kind` grows `BlockTopic` / `BlockTopicPointy`, marking the scaffold `given` a block body runs under — which raku does not model as a `given` at all, but as `implicit-topic => True` / `required-topic => 1` on the `Block` itself.

Execution ignores both markers; only the converter reads them.

The pointy spellings (`with X -> $a { }`, `else -> $p { }`, `orwith X -> $q { }`) bind their parameter inside that same scaffold, which raku spells as a `PointyBlock`. They carry the distinct tag so `.AST` reports the boundary instead of rendering an implicit-topic block that has swallowed the binding — which is what an untagged scaffold produced for a pointy `else` after an `orwith`.

## Both directions

- **`src/with_desugar.rs`** (new) holds what the parser and the RakuAST lowerer both need — the temp-name counter, the `.defined` condition, the topic-routing rule (an lvalue or literal condition topicalizes on the source, anything else on the temp) and the two conditional builders — so the desugar is spelled once instead of twice and cannot drift.
- **`src/rakuast/convert.rs`** renders the node, recovering the written condition from the `.defined` test and the block body from the scaffold `given`. The `elsifs` / `else` walk is now shared with `Statement::If`, which gains `orwith` clauses for free (`if 1 { } orwith 2 { }` is legal Raku and was measured). An `else` topicalizes exactly when the clause it continues does, matching rakudo: after `orwith` yes, after `elsif` no. A `with` block written *inside* an `else` stays a statement rather than being absorbed as a continuation clause.
- **`src/rakuast/lower.rs`** accepts the hand-built nodes and rebuilds the parser's shape, so the round trip is stable and `EVAL` runs on the existing compiler and VM path.
- **`src/rakuast/mod.rs`** registers the three classes.

Note the field-name asymmetry measured on rakudo: `Statement::With` names its block `then` and takes `elsifs` / `else`; `Statement::Without` names it `body` and takes neither (rakudo rejects `without … else` at compile time) — mirroring `Statement::If` vs `::Unless`.

## Verification

`.AST.gist` is **byte-identical to rakudo 2026.07** for `with 1 { say 2 }`, `without Nil { say 2 }`, `with … else`, `with … orwith … else`, `with … elsif … else`, `with … orwith … orwith …`, `if … orwith … else`, an empty body, and a `with` nested in an `else`. `EVAL(Q[…].AST)` agrees with rakudo on all of them, including the single evaluation of the condition and the write-back through an lvalue topic (`my $x = 5; with $x { $_++ }` gives 6 in both).

New pin `t/rakuast/rakuast-with-without-block.t` (25 tests: node classes, the `then` / `body` naming asymmetry, the topic flags, the `elsifs` chain, which `else` topicalizes, `EVAL` of the round-tripped AST, and the source-level semantics). **It passes under rakudo unchanged**, so it is a spec pin rather than a mutsu-shaped one.

`t/rakuast/rakuast-desugar-boundary.t` is updated: `with` was listed there as a construct that throws rather than leak its temp, and that point survives as the stronger assertion — it renders, and `__with_tmp` appears nowhere in the output — plus the two pointy boundaries.

One assertion uses a `.gist` match rather than `.elsifs`, because an absent optional field still throws on mutsu instead of returning an empty list (#8124, unchanged by this work).

Pre-publication gate, all run locally on this branch:

- `cargo fmt --all` + `make lint` — green (all four configurations).
- `make test` — **PASS**, 4101 files / 43644 tests.
- `make roast` — 1437 files / 219635 tests; the only failures are the three documented environment-only files, at exactly their documented shapes (`6.c/S32-io/file-tests.t` Failed: 4, tests 6-8/10; `S16-filehandles/filetest.t` Failed: 25, tests 57-64/69-72/77-80/101-125 odd; `S32-io/IO-Socket-Async.t` exit 124, planned 40 ran 17). This container runs as uid 0, the stated cause of the first two.

Closes #8123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8)_