### PR TITLE
fix: preserve repeated qualified role type checks

### DIFF
--- a/news/2026-09/role-param-qualified-type-reuse.md
+++ b/news/2026-09/role-param-qualified-type-reuse.md
@@ -1,0 +1,4 @@
+`Event::Test` imported by a role body remains a usable type object when the
+same qualified role parameter is checked again in the same process. Sigilless
+arguments that are bare type objects are no longer mistaken for writable caller
+variables and replaced by a container cell. (#8084)

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -2233,16 +2233,21 @@ impl Interpreter {
                             // method found". The `WrapVarRef` site distinguishes
                             // them: a real slot for `g($z)` / `g(p)`, the
                             // `u32::MAX` "known NOT a local of this frame" sentinel
-                            // for `g(C1)`. Only that explicit sentinel vetoes the
-                            // cell — a `None` slot (a method call, whose arguments
-                            // carry no varref tag) keeps the existing behaviour,
-                            // and a genuine free sigilless variable arrives as a
-                            // `ContainerRef` already (see `exec_wrap_var_ref_op`'s
-                            // container-capture reuse), which the arm below binds
-                            // directly. Explicit `is rw` / `is raw` are untouched.
+                            // for `g(C1)`. Method arguments do not currently carry
+                            // that tag, so also veto an untagged type object. A
+                            // qualified type name otherwise gets mistaken for a
+                            // writable sigilless variable and is replaced in the
+                            // environment by a `ContainerRef`; the next use then
+                            // cannot follow the imported type alias. Explicit
+                            // `is rw` / `is raw` are untouched.
                             let implicit_raw_veto = is_raw
                                 && !pd.traits.iter().any(|t| t == "raw")
-                                && args[positional_idx].varref_slot() == Some(u32::MAX);
+                                && (args[positional_idx].varref_slot() == Some(u32::MAX)
+                                    || (args[positional_idx].varref_slot().is_none()
+                                        && matches!(
+                                            args[positional_idx].unwrap_varref().view(),
+                                            ValueView::Package(_)
+                                        )));
                             if param_is_plain_scalar
                                 && source_is_plain_scalar
                                 && !source_is_indexed

--- a/t/lib/RoleUnrelatedModuleUserReuse.rakumod
+++ b/t/lib/RoleUnrelatedModuleUserReuse.rakumod
@@ -1,0 +1,10 @@
+use v6;
+unit role RoleUnrelatedModuleUserReuse;
+use RoleUnrelatedModuleShapes;
+
+method first(Event::Test:U \x) { 'm1' }
+method second(Event::Test \x) { 'm2' }
+
+method self-test() {
+    self.first(Event::Test) ~ self.second(Event::Test)
+}

--- a/t/lib/RoleUnrelatedModuleUserReuseA.rakumod
+++ b/t/lib/RoleUnrelatedModuleUserReuseA.rakumod
@@ -1,0 +1,9 @@
+use v6;
+unit role RoleUnrelatedModuleUserReuseA;
+use RoleUnrelatedModuleShapes;
+
+method first(Event::Test:U \x) { 'a' }
+
+method self-test() {
+    self.first(Event::Test:U)
+}

--- a/t/lib/RoleUnrelatedModuleUserReuseB.rakumod
+++ b/t/lib/RoleUnrelatedModuleUserReuseB.rakumod
@@ -1,0 +1,9 @@
+use v6;
+unit role RoleUnrelatedModuleUserReuseB;
+use RoleUnrelatedModuleShapes;
+
+method second(Event::Test \x) { 'b' }
+
+method self-test() {
+    self.second(Event::Test)
+}

--- a/t/oo/role/role-param-qualified-type-reuse-across-roles.t
+++ b/t/oo/role/role-param-qualified-type-reuse-across-roles.t
@@ -1,0 +1,17 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+plan 1;
+
+# #8084: the same body-imported qualified type must remain resolvable when two
+# separate roles check it in one process.
+
+use RoleUnrelatedModuleUserReuseA;
+use RoleUnrelatedModuleUserReuseB;
+
+class FirstRoleConsumer does RoleUnrelatedModuleUserReuseA {}
+class SecondRoleConsumer does RoleUnrelatedModuleUserReuseB {}
+
+is FirstRoleConsumer.new.self-test() ~ SecondRoleConsumer.new.self-test(), 'ab',
+    'a body-imported qualified type can be reused across two roles';

--- a/t/oo/role/role-param-qualified-type-reuse.t
+++ b/t/oo/role/role-param-qualified-type-reuse.t
@@ -1,0 +1,17 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+plan 1;
+
+# #8084: a qualified type imported by a role body was put into a caller cell
+# when passed to an implicitly raw sigilless parameter. The first method call
+# worked, but the second lookup saw the ContainerRef instead of the imported
+# type object and rejected the same argument.
+
+use RoleUnrelatedModuleUserReuse;
+
+class SameRoleConsumer does RoleUnrelatedModuleUserReuse {}
+
+is SameRoleConsumer.new.self-test(), 'm1m2',
+    'a body-imported qualified type can be reused by two methods in one role';


### PR DESCRIPTION
Summary:
- avoid treating untagged imported type objects as writable sigilless arguments
- preserve repeated qualified role-parameter checks in one process
- add regression coverage for one-role and two-role reuse

Validation:
- cargo fmt --all
- cargo clippy -- -D warnings
- make check-t-layout
- make test
- make roast

Closes #8084
