### PR TITLE
fix(parser): five gaps off the head of the 99-distribution parse cluster

### DIFF
--- a/news/2026-09/five-parse-gaps-off-the-head-of-the-cluster.md
+++ b/news/2026-09/five-parse-gaps-off-the-head-of-the-cluster.md
@@ -1,0 +1,140 @@
+# Five parse gaps off the head of the 99-distribution cluster
+
+[#7988](https://github.com/tokuhirom/mutsu/issues/7988) grouped 99 distributions
+by the only thing they had in common: mutsu described their parse failure by
+dumping the set of things its parser would have accepted. [#8065](https://github.com/tokuhirom/mutsu/pull/8065)
+fixed the diagnosis — every member now names the line the parser actually
+stopped on — and its survey answered the ticket's real question: the cluster is
+**a queue of small tickets, not a handful of large ones**, with a short head of
+constructs that each reach two or three distributions through a shared
+dependency.
+
+This is the head, worked. Five gaps, each a construct rakudo compiles and mutsu
+did not, each pinned against rakudo 2026.07.
+
+## 1. A named parameter's alias could not be a Unicode identifier
+
+```raku
+submethod BUILD(:ν(:$!nu) = 1) { }     # Statistics::Distributions
+```
+
+mutsu supports Unicode identifiers everywhere else — variables, subs, classes,
+methods — but the guard that decides whether `:name(...)` is an *alias* or a
+*type constraint* tested the first **byte** for `is_ascii_alphabetic`. A UTF-8
+lead byte such as `0xCE` is not ASCII-alphabetic, so `:ν(...)` fell into the
+type-constraint/coercion path, which parses no trailing default. The defaulted
+form failed outright and the undefaulted form silently lost the alias name:
+
+```
+sub f(:ν($nu) = 1) { }     Confused. … expected ')'
+sub f(:ν($nu))    { }      parsed, then "Unexpected named argument 'ν'"
+```
+
+That is the same failure the uppercase case (`:ASTART($a) = 0`) already had,
+reached by a different route. The guard now asks the identifier oracle
+`is_raku_identifier_start` about the first **character**. Reaches
+`Statistics::Distributions` and `Math::GameTheory`.
+
+## 2. A pointy block could not take a signature-literal parameter
+
+```raku
+-> :(PrettyDump $pretty, $ds, Int:D :$depth = 0 --> Str) { … }   # PrettyDump
+```
+
+This reads like a signature literal but is not one: rakudo parses it as **one
+parameter** — an anonymous named `$` whose sub-signature is the parenthesised
+list — so the block's signature gists as `(:$ ($a, $b))`. mutsu's *sub*
+parameter parser has always got this right; the pointy-block parameter parser
+is a separate hand-rolled list of shapes and accepted `:` only when a sigil
+followed, so the construct reached no branch at all and the whole block failed.
+
+The pointy parser now delegates this one shape to the sub-parameter parser
+rather than restating it — every other branch in that file is a hand-rolled
+copy of one of its cases, and this is the one place a copy buys nothing.
+`PrettyDump` goes `blocked_load` → loading cleanly; `Collection` and
+`RakuConfig` depend on it.
+
+## 3. `⚛-=` did not parse
+
+`runtime::core_infix_names` already listed both spellings rakudo declares —
+`⚛-=` with U+002D HYPHEN-MINUS and `⚛−=` with U+2212 MINUS SIGN — as operators
+mutsu claims to know, but no parser site ever recognised either; only `⚛+=` was
+handled, at three separate sites.
+
+`⚛+=` and `⚛-=` are the same read-modify-write on the same target and differ
+only in the sign of the delta, so both now lower to `__mutsu_atomic_add_var`
+with the subtract forms negating their right-hand side through one shared
+helper. The negation is applied to the delta expression, *before* the atomic
+update runs, so atomicity is unchanged. Reaches `Async::Workers`,
+`FFmpegProgressBar` and `Russian`.
+
+## 4. `⚛=` could not initialize a declaration
+
+```raku
+my $qu ⚛= $!queue-unblock;     # Async::Workers
+```
+
+mutsu accepted the operator only in an assignment to an already-declared
+variable. On a variable the declaration is only now creating there is nothing
+to be atomic against — no other thread can hold a reference to it yet — so
+rakudo treats this as an ordinary initialization, and so does mutsu now. Later
+`⚛` operations on the name still go through the atomic machinery, exactly as
+they do after a plain `my atomicint $i = 5`.
+
+With 3 and 4 together, `Async::Workers::Job`, `::Worker`, `::CX`, `::Msg` and
+`::X` all load; `Async::Workers` itself now stops only at a missing
+`AttrX::Mooish`.
+
+## 5. A bare type capture could not be followed by a return constraint
+
+```raku
+method add-enum-type(Str $name, ::Enum --> Promise) { … }   # Protocol::Postgres
+```
+
+The capture branch listed `)`, `]`, `,` and `;` as the things that may follow a
+**bare** capture — one with no variable of its own — but not `-->`. The arrow
+therefore fell through to the "anything after the capture is a parameter in its
+own right" path, which tried to parse `--> Promise)` as a parameter. The arrow
+belongs to the enclosing signature, exactly like the closing paren, so it joins
+that list. `Protocol::Postgres` now parses (and stops at an unrelated
+`Invalid typename 'EncodeBuffer'`); `Net::Postgres` depends on it.
+
+## One head construct deliberately not fixed
+
+`die "…":` (Math::FractionalPart, Astro::Utils, DateTime::Julian) is the
+invocant-colon listop form: rakudo reads `die "boom":` as `"boom".die` and
+raises `X::Method::NotFound`. mutsu does **not** implement those semantics for
+any listop — it drops the colon and calls the listop normally, which is why
+`say "hello":`, `sort @a:` and `return "r":` all "work" and `warn "w":` warns
+instead of failing. `die` is the only one that additionally fails to *parse*.
+
+Making `die` parse like its siblings would have traded a loud wrong answer for
+a quiet one, so it is filed as
+[#8141](https://github.com/tokuhirom/mutsu/issues/8141) with all five
+measurements rather than half-fixed here.
+
+## A note on method: `--dump-ast` is not a parse oracle
+
+Probing a module file with `--dump-ast` does not run its `use` statements, so
+any type the file imports is undeclared at the point the probe parses it.
+`Async::Workers::Job` looked like a sixth gap (`when CX::AW::StopWorker {`)
+until the error was compared with rakudo's: mutsu emits *exactly* rakudo's
+message, word for word, for an undeclared type in that position. Loaded
+properly with `-I`, the file parses. Two of the survey's remaining entries were
+this artefact rather than gaps.
+
+## Pins
+
+All four files pass verbatim under rakudo 2026.07 as well as under mutsu.
+
+- `t/routines/signature/unicode-named-param-alias.t` — 12 assertions, including
+  the ASCII, hyphenated and uppercase alias spellings that already worked and a
+  real type-constrained named parameter, which must still be a type.
+- `t/routines/signature/pointy-block-signature-literal-param.t` — 9, including
+  every other pointy parameter shape (ordinary, destructuring, named,
+  sigilless, type-only).
+- `t/routines/signature/signature-bare-type-capture-arrow.t` — 8, including
+  every terminator that already worked.
+- `t/concurrency/thread-lock/atomic-subtract-assign.t` — 13, including the
+  U+2212 spelling, a compound right-hand side (the negation must bind the whole
+  delta), and `⚛=` / `⚛+=` / `⚛++` / `--⚛` unchanged.

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -19,6 +19,45 @@ use super::{ident, parse_statement_modifier};
 
 static TMP_INDEX_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+/// Strip a leading atomic compound-assignment operator, returning the rest of
+/// the input and whether the delta must be negated.
+///
+/// `⚛+=` and `⚛-=` are the same read-modify-write on the same target; only the
+/// sign of the delta differs, so both lower to `__mutsu_atomic_add_var` and the
+/// subtract forms negate their right-hand side. Doing it here rather than with
+/// a second builtin keeps the atomicity identical — the negation is applied to
+/// the delta expression, before the atomic update ever runs.
+///
+/// rakudo declares the minus form under two spellings (see
+/// `runtime::core_infix_names`): ASCII HYPHEN-MINUS and U+2212 MINUS SIGN.
+/// Both were already listed there as operators mutsu claims to know, while the
+/// parser only ever recognised `⚛+=` — so `$i ⚛-= 2` (Async::Workers,
+/// FFmpegProgressBar, Russian) failed to parse at all.
+pub(crate) fn strip_atomic_compound_assign(rest: &str) -> Option<(&str, bool)> {
+    if let Some(stripped) = rest.strip_prefix("⚛+=") {
+        return Some((stripped, false));
+    }
+    for minus in ["⚛-=", "⚛\u{2212}="] {
+        if let Some(stripped) = rest.strip_prefix(minus) {
+            return Some((stripped, true));
+        }
+    }
+    None
+}
+
+/// Wrap an atomic compound assignment's right-hand side in unary minus when the
+/// operator was a subtract form. See [`strip_atomic_compound_assign`].
+pub(crate) fn atomic_delta_expr(rhs: Expr, negate: bool) -> Expr {
+    if negate {
+        Expr::Unary {
+            op: TokenKind::Minus,
+            expr: Box::new(rhs),
+        }
+    } else {
+        rhs
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompoundAssignOp {
     Comma,

--- a/src/parser/stmt/assign/assign_stmt.rs
+++ b/src/parser/stmt/assign/assign_stmt.rs
@@ -464,7 +464,7 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
         }
     }
     // Simple assignment
-    if let Some(stripped) = rest.strip_prefix("⚛+=") {
+    if let Some((stripped, negate)) = super::strip_atomic_compound_assign(rest) {
         let (rest, _) = ws(stripped)?;
         let (rest, rhs) = parse_assign_expr_or_comma(rest).map_err(|err| PError {
             messages: merge_expected_messages(
@@ -476,7 +476,10 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
         })?;
         let stmt = Stmt::Expr(Expr::Call {
             name: Symbol::intern("__mutsu_atomic_add_var"),
-            args: vec![Expr::Literal(Value::str(name)), rhs],
+            args: vec![
+                Expr::Literal(Value::str(name)),
+                super::atomic_delta_expr(rhs, negate),
+            ],
         });
         return parse_statement_modifier(rest, stmt);
     }

--- a/src/parser/stmt/assign/paren.rs
+++ b/src/parser/stmt/assign/paren.rs
@@ -97,7 +97,7 @@ pub(crate) fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
     }
     let (rest, lhs) = expression_no_sequence(rest)?;
     let (rest, _) = ws(rest)?;
-    if let Some(stripped) = rest.strip_prefix("⚛+=") {
+    if let Some((stripped, negate)) = super::strip_atomic_compound_assign(rest) {
         let name = match lhs {
             Expr::Var(name) => name,
             _ => return Err(PError::expected("atomic compound assignment expression")),
@@ -113,7 +113,10 @@ pub(crate) fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
             rest,
             Expr::Call {
                 name: Symbol::intern("__mutsu_atomic_add_var"),
-                args: vec![Expr::Literal(Value::str(name)), rhs],
+                args: vec![
+                    Expr::Literal(Value::str(name)),
+                    super::atomic_delta_expr(rhs, negate),
+                ],
             },
         ));
     }

--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -594,7 +594,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
             },
         ));
     }
-    if let Some(stripped) = r2.strip_prefix("⚛+=") {
+    if let Some((stripped, negate)) = super::strip_atomic_compound_assign(r2) {
         let (rest, _) = ws(stripped)?;
         let (rest, rhs) = match try_parse_assign_expr(rest) {
             Ok(r) => r,
@@ -605,7 +605,10 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
             rest,
             Expr::Call {
                 name: Symbol::intern("__mutsu_atomic_add_var"),
-                args: vec![Expr::Literal(Value::str(name)), rhs],
+                args: vec![
+                    Expr::Literal(Value::str(name)),
+                    super::atomic_delta_expr(rhs, negate),
+                ],
             },
         ));
     }

--- a/src/parser/stmt/control/pointy_param.rs
+++ b/src/parser/stmt/control/pointy_param.rs
@@ -15,6 +15,26 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         return Ok((r, p));
     }
 
+    // Anonymous named parameter carrying a sub-signature: `-> :($a, $b) { ... }`.
+    // Despite reading like a signature literal, rakudo parses this as ONE
+    // parameter — an anonymous named `$` whose sub-signature is `($a, $b)`, so
+    // `(-> :($a, $b) { }).signature.gist` is `(:$ ($a, $b))`. The sub-parameter
+    // parser already gets this exactly right (`sub (:($a, $b))` produces the
+    // same shape), so delegate to it instead of restating the shape here: every
+    // other branch below is a hand-rolled copy of one of its cases, and this is
+    // the one place a copy buys nothing. `block_param` is the only field that
+    // differs, and it is a property of the enclosing pointy block rather than
+    // of the parameter's spelling.
+    //
+    // Without this, `-> :(PrettyDump $pretty, $ds, Int:D :$depth = 0 --> Str)`
+    // (PrettyDump, and Collection / RakuConfig through it) reached no branch at
+    // all and the whole block failed to parse.
+    if input.starts_with(":(") {
+        let (r, mut p) = crate::parser::stmt::sub_param::parse_single_param(input)?;
+        p.block_param = true;
+        return Ok((r, p));
+    }
+
     // Optional type constraint before the variable
     // Use parse_type_constraint_expr to handle coercion types (e.g., Numeric(Cool)),
     // qualified names (Int::Odd), definedness markers (:D/:U), etc.

--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -95,6 +95,17 @@ pub(super) fn my_decl_assign_or_default(input: &str, s: MyDeclState) -> PResult<
         return handle_simple_assign(&rest[1..], s);
     }
 
+    // `my $qu ⚛= $!queue-unblock;` (Async::Workers) — an atomic store used as a
+    // declaration's initializer. On a variable the declaration is only now
+    // bringing into existence there is nothing to be atomic against: no other
+    // thread can hold a reference to it yet, so this is an ordinary
+    // initialization and rakudo treats it as one. Later `⚛` operations on the
+    // name still go through the atomic machinery, exactly as they do after a
+    // plain `my atomicint $i = 5`.
+    if let Some(stripped) = rest.strip_prefix("⚛=") {
+        return handle_simple_assign(stripped, s);
+    }
+
     // Method-call-assign .= in declaration: my Type $var .= method(args)
     if let Some(stripped) = rest.strip_prefix(".=") {
         return handle_method_call_assign(stripped, s);

--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -312,10 +312,19 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             p.default = Some(default);
             return Ok((r, p));
         }
+        // What can follow a BARE capture (`::Enum` with no variable of its
+        // own): the end of the list, the next parameter, or the signature's
+        // return constraint. `-->` belongs here for the same reason `)` does —
+        // it ends the parameter, and the arrow is the enclosing signature's to
+        // parse, not this parameter's. Without it, `method add-enum-type(Str
+        // $name, ::Enum --> Promise)` (Protocol::Postgres, and Net::Postgres
+        // through it) fell through to the "anything else is a parameter in its
+        // own right" path below, which tried to parse `--> Promise)` as one.
         if rest.starts_with(')')
             || rest.starts_with(']')
             || rest.starts_with(',')
             || rest.starts_with(';')
+            || rest.starts_with("-->")
         {
             let mut p = super::helpers::make_param(format!("__type_capture__{}", capture_name));
             p.type_capture = Some(capture_name);
@@ -370,11 +379,17 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
     // Restricting this to lowercase let an uppercase alias fall into the
     // type-constraint/coercion path, which returned without consuming a trailing
     // default (`:ASTART($a) = 0`).
+    //
+    // The test is on the first CHARACTER, through the same oracle
+    // `parse_raku_ident` starts from — not on the first BYTE. A Raku identifier
+    // may start with any Unicode alphabetic character, and an alias is an
+    // identifier like any other (`:ν(:$!nu) = 1` in Statistics::Distributions,
+    // `:σ($s)`, `:名前($s)`). A byte test sees a UTF-8 lead byte such as 0xCE,
+    // decides it is not a name, and drops the alias into exactly the
+    // type-constraint path this flag exists to avoid — the same failure the
+    // uppercase case above describes, reached by a different route.
     let skip_type_for_named_alias = named
-        && rest
-            .as_bytes()
-            .first()
-            .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+        && rest.starts_with(crate::parser::helpers::is_raku_identifier_start)
         && rest.contains('(');
     if type_constraint.is_none()
         && !skip_type_for_named_alias

--- a/t/concurrency/thread-lock/atomic-subtract-assign.t
+++ b/t/concurrency/thread-lock/atomic-subtract-assign.t
@@ -1,0 +1,91 @@
+use Test;
+
+# `$i ⚛-= $n` is the subtract half of the atomic compound assignment whose add
+# half (`⚛+=`) mutsu already had. Both spellings rakudo declares —
+# U+002D HYPHEN-MINUS and U+2212 MINUS SIGN — were already listed in
+# `runtime::core_infix_names` as operators mutsu claims to know, but no parser
+# site ever recognised either, so the statement failed to parse outright
+# (Async::Workers, FFmpegProgressBar, Russian).
+#
+# The two operators are the same read-modify-write on the same target and
+# differ only in the sign of the delta, so both lower to
+# `__mutsu_atomic_add_var` with the subtract forms negating their right-hand
+# side. The negation is applied to the delta expression, before the atomic
+# update runs, so atomicity is unchanged.
+
+plan 13;
+
+{
+    my atomicint $i = 5;
+    $i ⚛-= 2;
+    is ⚛$i, 3, 'the statement form subtracts';
+}
+
+{
+    my atomicint $i = 5;
+    my $r = ($i ⚛-= 2);
+    is $r, 3, 'the expression form yields the new value';
+    is ⚛$i, 3, 'and leaves it in the variable';
+}
+
+{
+    my atomicint $i = 5;
+    $i ⚛−= 2;          # U+2212 MINUS SIGN
+    is ⚛$i, 3, 'the U+2212 MINUS SIGN spelling subtracts too';
+}
+
+# The negation must bind the whole delta, not just its first term.
+{
+    my atomicint $i = 5;
+    $i ⚛-= 1 + 1;
+    is ⚛$i, 3, 'a compound right-hand side is negated as a whole';
+}
+
+{
+    my atomicint $i = 5;
+    my $n = 10;
+    $i ⚛-= $n;
+    is ⚛$i, -5, 'a variable right-hand side subtracts, and may go negative';
+}
+
+# The operators that already worked must keep working.
+{
+    my atomicint $i = 5;
+    $i ⚛+= 2;
+    is ⚛$i, 7, 'atomic add still works';
+
+    my atomicint $j = 5;
+    $j ⚛= 9;
+    is ⚛$j, 9, 'atomic assign still works';
+
+    my atomicint $k = 5;
+    $k⚛++;
+    is ⚛$k, 6, 'atomic postfix increment still works';
+
+    my atomicint $l = 5;
+    --⚛$l;
+    is ⚛$l, 4, 'atomic prefix decrement still works';
+}
+
+# `⚛=` as a DECLARATION's initializer (`my $qu ⚛= $!queue-unblock;` in
+# Async::Workers). On a variable the declaration is only now creating there is
+# nothing to be atomic against — no other thread can hold a reference to it
+# yet — so rakudo treats it as an ordinary initialization. mutsu accepted the
+# operator only in an assignment to an already-declared variable, so the
+# declaration form failed to parse.
+{
+    my atomicint $q = 3;
+    my $qu ⚛= $q;
+    is $qu, 3, 'an atomic store initializes a `my` declaration';
+
+    my atomicint $i ⚛= 5;
+    $i ⚛-= 2;
+    is ⚛$i, 3, 'and the declared variable still takes atomic updates afterwards';
+}
+
+# Repeated subtraction accumulates, so the lowering is not losing the update.
+{
+    my atomicint $i = 100;
+    $i ⚛-= 7 for ^5;
+    is ⚛$i, 65, 'repeated atomic subtraction accumulates';
+}

--- a/t/routines/signature/pointy-block-signature-literal-param.t
+++ b/t/routines/signature/pointy-block-signature-literal-param.t
@@ -1,0 +1,61 @@
+use Test;
+
+# `-> :($a, $b) { ... }` reads like a signature literal but is not one: rakudo
+# parses it as ONE parameter — an anonymous named `$` whose sub-signature is
+# `($a, $b)` — so the block's own signature gists as `(:$ ($a, $b))`.
+#
+# PrettyDump builds its handlers that way:
+#
+#     -> :(PrettyDump $pretty, $ds, Int:D :$depth = 0 --> Str) { ... }
+#
+# mutsu's sub-parameter parser has always got this right (`sub (:($a, $b))`),
+# but the pointy-block parameter parser is a separate hand-rolled list of
+# shapes and had no case for `:(` at all: it accepted `:` only when a sigil
+# followed. The construct therefore reached no branch and the whole block
+# failed to parse, taking PrettyDump — and Collection / RakuConfig, which
+# depend on it — down with it. The pointy parser now delegates this one shape
+# to the sub-parameter parser rather than restating it.
+
+plan 9;
+
+# The parameter is an anonymous named one carrying a sub-signature.
+{
+    my $b = -> :($a, $b) { 42 };
+    is $b.signature.gist, '(:$ ($a, $b))',
+        'a pointy `:(...)` parameter is an anonymous named param with a sub-signature';
+}
+
+# An empty one is optional, so the block is callable with no arguments.
+{
+    my $b = -> :() { 42 };
+    is $b(), 42, 'an empty `:()` parameter leaves the block callable with no args';
+}
+
+# The shape PrettyDump actually writes, including a type, a defaulted named
+# parameter inside the sub-signature and a return constraint.
+{
+    class PrettyDumpish { }
+    my $c = -> :(PrettyDumpish $pretty, $ds, Int:D :$depth = 0 --> Str) { 'handled' };
+    ok $c.defined, 'the PrettyDump handler shape parses';
+    ok $c.signature.gist.contains('PrettyDumpish $pretty'),
+        'and keeps the sub-signature it was given';
+}
+
+# Every other pointy parameter shape must be untouched — the new branch is
+# keyed on a literal `:(` prefix and nothing else reaches it.
+{
+    my $plain = -> $a, $b { $a + $b };
+    is $plain(1, 2), 3, 'an ordinary pointy block still works';
+
+    my $destructure = -> [$a, $b] { $a + $b };
+    is $destructure([1, 2]), 3, 'positional destructuring still works';
+
+    my $named = -> :$named { $named };
+    is $named(:named(3)), 3, 'a named pointy parameter still works';
+
+    my $sigilless = -> Int \v { v };
+    is $sigilless(4), 4, 'a typed sigilless pointy parameter still works';
+
+    my $typed-only = -> Int { 'type-only' };
+    is $typed-only(1), 'type-only', 'a type-only pointy parameter still works';
+}

--- a/t/routines/signature/signature-bare-type-capture-arrow.t
+++ b/t/routines/signature/signature-bare-type-capture-arrow.t
@@ -1,0 +1,53 @@
+use Test;
+
+# A BARE type capture — `::Enum` with no variable of its own — ends where the
+# next parameter or the signature's return constraint begins:
+#
+#     method add-enum-type(Str $name, ::Enum --> Promise) { ... }
+#
+# That is how Protocol::Postgres (and Net::Postgres, which depends on it)
+# declares it. mutsu's capture branch listed `)`, `]`, `,` and `;` as the
+# things that may follow a bare capture but not `-->`, so the arrow fell
+# through to the "anything after the capture is a parameter in its own right"
+# path, which then tried to parse `--> Promise)` as a parameter and failed.
+# The arrow belongs to the enclosing signature, exactly like the closing paren.
+
+plan 8;
+
+# The distribution's own shape.
+{
+    class C {
+        method add-enum-type(Str $name, ::Enum --> Promise) { Promise.kept($name) }
+    }
+    is C.add-enum-type('x', Int).result, 'x',
+        'a bare type capture may be followed by a return constraint';
+}
+
+# The capture is still a capture: it binds the argument's type.
+{
+    sub captured(::T --> Str) { T.^name }
+    is captured(Int), 'Int', 'the bare capture still binds the type it was given';
+    is captured(Str), 'Str', 'and follows the argument on a second call';
+}
+
+# More than one, and in the middle of a list.
+{
+    sub two(::T, ::U --> Str) { T.^name ~ '/' ~ U.^name }
+    is two(Int, Str), 'Int/Str', 'two bare captures before the arrow';
+
+    sub middle(::T, Int $n --> Int) { $n }
+    is middle(Str, 5), 5, 'a bare capture followed by an ordinary parameter';
+}
+
+# Every terminator that already worked must keep working — the change adds one
+# spelling to the list, it does not replace it.
+{
+    sub no-arrow(Str $n, ::Enum) { $n }
+    is no-arrow('x', Int), 'x', 'a bare capture at the end of the list still works';
+
+    sub with-var(::T $x --> Int) { 1 }
+    is with-var(5), 1, 'a capture that has its own variable still works with an arrow';
+
+    sub ordinary(Int $a --> Int) { $a }
+    is ordinary(3), 3, 'an ordinary parameter with a return constraint is unaffected';
+}

--- a/t/routines/signature/unicode-named-param-alias.t
+++ b/t/routines/signature/unicode-named-param-alias.t
@@ -1,0 +1,76 @@
+use Test;
+
+# A named parameter's external alias is an identifier like any other, so it may
+# start with any Unicode alphabetic character — `:ν(:$!nu) = 1` is how
+# Statistics::Distributions (and Math::GameTheory through it) writes a BUILD
+# submethod.
+#
+# mutsu supports Unicode identifiers everywhere else (variables, subs, classes,
+# methods), but the guard that recognises `:name(...)` as an alias rather than a
+# type constraint tested the first BYTE for `is_ascii_alphabetic`. A UTF-8 lead
+# byte such as 0xCE is not ASCII-alphabetic, so the alias fell into the
+# type-constraint/coercion path instead — which parses no trailing default, so
+# the defaulted form failed outright and the undefaulted form silently lost the
+# alias name:
+#
+#     sub f(:ν($nu) = 1) { }    # "Confused. ... expected ')'"
+#     sub f(:ν($nu))    { }     # parsed, then "Unexpected named argument 'ν'"
+#
+# That is the same failure the uppercase case (`:ASTART($a) = 0`) already had,
+# reached by a different route; the guard now asks the identifier oracle
+# `is_raku_identifier_start` about the first CHARACTER.
+
+plan 12;
+
+# The distribution's own shape: a Unicode alias onto a private attribute, with
+# a default.
+{
+    class C {
+        has $!nu;
+        submethod BUILD(:ν(:$!nu) = 1) { }
+        method nu { $!nu }
+    }
+    is C.new.nu, 1, 'a Unicode alias with a default takes the default';
+    is C.new(:ν(7)).nu, 7, 'and binds when the caller supplies it';
+}
+
+# Reduced to a plain sub, both levels of the alias and both with and without a
+# default.
+{
+    sub two-level(:ν(:$nu) = 1) { $nu }
+    is two-level(), 1, 'two-level Unicode alias, defaulted';
+    is two-level(:ν(5)), 5, 'two-level Unicode alias, supplied';
+
+    sub one-level(:ν($nu) = 1) { $nu }
+    is one-level(), 1, 'single-level Unicode alias, defaulted';
+    is one-level(:ν(5)), 5, 'single-level Unicode alias, supplied';
+
+    sub no-default(:ν($nu)) { $nu }
+    is no-default(:ν(5)), 5, 'single-level Unicode alias with no default';
+}
+
+# Not specific to Greek: any Unicode alphabetic start works.
+{
+    sub sigma(:σ($s)) { $s }
+    is sigma(:σ(2)), 2, 'a sigma alias binds';
+
+    sub cjk(:名前($s)) { $s }
+    is cjk(:名前(3)), 3, 'a CJK alias binds';
+}
+
+# The spellings that already worked must keep working — the guard got wider,
+# not different.
+{
+    sub ascii(:a-b($s)) { $s }
+    is ascii(:a-b(2)), 2, 'a hyphenated ASCII alias still binds';
+
+    sub upper(:ASTART($a) = 0) { $a }
+    is upper(:ASTART(9)), 9, 'an uppercase alias with a default still binds';
+}
+
+# And a real type constraint on a named parameter must still be a type
+# constraint, not be mistaken for an alias.
+{
+    sub typed(Int :$x = 3) { $x }
+    is typed(:x(8)), 8, 'a type-constrained named param is unaffected';
+}


### PR DESCRIPTION
Works the queue #7988 turned out to be. #8065 fixed that cluster's diagnosis and its survey answered the ticket's question — *a queue of small tickets, not a handful of large ones*, with a short head of constructs that each reach two or three distributions through a shared dependency. This is that head.

The issue **stays open**: the long tail is still there, and the survey comment says the right moment to file it individually is after a sweep re-clusters these records by their new construct-naming messages.

Write-up: `news/2026-09/five-parse-gaps-off-the-head-of-the-cluster.md`.

## The five gaps

Each is a construct rakudo 2026.07 compiles and mutsu did not.

**1. A named parameter's alias could not be a Unicode identifier** — `submethod BUILD(:ν(:$!nu) = 1) { }` (`Statistics::Distributions`, `Math::GameTheory`).

mutsu takes Unicode identifiers everywhere else — variables, subs, classes, methods — but the guard deciding whether `:name(...)` is an *alias* or a *type constraint* tested the first **byte** for `is_ascii_alphabetic`. A UTF-8 lead byte such as `0xCE` is not ASCII-alphabetic, so the alias fell into the type-constraint/coercion path, which parses no trailing default:

```
sub f(:ν($nu) = 1) { }     Confused. … expected ')'
sub f(:ν($nu))    { }      parsed, then "Unexpected named argument 'ν'"
```

Exactly the failure the uppercase case (`:ASTART($a) = 0`) already had, reached by a different route. The guard now asks the identifier oracle `is_raku_identifier_start` about the first **character**.

**2. A pointy block could not take a signature-literal parameter** — `-> :(PrettyDump $pretty, $ds, Int:D :$depth = 0 --> Str) { … }` (`PrettyDump` → `Collection`, `RakuConfig`).

Despite its spelling this is **one** parameter: an anonymous named `$` whose sub-signature is the parenthesised list, so the block gists as `(:$ ($a, $b))`. The *sub* parameter parser has always got this right; the pointy-block parser is a separate hand-rolled list of shapes that accepted `:` only before a sigil, so the construct reached no branch at all. It now delegates this one shape to the sub-parameter parser — every other branch in that file is a hand-rolled copy of one of its cases, and this is the one place a copy buys nothing.

**3. `⚛-=` did not parse** (`Async::Workers`, `FFmpegProgressBar`, `Russian`).

Both spellings rakudo declares (U+002D and U+2212) were already in `runtime::core_infix_names` as operators mutsu claims to know, but no parser site recognised either — only `⚛+=`, at three sites. The two are the same read-modify-write differing only in the delta's sign, so both lower to `__mutsu_atomic_add_var` with the subtract forms negating their RHS through one shared helper. The negation is applied to the delta expression, *before* the atomic update runs, so atomicity is unchanged.

**4. `⚛=` could not initialize a declaration** — `my $qu ⚛= $!queue-unblock;` (`Async::Workers`).

On a variable the declaration is only now creating there is nothing to be atomic against — no other thread can hold a reference to it yet — so rakudo treats it as an ordinary initialization. Later `⚛` operations on the name still go through the atomic machinery, as after a plain `my atomicint $i = 5`.

**5. A bare type capture could not be followed by a return constraint** — `method add-enum-type(Str $name, ::Enum --> Promise)` (`Protocol::Postgres` → `Net::Postgres`).

The terminator set for a **bare** capture listed `)`, `]`, `,` and `;` but not `-->`, so the arrow fell through to the "anything after the capture is a parameter in its own right" path, which tried to parse `--> Promise)` as one. The arrow belongs to the enclosing signature, exactly like the closing paren.

## Effect

`PrettyDump` and the five `Async::Workers::*` compunits go `blocked_load` → loading cleanly. `Protocol::Postgres` now parses and stops at an unrelated cluster (`Invalid typename 'EncodeBuffer'`). `Statistics::Distributions`, `Math::GameTheory` and `RakuConfig` parse and stop only at dependencies a local probe cannot resolve.

## One head construct deliberately not fixed — #8141

`die "…":` (`Math::FractionalPart`, `Astro::Utils`, `DateTime::Julian`) is the invocant-colon listop form: rakudo reads `die "boom":` as `"boom".die` and raises `X::Method::NotFound`. mutsu implements those semantics for **no** listop — it drops the colon — so `warn "w":` already gives a wrong answer and `say "hello":` / `sort @a:` / `return "r":` agree with rakudo only by coincidence. `die` is just the one that fails loudly.

Making `die` merely *parse* like its siblings would trade a loud wrong answer for a quiet one and hide the shared gap behind three distributions that look fixed, so it is filed as **#8141** with all five measurements instead.

## A method correction worth recording

`--dump-ast` is **not** a parse oracle: it does not run a module's `use` statements, so every imported type reads as undeclared. `Async::Workers::Job` looked like a sixth gap (`when CX::AW::StopWorker {`) until its error was compared against rakudo's — mutsu emits rakudo's message *word for word* for an undeclared type in that position. Loaded properly with `-I`, the file parses. Two of the survey's remaining entries were this artefact rather than gaps.

## Tests

All four pass **verbatim under rakudo 2026.07** as well as under mutsu.

- `t/routines/signature/unicode-named-param-alias.t` (12) — plus the ASCII, hyphenated and uppercase alias spellings that already worked, and a real type-constrained named parameter, which must still be a type.
- `t/routines/signature/pointy-block-signature-literal-param.t` (9) — plus every other pointy parameter shape: ordinary, destructuring, named, sigilless, type-only.
- `t/routines/signature/signature-bare-type-capture-arrow.t` (8) — plus every terminator that already worked.
- `t/concurrency/thread-lock/atomic-subtract-assign.t` (13) — plus the U+2212 spelling, a compound RHS (the negation must bind the whole delta), and `⚛=` / `⚛+=` / `⚛++` / `--⚛` unchanged.

Ran locally before publishing: `cargo fmt --all`; `make lint` (all four configurations) green; `make test` green (4106 files, 43701 tests); `make roast` red only on the three files `docs/agent-environments.md` documents for this container — `6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` (`id -u` is 0 here, so the `chmod` assertions cannot pass) and `S32-io/IO-Socket-Async.t` (exit 124 under the network sandbox) — each with exactly the documented subtest range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pz6URmTWmqMP41wKgpjkRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pz6URmTWmqMP41wKgpjkRo)_