### PR TITLE
fix(dispatch): stop evaluating parameter defaults nothing reads during matching

### DIFF
--- a/news/2026-09/multi-dispatch-stops-evaluating-defaults-nothing-reads.md
+++ b/news/2026-09/multi-dispatch-stops-evaluating-defaults-nothing-reads.md
@@ -1,0 +1,65 @@
+# Multi dispatch stops evaluating parameter defaults that nothing reads
+
+A `multi` whose candidates carry non-constant parameter defaults warned once per
+call about a `Nil` that never appeared in the result:
+
+```raku
+multi m(Int $c, $d = $c * 2)   { "int:$c/$d" }
+multi m(Str $c, $d = $c ~ "!") { "str:$c/$d" }
+say m("a");
+```
+
+```
+Use of Nil in string context
+  in block <unit> at nilwarn.raku line 3
+str:a/a!
+```
+
+The value was right; only the warning was wrong. The same signature written as a
+plain `sub` was silent, which pointed at the dispatch path rather than at the
+default itself ([#8078](https://github.com/tokuhirom/mutsu/issues/8078)).
+
+## The evaluation had exactly one consumer, and it was optional
+
+`Interpreter::args_match_params` checks an *unsupplied* parameter against the
+value it would actually bind, so that dispatch and binding agree — a candidate
+selected on its defaulted parameter must not then die binding the very call it
+was selected for ([#8089](https://github.com/tokuhirom/mutsu/issues/8089)). Part
+of that is evaluating the parameter's default so a `where` clause can be tested
+against it.
+
+The evaluation was unconditional: every unsupplied parameter with a default had
+it evaluated on every dispatch, whether or not the parameter carried a `where`
+clause — and `where_default` was read in exactly one place, inside
+`if let Some(where_expr) = &pd.where_constraint`. For a candidate with no
+`where`, the result was computed and immediately dropped.
+
+Dropping it silently would have been merely wasteful. Dropping it *loudly* is the
+bug: matching runs before the arguments are bound to parameter names, so a
+default that reads an earlier parameter (`$d = $c ~ "!"`) saw an unbound `$c`,
+took the `Nil` string-context path, and printed the warning that path always
+prints. `$c * 2` was unaffected only because numeric context does not warn — the
+Int candidate was evaluating a bogus default too, just quietly.
+
+The fix gates the evaluation on `pd.where_constraint.is_some()`. Nothing else
+read it, so nothing else changes: a candidate is still selected on its defaulted
+`where`-parameter (pinned by the existing
+`t/routines/signature/optional-param-where-runs-when-omitted.t`, and again here),
+and every other candidate now pays no default evaluation at dispatch time at all.
+
+## Why the regression test watches STDERR
+
+The obvious pin — a `CONTROL { when CX::Warn {...} }` counter around the call, as
+`t/types/nil-str-context-warning.t` uses — counts **zero** on the broken build.
+The warning is raised on the dispatch path, outside the caller's handler scope,
+so an in-process handler never sees it while the text still reaches the terminal.
+`t/routines/dispatch/multi-nonconstant-default-no-spurious-warn.t` therefore runs
+each snippet as a subprocess and asserts on its STDERR, the way
+`t/modules/module-parse-warning-once.t` does. On the unfixed binary it fails on
+exactly the two STDERR assertions; under `raku` it passes as written.
+
+That the handler cannot see this warning is itself worth knowing: a warning
+emitted during candidate matching is currently unsuppressable from Raku code
+(`quietly` would not have silenced it either). Removing the only known source of
+one was the right first move; if another turns up, the handler scope on the
+dispatch path is the thing to fix.

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -603,13 +603,22 @@ impl Interpreter {
                 // first one declared always won (#8089). Dispatch and binding
                 // have to agree here, or a candidate is selected and then dies
                 // binding the very call it was selected for.
-                let where_default =
-                    if !arg_was_supplied && let Some(default_expr) = pd.default.as_ref() {
-                        self.eval_block_value(&[Stmt::Expr(default_expr.clone())])
-                            .ok()
-                    } else {
-                        None
-                    };
+                // Only a `where` clause consumes this, so it is evaluated only
+                // when there is one. Evaluating it unconditionally ran every
+                // candidate's default once per dispatch, in a scope where the
+                // *earlier* parameters are not bound yet -- so a default that
+                // reads a sibling (`multi m(Str $c, $d = $c ~ "!")`) saw an
+                // unbound `$c` and emitted a spurious "Use of Nil in string
+                // context" for a value that was then thrown away (#8078).
+                let where_default = if pd.where_constraint.is_some()
+                    && !arg_was_supplied
+                    && let Some(default_expr) = pd.default.as_ref()
+                {
+                    self.eval_block_value(&[Stmt::Expr(default_expr.clone())])
+                        .ok()
+                } else {
+                    None
+                };
                 if let Some(where_expr) = &pd.where_constraint {
                     let Some(arg) = where_default.as_ref().or(arg_for_checks.as_ref()) else {
                         return false;

--- a/t/routines/dispatch/multi-nonconstant-default-no-spurious-warn.t
+++ b/t/routines/dispatch/multi-nonconstant-default-no-spurious-warn.t
@@ -1,0 +1,64 @@
+use v6;
+use Test;
+
+# A `multi` candidate whose parameter default is a non-constant expression
+# reading an earlier parameter must not emit a warning while the candidate is
+# being *matched*. mutsu evaluated every unsupplied parameter's default on the
+# dispatch path -- in a scope where the earlier parameters are not bound yet --
+# even for a candidate with no `where` clause, which is the only consumer of
+# that value. `$d = $c ~ "!"` therefore saw an unbound `$c`, warned "Use of Nil
+# in string context", and threw the result away; the value finally bound was
+# correct, so only the warning was wrong (#8078).
+#
+# The warning has to be observed on a subprocess's STDERR rather than with a
+# `CONTROL`/`CX::Warn` handler: it was raised on the dispatch path, outside the
+# caller's handler scope, so an in-process handler counted zero while the text
+# still reached the terminal. Checking STDERR is what actually pins the bug.
+
+plan 8;
+
+sub run-snippet($code) {
+    my $proc = run($*EXECUTABLE, '-e', $code, :out, :err);
+    (
+        out => $proc.out.slurp(:close).trim,
+        err => $proc.err.slurp(:close),
+    );
+}
+
+# --- the reported repro: two candidates, both with sibling-reading defaults ---
+my $two = q:to/CODE/;
+multi m(Int $c, $d = $c * 2)   { "int:$c/$d" }
+multi m(Str $c, $d = $c ~ "!") { "str:$c/$d" }
+say m("a");
+say m(3);
+CODE
+
+my %two = run-snippet($two);
+is %two<out>, "str:a/a!\nint:3/6", 'each candidate binds its own sibling-reading default';
+is %two<err>, '', 'dispatching to either candidate prints nothing on STDERR';
+
+# --- one candidate is enough: the losing candidate is not the cause ---
+my %one = run-snippet(q:to/CODE/);
+multi one(Str $c, $d = $c ~ "!") { "$c/$d" }
+say one("z");
+CODE
+is %one<out>, 'z/z!', 'a lone multi candidate binds its sibling-reading default';
+is %one<err>, '', 'a lone multi candidate prints nothing on STDERR';
+
+# --- the plain-sub baseline, which was always silent ---
+my %plain = run-snippet(q:to/CODE/);
+sub plain(Str $c, $d = $c ~ "!") { "$c/$d" }
+say plain("y");
+CODE
+is %plain<out>, 'y/y!', 'a plain sub binds its sibling-reading default';
+is %plain<err>, '', 'a plain sub prints nothing on STDERR';
+
+# --- a `where` clause DOES still consume the evaluated default (#8089) ---
+# Dispatch has to agree with binding here: the first candidate below is
+# selectable only because its omitted parameter's default is evaluated and
+# tested against the `where`. Keeping that working is what stops the fix above
+# from becoming "never evaluate a default during matching".
+multi pick($c, $d where { $_ eq 'yes' } = 'yes') { "yes:$c" }
+multi pick($c, $d)                               { "other:$c/$d" }
+is pick(1),       'yes:1',      'a candidate is still selected on its defaulted where-parameter';
+is pick(1, 'no'), 'other:1/no', 'a supplied argument still fails the where and picks the other candidate';


### PR DESCRIPTION
Closes #8078.

## The bug

A `multi` whose candidates carry non-constant parameter defaults warned once per call about a `Nil` that never appeared in the result:

```raku
multi m(Int $c, $d = $c * 2)   { "int:$c/$d" }
multi m(Str $c, $d = $c ~ "!") { "str:$c/$d" }
say m("a");
```

| | output |
| --- | --- |
| `raku` | `str:a/a!` |
| `mutsu` | `Use of Nil in string context`<br>`  in block <unit> at nilwarn.raku line 3`<br>`str:a/a!` |

The value was right; only the warning was wrong.

## Root cause: the evaluation had exactly one consumer, and it was optional

`Interpreter::args_match_params` checks an *unsupplied* parameter against the value it would actually bind, so that dispatch and binding agree — a candidate selected on its defaulted parameter must not then die binding the very call it was selected for (#8089). Part of that is evaluating the parameter's default so a `where` clause can be tested against it.

The evaluation was unconditional, but `where_default` is read in exactly one place: inside `if let Some(where_expr) = &pd.where_constraint`. For a candidate with no `where`, the result was computed and immediately dropped.

Dropping it silently would have been merely wasteful. Dropping it *loudly* is the bug: matching runs before the arguments are bound to parameter names, so a default that reads an earlier parameter (`$d = $c ~ "!"`) saw an unbound `$c`, took the `Nil` string-context path, and printed the warning that path always prints. `$c * 2` was unaffected only because numeric context does not warn — the Int candidate was evaluating a bogus default too, just quietly. The issue's own hypothesis (the *losing* candidate's default leaking) turned out to be wrong: a single candidate on its own reproduces it.

The fix gates the evaluation on `pd.where_constraint.is_some()`. Nothing else read it, so nothing else changes — and every candidate without a `where` now pays no default evaluation at dispatch time at all.

## Why the test watches STDERR

The obvious pin — a `CONTROL { when CX::Warn {...} }` counter, as `t/types/nil-str-context-warning.t` uses — counts **zero** on the broken build. The warning is raised on the dispatch path, outside the caller's handler scope, so an in-process handler never sees it while the text still reaches the terminal. (Worth knowing on its own: a warning emitted during candidate matching is currently unsuppressable from Raku code — `quietly` would not have silenced it either.)

`t/routines/dispatch/multi-nonconstant-default-no-spurious-warn.t` (8 assertions) therefore runs each snippet as a subprocess and asserts on its STDERR, the way `t/modules/module-parse-warning-once.t` does. It covers the two-candidate repro, a lone multi candidate (which reproduces it just as well), the plain-`sub` baseline that was always silent, and the #8089 shape that must keep working. On the unfixed binary it fails on exactly the two STDERR assertions; under `raku` it passes as written. `t/routines/signature/optional-param-where-runs-when-omitted.t` (#8089's own pin) stays green.

## Pre-publication gates

- `cargo fmt --all`, `make check-t-layout`: clean.
- `make lint`: all four configurations green.
- `make test`: **PASS** — 4101 files, 43627 tests.
- `make roast`: three failures, all three exactly the container-specific known reds in `docs/agent-environments.md`, at their documented shapes — `roast/6.c/S32-io/file-tests.t` `Failed: 4` (tests 6-8, 10) and `roast/S16-filehandles/filetest.t` `Failed: 25` (57-64, 69-72, 77-80, 101, 103, 105, 107), both from running as `uid 0`; `roast/S32-io/IO-Socket-Async.t` exit 124 from the sandboxed network. Nothing else in the whitelist failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK)_