### PR TITLE
fix: dispatch a method for the listop invocant colon instead of dropping it

### DIFF
--- a/news/2026-09/listop-invocant-colon-dispatches-a-method.md
+++ b/news/2026-09/listop-invocant-colon-dispatches-a-method.md
@@ -1,0 +1,60 @@
+# The listop invocant colon dispatches a method instead of being dropped
+
+Raku's listop invocant colon makes the first argument the *invocant*: `foo $x: @args`
+is `$x.foo(@args)`. With nothing after the colon, `die "boom":` is therefore
+`"boom".die` — and since `Str` has no `die` method, rakudo raises
+`X::Method::NotFound`.
+
+mutsu implemented that rule for the generic no-paren listop path
+(`try_parse_no_paren_invocant_colon_call`) and for the parenthesized spelling
+`foo($x:)`, but three places bypassed it, each in a different way:
+
+* **The dedicated statement parsers.** `die`/`fail`/`take`/`take-rw` consume their
+  argument with a plain `expression` call, which stops *before* the colon and left
+  it unconsumed — so `die "boom":` did not parse at all. `return $x:` had a
+  targeted patch that consumed a bare trailing colon and threw it away.
+* **The tail-`Stmt::Call` value path.** When a `Stmt::Call` is the last statement of
+  a sub body, its arguments are remapped to expression arguments by
+  `call_args_to_expr_args`, which flattens `CallArg::Invocant(e)` to a plain
+  positional. `sub g() { warn "w": }` therefore *warned* where rakudo throws.
+* **`compile_tail_stmt_call_value`.** The other tail path did not flatten the
+  invocant — it fell through to the named/slip branch and hit its `unreachable!()`,
+  so `warn "w":` as the program's final statement panicked the compiler.
+
+The visible damage was graded. `say "hello":`, `sort @a:` and `return $x:` agreed
+with rakudo *by coincidence* — dropping the colon and dispatching the method happen
+to produce the same result there. `warn "w":` was a live wrong answer. `die "boom":`
+was a parse error, which is what blocked `Math::FractionalPart` (and through it
+`Astro::Utils` and `DateTime::Julian`) from loading at all.
+
+Fixing only `die`'s parse would have traded the loud failure for a quiet one: the
+module would load and then silently `die "FATAL: ..."` where rakudo raises
+`X::Method::NotFound`. So the shared rule was fixed instead.
+
+## What changed
+
+* `control_stmts.rs` gains `try_invocant_colon_stmt`, a thin wrapper over the same
+  `try_parse_no_paren_invocant_colon_call` every other listop already uses.
+  `die`/`fail`/`take`/`take-rw`/`return` each consult it after parsing their
+  argument, so all five now build the method call rather than dropping the colon
+  (`return`'s bespoke bare-colon patch is gone).
+* `Compiler::invocant_colon_method_call` is the one place that turns a
+  `Vec<CallArg>` carrying a leading `CallArg::Invocant` into the equivalent
+  `Expr::MethodCall`. `compile_stmt`'s `Stmt::Call` arm (which had this inline),
+  `compile_tail_stmt_call_value`, and the sub-body tail-`Stmt::Call` arm all route
+  through it, so no compile path can silently flatten an invocant again.
+  `call_args_to_expr_args` documents that callers must rule out the invocant first.
+
+All five listops from the issue's survey table now match rakudo, and they match it
+for the right reason. `return $x:` keeps its control transfer and its return-type
+check, because `Mu.return` goes through the routine's return path exactly as
+`return $x` does.
+
+`t/routines/call/call-listop-invocant-colon.t` pins the whole family — the listops
+whose method exists (`sort`, `return`, `take`), the ones whose method does not
+(`warn`, `die`, `fail`, `take-rw`), both the mid-body and final-statement compile
+paths, argument passing after the colon, and the two things that are *not* invocant
+colons (a leading colonpair adverb, and the `::` of a type name). It passes under
+rakudo unchanged.
+
+Closes #8141.

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -1234,6 +1234,15 @@ impl Compiler {
         name: crate::symbol::Symbol,
         args: &[CallArg],
     ) {
+        // An invocant colon makes this a method call on the first argument
+        // (`warn $x:` is `$x.warn`), exactly as the statement-position
+        // `Stmt::Call` arm already handles. Without this the `CallArg::Invocant`
+        // reached the named/slip branch below and hit its `unreachable!()`
+        // (#8141).
+        if let Some(method_call) = Self::invocant_colon_method_call(name, args) {
+            self.compile_expr(&method_call);
+            return;
+        }
         let rewritten_args = Self::rewrite_stmt_call_args(&name.resolve(), args);
         let positional_only = rewritten_args
             .iter()

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -104,9 +104,47 @@ impl Compiler {
         out
     }
 
+    /// The listop invocant colon: `foo($obj:)`, and the no-paren `foo $obj: @a`,
+    /// both make the first argument the *invocant*, so the call IS the method
+    /// call `$obj.foo(@a)`.
+    ///
+    /// Every path that compiles a `Stmt::Call` must consult this before treating
+    /// the argument list as ordinary positionals. `call_args_to_expr_args` below
+    /// cannot express the distinction — it maps `CallArg::Invocant(e)` to a plain
+    /// positional — so a tail `Stmt::Call` used to silently drop the colon and
+    /// call the sub normally. That is a wrong answer wherever the method does not
+    /// exist: `warn "w":` is `X::Method::NotFound` in Rakudo, not a warning
+    /// (#8141).
+    pub(super) fn invocant_colon_method_call(
+        name: crate::symbol::Symbol,
+        args: &[crate::ast::CallArg],
+    ) -> Option<Expr> {
+        let crate::ast::CallArg::Invocant(invocant) = args.first()? else {
+            return None;
+        };
+        let method_args: Vec<Expr> = args[1..]
+            .iter()
+            .filter_map(|arg| match arg {
+                crate::ast::CallArg::Positional(e) => Some(e.clone()),
+                _ => None,
+            })
+            .collect();
+        Some(Expr::MethodCall {
+            target: Box::new(invocant.clone()),
+            name,
+            args: method_args,
+            modifier: None,
+            quoted: false,
+        })
+    }
+
     /// Convert `Stmt::Call`'s `Vec<CallArg>` to `Vec<Expr>` for expression-level
     /// compilation (needed when a Stmt::Call is the last statement in a sub body
     /// and its return value must be preserved as implicit return).
+    ///
+    /// Callers must first rule out an invocant colon with
+    /// [`Compiler::invocant_colon_method_call`] — this mapping flattens
+    /// `CallArg::Invocant` to a positional and would drop it.
     pub(super) fn call_args_to_expr_args(args: &[crate::ast::CallArg]) -> Vec<Expr> {
         args.iter()
             .map(|arg| match arg {
@@ -737,6 +775,13 @@ impl Compiler {
                     // Stmt::Call as last statement: convert to expression-level
                     // Expr::Call so the return value is left on the stack.
                     Stmt::Call { name, args } => {
+                        // An invocant colon makes this a method call, not a sub
+                        // call (`warn $x:` is `$x.warn`); the arg-list mapping
+                        // below cannot carry that, so check it first.
+                        if let Some(method_call) = Self::invocant_colon_method_call(*name, args) {
+                            sub_compiler.compile_expr(&method_call);
+                            continue;
+                        }
                         let expr_args: Vec<Expr> = Self::call_args_to_expr_args(args);
                         sub_compiler.compile_expr(&Expr::Call {
                             name: *name,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2517,25 +2517,7 @@ impl Compiler {
             }
             Stmt::Call { name, args } => {
                 // Check for invocant colon syntax: foo($obj:) → $obj.foo()
-                if let Some(CallArg::Invocant(_)) = args.first() {
-                    let invocant_expr = match &args[0] {
-                        CallArg::Invocant(e) => e.clone(),
-                        _ => unreachable!(),
-                    };
-                    let method_args: Vec<Expr> = args[1..]
-                        .iter()
-                        .filter_map(|arg| match arg {
-                            CallArg::Positional(e) => Some(e.clone()),
-                            _ => None,
-                        })
-                        .collect();
-                    let method_call = Expr::MethodCall {
-                        target: Box::new(invocant_expr),
-                        name: *name,
-                        args: method_args,
-                        modifier: None,
-                        quoted: false,
-                    };
+                if let Some(method_call) = Self::invocant_colon_method_call(*name, args) {
                     self.compile_expr(&method_call);
                     // Sink context: a method-call statement (`foo($obj:);`,
                     // i.e. `$obj.foo();`) sinks its value, and sinking an

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -11,6 +11,7 @@ pub(super) use circumfix::declared_circumfix_op;
 pub(super) use identifier_call::identifier_or_call;
 pub(in crate::parser) use listop::{
     colon_starts_colonpair, expr_is_colonpair, parse_expr_listop_args, try_adjacent_colonpair_arg,
+    try_parse_no_paren_invocant_colon_call,
 };
 pub(in crate::parser) use predicates::{is_infix_word_op, is_keyword};
 pub(super) use term_literals::{class_literal, declared_term_symbol, keyword_literal, whatever};

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -2,6 +2,30 @@ use super::*;
 
 static TAKE_VALUE_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
+/// The listop invocant colon, for the listops that have a dedicated *statement*
+/// parser (`die`/`fail`/`take`/`take-rw`/`return`) instead of going through the
+/// generic no-paren listop path.
+///
+/// Raku's invocant colon makes the first argument the invocant, so `die $x:` is
+/// `$x.die` and `take $x:` is `$x.take` — exactly what
+/// `try_parse_no_paren_invocant_colon_call` already builds for every other
+/// listop. These parsers each consumed their argument with a plain `expression`
+/// call, which stops *before* the colon, so `die "boom":` did not parse at all
+/// and `return $x:` silently dropped the colon. Routing them through the same
+/// helper keeps one rule for the whole family (#8141).
+///
+/// Returns `Some(stmt)` together with the remaining input when the colon is
+/// really an invocant colon; `None` (and the input untouched) otherwise.
+fn try_invocant_colon_stmt<'a>(name: &str, arg: &Expr, rest: &'a str) -> PResult<'a, Option<Stmt>> {
+    let (rest, method_call) =
+        crate::parser::primary::ident::try_parse_no_paren_invocant_colon_call(
+            name,
+            arg.clone(),
+            rest,
+        )?;
+    Ok((rest, method_call.map(Stmt::Expr)))
+}
+
 /// Parse `return` statement.
 pub(crate) fn return_stmt(input: &str) -> PResult<'_, Stmt> {
     // If "return" is a declared term symbol (e.g. sigilless variable \return),
@@ -60,24 +84,16 @@ pub(crate) fn return_stmt(input: &str) -> PResult<'_, Stmt> {
             rest
         }
     };
-    // `return $x:` is the indirect-method-call spelling `$x.return`, which
-    // returns `$x` from the enclosing routine — identical to `return $x`. Accept
-    // a bare trailing colon (no colon-args), i.e. a `:` immediately followed by a
-    // statement terminator, and consume it. A `:` that starts an adverb/pair
-    // (`:foo`, `:$x`) is left alone. (Geo::Ellipsoid::Utils writes `return $x:`.)
-    let rest = {
-        let (after_ws, _) = ws(rest)?;
-        if let Some(after_colon) = after_ws.strip_prefix(':').filter(|r| !r.starts_with(':')) {
-            let (probe, _) = ws(after_colon)?;
-            if probe.is_empty() || probe.starts_with(';') || probe.starts_with('}') {
-                after_colon
-            } else {
-                rest
-            }
-        } else {
-            rest
-        }
-    };
+    // `return $x:` is the listop invocant colon: `$x.return`, which returns `$x`
+    // from the enclosing routine. Dispatch the method rather than dropping the
+    // colon, so this spelling follows the same rule as every other listop
+    // (#8141) — `Mu.return` transfers control exactly as `return $x` does, and
+    // the return-type check still fires at the routine boundary.
+    // (Geo::Ellipsoid::Utils writes `return $x:`.)
+    let (after_invocant, invocant_stmt) = try_invocant_colon_stmt("return", &expr, rest)?;
+    if let Some(stmt) = invocant_stmt {
+        return parse_statement_modifier(after_invocant, stmt);
+    }
     let stmt = Stmt::Return(expr);
     parse_statement_modifier(rest, stmt)
 }
@@ -164,6 +180,15 @@ pub(crate) fn die_stmt(input: &str) -> PResult<'_, Stmt> {
     // (or `fail` returns a Failure) with `X` and the tail is dead code. Parse the
     // argument no-word-logical and consume (discard) any trailing tail.
     let (rest, expr) = expression_no_word_logical(rest)?;
+    // `die $x:` / `fail $x:` is the listop invocant colon: `$x.die` / `$x.fail`.
+    // Neither method exists on `Str`, so Rakudo raises X::Method::NotFound —
+    // which is the whole point. Dropping the colon and dying with `$x` instead
+    // would turn a loud parse error into a quiet wrong answer.
+    let listop_name = if is_fail { "fail" } else { "die" };
+    let (after_invocant, invocant_stmt) = try_invocant_colon_stmt(listop_name, &expr, rest)?;
+    if let Some(stmt) = invocant_stmt {
+        return parse_statement_modifier(after_invocant, stmt);
+    }
     let rest = {
         let (r, _) = ws(rest)?;
         if crate::parser::expr::starts_with_loose_word_logical(r) {
@@ -202,6 +227,11 @@ pub(crate) fn take_stmt(input: &str) -> PResult<'_, Stmt> {
     {
         let (rest, expr) = parse_comma_or_expr(rest)?;
         let expr = unwrap_single_trailing_comma(expr);
+        // `take-rw $x:` is the listop invocant colon: `$x.take-rw`.
+        let (after_invocant, invocant_stmt) = try_invocant_colon_stmt("take-rw", &expr, rest)?;
+        if let Some(stmt) = invocant_stmt {
+            return parse_statement_modifier(after_invocant, stmt);
+        }
         // `take-rw`: is_rw=true. The compiler captures the source container so the
         // gathered value keeps container identity (`=:=`) with the original lvalue.
         return parse_statement_modifier(rest, Stmt::Take(expr, true));
@@ -213,6 +243,11 @@ pub(crate) fn take_stmt(input: &str) -> PResult<'_, Stmt> {
     // side effects, then use that same taken value to drive the short-circuit.
     let (rest, expr) = crate::parser::stmt::assign::parse_comma_or_expr_no_word_logical(rest)?;
     let expr = unwrap_single_trailing_comma(expr);
+    // `take $x:` is the listop invocant colon: `$x.take`.
+    let (after_invocant, invocant_stmt) = try_invocant_colon_stmt("take", &expr, rest)?;
+    if let Some(stmt) = invocant_stmt {
+        return parse_statement_modifier(after_invocant, stmt);
+    }
     let (r, _) = ws(rest)?;
     let stmt = if crate::parser::expr::starts_with_loose_word_logical(r) {
         let id = TAKE_VALUE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/t/routines/call/call-listop-invocant-colon.t
+++ b/t/routines/call/call-listop-invocant-colon.t
@@ -1,0 +1,86 @@
+use Test;
+
+# Raku's listop invocant colon makes the FIRST argument the invocant:
+# `foo $x: @args` is `$x.foo(@args)`. mutsu used to drop the colon and call the
+# listop normally, which agreed with rakudo only by coincidence (`say`, `sort`,
+# `return`) and gave a wrong answer where it did not (`warn "w":` warned instead
+# of throwing X::Method::NotFound). `die`/`fail`/`take` did not parse at all,
+# because their dedicated statement parsers stopped before the colon.
+#
+# This file pins the shared rule across the whole family rather than just the
+# constructs that happened to be broken. See issue #8141.
+
+plan 16;
+
+# --- listops whose method DOES exist: the colon dispatches it ---------------
+
+my @a = 3, 1, 2;
+my $sorted = sort @a:;
+is $sorted.List.raku, (1, 2, 3).raku, 'sort @a: dispatches @a.sort';
+
+sub returns_it() { my $x = 42; return $x: }
+is returns_it(), 42, 'return $x: dispatches $x.return and returns from the routine';
+
+sub returns_early() { return "r": ; flunk "return \$x: did not transfer control" }
+is returns_early(), "r", 'return $x: transfers control like return $x';
+
+sub taker() { take "t": }
+my $taken = gather { taker() };
+is $taken.List.raku, ("t",).raku, 'take $x: dispatches $x.take';
+
+# `Str` has no `take-rw` method, so the colon throws here exactly as it does
+# for `warn`/`die`/`fail` below.
+throws-like 'my @r = gather { my $v = "u"; take-rw $v: }', X::Method::NotFound,
+    method => 'take-rw', typename => 'Str',
+    'take-rw $x: dispatches $x.take-rw';
+
+# The return-type check still fires at the routine boundary, so the method
+# dispatch really is routed through the routine's return path.
+throws-like 'sub typed(--> Int) { return "r": }; typed()',
+    X::TypeCheck::Return,
+    'return $x: still type-checks the return value';
+
+# --- listops whose method does NOT exist: the colon must throw --------------
+
+throws-like 'sub g() { warn "w": }; g()', X::Method::NotFound,
+    method => 'warn', typename => 'Str',
+    'warn $x: is $x.warn, not a warning';
+
+throws-like 'sub f() { die "boom": }; f()', X::Method::NotFound,
+    method => 'die', typename => 'Str',
+    'die $x: is $x.die, not a die with that message';
+
+throws-like 'sub f() { fail "boom": }; f()', X::Method::NotFound,
+    method => 'fail', typename => 'Str',
+    'fail $x: is $x.fail, not a fail with that message';
+
+# The same three outside a routine body: the tail-statement compile path used to
+# differ from the mid-body one (it panicked on the invocant instead of throwing).
+throws-like 'warn "w":', X::Method::NotFound,
+    'warn $x: as the final statement of the program';
+
+throws-like 'die "boom":', X::Method::NotFound,
+    'die $x: as the final statement of the program';
+
+throws-like 'say "x"; warn "w":', X::Method::NotFound,
+    'warn $x: as the final statement after another statement';
+
+# --- the invocant colon carries the remaining arguments ---------------------
+
+class Greeter {
+    method greet($a, $b) { "$a-$b" }
+}
+my $g = Greeter.new;
+is (greet $g: "x", "y"), "x-y", 'listop invocant colon passes the remaining args';
+
+# --- a colonpair is NOT an invocant colon -----------------------------------
+
+sub adverbed($x, :$loud) { $loud ?? uc($x) !! $x }
+is adverbed("q", :loud), "Q", 'a leading colonpair adverb is not an invocant colon';
+
+sub plain_ret() { return 5 }
+is plain_ret(), 5, 'plain return still works';
+
+# `::` in a type name must not be read as an invocant colon either.
+throws-like 'die X::AdHoc.new(payload => "p")', X::AdHoc,
+    'die X::Name.new(...) is not affected by the invocant-colon rule';


### PR DESCRIPTION
Raku's listop invocant colon makes the first argument the *invocant*: `foo $x: @args` is `$x.foo(@args)`. With nothing after the colon, `die "boom":` is `"boom".die`, and since `Str` has no `die` method rakudo raises `X::Method::NotFound`.

mutsu implemented that rule for the generic no-paren listop path (`try_parse_no_paren_invocant_colon_call`) and for the parenthesized `foo($x:)`, but three places bypassed it — each differently.

## The three gaps

**The dedicated statement parsers.** `die`/`fail`/`take`/`take-rw` consume their argument with a plain `expression` call, which stops *before* the colon and left it unconsumed — so `die "boom":` did not parse at all. `return $x:` had a targeted patch that consumed a bare trailing colon and threw it away.

**The tail-`Stmt::Call` value path.** When a `Stmt::Call` is the last statement of a sub body its arguments are remapped by `call_args_to_expr_args`, which flattens `CallArg::Invocant(e)` to a plain positional. `sub g() { warn "w": }` therefore *warned* where rakudo throws.

**`compile_tail_stmt_call_value`.** The other tail path did not flatten the invocant — it fell through to the named/slip branch and hit its `unreachable!()`, so `warn "w":` as the program's final statement **panicked the compiler**.

## Why one fix and not two

The visible damage was graded. `say "hello":`, `sort @a:` and `return $x:` agreed with rakudo *by coincidence* — dropping the colon and dispatching the method happen to produce the same result there. `warn "w":` was a live wrong answer. `die "boom":` was a parse error, and it is what blocked `Math::FractionalPart` (and through it `Astro::Utils` and `DateTime::Julian`) from loading.

Fixing only `die`'s parse would have traded that loud failure for a quiet one: the module would load and then silently `die "FATAL: ..."` where rakudo raises `X::Method::NotFound`. So the shared rule is fixed instead, and all five rows of the issue's survey table now agree with rakudo *for the right reason*.

## Changes

* `control_stmts.rs` gains `try_invocant_colon_stmt`, a thin wrapper over the same `try_parse_no_paren_invocant_colon_call` every other listop already uses. `die`/`fail`/`take`/`take-rw`/`return` each consult it after parsing their argument. `return`'s bespoke bare-colon patch is removed — `Mu.return` goes through the routine's return path, so both the control transfer and the return-type check still fire (pinned by tests).
* `Compiler::invocant_colon_method_call` becomes the single place that turns a `Vec<CallArg>` carrying a leading `CallArg::Invocant` into the equivalent `Expr::MethodCall`. `compile_stmt`'s `Stmt::Call` arm (which had this inline), `compile_tail_stmt_call_value`, and the sub-body tail-`Stmt::Call` arm all route through it, so no compile path can silently flatten an invocant again. `call_args_to_expr_args` documents that callers must rule out the invocant first.

## Measured against rakudo 2026.07

| construct | rakudo | mutsu before | mutsu after |
|---|---|---|---|
| `say "hello":` | `hello` | `hello` (colon dropped) | `hello` (`"hello".say`) |
| `say sort @a:` | `(1 2 3)` | `(1 2 3)` (colon dropped) | `(1 2 3)` (`@a.sort`) |
| `return "r":` | `r` | `r` (colon dropped) | `r` (`"r".return`) |
| `warn "w":` (in a sub) | `X::Method::NotFound` | warned `w` | `X::Method::NotFound` |
| `warn "w":` (final stmt) | `X::Method::NotFound` | **compiler panic** | `X::Method::NotFound` |
| `die "boom":` | `X::Method::NotFound` | **parse error** | `X::Method::NotFound` |
| `fail "boom":` | `X::Method::NotFound` | **parse error** | `X::Method::NotFound` |
| `take "t":` | `(t)` | **parse error** | `(t)` (`"t".take`) |
| `take-rw $v:` | `X::Method::NotFound` | **parse error** | `X::Method::NotFound` |

The exact `Math::FractionalPart` line now parses and raises `X::Method::NotFound`, matching rakudo.

## Tests

`t/routines/call/call-listop-invocant-colon.t` (16 assertions) pins the whole family rather than just the broken constructs: listops whose method exists, listops whose method does not, both the mid-body and final-statement compile paths, argument passing after the colon, and the two things that are *not* invocant colons (a leading colonpair adverb, and the `::` of a type name). **It passes under rakudo 2026.07 unchanged**, so it is a spec test, not a mutsu-shaped one.

## Verification

* `cargo fmt --all` — clean
* `make lint` — green (all four configurations)
* `make test` — green, 4116 files / 43809 tests
* `make roast` — green apart from the three container-only failures documented in `docs/agent-environments.md` (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` run as `uid 0`; `S32-io/IO-Socket-Async.t` needs unsandboxed network), with the exact test numbers that document lists

## Aside

While measuring `take-rw` I found an unrelated pre-existing bug and filed it as #8159: an exception thrown inside `gather { ... }` is silently swallowed when the `Seq` is consumed lazily (`say gather { "u".nosuchmethod }` prints an empty line and exits 0), while the eager `my @r = gather {...}` spelling propagates it correctly. Not touched here.

Closes #8141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pz6URmTWmqMP41wKgpjkRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pz6URmTWmqMP41wKgpjkRo)_