### PR TITLE
fix(vm): reject named args on positional light calls

### DIFF
--- a/news/2026-09/positional-light-rejects-named-arguments.md
+++ b/news/2026-09/positional-light-rejects-named-arguments.md
@@ -1,0 +1,3 @@
+Positional light-call dispatch now keeps syntactically named arguments on the
+general binder path, so a named argument is rejected instead of being bound to
+a positional parameter.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2813,7 +2813,7 @@ impl Compiler {
                     self.declare_local(name);
                 }
             }
-            entries.push(if let Some(name) = Self::positional_arg_source_name(arg) {
+            let source = if let Some(name) = Self::positional_arg_source_name(arg) {
                 // §1.4/§1.5: bake the caller's local slot for a plain source var
                 // as `Pair(name, Int(slot))`, so the rw-arg writeback can target
                 // the LIVE (inner shadow) slot instead of the by-name `position`
@@ -2828,6 +2828,21 @@ impl Compiler {
                 }
             } else {
                 Value::NIL
+            };
+            // ADR-0021: the namedness of an argument belongs to the call site,
+            // not to the runtime Pair flavour. Preserve that fact alongside
+            // the existing source descriptor so positional-light dispatch can
+            // refuse a named argument without losing rw-source tracking. A
+            // bare `FALSE` means named-without-a-source; an array beginning
+            // with `FALSE` carries the ordinary source descriptor in slot 1.
+            entries.push(if Self::is_named_arg_expr(arg) {
+                if source.is_nil() {
+                    Value::FALSE
+                } else {
+                    Value::array(vec![Value::FALSE, source])
+                }
+            } else {
+                source
             });
         }
         if entries.iter().all(|v| v.is_nil()) {

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1759,7 +1759,23 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             {
                 return Ok(Expr::DoStmt(Box::new(lower_stmt_inner(declaration)?)));
             }
-            lower_expr(inner)
+            let lowered = lower_expr(inner)?;
+            // A parenthesized bareword fat-arrow is a positional Pair at the
+            // call site (`f((a => 1))`), even though RakuAST represents the
+            // pair itself with the same `FatArrow` node as an unparenthesized
+            // named argument. Preserve the parser's `PositionalPair` marker
+            // across the RakuAST round trip so call-site namedness remains
+            // observable to the compiler.
+            if matches!(
+                &lowered,
+                Expr::Binary {
+                    op: crate::token_kind::TokenKind::FatArrow,
+                    ..
+                }
+            ) {
+                return Ok(Expr::PositionalPair(Box::new(lowered)));
+            }
+            Ok(lowered)
         }
         // `[1, 2, 3]` -> an array literal. The composer wraps a `SemiList` of a
         // single `Statement::Expression` (a comma list, or a lone element).

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -30,6 +30,7 @@ impl Interpreter {
         name: &str,
         args: &[Value],
         arg_sources: &Option<Vec<Option<String>>>,
+        call_has_named: bool,
         compiled_fns: &CompiledFns,
     ) -> Result<Option<Value>, RuntimeError> {
         // Skip auto-threading for internal functions and junction constructors
@@ -181,6 +182,7 @@ impl Interpreter {
                 name,
                 &threaded_args,
                 arg_sources,
+                call_has_named,
                 compiled_fns,
             )? {
                 results.push(recursive_result);
@@ -192,6 +194,7 @@ impl Interpreter {
                     name,
                     threaded_args,
                     arg_sources.clone(),
+                    call_has_named,
                     call_me_override,
                     compiled_fns,
                 )?;

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -381,7 +381,7 @@ impl Interpreter {
         // `_inner`, not the wrapper: this frame's mask is already published by
         // `exec_call_func_named_op`, and re-entering the wrapper would
         // overwrite it with a zero it was never given.
-        self.exec_call_func_op_inner(code, name_idx, arity, arg_sources_idx, compiled_fns)
+        self.exec_call_func_op_inner(code, name_idx, arity, arg_sources_idx, true, compiled_fns)
     }
 
     /// Publish the call site's literal-argument mask for the duration of the
@@ -400,7 +400,15 @@ impl Interpreter {
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         let saved = std::mem::replace(&mut self.literal_native_args, literal_native_args);
-        let r = self.exec_call_func_op_inner(code, name_idx, arity, arg_sources_idx, compiled_fns);
+        let call_has_named = Self::stack_args_have_named(code, arg_sources_idx);
+        let r = self.exec_call_func_op_inner(
+            code,
+            name_idx,
+            arity,
+            arg_sources_idx,
+            call_has_named,
+            compiled_fns,
+        );
         self.literal_native_args = saved;
         r
     }
@@ -411,6 +419,7 @@ impl Interpreter {
         name_idx: u32,
         arity: u32,
         arg_sources_idx: Option<u32>,
+        call_has_named: bool,
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_function_dispatch();
@@ -670,6 +679,7 @@ impl Interpreter {
                             Self::call_shares_container_into_scalar_param(cf, stack_args);
                         if !has_junction
                             && !call_has_slip
+                            && !call_has_named
                             && !share_into_scalar
                             // This cache is keyed by NAME, so one entry serves
                             // every arity the call sites use. A routine the
@@ -927,6 +937,7 @@ impl Interpreter {
                         } else if !share_into_scalar
                             && !named_share
                             && !mainline_capture_blocked
+                            && !call_has_named
                             && Self::is_positional_light_call_eligible(
                                 &cf,
                                 name_str,
@@ -1212,9 +1223,14 @@ impl Interpreter {
         // Junction auto-threading for function call arguments:
         // If any positional arg is a Junction and the function parameter doesn't accept
         // Junction (i.e., not typed as Mu or Junction), auto-thread over the junction.
-        if let Some(autothread_result) =
-            self.maybe_autothread_func_call(code, &name, &args, &arg_sources, compiled_fns)?
-        {
+        if let Some(autothread_result) = self.maybe_autothread_func_call(
+            code,
+            &name,
+            &args,
+            &arg_sources,
+            call_has_named,
+            compiled_fns,
+        )? {
             self.stack.push(autothread_result);
             // Slice F: the threaded eigenstate calls may have mutated captured-outer
             // variables (`sub j($x) { $count++ }`); write their accumulated final
@@ -1326,6 +1342,7 @@ impl Interpreter {
             &name,
             args,
             arg_sources,
+            call_has_named,
             call_me_override,
             compiled_fns,
         ) {
@@ -1546,12 +1563,14 @@ impl Interpreter {
 
     /// Inner dispatch for function calls. Handles CALL-ME override, compiled functions,
     /// native functions, and interpreter fallback. Returns the result value.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn dispatch_func_call_inner(
         &mut self,
         code: &CompiledCode,
         name: &str,
         args: Vec<Value>,
         arg_sources: Option<Vec<Option<String>>>,
+        call_has_named: bool,
         call_me_override: Option<Value>,
         compiled_fns: &CompiledFns,
     ) -> Result<Value, RuntimeError> {
@@ -1620,12 +1639,14 @@ impl Interpreter {
             if let Some(cf) = compiled {
                 // Try positional light call path first (ultra-fast, no env clone).
                 // Skip for multi functions since the cache doesn't differentiate by arg types.
-                if Self::is_positional_light_call_eligible(
-                    cf,
-                    name,
-                    Self::positional_light_argc(&args),
-                    &args,
-                ) && !Self::call_shares_container_into_scalar_param(cf, &args)
+                if !call_has_named
+                    && Self::is_positional_light_call_eligible(
+                        cf,
+                        name,
+                        Self::positional_light_argc(&args),
+                        &args,
+                    )
+                    && !Self::call_shares_container_into_scalar_param(cf, &args)
                     && !self.has_multi_candidates_cached(name)
                     && !loan_env!(self, routine_is_test_assertion_by_name(name, &args))
                     && self.wrap_sub_id_for_name(name).is_none()

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -78,6 +78,36 @@ impl Interpreter {
         Self::decode_arg_slip_positions(code, arg_sources_idx).is_some()
     }
 
+    /// Does this call site contain a syntactically named argument?
+    ///
+    /// ADR-0021 makes namedness a call-site property. `FALSE` is the compact
+    /// descriptor for a named argument without an rw source; an array whose
+    /// first element is `FALSE` carries the ordinary rw-source descriptor in
+    /// its second element. This is deliberately separate from the runtime
+    /// Pair flavour, which cannot distinguish `f(:x)` from a positional Pair
+    /// by the time the positional-light binder sees the value.
+    #[inline]
+    pub(super) fn stack_args_have_named(code: &CompiledCode, arg_sources_idx: Option<u32>) -> bool {
+        let Some(idx) = arg_sources_idx else {
+            return false;
+        };
+        let ValueView::Array(items, ..) = code.constants[idx as usize].view() else {
+            return false;
+        };
+        items.iter().any(Self::arg_source_entry_is_named)
+    }
+
+    #[inline]
+    fn arg_source_entry_is_named(item: &Value) -> bool {
+        match item.view() {
+            ValueView::Bool(false) => true,
+            ValueView::Array(items, ..) => items
+                .first()
+                .is_some_and(|marker| matches!(marker.view(), ValueView::Bool(false))),
+            _ => false,
+        }
+    }
+
     /// Spread a call's raw arguments by call-site syntax (ADR-0054 S1/S2),
     /// not by a value's runtime Slip-shape: only a position the compiler
     /// recorded as `|EXPR` (`decode_arg_slip_positions`) spreads. Every other
@@ -217,25 +247,43 @@ impl Interpreter {
         let mut slots: Vec<(String, u32)> = Vec::new();
         let names: Vec<Option<String>> = items
             .iter()
-            .map(|item| match item.view() {
-                ValueView::Str(name) => Some(name.to_string()),
-                // A slotted source is `Pair(name, Int(slot))`; extract the name here
-                // (byte-identical for name-only consumers) and record the slot.
-                ValueView::Pair(name, val) => {
-                    if let ValueView::Int(slot) = val.view()
-                        && slot >= 0
-                    {
-                        slots.push((name.clone(), slot as u32));
+            .map(|item| {
+                Self::decode_arg_source_entry(item).map(|(name, slot)| {
+                    if let Some(slot) = slot {
+                        slots.push((name.clone(), slot));
                     }
-                    Some(name.clone())
-                }
-                _ => None,
+                    name
+                })
             })
             .collect();
         for (name, slot) in slots {
             self.pending_call_arg_source_slots.insert(name, slot);
         }
         Some(names)
+    }
+
+    /// Decode the source half of an argument descriptor. Named arguments use
+    /// `[FALSE, source]` so this helper keeps their source name/slot visible
+    /// to rw writeback and container-sharing checks.
+    fn decode_arg_source_entry(item: &Value) -> Option<(String, Option<u32>)> {
+        match item.view() {
+            ValueView::Str(name) => Some((name.to_string(), None)),
+            ValueView::Pair(name, val) => {
+                let slot = match val.view() {
+                    ValueView::Int(slot) if slot >= 0 => Some(slot as u32),
+                    _ => None,
+                };
+                Some((name.clone(), slot))
+            }
+            ValueView::Array(items, ..)
+                if items
+                    .first()
+                    .is_some_and(|marker| matches!(marker.view(), ValueView::Bool(false))) =>
+            {
+                items.get(1).and_then(Self::decode_arg_source_entry)
+            }
+            _ => None,
+        }
     }
 
     /// Positions this call wrote as `|EXPR` (ADR-0054 S1/S2), decoded from the

--- a/t/vm/frames/positional-light-rejects-named-arguments.t
+++ b/t/vm/frames/positional-light-rejects-named-arguments.t
@@ -1,0 +1,23 @@
+use Test;
+
+# The positional-light binder receives Pair values by position. A named
+# argument must therefore keep this call on the general binder, which rejects
+# it instead of binding the Pair to the next positional parameter.
+
+plan 6;
+
+sub constant-default($x, $y = 2) { "$x/$y" }
+
+is constant-default(1, 2), '1/2',
+    'a full-arity call still uses the positional light path';
+dies-ok { constant-default(1, :verbose) },
+    'a bare named argument is not bound positionally';
+dies-ok { constant-default(1, :verbose(True)) },
+    'a valued named argument is not bound positionally';
+is constant-default(3), '3/2',
+    'the constant default still fills an omitted parameter';
+sub positional-pair($x, $y = 2) { $y.^name }
+is positional-pair(4, (y => 9)), 'Pair',
+    'a parenthesized Pair remains a positional argument';
+is constant-default(5, 6), '5/6',
+    'the cache remains usable after a rejected named call';


### PR DESCRIPTION
Closes #8077

## Summary

- carry call-site namedness through the existing argument-source descriptor
- keep syntactically named arguments on the general binder path across cached, OTF, cold, and autothread dispatch
- preserve rw source descriptors and parenthesized Pair semantics across RakuAST lowering
- add a focused regression test and news entry

## Validation

- `cargo fmt --all`
- `make lint`
- `make test` — 4101 files, 43625 tests, PASS
- `make roast` — 1437 files, 219658 tests, PASS
