### PR TITLE
perf(vm): consult the plain `@a[$i] = $v` lane before the element store's preamble

### DIFF
--- a/news/2026-09/fast-array-element-assign-runs-before-the-preamble.md
+++ b/news/2026-09/fast-array-element-assign-runs-before-the-preamble.md
@@ -1,0 +1,100 @@
+# The plain `@a[$i] = $v` store stops paying for the preamble it never needed
+
+[#8107](https://github.com/tokuhirom/mutsu/pull/8107) gave the positional element store a fast lane
+(`try_fast_array_element_assign`) that answers the target's declaration questions from the
+container's own embedded metadata instead of re-deriving them by string key. It reduced the store
+itself to a `Vec` slot write — but it was wired in at the *bottom* of
+`exec_index_assign_expr_named_op`'s dispatch chain, so a plain `@a[$i] = $v` still walked the whole
+shared preamble on the way down to it.
+
+That preamble is not small. Before any fast lane is consulted, an element store runs:
+
+- a `Range`-receiver probe against the compiler-baked local slot **and** against env, each cloning
+  the value it finds;
+- `try_deferred_token_index_assign`, which allocated the variable name as an owned `String` and then
+  scanned `code.locals` by name;
+- the ADR-0039 unit-lexical cell lookup, plus the env seed/restore it guards;
+- `reify_lazy_array_slot`, in case the array is a `LazyList` with a tail to materialize;
+- the ADR-0040 rvalue itemization hook (`fetch_proxy_for_store` → `into_deref` →
+  `itemize_for_element_store`);
+- a `Seq`-destination probe and a `Proxy`-destination probe, which between them resolve the target,
+  clone it, and clone the addressed element through any alias cells;
+- the two name-keyed cross-thread lanes and the Associative fast lane.
+
+Measured on a `--profile profiling` build by differencing two callgrind runs (a 4,000-iteration loop
+with the store against the identical loop without it), that residue was **3,097 instructions and one
+heap allocation per store**, on top of a slot write that costs a few dozen.
+
+The observation that makes this fixable is that **every one of those probes asks about a shape the
+lane has already refused**: a `Range` receiver, a deferred vivification token, a unit lexical, a
+`LazyList`, a `Seq`, a `Proxy`, an aggregate rvalue. They are not questions the store needs
+answered; they are questions the *other* stores need answered.
+
+## What landed
+
+`try_fast_array_element_assign_early` — the same lane, consulted **first**, before the preamble
+rather than after it. It is a thin wrapper that establishes, on its own, the handful of facts the
+preamble would otherwise have established for it:
+
+- `element_share_pending` and `shared_vars_active` are both clear (the `=`-element share is captured
+  in the preamble, and the two cross-thread lanes gate on the second flag);
+- the subscript is a plain non-negative `Int`;
+- the rvalue is a plain scalar, from a deliberate **allow-list** — so `fetch_proxy_for_store` and
+  `itemize_for_element_store` are provably the identity and can be skipped. An aggregate rvalue
+  itemizes, can be the target itself (`@a[0] = @a` stores a genuinely circular structure), and a
+  `Proxy` rvalue must `FETCH`; all three fall through to the unchanged full path;
+- `unit_lexical_container_cell` finds nothing for the name (this is *not* the same probe as the
+  `unit_lexical_slot` the lane already ran — the cell lookup checks the MAINLINE bucket first, which
+  the slot resolver does not);
+- the deferred-token probe's by-name slot search cannot find a slot the lane's own dual-store
+  coherence check skipped, which is possible only when the baked `target_slot` is out of range for
+  the frame.
+
+The wrapper touches nothing — not the stack, not env, not a local slot — unless the lane it calls
+commits, so a decline is free and everything downstream runs exactly as it did before.
+
+Separately, `try_deferred_token_index_assign` now borrows the variable name out of the constant pool
+instead of copying it. `code` outlives the op and is a distinct borrow from `&mut self`, so the
+owned copy bought nothing; it was the last per-store heap allocation #8069 measured.
+
+## Measured
+
+Same method as above, one base (`3f8b9c0a`), `MUTSU_JIT=off`, `target/profiling`:
+
+| per in-range store | before | after |
+| --- | ---: | ---: |
+| instructions | 3,097 | **1,210** |
+| heap allocations | 1.02 | **0.02** |
+| `Symbol::intern` calls | 0 | 0 |
+
+Wall clock on the same container, marginal cost isolated by subtracting an identical loop with the
+store removed (`target/release`, median of three): **564 ns → 277 ns** per store. rakudo's marginal
+cost on this box is roughly 40 ns, so the gap is now ~7x rather than ~14x.
+
+`benchmarks/bench-index-store.raku` goes 0.968 s → 0.829 s against rakudo's 0.715 s here (ratio
+1.35 → 1.16), and `bench-threads` 0.776 s → 0.708 s against 0.483 s (1.61 → 1.47). Those two are
+local A/B numbers for orientation only — `bench-history.tsv` on the `bench-data` branch remains the
+authority for benchmark rows in documents.
+
+## What this does not do
+
+`bench-threads` is still above 1.0, and it will stay there until #8069 §4.2-§4.4 are addressed: the
+lane stands down for the whole process once a second mutator thread exists, so the concurrent half
+of that row is untouched by anything here. Of #8069's acceptance list, the "**0** `Symbol::intern`
+calls and **0** heap allocations per store" half is now met and pinned; the ≤150 ns marginal-cost
+half is not (277 ns), and the shared-container scaling bullets belong to the sections still open.
+
+The remaining ~1,210 instructions are no longer preamble. They are the opcode dispatch itself plus
+the lane's own guard sequence — roughly twenty checks, several of which are hash probes that a
+resolved container descriptor addressed by slot (#8069 §4.1 proper) would collapse into a single
+`flags == 0` test. That descriptor is still the right end state; this change makes the cost of not
+having it visible, and small enough to measure.
+
+## Pinned by
+
+`t/collections/fast-array-element-assign.t` grows a section for the shapes the early call site now
+has to refuse on its own: a module routine's file-scope `@` (new fixture
+`t/lib/FastElemUnitLexical.rakumod`, which must not write the loading script's same-named array), a
+`Range` receiver, a deferred vivification token, a lazy array whose tail must survive the store, a
+`Seq` receiver that writes through its producer's element cells, a marked `=`-element share, and a
+concurrent store from four `start` blocks. All 44 assertions in that file pass under rakudo as well.

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -595,6 +595,16 @@ impl Interpreter {
         is_positional: bool,
         target_slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
+        // #8069 §4.1: a plain `@a[$i] = $v` is a `Vec` slot write, and every
+        // probe below asks about a shape that store has already been refused
+        // for. Consulted FIRST so the common store pays none of them; it
+        // touches nothing unless it commits, so a decline leaves the rest of
+        // this function running exactly as it did before.
+        if let Some(result) =
+            self.try_fast_array_element_assign_early(code, name_idx, is_positional, target_slot)
+        {
+            return result;
+        }
         // The VM local slot is authoritative for a lexical scalar between env
         // synchronization points.  A Range receiver is immutable even when the
         // scalar wrapper came from ordinary `my $r = ...` assignment.

--- a/src/vm/vm_var_assign_element_fast.rs
+++ b/src/vm/vm_var_assign_element_fast.rs
@@ -29,6 +29,124 @@
 use super::*;
 
 impl Interpreter {
+    /// [`Self::try_fast_array_element_assign`], consulted *before* the element
+    /// store's shared preamble rather than after it.
+    ///
+    /// The lane below deletes the store's own cost, but it used to sit at the
+    /// bottom of `exec_index_assign_expr_named_op`'s dispatch chain, so a plain
+    /// `@a[$i] = $v` still paid the whole preamble on the way down: a `Range`
+    /// receiver probe against both the local slot and env, a deferred
+    /// vivification-token probe (which allocated the variable name as a
+    /// `String` and scanned `code.locals` by name), the ADR-0039 unit-lexical
+    /// cell seed/restore, a lazy-array reify probe, the rvalue itemization
+    /// hook, and a `Seq`/`Proxy` destination resolve that clones the target and
+    /// the addressed element. Measured on a `--profile profiling` build
+    /// (#8069), that residue was **3,097 instructions and one heap allocation**
+    /// per store after the lane itself had been reduced to a `Vec` slot write;
+    /// running the lane first brings it to 1,210 instructions and none.
+    ///
+    /// Every one of those probes asks about a shape this lane has *already
+    /// refused* -- a `Range`, a token, a unit lexical, a `LazyList`, a `Seq`, a
+    /// `Proxy`, an aggregate rvalue. So the honest order is to ask the cheap,
+    /// container-answered questions first and only run the preamble for the
+    /// stores that actually need it. This function is that reordering: it adds
+    /// the handful of guards that the preamble would otherwise have
+    /// established, then defers to the same lane.
+    ///
+    /// It touches nothing -- not the stack, not env, not a local slot -- unless
+    /// the lane it calls commits, so declining is free and the full path
+    /// downstream runs exactly as it did before.
+    pub(crate) fn try_fast_array_element_assign_early(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        is_positional: bool,
+        target_slot: Option<u32>,
+    ) -> Option<Result<(), RuntimeError>> {
+        if !is_positional {
+            return None;
+        }
+        // Slice 2b's `=`-element share is captured in the preamble and consumed
+        // by the lane's caller; the early call site is above that capture, so
+        // the only safe answer while one is pending is to decline (and, above
+        // all, NOT to clear the flag).
+        if self.element_share_pending {
+            return None;
+        }
+        // The two name-keyed cross-thread lanes (`try_shared_hash_element_assign`
+        // / `try_shared_array_element_assign`) are skipped by running here, and
+        // they own the store whenever a thread shares this env. Their own gate
+        // is this exact flag.
+        if self.shared_vars_active {
+            return None;
+        }
+        let stack_len = self.stack.len();
+        if stack_len < 2 {
+            return None;
+        }
+        // The preamble's `Whatever` refusal, the `Seq` element-cell store and
+        // the slice paths all need a subscript this lane would reject anyway;
+        // check it up front so the guards below are only paid for the shape the
+        // lane can actually serve.
+        if !matches!(self.stack[stack_len - 1].view(), ValueView::Int(n) if n >= 0) {
+            return None;
+        }
+        // `itemize_for_element_store` (the preamble's ADR-0040 rvalue hook) and
+        // `fetch_proxy_for_store` are both the IDENTITY on a plain scalar
+        // rvalue, which is what lets this call site skip them. An aggregate
+        // rvalue itemizes, can BE the target (`@a[0] = @a` stores a genuinely
+        // circular structure), and a `Proxy` rvalue must FETCH -- all three are
+        // the preamble's business. Deliberately an allow-list: a variant this
+        // lane has not reasoned about falls through to the unchanged full path.
+        if !matches!(
+            self.stack[stack_len - 2].view(),
+            ValueView::Int(_)
+                | ValueView::BigInt(_)
+                | ValueView::Num(_)
+                | ValueView::Str(_)
+                | ValueView::Bool(_)
+                | ValueView::Rat(..)
+                | ValueView::FatRat(..)
+                | ValueView::BigRat(..)
+                | ValueView::Complex(..)
+                | ValueView::Enum { .. }
+                | ValueView::Instance { .. }
+                | ValueView::Version { .. }
+        ) {
+            return None;
+        }
+        let var_name = Self::const_str(code, name_idx);
+        // Checked here as well as in the lane: every guard below is keyed on
+        // the name, and only an `@` name can reach the lane at all.
+        if !var_name.as_bytes().starts_with(b"@") {
+            return None;
+        }
+        // ADR-0039 slice 1: a compunit's own file-scope `@` is stored in the
+        // `unit_lexicals` cell, and the preamble seeds env from it around the
+        // store. The lane reads env directly, so it must not run for a name the
+        // seed would have redirected. (`unit_lexical_slot`, which the lane
+        // already probes, does not see the MAINLINE bucket this cell lookup
+        // checks first, so the two are not interchangeable.) Opens with the
+        // same `unit_lexicals.is_empty()` gate, so a program with no captured
+        // file-scope lexicals pays one `is_empty`.
+        if self.unit_lexical_container_cell(var_name).is_some() {
+            return None;
+        }
+        // A variable still holding a deferred vivification token is resolved by
+        // `try_deferred_token_index_assign`, which finds its slot BY NAME. The
+        // lane's own dual-store coherence check uses the compiler-baked
+        // `target_slot` and would catch the token there -- except when the
+        // baked slot is out of range for this frame, where the lane skips the
+        // check entirely and the by-name search would still find one. Close
+        // that gap explicitly; in the common case it is one comparison.
+        if target_slot.is_some_and(|slot| (slot as usize) >= self.locals.len())
+            && self.find_local_slot(code, var_name).is_some()
+        {
+            return None;
+        }
+        self.try_fast_array_element_assign(code, name_idx, is_positional, target_slot, false)
+    }
+
     /// Fast path for a simple positional element store: `@a[$i] = $v`.
     ///
     /// Returns `Some(Ok(()))` when it handled the store, `None` when the caller

--- a/src/vm/vm_var_deferred_token.rs
+++ b/src/vm/vm_var_deferred_token.rs
@@ -46,8 +46,12 @@ impl Interpreter {
         if depth == 0 || self.stack.len() < depth + 1 {
             return None;
         }
-        let var_name = Self::const_str(code, name_idx).to_string();
-        let slot = self.find_local_slot(code, &var_name)?;
+        // Borrowed from the constant pool, not copied: `code` outlives the op
+        // and is a distinct borrow from `&mut self`. This probe runs on EVERY
+        // element store and delete, and the owned copy was the last remaining
+        // per-store heap allocation #8069 measured.
+        let var_name = Self::const_str(code, name_idx);
+        let slot = self.find_local_slot(code, var_name)?;
         let token = self.locals.get(slot)?.clone();
         let ValueView::HashEntryRef { eager, .. } = token.view() else {
             return None;

--- a/t/collections/fast-array-element-assign.t
+++ b/t/collections/fast-array-element-assign.t
@@ -1,4 +1,6 @@
+use lib 't/lib';
 use Test;
+use FastElemUnitLexical;
 
 # `@a[$i] = $v` on a plain, untyped, unbound array with an in-range Int index
 # is served by `try_fast_array_element_assign` (#8069 §2), which bypasses the
@@ -7,7 +9,7 @@ use Test;
 # lane (and must still be right) or makes it decline (and must still reach the
 # path that handles it).
 
-plan 34;
+plan 44;
 
 # --- the fast lane itself -----------------------------------------------
 
@@ -149,3 +151,57 @@ my @ident = 0 xx 2;
 my $before = @ident.WHICH;
 @ident[0] = 1;
 is @ident.WHICH, $before, 'the array keeps its identity across an element store';
+
+# --- shapes the EARLY call site must decline -----------------------------
+#
+# The lane is consulted before the element store's shared preamble (#8069
+# S4.1 follow-up), so it now has to refuse, on its own, every shape that
+# preamble used to resolve first. One pin per skipped step.
+
+# A compunit's own file-scope `@` is authoritatively the `unit_lexicals` cell;
+# the bare env key of the same name belongs to whatever scope LOADED the
+# module. The preamble seeds env from that cell around the store, so the lane
+# must not run for such a name.
+my @roster = 'script' xx 3;
+set-slot(1, 'module');
+is read-slot(1), 'module', "a module routine's store reaches its own file-scope array";
+is @roster[1], 'script', "and leaves the loading script's same-named array alone";
+
+# A `Range` receiver is immutable; the refusal lives in the preamble.
+my $range-recv = 1..5;
+dies-ok { $range-recv[0] = 9 }, 'a Range receiver still refuses an element store';
+
+# A variable still holding a DEFERRED vivification token has no container yet:
+# the store has to walk-create the path and promote the binding to a cell.
+my %deferred;
+my $tok := %deferred<g>;
+$tok[0] = 'x';
+is %deferred<g>.raku, '$["x"]', 'a deferred vivification token still walk-creates its path';
+
+# A lazy array reifies a bounded prefix around the store and must NOT collapse
+# into a finite Array.
+my @lz = lazy (1, 2, 3, 4).Seq;
+@lz[0] = 9;
+is @lz[0], 9, 'an element store on a lazy array lands';
+is @lz[3], 4, 'and the lazy tail survives it';
+
+# A `Seq` receiver writes THROUGH the producer's element cells.
+my @seq-base = 1, 2, 3;
+my \seq-view = @seq-base.values;
+seq-view[0] = 'x';
+is @seq-base.raku, '["x", 2, 3]', 'a Seq receiver still writes through its element cells';
+
+# Slice 2b: `@aoa[i] = @row` is compiled as a `:=` bind plus an element-share
+# mark, which the preamble captures. The lane cannot honour a pending share.
+my @aoa = [0, 0];
+my @row = 7, 8;
+@aoa[0] = @row;
+is @aoa.raku, '[[7, 8], 0]', 'an aggregate rvalue still stores as one element';
+@row[0] = 100;
+is @aoa[0][0], 100, 'and the marked element still shares with its source';
+
+# Once a second mutator thread exists the store belongs to the name-keyed
+# cross-thread lanes, whose gate the early call site checks before the lane.
+my @shared = 0 xx 4;
+await (^4).map: -> $i { start { @shared[$i] = $i + 1 } };
+is @shared.raku, '[1, 2, 3, 4]', 'every concurrent element store lands';

--- a/t/lib/FastElemUnitLexical.rakumod
+++ b/t/lib/FastElemUnitLexical.rakumod
@@ -1,0 +1,15 @@
+unit module FastElemUnitLexical;
+
+# A compunit's own file-scope `@` lives in the `unit_lexicals` cell, not in the
+# bare env key of whatever scope loaded this module. `set-slot` must therefore
+# write THIS array, even when the loading script has a same-named `@roster` of
+# its own.
+my @roster = 0 xx 3;
+
+sub set-slot($i, $v) is export {
+    @roster[$i] = $v;
+}
+
+sub read-slot($i) is export {
+    @roster[$i];
+}


### PR DESCRIPTION
#8107 reduced a plain positional element store to a `Vec` slot write — but wired the lane in at the **bottom** of `exec_index_assign_expr_named_op`'s dispatch chain, so the store still walked the whole shared preamble on the way down to it. That residue was the "next thing" #8107's own release note pointed at.

## The preamble a plain store was paying for

Before any fast lane is consulted, an element store runs:

- a `Range`-receiver probe against the compiler-baked local slot **and** against env, each cloning the value it finds;
- `try_deferred_token_index_assign`, which allocated the variable name as an owned `String` and then scanned `code.locals` by name;
- the ADR-0039 unit-lexical cell lookup, plus the env seed/restore it guards;
- `reify_lazy_array_slot`, in case the array is a `LazyList` with a tail to materialize;
- the ADR-0040 rvalue itemization hook (`fetch_proxy_for_store` → `into_deref` → `itemize_for_element_store`);
- a `Seq`-destination probe and a `Proxy`-destination probe, which between them resolve the target, clone it, and clone the addressed element through any alias cells;
- the two name-keyed cross-thread lanes and the Associative fast lane.

**Every one of those probes asks about a shape the lane has already refused** — a `Range`, a token, a unit lexical, a `LazyList`, a `Seq`, a `Proxy`, an aggregate rvalue. They are questions the *other* stores need answered, not this one.

## What this does

`try_fast_array_element_assign_early` is the same lane, consulted first. It is a thin wrapper that establishes, on its own, the facts the preamble would otherwise have established for it:

- `element_share_pending` and `shared_vars_active` are both clear (the `=`-element share is captured in the preamble, and the two cross-thread lanes gate on the second flag);
- the subscript is a plain non-negative `Int`;
- the rvalue is a plain scalar, from a deliberate **allow-list** — which is what makes `fetch_proxy_for_store` and `itemize_for_element_store` provably the identity and therefore skippable. An aggregate rvalue itemizes, can be the target itself (`@a[0] = @a` stores a genuinely circular structure), and a `Proxy` rvalue must `FETCH`; all three fall through to the unchanged full path;
- `unit_lexical_container_cell` finds nothing for the name — *not* the same probe as the `unit_lexical_slot` the lane already ran, since the cell lookup checks the MAINLINE bucket first;
- the deferred token's by-name slot search cannot find a slot the lane's own dual-store coherence check skipped, which is possible only when the baked `target_slot` is out of range for the frame.

The wrapper touches nothing — not the stack, not env, not a local slot — unless the lane it calls commits, so a decline is free and everything downstream runs exactly as it did before.

Separately, `try_deferred_token_index_assign` now borrows the variable name out of the constant pool instead of copying it (`code` outlives the op and is a distinct borrow from `&mut self`, so the owned copy bought nothing). It was the last per-store heap allocation #8069 measured.

## Measured

Differencing two callgrind runs — a 4,000-iteration loop with the store against the identical loop without it — on one base (`3f8b9c0a`), `MUTSU_JIT=off`, `target/profiling`:

| per in-range store | before | after |
| --- | ---: | ---: |
| instructions | 3,097 | **1,210** |
| heap allocations | 1.02 | **0.02** |
| `Symbol::intern` calls | 0 | 0 |

Wall clock on the same container, marginal cost isolated by subtracting an identical loop with the store removed (`target/release`, median of three): **564 ns → 277 ns** per store, against rakudo's ~40 ns here.

`benchmarks/bench-index-store.raku` 0.968 s → 0.829 s (rakudo 0.715 s here; ratio 1.35 → 1.16) and `bench-threads` 0.776 s → 0.708 s (rakudo 0.483 s; 1.61 → 1.47). Those two are local A/B numbers for orientation only — `bench-history.tsv` remains the authority for benchmark rows in documents.

## Scope

This is still the **single-threaded** half of #8069. The lane stands down for the whole process once a second mutator thread exists, so §4.2–§4.4 (the shared-container lane, the read-side lock, the double refcount) are untouched and the issue stays open. Of #8069 §5's acceptance list, the "**0** interns and **0** heap allocations per store" half is now met; the ≤150 ns marginal-cost half is not.

## Testing

- `make test` — PASS (4,102 files, 43,669 tests).
- `make roast` — the only failures are the three `docs/agent-environments.md` documents as container-only: `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` (both run as `uid 0`, so their `chmod`-based assertions are meaningless) and `roast/S32-io/IO-Socket-Async.t` (sandboxed network, exit 124 at "planned 40 ran 17").
- `make lint` — all four configurations green (default clippy, `jit` off, wasm32 lib, rustdoc).
- `t/collections/fast-array-element-assign.t` grows a section pinning the shapes the early call site now has to refuse on its own: a module routine's file-scope `@` (new fixture `t/lib/FastElemUnitLexical.rakumod`, which must not write the loading script's same-named array), a `Range` receiver, a deferred vivification token, a lazy array whose tail must survive the store, a `Seq` receiver that writes through its producer's element cells, a marked `=`-element share, and a concurrent store from four `start` blocks. All 44 assertions in that file pass under rakudo as well.

Refs #8069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoRrJgwXv3pryDCnR3aYKS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoRrJgwXv3pryDCnR3aYKS)_