### PR TITLE
fix(oo): a role header's `is Trait` reaches trait_mod:&lt;is&gt;, whatever its case

### DIFF
--- a/news/2026-09/role-header-is-trait-reaches-trait-mod.md
+++ b/news/2026-09/role-header-is-trait-reaches-trait-mod.md
@@ -1,0 +1,61 @@
+# A role header's `is Trait` reaches `trait_mod:<is>`, whatever its case
+
+Raku spells a declarator-level trait `is Foo`, and decides what that means from
+whether `Foo` names a known type — never from its capitalisation. If it does not
+name a type, `is Foo` desugars to the named argument `trait_mod:<is>($type,
+:Foo)`. The class side learnt that when the `Staticish` distribution's
+`class Foo is Static { }` was fixed; the role side kept the older, wrong rule:
+
+```raku
+multi sub trait_mod:<is>(Mu:U $doee, :$Marked!) { say "trait fired on " ~ $doee.^name }
+role Rr is Marked { }
+```
+
+| | output |
+| --- | --- |
+| `raku` | `trait fired on Rr` |
+| `mutsu` | `Unknown role: Marked` |
+
+`registration_role_body.rs` deferred an unresolvable parent name to custom trait
+dispatch only when the name began with a lowercase letter — so `role Rr is
+marked { }` worked and the overwhelmingly common capitalised spelling did not
+([#8100](https://github.com/tokuhirom/mutsu/issues/8100)).
+
+## Why the gate could not just be deleted
+
+The class path can widen the rule freely because it knows which parents were
+written with `does`: `validate_class_parents` takes `parents` and
+`does_parents` as separate lists. The role path knew nothing of the sort. The
+parser folds a role header's `does Parent`, `is Parent` and `hides Parent`
+clauses into the *same* synthetic `Stmt::DoesDecl` statements prepended to the
+body, and `RoleParentOp` — the typed plan op the role-body walk reads them back
+through — carried `name`, `hides` and `args` but no declarator.
+
+Dropping the lowercase gate as-is would therefore also have widened `does`:
+`role R does NoSuchRole { }` would have stopped being `Unknown role:
+NoSuchRole` and become `X::Inheritance::UnknownParent` via the no-candidate
+fallback — an inheritance error for a composition typo.
+
+So the declarator is now carried end to end: `Stmt::DoesDecl` gains a
+`from_is` flag (set by both role-header parsers, the block form in
+`role_decl.rs` and the `unit role` form in `package_decl.rs`), `decl_plan.rs`
+copies it onto `RoleParentOp`, and the deferral widens for `is` parents only.
+The `does` arm keeps the narrow lowercase rule it had, so its typo diagnostic is
+byte-identical to before.
+
+## What now works
+
+`role Rr is Marked { }` fires the user's handler, the role composes into a class
+with its methods intact, and the trait name stays out of `.^roles` (it is a
+trait, not a parent — rakudo reports zero composed roles there too). A genuine
+`is` typo still raises `X::Inheritance::UnknownParent` with the same message
+rakudo prints, because the dispatch site in `vm_typedecl_ops.rs` turns a
+no-matching-candidate result back into `unknown_parent_error`. The `unit role`
+spelling is covered by the same change and was measured against `raku` with the
+trait exported from a second module (a `unit role` cannot define its own
+`trait_mod` before its header).
+
+Pinned by `t/oo/role/uppercase-is-trait-reaches-trait-mod-on-a-role.t` (10
+assertions, green under `raku` as written) — the role-side mirror of the
+class-side `t/oo/trait/uppercase-is-trait-reaches-trait-mod.t` — and by a parser
+unit test asserting the `from_is` flag itself for both spellings.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1703,6 +1703,15 @@ pub(crate) enum Stmt {
         /// purely additive, no consumer yet (D4-2/D4-3/D7-3).
         #[serde(default)]
         args: Option<Vec<Expr>>,
+        /// This synthetic statement came from an `is Parent` clause on a role
+        /// header rather than from `does Parent`. Raku decides `is Foo` from
+        /// whether `Foo` names a known type, never from its capitalisation, so
+        /// an unknown `is` name is a custom `trait_mod:<is>` trait; an unknown
+        /// `does` name is a typo. The two spellings are otherwise folded into
+        /// the same statement, so without this flag the role path cannot tell
+        /// them apart (#8100).
+        #[serde(default)]
+        from_is: bool,
     },
     TrustsDecl {
         name: Symbol,

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -796,7 +796,11 @@ impl Compiler {
                 other => vec![other],
             })
             .filter_map(|stmt| match stmt {
-                Stmt::DoesDecl { name, args } => {
+                Stmt::DoesDecl {
+                    name,
+                    args,
+                    from_is,
+                } => {
                     let name_str = name.resolve();
                     if name_str == "__mutsu_role_hidden__" {
                         return Some(crate::opcode::RoleParentOp {
@@ -804,6 +808,7 @@ impl Compiler {
                             hides: false,
                             hidden: true,
                             args: None,
+                            from_is: false,
                         });
                     }
                     if let Some(hidden_name) = name_str.strip_prefix("__mutsu_role_hides__") {
@@ -812,6 +817,7 @@ impl Compiler {
                             hides: true,
                             hidden: false,
                             args: None,
+                            from_is: false,
                         });
                     }
                     Some(crate::opcode::RoleParentOp {
@@ -824,6 +830,7 @@ impl Compiler {
                                 .map(|e| self.compile_decl_trait_arg(e))
                                 .collect()
                         }),
+                        from_is: *from_is,
                     })
                 }
                 _ => None,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3937,6 +3937,11 @@ pub(crate) struct RoleParentOp {
     /// consumer falls back to the string path exactly as the class-header
     /// site (D4-3) does.
     pub(crate) args: Option<Vec<DeclTraitArg>>,
+    /// This parent came from `is Parent` on the role header, not from `does
+    /// Parent`. An unknown `is` name is a custom `trait_mod:<is>` trait and is
+    /// deferred to trait dispatch; an unknown `does` name stays the
+    /// `Unknown role:` error it has always been (#8100).
+    pub(crate) from_is: bool,
 }
 
 /// One role-body statement, typed (ADR-0019 D7-4) — the role-side twin of

--- a/src/parser/primary/misc/anon_decl.rs
+++ b/src/parser/primary/misc/anon_decl.rs
@@ -126,6 +126,7 @@ pub(crate) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
             Stmt::DoesDecl {
                 name: Symbol::intern(role_name),
                 args: None,
+                from_is: false,
             },
         );
     }

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -732,6 +732,7 @@ pub(crate) fn also_trait_stmt(input: &str) -> PResult<'_, Stmt> {
             Stmt::DoesDecl {
                 name: Symbol::intern(&name),
                 args,
+                from_is: false,
             },
         ));
     }

--- a/src/parser/stmt/class/grammar_module.rs
+++ b/src/parser/stmt/class/grammar_module.rs
@@ -20,6 +20,7 @@ pub(crate) fn does_decl(input: &str) -> PResult<'_, Stmt> {
         Stmt::DoesDecl {
             name: Symbol::intern(&name),
             args: None,
+            from_is: false,
         },
     ))
 }

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -387,7 +387,9 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
             r = r2;
         }
         // Optional parent/trait clauses in any order (mirrors block-form roles).
-        let mut parent_roles: Vec<(String, Option<Vec<crate::ast::Expr>>)> = Vec::new();
+        // (name, bracket args, came-from-`is`) — see the block-form role
+        // parser for why the declarator has to survive into the body (#8100).
+        let mut parent_roles: Vec<(String, Option<Vec<crate::ast::Expr>>, bool)> = Vec::new();
         let mut is_export = false;
         let mut export_tags: Vec<String> = Vec::new();
         let mut role_is_rw = false;
@@ -400,7 +402,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                 let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
                 let (r2, _) = ws(r2)?;
                 let args = super::class_decl::parse_bracket_arg_exprs(bracket_suffix);
-                parent_roles.push((format!("{}{}", role_name, bracket_suffix), args));
+                parent_roles.push((format!("{}{}", role_name, bracket_suffix), args, false));
                 r = r2;
                 continue;
             }
@@ -438,7 +440,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     let has_parens = r2.starts_with('(');
                     let r2 = skip_balanced_parens(r2);
                     if !has_parens && trait_name.starts_with(|c: char| c.is_ascii_uppercase()) {
-                        parent_roles.push((trait_name, None));
+                        parent_roles.push((trait_name, None, true));
                     } else {
                         custom_traits.push((trait_name, None));
                     }
@@ -454,12 +456,13 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         // body, so make the declaration visible before that parsing starts.
         super::super::simple::register_user_type(&name);
         let mut body: Vec<Stmt> = Vec::new();
-        for (role_name, args) in parent_roles.into_iter().rev() {
+        for (role_name, args, from_is) in parent_roles.into_iter().rev() {
             body.insert(
                 0,
                 Stmt::DoesDecl {
                     name: Symbol::intern(&role_name),
                     args,
+                    from_is,
                 },
             );
         }

--- a/src/parser/stmt/class/role_decl.rs
+++ b/src/parser/stmt/class/role_decl.rs
@@ -296,7 +296,11 @@ pub(crate) fn role_decl_with_keyword<'a>(input: &'a str, kw: &str) -> PResult<'a
         type_param_defs = tpd;
         rest = rest2;
     }
-    let mut parent_roles: Vec<(String, Option<Vec<Expr>>)> = Vec::new();
+    // (name, bracket args, came-from-`is`). The third element keeps the
+    // declarator: `role R is Unknown` is a custom `trait_mod:<is>` trait,
+    // `role R does Unknown` is a typo, and the runtime cannot tell them apart
+    // once both are folded into the same synthetic `DoesDecl` (#8100).
+    let mut parent_roles: Vec<(String, Option<Vec<Expr>>, bool)> = Vec::new();
     let mut is_hidden_role = false;
     let mut role_is_rw = false;
     let mut is_export = false;
@@ -318,7 +322,7 @@ pub(crate) fn role_decl_with_keyword<'a>(input: &'a str, kw: &str) -> PResult<'a
             let (r, bracket_suffix) = parse_optional_bracket_suffix(r)?;
             let (r, _) = ws(r)?;
             let args = super::class_decl::parse_bracket_arg_exprs(bracket_suffix);
-            parent_roles.push((format!("{}{}", role_name, bracket_suffix), args));
+            parent_roles.push((format!("{}{}", role_name, bracket_suffix), args, false));
             rest = r;
             continue;
         }
@@ -401,7 +405,7 @@ pub(crate) fn role_decl_with_keyword<'a>(input: &'a str, kw: &str) -> PResult<'a
                     // No parens — treat as parent role. If it's actually
                     // a custom trait, the runtime will handle it via
                     // trait_mod:<is> when the role name is not found.
-                    parent_roles.push((trait_name, None));
+                    parent_roles.push((trait_name, None, true));
                     let (r, _) = ws(r)?;
                     rest = r;
                 }
@@ -413,9 +417,9 @@ pub(crate) fn role_decl_with_keyword<'a>(input: &'a str, kw: &str) -> PResult<'a
             let (r, hidden_name) = qualified_ident(r)?;
             let (r, _) = ws(r)?;
             // Track as a parent relationship
-            parent_roles.push((hidden_name.clone(), None));
+            parent_roles.push((hidden_name.clone(), None, false));
             // Also mark the hidden relationship with a special marker
-            parent_roles.push((format!("__mutsu_role_hides__{}", hidden_name), None));
+            parent_roles.push((format!("__mutsu_role_hides__{}", hidden_name), None, false));
             rest = r;
             continue;
         }
@@ -451,15 +455,17 @@ pub(crate) fn role_decl_with_keyword<'a>(input: &'a str, kw: &str) -> PResult<'a
             Stmt::DoesDecl {
                 name: Symbol::intern("__mutsu_role_hidden__"),
                 args: None,
+                from_is: false,
             },
         );
     }
-    for (role_name, args) in parent_roles.into_iter().rev() {
+    for (role_name, args, from_is) in parent_roles.into_iter().rev() {
         body.insert(
             0,
             Stmt::DoesDecl {
                 name: Symbol::intern(&role_name),
                 args,
+                from_is,
             },
         );
     }

--- a/src/parser/stmt/tests_3.rs
+++ b/src/parser/stmt/tests_3.rs
@@ -223,11 +223,37 @@ fn parse_role_decl_does_clause_captures_bracket_exprs() {
     let Stmt::RoleDecl { body, .. } = &stmts[0] else {
         panic!("expected RoleDecl");
     };
-    let Stmt::DoesDecl { name, args } = &body[0] else {
+    let Stmt::DoesDecl {
+        name,
+        args,
+        from_is,
+    } = &body[0]
+    else {
         panic!("expected DoesDecl as the first body statement");
     };
     assert_eq!(name.as_str(), "R1[Int]");
     assert_eq!(args.as_ref().map(Vec::len), Some(1));
+    assert!(!from_is, "a `does` clause is not an `is` clause");
+}
+
+/// #8100: `is Parent` and `does Parent` on a role header are folded into the
+/// same synthetic `DoesDecl`, so the declarator has to survive on the
+/// statement — an unknown `is` name is a `trait_mod:<is>` trait, an unknown
+/// `does` name is a typo.
+#[test]
+fn parse_role_decl_records_whether_a_parent_came_from_is() {
+    for (src, expected) in [("role R2 is R1 { }", true), ("role R2 does R1 { }", false)] {
+        let (rest, stmts) = program(src).unwrap();
+        assert_eq!(rest, "");
+        let Stmt::RoleDecl { body, .. } = &stmts[0] else {
+            panic!("expected RoleDecl for {src}");
+        };
+        let Stmt::DoesDecl { name, from_is, .. } = &body[0] else {
+            panic!("expected DoesDecl as the first body statement of {src}");
+        };
+        assert_eq!(name.as_str(), "R1");
+        assert_eq!(*from_is, expected, "declarator flag for {src}");
+    }
 }
 
 #[test]

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -289,13 +289,31 @@ impl Interpreter {
         {
             Some(r) => r,
             None => {
-                // If trait_mod:<is> is defined and this is a lowercase name,
-                // defer to custom trait dispatch instead of erroring.
+                // `is Foo` on a name that is NOT a known type is rakudo's
+                // spelling of the named trait argument `trait_mod:<is>($type,
+                // :Foo)`, exactly as on the class side
+                // (`validate_class_parents`). Raku decides that from whether
+                // `Foo` names a known type, never from its capitalisation, so
+                // every unknown `is` parent is deferred to custom trait
+                // dispatch when the program defines a `trait_mod:<is>` at all;
+                // the dispatch site (`vm_typedecl_ops.rs`) turns a
+                // no-matching-candidate result back into
+                // `X::Inheritance::UnknownParent`, so a genuine `is` typo still
+                // raises. This used to be restricted to lowercase names, which
+                // made `role R is Marked { }` -- the overwhelmingly common
+                // spelling of a trait -- an `Unknown role: Marked` error
+                // (#8100).
+                //
+                // A `does` parent keeps the narrower lowercase rule: `does
+                // NoSuchRole` is a typo, not a trait, and must stay the
+                // `Unknown role:` error below rather than becoming an
+                // unknown-*parent* one.
                 if (self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>"))
-                    && role_name_str
-                        .chars()
-                        .next()
-                        .is_some_and(|c| c.is_ascii_lowercase())
+                    && (op.from_is
+                        || role_name_str
+                            .chars()
+                            .next()
+                            .is_some_and(|c| c.is_ascii_lowercase()))
                 {
                     cx.role_def
                         .deferred_custom_traits

--- a/t/oo/role/uppercase-is-trait-reaches-trait-mod-on-a-role.t
+++ b/t/oo/role/uppercase-is-trait-reaches-trait-mod-on-a-role.t
@@ -1,0 +1,71 @@
+use Test;
+
+# The role-side mirror of `uppercase-is-trait-reaches-trait-mod.t` (#8100).
+#
+# Raku spells a declarator-level trait `is Foo` and decides what it means from
+# whether `Foo` names a known type, never from its capitalisation. The class
+# path learnt that; the role path still deferred to `trait_mod:<is>` only for a
+# LOWERCASE name, so `role Rr is Marked { }` -- the overwhelmingly common
+# spelling of a trait -- died with `Unknown role: Marked`.
+#
+# The gate could not simply be dropped, because a role's `is Parent` and `does
+# Parent` clauses are folded into the SAME synthetic statement: widening the
+# deferral for both would have turned a `does` typo into an unknown-*parent*
+# error. The declarator is now carried through to the runtime
+# (`Stmt::DoesDecl::from_is` -> `RoleParentOp::from_is`), so only the `is` side
+# widened and the `does` side is untouched -- which is what the last two
+# assertions pin.
+
+plan 10;
+
+use MONKEY-SEE-NO-EVAL;
+
+my %fired;
+multi sub trait_mod:<is>(Mu:U $doee, :$Marked!)   { %fired{'Marked'} = $doee.^name }
+multi sub trait_mod:<is>(Mu:U $doee, :$lowered!)  { %fired{'lowered'} = $doee.^name }
+multi sub trait_mod:<is>(Mu:U $doee, :$Explodes!) { die "boom from handler" }
+
+role Rr is Marked { method hi { 'hi' } }
+role Gg is lowered { }
+
+is %fired{'Marked'}, 'Rr', 'an uppercase `is Trait` on a role reaches the user trait_mod:<is>';
+is Rr.^name, 'Rr', 'and the role is otherwise a normal role';
+is Rr.^roles.elems, 0, 'the uppercase trait name did not become a composed role';
+
+# The role still composes, and its methods arrive in the consuming class.
+class C does Rr { }
+is C.new.hi, 'hi', 'the role composes into a class and brings its methods';
+
+is %fired{'lowered'}, 'Gg', 'a lowercase trait name on a role still reaches its handler';
+
+# The trait argument is the named one, so a name no candidate claims is still
+# an unknown parent rather than a silently-accepted trait.
+throws-like 'role Beta is AlsoNotATrait { }', X::Inheritance::UnknownParent,
+    'an uppercase name no candidate claims is still X::Inheritance::UnknownParent';
+
+# An error raised from inside a matching handler still propagates as itself.
+throws-like 'role Delta is Explodes { }', X::AdHoc,
+    'an error from inside a matching uppercase handler still propagates';
+
+# A known parent role reached through `is` is still ordinary composition.
+{
+    role Base { method who { 'base' } }
+    role Derived is Base { }
+    class D does Derived { }
+    is D.new.who, 'base', 'a known uppercase `is` parent is still composed as a role';
+}
+
+# ...and so is one reached through `does`.
+{
+    role DoesBase { method who2 { 'does-base' } }
+    role DoesDerived does DoesBase { }
+    class E does DoesDerived { }
+    is E.new.who2, 'does-base', 'a known `does` parent is unaffected';
+}
+
+# A `does` clause naming nothing is a TYPO, not a trait: it must keep dying
+# even though a `trait_mod:<is>` is in scope. (rakudo reports `Invalid typename
+# 'NoSuchRole'`; mutsu reports `Unknown role: NoSuchRole`. The point pinned
+# here is that the widened `is` deferral did not swallow it.)
+dies-ok { EVAL 'role Zeta does NoSuchRoleAtAll { }' },
+    'an unknown `does` parent still dies';


### PR DESCRIPTION
Closes #8100 — the role-side mirror of the class-side fix in #7996.

## The gap

Raku spells a declarator-level trait `is Foo` and decides what it means from whether `Foo` names a known type, never from its capitalisation: an unknown name desugars to the named argument `trait_mod:<is>($type, :Foo)`.

```raku
multi sub trait_mod:<is>(Mu:U $doee, :$Marked!) { say "trait fired on " ~ $doee.^name }
role Rr is Marked { }
```

| | output |
| --- | --- |
| `raku` | `trait fired on Rr` |
| `mutsu` before | `Unknown role: Marked` |
| `mutsu` after | `trait fired on Rr` |

`registration_role_body.rs` deferred an unresolvable parent to custom trait dispatch only for a lowercase name, so `role Rr is marked { }` worked and the overwhelmingly common capitalised spelling did not.

## Why the gate could not just be deleted

`validate_class_parents` can widen freely because it is handed `parents` and `does_parents` as separate lists. The role path had no such distinction: both role-header parsers fold `does Parent` and `is Parent` into the *same* synthetic `Stmt::DoesDecl` statements prepended to the body, and `RoleParentOp` — the typed plan op the role-body walk reads them back through — carried `name`, `hides` and `args` but no declarator.

Dropping the gate as-is would therefore also have widened `does`: `role R does NoSuchRole { }` would have stopped being `Unknown role: NoSuchRole` and become `X::Inheritance::UnknownParent` via the no-candidate fallback — an inheritance error for a composition typo.

So the declarator is carried end to end instead:

- `Stmt::DoesDecl` gains `from_is` (`#[serde(default)]`, so serialized ASTs are unaffected), set by the block-form header parser (`role_decl.rs`) and the `unit role` one (`package_decl.rs`); every other construction site passes `false`.
- `decl_plan.rs` copies it onto `RoleParentOp`.
- The deferral in `registration_role_body.rs` widens for `is` parents only. The `does` arm keeps the narrow lowercase rule it had, so its diagnostic is byte-identical to before.

## Behaviour after, measured against `raku`

| | mutsu | raku |
|---|---|---|
| `role Rr is Marked { }` (handler defined) | trait fires | trait fires |
| `Rr.^roles.elems` | `0` | `0` |
| `role Rr is marked { }` (lowercase) | trait fires | trait fires |
| `role Rr is NoSuchTrait { }` | `'Rr' cannot inherit from 'NoSuchTrait' because it is unknown.` | same message |
| `role Rr does NoSuchRole { }` | `Unknown role: NoSuchRole` (unchanged) | `Invalid typename 'NoSuchRole'` |
| `role Derived is Base { }` (Base a real role) | composed | composed |

The `unit role R is Marked;` spelling goes through the same change and was measured too, with the trait exported from a second module (a `unit role` cannot define its own `trait_mod` ahead of its own header). The remaining `does`-typo message difference is pre-existing and out of scope here.

## Tests

- `t/oo/role/uppercase-is-trait-reaches-trait-mod-on-a-role.t` (10 assertions) — the mirror of the class-side `t/oo/trait/uppercase-is-trait-reaches-trait-mod.t`: uppercase and lowercase handlers firing, the trait name staying out of `.^roles`, the role still composing with its methods, an unclaimed uppercase name still `X::Inheritance::UnknownParent`, an error from inside a matching handler still propagating, a real `is` parent and a real `does` parent both still composed, and an unknown `does` parent still dying. Green under `raku` as written.
- `parse_role_decl_records_whether_a_parent_came_from_is` in `src/parser/stmt/tests_3.rs` pins the new flag itself for both spellings; the existing `does`-bracket test now also asserts `!from_is`.
- `t/oo/trait/user-trait-mod-does-not-consume-every-trait.t` (which pins `role Zorb is nosuchtrait { }` → `X::Inheritance::UnknownParent`) and the rest of `t/oo/trait/` stay green.

## Pre-publication gates

- `cargo fmt --all`, `make check-t-layout`: clean.
- `make lint`: all four configurations green.
- `make test`: **PASS** — 4102 files, 43637 tests.
- `make roast`: three failures, all three exactly the container-specific known reds in `docs/agent-environments.md`, at their documented shapes — `roast/6.c/S32-io/file-tests.t` `Failed: 4` (tests 6-8, 10) and `roast/S16-filehandles/filetest.t` `Failed: 25` (57-64, 69-72, 77-80, 101, 103, 105, 107, 109, 111, 117, 121, 125), both from running as `uid 0`; `roast/S32-io/IO-Socket-Async.t` exit 124 from the sandboxed network. Nothing else in the whitelist failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK)_