### PR TITLE
fix(grammar): restore both halves of a $*-sigil dynvar alias pair after .parse

### DIFF
--- a/news/2026-09/grammar-dynvar-scalar-alias-restore.md
+++ b/news/2026-09/grammar-dynvar-scalar-alias-restore.md
@@ -1,0 +1,32 @@
+# A grammar `:my $*VAR` no longer leaks past `.parse` into the caller's scope
+
+`:my $*VAR = …;` inside a grammar rule body declares a dynamic variable, and
+`establish_grammar_dynamic_vars` (`src/runtime/methods_grammar.rs`) evaluates such declarations
+into `self.env` before the parse starts, saving the prior value so `.parse`'s caller sees it
+restored afterward. The save/restore was keyed on `dynamic_decl_var_key`'s result directly — which
+keeps the `$` sigil (`$*LAST`) — while the actual runtime storage for a `$*`-sigil dynamic variable
+lives under a bare-name/sigil-kept **alias pair** kept in sync by
+`set_env_with_main_alias_inner`'s `twigil_dynamic_alias` (`*LAST` and `$*LAST` both hold the same
+value, updated together). Saving and restoring only the sigil-kept half left the bare half's value
+in place, so a `rust-gdb` trace on every `Env::insert` of the variable's key showed the restore loop
+correctly clearing `*LAST` while `$*LAST` (the half a plain `$*LAST` read actually resolves through)
+kept its stale value — the observable leak.
+
+The fix tracks and restores both halves of the pair for a `$`-sigil dynamic variable.  `@*`/`%*`
+dynamic variables have no such pair (only ever one, sigil-kept key) and are unaffected.
+
+```raku
+grammar H {
+    token sigil:sym<dollar> { :my $*LAST = 'dollar'; '$' }
+    ...
+}
+H.parse('$', :actions(B));
+say $*LAST // 'unset';   # mutsu (before): dollar   raku / mutsu (after): unset
+```
+
+A narrower, deeper half of the original report — the same declaration is also visible, *during* the
+parse, to actions of sibling rules that never matched at all (an LTM candidate that loses still runs
+its `:my` declaration) — needed real per-rule dynamic-scope tracking through the token-call/LTM
+candidate machinery, which is a cross-cutting change, not a local fix; filed separately as #8148.
+
+Fixes #8096 (the leaks-past-`.parse` half).

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -72,14 +72,34 @@ impl Interpreter {
         }
         // Evaluate each declaration in `self.env`, saving the prior value.
         let mut saved: Vec<(String, Option<Value>)> = Vec::new();
-        for (code, var_key) in decls
+        for (code, raw_key) in decls
             .iter()
             .filter_map(|d| Self::dynamic_decl_var_key(d).map(|k| (d, k)))
         {
+            // A `$`-sigil dynamic variable lives in env under TWO keys kept in
+            // sync as an alias pair by `set_env_with_main_alias_inner`'s
+            // `twigil_dynamic_alias`: the bare form (`$*S` -> `*S`, what a
+            // `my $*x = ...;` declaration and the reduce-time
+            // `install_fresh_rule_dynvars` write and read) and the sigil-kept
+            // form (`$*S`) that a plain `$*x` read can also resolve through.
+            // `@*A` / `%*H` have no such pair -- only their sigil-kept key
+            // exists. Saving/restoring only one half of the pair left the
+            // other one untouched by the restore below, so a `$*`-sigil
+            // declaration leaked past `.parse` into the caller's scope
+            // (#8096).
+            let is_scalar_dynvar = raw_key.starts_with('$');
+            let var_key = match raw_key.strip_prefix('$') {
+                Some(rest) => rest.to_string(),
+                None => raw_key,
+            };
             if saved.iter().any(|(k, _)| k == &var_key) {
                 continue;
             }
             saved.push((var_key.clone(), self.env.get(&var_key).cloned()));
+            if is_scalar_dynvar {
+                let alias_key = format!("${var_key}");
+                saved.push((alias_key.clone(), self.env.get(&alias_key).cloned()));
+            }
             let source = format!("{code};");
             if let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&source) {
                 let _ = self.eval_block_value(&stmts);

--- a/t/grammar/grammar-dynvar-scope-leak.t
+++ b/t/grammar/grammar-dynvar-scope-leak.t
@@ -1,0 +1,53 @@
+use Test;
+
+# `:my $*VAR = …;` inside a grammar rule body declares a dynamic variable
+# scoped to that rule's own match, in rakudo's model. mutsu instead
+# establishes every such declaration in `self.env` before the parse starts,
+# and until now failed to fully undo it afterward for a SCALAR (`$*`)
+# variable: `set_env_with_main_alias_inner` keeps a `$*x`/`*x` alias PAIR in
+# sync (a bare env key `*x` and a sigil-kept `$*x`), but the establish/restore
+# save-and-restore only tracked one half of that pair -- so restoring left the
+# other half's stale value in place, and `$*LAST` was still visible to the
+# caller after `.parse` returned (GH #8096).
+#
+# The narrower "established for the whole parse rather than only the
+# declaring rule's own match" half of #8096 (a `:my` in a losing LTM
+# candidate still runs and is visible to actions of unrelated/sibling rules)
+# is NOT fixed here and is NOT asserted below -- see the issue for that
+# remaining, deeper gap.
+
+plan 4;
+
+grammar H {
+    proto token sigil { * }
+    token sigil:sym<dollar> { :my $*LAST = 'dollar'; '$' }
+    token sigil:sym<at>     { '@' }
+    token TOP { <sigil> }
+}
+class B { method TOP($/) { make $*LAST // 'none' } }
+
+H.parse('$', :actions(B));
+is ($*LAST // 'unset'), 'unset', 'a $*-sigil grammar dynvar does not leak past .parse (1)';
+
+H.parse('@', :actions(B));
+is ($*LAST // 'unset'), 'unset', 'and not after a second .parse either (2)';
+
+# A pre-existing outer `$*LAST` must survive a parse of the same name
+# unharmed (the restore puts back what was there, not just removes it).
+{
+    my $*LAST = 'outer';
+    H.parse('$', :actions(B));
+    is $*LAST, 'outer', 'a pre-existing same-named dynvar is restored after .parse';
+}
+
+# The `@*`/`%*`-sigil case (no alias pair -- only ever had one key) keeps
+# working: no regression from the `$*`-specific alias-pair fix above.
+grammar P {
+    token TOP { :my @*SEEN = (); <item>+ % ',' }
+    token item { \w+ }
+}
+class PA {
+    method item($/) { @*SEEN.push(~$/) }
+    method TOP($/) { make @*SEEN.join('|') }
+}
+is P.parse('a,b,c', :actions(PA)).made, 'a|b|c', 'an @*-sigil grammar dynvar still accumulates across sibling matches';


### PR DESCRIPTION
## Summary

`:my $*VAR = …;` inside a grammar rule body declares a dynamic variable, and
`establish_grammar_dynamic_vars` (`src/runtime/methods_grammar.rs`) evaluates such declarations
into `self.env` before the parse starts, saving the prior value so `.parse`'s caller sees it
restored afterward.

## Repro

```raku
grammar H {
    proto token sigil { * }
    token sigil:sym<dollar> { :my $*LAST = 'dollar'; '$' }
    token sigil:sym<at>     { '@' }
    token TOP { <sigil> }
}
class B { method TOP($/) { make $*LAST // 'none' } }
H.parse('$', :actions(B));
say $*LAST // 'unset';
```
| | rakudo | mutsu (before) |
|---|---|---|
| output | `unset` | `dollar` |

## Root cause (traced with `rust-gdb`)

Breaking on every `Env::insert` of the variable's key showed writes from two spots
(`exec_set_local_op_inner` and `sync_env_from_locals`, both via
`set_env_with_main_alias_inner`) landing on **two** keys: the bare form (`*LAST`) and a sigil-kept
alias (`$*LAST`), kept in sync by `twigil_dynamic_alias` — a pairing `@*`/`%*` variables do not
have (only ever one, sigil-kept key). `establish_grammar_dynamic_vars`'s save/restore was keyed on
`dynamic_decl_var_key`'s result directly, which keeps the sigil (`$*LAST`) — so it saved/restored
the wrong half of the pair: the restore loop correctly cleared `*LAST` (confirmed with a breakpoint
right there), but never touched `$*LAST`, the half a plain `$*LAST` read actually resolves through.

## Fix

Track and restore **both** halves of the pair for a `$`-sigil dynamic variable. `@*`/`%*` variables
are unaffected (no pair to mishandle).

## What this does not fix — filed as #8148

A narrower, deeper half of the original report: the same declaration is also visible, *during* the
parse, to actions of sibling rules that never matched at all (a losing LTM candidate still runs its
`:my` declaration — traced this too: `sigil:sym<dollar>` gets tried as a proto-token candidate even
when `sigil:sym<at>` wins, and its `VarDecl` atom isn't made inert during that trial the way a
`{ … }` code atom already is under `LTM_DECLARATIVE_MODE`). Fixing that needs real per-rule
dynamic-scope tracking through the token-call/LTM candidate machinery — a cross-cutting change, not
a local fix. Filed as #8148 with the trace evidence.

Closes #8096

## Testing

- `t/grammar/grammar-dynvar-scope-leak.t` — new: the reported repro (twice, to catch a
  first-parse-only fix), a pre-existing same-named outer `$*LAST` restored correctly (not just
  removed), and an `@*`-sigil dynvar regression check (no pair, must keep working).
- `cargo fmt --all`, `make lint` — green (all four configurations).
- `make test` — green, `Files=4107, Tests=43700, Result: PASS`.
- `make roast` — the only failures are the documented container-only entries in
  `docs/agent-environments.md` (`6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t` — this
  container runs as `uid 0`); both pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_