### PR TITLE
fix: preserve regex declaration source boundaries

### DIFF
--- a/docs/adr/0088-rakuast-regex-boundary-tree.md
+++ b/docs/adr/0088-rakuast-regex-boundary-tree.md
@@ -405,3 +405,29 @@ that the execution plan comes from the retained tree rather than the value's
 compatibility string. Other regex entry points that currently accept only a
 pattern string, declaration normalization, captures, subrules, and dynamic
 regex nodes remain follow-up slices.
+
+## 10. Declaration source-whitespace and execution-provenance slice (2026-09-12)
+
+Declaration trees now retain the source whitespace boundary that RakuAST
+exposes. `WithWhitespace` marks the term before a written whitespace run; the
+root declaration receives the model's implicit final wrapper, while nested
+groups receive wrappers only for whitespace written inside them. This preserves
+the distinction between `rule x { a[bc]d }` and `rule x { a [bc] d }` without
+encoding execution-only whitespace into the source tree. Source rendering uses
+the same markers, so lowering a declaration from RakuAST does not introduce
+spaces between source-adjacent terms.
+
+Declaration bodies also carry their source tree on the regex value. The named
+regex smartmatch entry point consumes that value through the existing
+`RegexPattern` matcher. Token and regex declarations ignore the model
+wrappers; rule declarations add a `WsRule` only between terms marked with a
+written whitespace boundary. The final model wrapper never consumes trailing
+input, matching the established declaration normalizer. Dynamic declarations
+and matcher entry points that still require a pattern string remain on the
+legacy fallback path.
+
+The focused regressions are in `t/rakuast/rakuast-regex.t`,
+`t/regex/regex-tree-static-execution.t`, and
+`t/regex/regex-tree-value-provenance.t`. They pin AST parity for adjacent
+groups, an EVAL'd rule's execution boundary, and repeated named-rule
+smartmatches.

--- a/news/2026-09/rakuast-regex-declaration-whitespace.md
+++ b/news/2026-09/rakuast-regex-declaration-whitespace.md
@@ -1,0 +1,7 @@
+# Regex declaration trees preserve source whitespace boundaries
+
+Regex and grammar declarations now retain the source-level whitespace markers
+that RakuAST exposes, including adjacency around groups and the implicit final
+rule term. Reconstructed rules lower their sigspace policy from that tree, so a
+source-adjacent group is not changed into a whitespace-separated execution
+pattern.

--- a/src/parser/stmt/class/grammar_module.rs
+++ b/src/parser/stmt/class/grammar_module.rs
@@ -95,7 +95,18 @@ pub(crate) fn token_decl(input: &str) -> PResult<'_, Stmt> {
         return Err(null_regex_error());
     }
     let source_pattern = normalize_token_pattern(&pattern);
-    let source_regex = crate::regex_tree::RegexTree::parse_static(&source_pattern, true);
+    let regex_kind = if is_rule {
+        crate::regex_tree::RegexDeclKind::Rule
+    } else if is_regex {
+        crate::regex_tree::RegexDeclKind::Regex
+    } else {
+        crate::regex_tree::RegexDeclKind::Token
+    };
+    let source_regex =
+        crate::regex_tree::RegexTree::parse_static(&source_pattern, true).map(|mut tree| {
+            tree.declaration_kind = Some(regex_kind);
+            tree
+        });
     pattern = source_pattern;
     if is_rule {
         pattern = inject_implicit_rule_ws(&pattern);
@@ -110,7 +121,11 @@ pub(crate) fn token_decl(input: &str) -> PResult<'_, Stmt> {
     if is_ratchet {
         pattern = format!(":ratchet {pattern}");
     }
-    let body = vec![Stmt::Expr(Expr::Literal(Value::regex(pattern)))];
+    let regex_value = Value::regex(pattern);
+    let body = vec![Stmt::Expr(Expr::Literal(match &source_regex {
+        Some(tree) => regex_value.with_regex_source_tree(tree.clone()),
+        None => regex_value,
+    }))];
 
     if is_rule {
         Ok((
@@ -135,11 +150,7 @@ pub(crate) fn token_decl(input: &str) -> PResult<'_, Stmt> {
                 param_defs,
                 body,
                 source_regex,
-                regex_kind: if is_regex {
-                    crate::regex_tree::RegexDeclKind::Regex
-                } else {
-                    crate::regex_tree::RegexDeclKind::Token
-                },
+                regex_kind,
                 multi: is_multi,
                 is_my: false,
                 is_our: false,

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -597,10 +597,17 @@ fn lower_grammar(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 fn lower_regex_declaration(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let name = call_name_str(node)?;
     let body = named_child(node, "body")?;
+    let declaration_kind = match node.class {
+        RakuAstClass::RegexDeclaration => crate::regex_tree::RegexDeclKind::Regex,
+        RakuAstClass::TokenDeclaration => crate::regex_tree::RegexDeclKind::Token,
+        RakuAstClass::RuleDeclaration => crate::regex_tree::RegexDeclKind::Rule,
+        _ => return Err(unsupported(node)),
+    };
     let tree = RegexTree {
         body: lower_regex_node(body)?,
         match_immediately: false,
         adverbs: Vec::new(),
+        declaration_kind: Some(declaration_kind),
     };
     let source = tree.to_source();
     let execution_pattern = match node.class {
@@ -611,9 +618,10 @@ fn lower_regex_declaration(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
             let pattern = crate::parser::inject_separator_ws(&pattern);
             format!(":ratchet {pattern}")
         }
-        _ => return Err(unsupported(node)),
+        _ => unreachable!("declaration kind was checked above"),
     };
-    let body = vec![Stmt::Expr(Expr::Literal(Value::regex(execution_pattern)))];
+    let value = Value::regex(execution_pattern).with_regex_source_tree(tree.clone());
+    let body = vec![Stmt::Expr(Expr::Literal(value))];
     let source_regex = Some(tree);
     match node.class {
         RakuAstClass::RegexDeclaration | RakuAstClass::TokenDeclaration => Ok(Stmt::TokenDecl {
@@ -1661,6 +1669,7 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 body: lower_regex_node(body)?,
                 match_immediately,
                 adverbs,
+                declaration_kind: None,
             };
             let value = regex_execution_value(&tree)?;
             if tree.match_immediately {

--- a/src/regex_tree.rs
+++ b/src/regex_tree.rs
@@ -13,6 +13,12 @@ pub(crate) struct RegexTree {
     pub(crate) match_immediately: bool,
     #[serde(default)]
     pub(crate) adverbs: Vec<RegexAdverb>,
+    /// The declaration policy that produced this tree, when it came from a
+    /// `regex`, `token`, or `rule` declaration. Execution-only prefixes such
+    /// as `:ratchet` remain outside the source tree and are applied by the
+    /// execution lowerer.
+    #[serde(default)]
+    pub(crate) declaration_kind: Option<RegexDeclKind>,
 }
 
 #[derive(
@@ -64,19 +70,13 @@ impl RegexTree {
             pos: 0,
             declaration,
         };
-        let body = parser.parse_alternation(&[])?;
+        let body = parser.parse_alternation(&[], declaration)?;
         parser.skip_whitespace();
         (parser.pos == parser.chars.len()).then_some(Self {
-            body: if !declaration
-                && let RegexNode::Literal(text) = &body
-                && text.chars().count() > 1
-            {
-                RegexNode::Sequence(vec![body])
-            } else {
-                body
-            },
+            body: sequence_for_multichar_literal(body),
             match_immediately: false,
             adverbs: Vec::new(),
+            declaration_kind: None,
         })
     }
 
@@ -134,6 +134,7 @@ impl RegexTree {
             ratchet: bool,
             ignore_case: bool,
             ignore_mark: bool,
+            rule_sigspace: bool,
         ) -> Option<Vec<crate::runtime::RegexToken>> {
             match node {
                 RegexNode::Literal(text) => {
@@ -210,8 +211,27 @@ impl RegexTree {
                 )]),
                 RegexNode::Sequence(nodes) => {
                     let mut tokens = Vec::new();
-                    for child in nodes {
-                        tokens.extend(lower_node(child, ratchet, ignore_case, ignore_mark)?);
+                    for (index, child) in nodes.iter().enumerate() {
+                        tokens.extend(lower_node(
+                            child,
+                            ratchet,
+                            ignore_case,
+                            ignore_mark,
+                            rule_sigspace,
+                        )?);
+                        // WithWhitespace marks whitespace after its child.
+                        // A final wrapper is the RakuAST model's implicit
+                        // declaration boundary, not trailing input to consume.
+                        if rule_sigspace
+                            && index + 1 < nodes.len()
+                            && matches!(child, RegexNode::WithWhitespace(_))
+                        {
+                            tokens.push(token(
+                                crate::runtime::RegexAtom::WsRule,
+                                crate::runtime::RegexQuant::One,
+                                ratchet,
+                            ));
+                        }
                     }
                     Some(tokens)
                 }
@@ -219,7 +239,7 @@ impl RegexTree {
                     let alternatives = branches
                         .iter()
                         .map(|branch| {
-                            lower_node(branch, ratchet, ignore_case, ignore_mark)
+                            lower_node(branch, ratchet, ignore_case, ignore_mark, rule_sigspace)
                                 .map(|tokens| pattern(tokens, ignore_case, ignore_mark))
                         })
                         .collect::<Option<Vec<_>>>()?;
@@ -230,7 +250,8 @@ impl RegexTree {
                     )])
                 }
                 RegexNode::Group(child) => {
-                    let tokens = lower_node(child, ratchet, ignore_case, ignore_mark)?;
+                    let tokens =
+                        lower_node(child, ratchet, ignore_case, ignore_mark, rule_sigspace)?;
                     Some(vec![token(
                         crate::runtime::RegexAtom::Group(pattern(tokens, ignore_case, ignore_mark)),
                         crate::runtime::RegexQuant::One,
@@ -243,7 +264,8 @@ impl RegexTree {
                         RegexQuantifier::OneOrMore => crate::runtime::RegexQuant::OneOrMore,
                         RegexQuantifier::ZeroOrOne => crate::runtime::RegexQuant::ZeroOrOne,
                     };
-                    let mut tokens = lower_node(atom, ratchet, ignore_case, ignore_mark)?;
+                    let mut tokens =
+                        lower_node(atom, ratchet, ignore_case, ignore_mark, rule_sigspace)?;
                     if tokens.len() == 1 {
                         tokens[0].quant = quant;
                         return Some(tokens);
@@ -254,18 +276,23 @@ impl RegexTree {
                         ratchet,
                     )])
                 }
-                // `WithWhitespace` is a RakuAST semantic wrapper. Written
-                // regex whitespace is insignificant unless the runtime
-                // `:sigspace` policy is active, which this static bridge does
-                // not claim to lower.
+                // `WithWhitespace` is a source/model wrapper for ordinary,
+                // token, and regex trees. Rule declaration policy consumes it
+                // as `WsRule` between terms in the enclosing sequence.
                 RegexNode::WithWhitespace(child) => {
-                    lower_node(child, ratchet, ignore_case, ignore_mark)
+                    lower_node(child, ratchet, ignore_case, ignore_mark, rule_sigspace)
                 }
             }
         }
 
         Some(pattern(
-            lower_node(&self.body, ratchet, ignore_case, ignore_mark)?,
+            lower_node(
+                &self.body,
+                ratchet,
+                ignore_case,
+                ignore_mark,
+                self.declaration_kind == Some(RegexDeclKind::Rule),
+            )?,
             ignore_case,
             ignore_mark,
         ))
@@ -289,16 +316,33 @@ impl RegexNode {
                 let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
                 format!("\"{escaped}\"")
             }
-            Self::Sequence(nodes) => nodes
-                .iter()
-                .map(Self::to_source)
-                .collect::<Vec<_>>()
-                .join(" "),
-            Self::Alternation(nodes) => nodes
-                .iter()
-                .map(Self::to_source)
-                .collect::<Vec<_>>()
-                .join(" | "),
+            Self::Sequence(nodes) => {
+                nodes
+                    .iter()
+                    .enumerate()
+                    .fold(String::new(), |mut source, (index, node)| {
+                        if index > 0 && has_whitespace_after(&nodes[index - 1]) {
+                            source.push(' ');
+                        }
+                        source.push_str(&node.to_source());
+                        source
+                    })
+            }
+            Self::Alternation(nodes) => {
+                nodes
+                    .iter()
+                    .enumerate()
+                    .fold(String::new(), |mut source, (index, node)| {
+                        if index > 0 {
+                            if has_whitespace_after(&nodes[index - 1]) {
+                                source.push(' ');
+                            }
+                            source.push('|');
+                        }
+                        source.push_str(&node.to_source());
+                        source
+                    })
+            }
             Self::Group(child) => format!("[{}]", child.to_source()),
             Self::Quantified { atom, quantifier } => {
                 let suffix = match quantifier {
@@ -314,6 +358,22 @@ impl RegexNode {
     }
 }
 
+fn sequence_for_multichar_literal(node: RegexNode) -> RegexNode {
+    match node {
+        RegexNode::Literal(text) if text.chars().count() > 1 => {
+            RegexNode::Sequence(vec![RegexNode::Literal(text)])
+        }
+        RegexNode::WithWhitespace(inner) if matches!(inner.as_ref(), RegexNode::Literal(text) if text.chars().count() > 1) => {
+            RegexNode::Sequence(vec![RegexNode::WithWhitespace(inner)])
+        }
+        node => node,
+    }
+}
+
+fn has_whitespace_after(node: &RegexNode) -> bool {
+    matches!(node, RegexNode::WithWhitespace(_))
+}
+
 struct Parser {
     chars: Vec<char>,
     pos: usize,
@@ -321,10 +381,13 @@ struct Parser {
 }
 
 impl Parser {
-    fn parse_alternation(&mut self, stops: &[char]) -> Option<RegexNode> {
+    fn parse_alternation(&mut self, stops: &[char], top_level: bool) -> Option<RegexNode> {
         let mut branches = vec![self.parse_sequence(stops)?];
         while self.consume_if('|') {
             branches.push(self.parse_sequence(stops)?);
+        }
+        if top_level && let Some(last) = branches.last_mut() {
+            wrap_last_node(last);
         }
         if branches.len() == 1 {
             Some(branches.pop().unwrap())
@@ -340,9 +403,15 @@ impl Parser {
             self.skip_whitespace();
             let saw_whitespace = self.pos != before;
             let Some(&ch) = self.chars.get(self.pos) else {
+                if saw_whitespace {
+                    wrap_last_with_whitespace(&mut nodes);
+                }
                 break;
             };
             if stops.contains(&ch) || ch == '|' {
+                if saw_whitespace {
+                    wrap_last_with_whitespace(&mut nodes);
+                }
                 break;
             }
             let mut atom = self.parse_atom(stops)?;
@@ -373,15 +442,20 @@ impl Parser {
                 }
             }
 
-            if self.declaration || saw_whitespace && !nodes.is_empty() {
-                // In a declaration, sigspace applies to every top-level atom.
-                // In an ordinary regex, whitespace belongs to the atom before
-                // the next source atom (`/a b/` -> WithWhitespace(a), b).
-                if self.declaration {
-                    atom = RegexNode::WithWhitespace(Box::new(atom));
-                } else if let Some(previous) = nodes.pop() {
-                    nodes.push(RegexNode::WithWhitespace(Box::new(previous)));
+            if self.declaration {
+                // WithWhitespace belongs to the term before a written space.
+                // The root declaration gets one implicit final wrapper, while
+                // nested groups only retain wrappers caused by their own
+                // written whitespace. This is the distinction Rakudo exposes
+                // for `rule x { a[bc]d }`.
+                if saw_whitespace {
+                    wrap_last_with_whitespace(&mut nodes);
                 }
+            } else if saw_whitespace
+                && !nodes.is_empty()
+                && let Some(previous) = nodes.pop()
+            {
+                nodes.push(RegexNode::WithWhitespace(Box::new(previous)));
             }
             nodes.push(atom);
         }
@@ -403,11 +477,13 @@ impl Parser {
             '\\' => self.parse_escape(),
             '[' => {
                 self.pos += 1;
-                let inner = self.parse_alternation(&[']'])?;
+                let inner = self.parse_alternation(&[']'], false)?;
                 if !self.consume_if(']') {
                     return None;
                 }
-                Some(RegexNode::Group(Box::new(inner)))
+                Some(RegexNode::Group(Box::new(sequence_for_multichar_literal(
+                    inner,
+                ))))
             }
             // Parentheses are capture groups in regex slang.  Captures need
             // runtime slot metadata, which this source tree does not retain;
@@ -490,5 +566,28 @@ impl Parser {
         } else {
             false
         }
+    }
+}
+
+fn wrap_last_with_whitespace(nodes: &mut [RegexNode]) {
+    if let Some(last) = nodes.last_mut()
+        && !matches!(last, RegexNode::WithWhitespace(_))
+    {
+        let node = std::mem::replace(last, RegexNode::Sequence(Vec::new()));
+        *last = RegexNode::WithWhitespace(Box::new(node));
+    }
+}
+
+fn wrap_last_node(node: &mut RegexNode) {
+    match node {
+        RegexNode::Sequence(nodes) => wrap_last_with_whitespace(nodes),
+        other => wrap_node_with_whitespace(other),
+    }
+}
+
+fn wrap_node_with_whitespace(node: &mut RegexNode) {
+    if !matches!(node, RegexNode::WithWhitespace(_)) {
+        let old = std::mem::replace(node, RegexNode::Sequence(Vec::new()));
+        *node = RegexNode::WithWhitespace(Box::new(old));
     }
 }

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -207,12 +207,16 @@ impl Interpreter {
             _ => return None,
         };
         // The value-aware path is intentionally only a leaf for the static
-        // tree slice. Declarative prefixes and the anchored single-subrule
-        // ranking path have side effects and package-resolution steps that the
-        // ordinary string entry point owns; preserve those semantics intact.
-        if regex.regex_source_tree().is_none()
-            || Self::parse_anchored_single_subrule(&pattern).is_some()
-            || !Self::parse_regex_declarative_prefix(&pattern).0.is_empty()
+        // tree slice. Declarative prefixes on source-less values and the
+        // anchored single-subrule ranking path have side effects and
+        // package-resolution steps that the ordinary string entry point owns;
+        // preserve those semantics intact.
+        let Some(tree) = regex.regex_source_tree() else {
+            return self.regex_match_with_captures(&pattern, text);
+        };
+        if Self::parse_anchored_single_subrule(&pattern).is_some()
+            || (!Self::parse_regex_declarative_prefix(&pattern).0.is_empty()
+                && tree.declaration_kind.is_none())
         {
             return self.regex_match_with_captures(&pattern, text);
         }

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -1636,4 +1636,30 @@ mod static_execution_tests {
             .collect();
         assert_eq!(literals, "tree");
     }
+
+    #[test]
+    fn lowers_rule_declaration_whitespace_from_source_tree() {
+        let mut tree = RegexTree::parse_static("a b", true).expect("source tree");
+        tree.declaration_kind = Some(crate::regex_tree::RegexDeclKind::Rule);
+        let pattern = tree
+            .lower_execution(false, false, false)
+            .expect("execution plan");
+        assert!(matches!(
+            pattern.tokens.as_slice(),
+            [
+                RegexToken {
+                    atom: RegexAtom::Literal('a'),
+                    ..
+                },
+                RegexToken {
+                    atom: RegexAtom::WsRule,
+                    ..
+                },
+                RegexToken {
+                    atom: RegexAtom::Literal('b'),
+                    ..
+                }
+            ]
+        ));
+    }
 }

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -641,13 +641,13 @@ impl Interpreter {
         out
     }
 
-    /// Extract the regex pattern string from a named token/regex definition.
-    /// Returns `Some(pattern)` if the token body contains a single regex literal.
-    pub(in crate::runtime) fn extract_token_regex_pattern(&self, name: &str) -> Option<String> {
+    /// Extract the regex value from a named token/regex definition.
+    /// Returns `Some(value)` if the token body contains a single regex literal.
+    /// The value may carry the declaration's source tree alongside its
+    /// compatibility spelling.
+    pub(in crate::runtime) fn extract_token_regex_value(&self, name: &str) -> Option<Value> {
         let defs = self.resolve_token_defs(name)?;
         let def = defs.first()?;
-        // Look for a body consisting of a single Expr(Literal(Regex(pat))),
-        // skipping SetLine statements.
         let effective: Vec<_> = def
             .body
             .iter()
@@ -655,10 +655,21 @@ impl Interpreter {
             .collect();
         if effective.len() == 1
             && let Stmt::Expr(Expr::Literal(lit)) = effective[0]
-            && let ValueView::Regex(pat) = lit.view()
+            && matches!(lit.view(), ValueView::Regex(_))
         {
-            return Some(pat.to_string());
+            return Some(lit.clone());
         }
         None
+    }
+
+    /// Extract the regex pattern string from a named token/regex definition.
+    /// This compatibility helper is retained for matcher entry points that
+    /// have not migrated to the value-aware source-tree path yet.
+    pub(in crate::runtime) fn extract_token_regex_pattern(&self, name: &str) -> Option<String> {
+        let value = self.extract_token_regex_value(name)?;
+        match value.view() {
+            ValueView::Regex(pattern) => Some(pattern.to_string()),
+            _ => None,
+        }
     }
 }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -492,11 +492,13 @@ impl Interpreter {
                     package,
                 },
             ) => {
-                // Look up the token def and extract the regex pattern from its body
+                // Look up the token def and retain its source tree when the
+                // declaration body has one. The compatibility spelling still
+                // drives the legacy fallback for dynamic declarations.
                 let qualified = format!("{}::{}", package, name);
-                if let Some(pat) = self
-                    .extract_token_regex_pattern(&qualified)
-                    .or_else(|| self.extract_token_regex_pattern(&name.resolve()))
+                if let Some(regex) = self
+                    .extract_token_regex_value(&qualified)
+                    .or_else(|| self.extract_token_regex_value(&name.resolve()))
                 {
                     let text = self.regex_match_text(left);
                     // Push routine frame so &?ROUTINE resolves inside code blocks
@@ -513,7 +515,8 @@ impl Interpreter {
                         def_file: None,
                         invocation_id,
                     });
-                    if let Some(mut captures) = self.regex_match_with_captures(&pat, &text) {
+                    if let Some(mut captures) = self.regex_match_with_captures_value(&regex, &text)
+                    {
                         self.reset_capture_env_vars();
                         // Set positional captures before executing code blocks
                         for (i, v) in captures.positional.iter().enumerate() {

--- a/t/rakuast/rakuast-regex.t
+++ b/t/rakuast/rakuast-regex.t
@@ -8,7 +8,7 @@ use Test;
 # shapes Rakudo exposes. These examples are intentionally static: dynamic
 # assertions and interpolations remain explicit follow-up boundaries.
 
-plan 15;
+plan 16;
 
 is Q[/a/].AST.gist, q:to/END/.chomp, 'a regex literal has a Literal body';
     RakuAST::StatementList.new(
@@ -122,6 +122,38 @@ is Q[grammar GRegexRule { rule x { "a" } }].AST.gist, q:to/END/.chomp, 'grammar 
                             RakuAST::StrLiteral.new("a"),
                           )
                         )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+is Q[grammar GRegexAdjacent { rule x { a[bc]d } }].AST.gist, q:to/END/.chomp, 'declaration regex trees retain adjacency around groups';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Grammar.new(
+          name => RakuAST::Name.from-identifier("GRegexAdjacent"),
+          body => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::RuleDeclaration.new(
+                    name => RakuAST::Name.from-identifier("x"),
+                    body => RakuAST::Regex::Sequence.new(
+                      RakuAST::Regex::Literal.new("a"),
+                      RakuAST::Regex::Group.new(
+                        RakuAST::Regex::Sequence.new(
+                          RakuAST::Regex::Literal.new("bc")
+                        )
+                      ),
+                      RakuAST::Regex::WithWhitespace.new(
+                        RakuAST::Regex::Literal.new("d")
                       )
                     )
                   )

--- a/t/regex/regex-tree-static-execution.t
+++ b/t/regex/regex-tree-static-execution.t
@@ -6,7 +6,7 @@ use Test;
 # ADR-0088 issue #8033: static RegexTree nodes lower directly to the matcher
 # plan.  Dynamic regex content remains on the established runtime parser path.
 
-plan 8;
+plan 11;
 
 my $literal = EVAL(Q[/test/].AST);
 ok 'test' ~~ $literal, 'a static literal lowered from RakuAST matches';
@@ -21,3 +21,11 @@ my $grammar = EVAL(Q[grammar GRegexTreeExecution { token digits { \d+ } }].AST);
 ok $grammar.parse('123', :rule<digits>), 'a lowered token declaration matches';
 ok $grammar.parse('456', :rule<digits>), 'a lowered token declaration matches again';
 nok $grammar.parse('abc', :rule<digits>), 'the lowered token rejects a non-match';
+
+my $rule-grammar = EVAL(Q[grammar GRegexTreeRuleExecution { rule pair { a[bc] d } }].AST);
+ok $rule-grammar.parse('abc d', :rule<pair>),
+    'a lowered rule keeps source adjacency while applying sigspace';
+ok $rule-grammar.parse('abc d', :rule<pair>),
+    'a lowered rule can apply its source tree a second time';
+nok $rule-grammar.parse('abcd', :rule<pair>),
+    'a lowered rule rejects a missing source whitespace boundary';

--- a/t/regex/regex-tree-value-provenance.t
+++ b/t/regex/regex-tree-value-provenance.t
@@ -8,7 +8,7 @@ use Test;
 # existing RegexPattern matcher; dynamic regex contents remain on the fallback
 # path.
 
-plan 7;
+plan 9;
 
 my $rx = /test/;
 ok 'test' ~~ $rx, 'a parsed regex value keeps matching after storage';
@@ -30,3 +30,9 @@ my $constructed = RakuAST::QuotedRegex.new(
 my $constructed-value = EVAL($constructed);
 ok 'tree' ~~ $constructed-value, 'a constructed tree travels through EVAL';
 nok 'stale' ~~ $constructed-value, 'constructed provenance does not alter semantics';
+
+grammar GRegexDeclaredValue { rule pair { a[bc] d } }
+ok 'abc d' ~~ &GRegexDeclaredValue::pair,
+    'a named rule lowers its declaration tree through smartmatch';
+ok 'abc d' ~~ &GRegexDeclaredValue::pair,
+    'a named rule reuses its declaration tree without duplicate normalization';


### PR DESCRIPTION
## Summary

- retain source-level `RegexTree` provenance on parser and RakuAST regex declarations
- preserve `WithWhitespace` boundaries around adjacent declaration terms and lower rule sigspace from those markers
- route named regex smartmatch through the retained declaration value, with legacy fallback for unsupported/dynamic paths
- add AST, execution, provenance, ADR, and news coverage

This is the next bounded implementation slice of #8033; the campaign issue remains open for dynamic regex contents, captures, subrules, runtime adverb arguments, and other string-only matcher entry points.

## Validation

- `make lint`
- `make test`
- `make roast`

Part of #8033,