### PR TITLE
feat(rakuast): an absent optional field answers instead of dying

### DIFF
--- a/news/2026-09/rakuast-absent-optional-fields-answer.md
+++ b/news/2026-09/rakuast-absent-optional-fields-answer.md
@@ -1,0 +1,84 @@
+# RakuAST: an absent optional field answers instead of dying
+
+A RakuAST node stores only the fields its source actually produced. The renderer
+elides an `if` with no `else`, an empty `elsifs`, a `dwim-left` that is false —
+and until now so did the accessor layer, which built a node's method set out of
+the fields the node happened to hold. Asking a statement for a modifier it did
+not have was therefore a hard error:
+
+```
+$ mutsu -e 'say Q[say 1 with 2].AST.statements[0].loop-modifier.defined'
+No such method 'loop-modifier' for invocant of type 'RakuAST::Statement::Expression'
+```
+
+Rakudo declares every field as an attribute, so the same call is legal there and
+answers with an undefined value — which is exactly what makes `.defined` the
+natural way to test for an optional clause:
+
+```
+$ raku -e 'say Q[say 1 with 2].AST.statements[0].loop-modifier.defined'
+False
+```
+
+The cost of the gap was paid in the tests: "the `with` modifier does not occupy
+the loop-modifier slot" had to be spelled `unlike ....AST.gist, /'loop-modifier'/`,
+a string match standing in for a structural check, and the same trick pinned
+"a `with` block inside an `else` is a statement, not an `elsif` clause"
+(#8123's release note flagged both).
+
+## What changed
+
+The declaration is now separate from what a node carries.
+`src/rakuast/fields.rs` holds, per class, the fields that class declares
+together with what each answers when the node does not carry it, and
+`node_accessor` consults it after its lookup over the node's own fields misses.
+`.^attributes(:local)` and `.^methods(:local)` are derived from the same table,
+so introspection and dispatch can no longer disagree about which accessors
+exist.
+
+Each answer is a measured shape, not a uniform `Nil`:
+
+- an absent node-typed field answers with its **declared type object** —
+  `.else` on an `if` without one is `(Block)`, `.loop-modifier` is `(Loop)`,
+  `.initializer` on `my $x` is `(Initializer)`;
+- an absent `List` field answers `()`, never undefined — an `if` with no `elsif`
+  has `.elsifs.elems == 0`, not an exception and not a type object;
+- a `Bool` flag the renderer elides answers `False`, and an `int` flag `0`
+  (`Pragma.off`);
+- a field whose *empty* value the renderer elides answers with that empty node:
+  `sub f { }` gists with no `signature`, but `.signature` is a defined,
+  parameterless `RakuAST::Signature`, as on rakudo;
+- `Parameter.optional` is tri-state on rakudo — `False` on a plain positional,
+  but left unset when optionality follows from something else (a default, a
+  slurpy, a named parameter) — so an absent one answers with an undefined
+  `Bool`;
+- a structurally required field (`ApplyInfix.left`) declares no absent answer and
+  still falls through to ordinary "no such method" dispatch, rather than
+  inventing a value for a malformed node.
+
+Two ad-hoc special cases disappeared into the table (`MetaInfix::Hyper`'s
+`dwim-left`/`dwim-right`, and `Pragma`'s `argument`/`off`), and both were
+answering with the wrong *type* while being right about truthiness:
+`Pragma.argument` handed back `Nil` where rakudo has `(Expression)`, and
+`Pragma.off` `False` where rakudo has `0`.
+
+Alongside this, `RakuAST::StatementModifier::If` / `::Unless` / `::With` /
+`::Without` / `::Given` gained the `.expression` accessor they had never
+exposed, and `Statement::Expression` gained the `condition-modifier` slot it
+could fill but not declare.
+
+## Verification
+
+A sweep over 21 sample programs walked every node of each tree and called every
+declared accessor under both implementations: 289 lines of class/accessor/
+type/definedness, identical but for one line. That one is a pre-existing
+converter difference unrelated to this change — `Parameter.slurpy` stores an
+empty node in mutsu where rakudo stores the `RakuAST::Parameter::Slurpy::*`
+type object itself, so the field renders identically but reads as defined
+(filed as #8157).
+
+`t/rakuast/rakuast-absent-field-accessors.t` pins the mechanism, and the two
+`.gist` string matches named above are now the structural checks they were
+standing in for. Every assertion passes under both mutsu and raku.
+
+Closes #8124.

--- a/src/rakuast/fields.rs
+++ b/src/rakuast/fields.rs
@@ -1,0 +1,223 @@
+//! The model fields each RakuAST class declares, and what an accessor answers
+//! when the node does not carry one.
+//!
+//! A RakuAST node only stores the fields its source actually produced — the
+//! renderer elides an absent `else`, an empty `elsifs`, a false `dwim-left`.
+//! Rakudo, by contrast, declares every field as an attribute, so asking for one
+//! that is not there is legal and answers with an undefined (or empty, or
+//! false) value; that is what makes `.defined` the natural way to test for an
+//! optional clause:
+//!
+//! ```text
+//! $ raku -e 'say Q[say 1 with 2].AST.statements[0].loop-modifier.defined'
+//! False
+//! ```
+//!
+//! So the field list here is the *declaration*, separate from the fields a
+//! given node happens to hold: [`node_accessor`](super::node_accessor) consults
+//! it when its lookup over the node's own fields misses, and
+//! `.^attributes(:local)` / `.^methods(:local)` report it so introspection and
+//! dispatch cannot disagree about which accessors exist.
+//!
+//! Every [`Absent`] answer below was measured against rakudo 2026.07 — both the
+//! value (`.^attributes` reports the declared type; an unset attribute holds
+//! that type's type object) and the shape (`List` answers `()`, never
+//! undefined; a `Bool` flag answers `False`; an `int` flag answers `0`).
+
+use super::RakuAstClass;
+use crate::symbol::Symbol;
+use crate::value::Value;
+
+/// What a declared model field answers with when a node does not carry it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Absent {
+    /// An undefined type object of the field's declared type — what rakudo's
+    /// unset attribute holds (`.else` on an `if` with no else is `(Block)`).
+    TypeObject(&'static str),
+    /// An empty list. A `List`-typed field is never undefined in rakudo: an
+    /// `if` with no `elsif` answers `()`, not a type object.
+    EmptyList,
+    /// `False`, for a `Bool` flag the renderer elides when it is false.
+    False,
+    /// `0`, for an `int` flag (rakudo's `Pragma.off`).
+    Zero,
+    /// An empty node of the given class. A field rakudo always fills but whose
+    /// *empty* value its renderer elides — `sub f { }` gists with no
+    /// `signature`, yet `.signature` answers a defined, parameterless
+    /// `RakuAST::Signature`.
+    EmptyNode(RakuAstClass),
+    /// Structurally required: a well-formed node always carries it, so there is
+    /// no absent value to invent. Asking for it on a malformed node falls
+    /// through to ordinary "no such method" dispatch rather than answering with
+    /// a fiction.
+    Required,
+}
+
+impl Absent {
+    /// The value the accessor answers with, or `None` for a required field.
+    pub(super) fn value(self) -> Option<Value> {
+        Some(match self {
+            Absent::TypeObject(name) => Value::package(Symbol::intern(name)),
+            Absent::EmptyList => Value::array(Vec::new()),
+            Absent::False => Value::truth(false),
+            Absent::Zero => Value::int(0),
+            Absent::EmptyNode(class) => Value::rakuast(Box::new(super::RakuAstNode {
+                class,
+                fields: Vec::new(),
+            })),
+            Absent::Required => return None,
+        })
+    }
+}
+
+const EXPRESSION: Absent = Absent::TypeObject("RakuAST::Expression");
+const BLOCK: Absent = Absent::TypeObject("RakuAST::Block");
+
+/// The fields a RakuAST class declares, in rakudo's own declaration order
+/// (which is the order `.^attributes` reports and the renderer emits).
+pub(super) fn model_fields(class: RakuAstClass) -> &'static [(&'static str, Absent)] {
+    use RakuAstClass::*;
+    match class {
+        StatementList => &[("statements", Absent::EmptyList)],
+        StatementExpression => &[
+            ("expression", Absent::Required),
+            (
+                "condition-modifier",
+                Absent::TypeObject("RakuAST::StatementModifier::Condition"),
+            ),
+            (
+                "loop-modifier",
+                Absent::TypeObject("RakuAST::StatementModifier::Loop"),
+            ),
+        ],
+        IntLiteral | RatLiteral | StrLiteral => &[("value", Absent::Required)],
+        VarLexical => &[("name", Absent::Required)],
+        ApplyInfix => &[
+            ("left", Absent::Required),
+            ("infix", Absent::Required),
+            ("right", Absent::Required),
+        ],
+        FunctionInfix => &[("function", Absent::Required)],
+        ApplyPrefix => &[("prefix", Absent::Required), ("operand", Absent::Required)],
+        ApplyPostfix => &[("operand", Absent::Required), ("postfix", Absent::Required)],
+        Postfix => &[("operator", Absent::Required)],
+        Block => &[("body", Absent::TypeObject("RakuAST::Blockoid"))],
+        Blockoid => &[("statement-list", Absent::Required)],
+        Sub => &[
+            ("name", Absent::TypeObject("RakuAST::Name")),
+            ("signature", Absent::EmptyNode(Signature)),
+            ("traits", Absent::EmptyList),
+            ("body", Absent::Required),
+        ],
+        Signature => &[
+            ("parameters", Absent::EmptyList),
+            ("returns", Absent::TypeObject("RakuAST::Node")),
+        ],
+        MetaInfixAssign => &[("infix", Absent::Required)],
+        MetaInfixHyper => &[
+            ("dwim-left", Absent::False),
+            ("infix", Absent::Required),
+            ("dwim-right", Absent::False),
+        ],
+        TraitReturns | TraitOf => &[("type", Absent::Required)],
+        Parameter => &[
+            ("type", Absent::TypeObject("RakuAST::Type")),
+            ("names", Absent::EmptyList),
+            ("type-captures", Absent::EmptyList),
+            ("target", Absent::TypeObject("RakuAST::ParameterTarget")),
+            // Tri-state on rakudo: `False` on a plain positional, but left
+            // UNSET (an undefined `Bool`) when optionality follows from
+            // something else — a default, a slurpy, a named parameter.
+            ("optional", Absent::TypeObject("Bool")),
+            ("default", EXPRESSION),
+            ("where", EXPRESSION),
+            ("slurpy", Absent::TypeObject("RakuAST::Parameter::Slurpy")),
+            ("sub-signature", Absent::TypeObject("RakuAST::Signature")),
+        ],
+        ParameterTargetVar => &[("name", Absent::Required)],
+        VarDeclarationSimple => &[
+            ("sigil", Absent::Required),
+            ("desigilname", Absent::Required),
+            ("initializer", Absent::TypeObject("RakuAST::Initializer")),
+        ],
+        InitializerAssign => &[("expression", Absent::Required)],
+        TypeSimple | TypeSetting | TypeCapture => &[("name", Absent::Required)],
+        TypeEnum => &[("name", Absent::Required), ("term", Absent::Required)],
+        QuotedRegex => &[
+            ("match-immediately", Absent::False),
+            ("body", Absent::Required),
+            ("adverbs", Absent::EmptyList),
+        ],
+        RegexSequence | RegexAlternation => &[("terms", Absent::EmptyList)],
+        RegexLiteral => &[("text", Absent::Required)],
+        RegexQuote => &[("quoted", Absent::Required)],
+        RegexGroup | RegexWithWhitespace => &[("regex", Absent::Required)],
+        RegexQuantifiedAtom => &[
+            ("atom", Absent::Required),
+            ("quantifier", Absent::Required),
+            ("separator", Absent::TypeObject("RakuAST::Regex::Term")),
+            ("trailing-separator", Absent::False),
+        ],
+        RegexDeclaration | TokenDeclaration | RuleDeclaration => {
+            &[("name", Absent::Required), ("body", Absent::Required)]
+        }
+        Grammar => &[("name", Absent::Required), ("body", Absent::Required)],
+        Pragma => &[
+            ("name", Absent::Required),
+            ("argument", EXPRESSION),
+            ("off", Absent::Zero),
+        ],
+        // The conditional family. `If` and `With` take the `elsif`/`orwith`
+        // chain and an `else`; `Unless` and `Without` take neither (rakudo
+        // rejects them at compile time) and name their block `body` rather than
+        // `then` — the asymmetry #8123 matched.
+        StatementIf | StatementWith => &[
+            ("condition", Absent::Required),
+            ("then", Absent::Required),
+            ("elsifs", Absent::EmptyList),
+            ("else", BLOCK),
+        ],
+        StatementUnless | StatementWithout => {
+            &[("condition", Absent::Required), ("body", Absent::Required)]
+        }
+        StatementElsif | StatementOrwith => {
+            &[("condition", Absent::Required), ("then", Absent::Required)]
+        }
+        // Every statement modifier exposes the condition/topic it was written
+        // with as `.expression`, which mutsu stores as the node's single
+        // positional field.
+        StatementModifierGiven
+        | StatementModifierIf
+        | StatementModifierUnless
+        | StatementModifierWith
+        | StatementModifierWithout => &[("expression", Absent::Required)],
+        _ => &[],
+    }
+}
+
+/// The accessor a class exposes over its single positional field. The named
+/// lookup runs first, so a class with a *named* field of the same name (e.g.
+/// `Call::Name.name`) is unaffected.
+pub(super) fn positional_accessor(class: RakuAstClass) -> Option<&'static str> {
+    use RakuAstClass::*;
+    Some(match class {
+        IntLiteral | RatLiteral | StrLiteral => "value",
+        FunctionInfix => "function",
+        VarLexical => "name",
+        Blockoid => "statement-list",
+        InitializerAssign => "expression",
+        MetaInfixAssign => "infix",
+        TypeSimple | TypeSetting | TypeCapture => "name",
+        TraitReturns | TraitOf => "type",
+        RegexLiteral => "text",
+        RegexQuote => "quoted",
+        RegexSequence | RegexAlternation => "terms",
+        RegexGroup | RegexWithWhitespace => "regex",
+        StatementModifierGiven
+        | StatementModifierIf
+        | StatementModifierUnless
+        | StatementModifierWith
+        | StatementModifierWithout => "expression",
+        _ => return None,
+    })
+}

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -11,6 +11,7 @@
 //! phasing (construction, EVAL, macros are later phases).
 
 mod convert;
+mod fields;
 mod formatter;
 mod lower;
 mod render;
@@ -649,6 +650,11 @@ fn is_registered_type_object(class_name: &str) -> bool {
             | "RakuAST::Postcircumfix"
             | "RakuAST::Circumfix"
             | "RakuAST::StatementModifier"
+            // The two abstract halves of the StatementModifier hierarchy: an
+            // absent `condition-modifier` / `loop-modifier` answers with one of
+            // these type objects, so they have to be nameable.
+            | "RakuAST::StatementModifier::Condition"
+            | "RakuAST::StatementModifier::Loop"
             | "RakuAST::StatementPrefix"
             | "RakuAST::MetaPostfix"
             | "RakuAST::MetaInfix"
@@ -1667,21 +1673,6 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
             return Some(field_to_value(&f.value));
         }
     }
-    // A declared-but-omitted boolean field reads as `False`: raku's gist elides
-    // `dwim-left` / `dwim-right` when they are false, but the accessors still
-    // answer.
-    if node.class == RakuAstClass::MetaInfixHyper && matches!(method, "dwim-left" | "dwim-right") {
-        return Some(Value::truth(false));
-    }
-    if node.class == RakuAstClass::Pragma {
-        match method {
-            // Rakudo declares both fields but omits their false/empty values
-            // from `.gist` for the argument-less form.
-            "argument" => return Some(Value::NIL),
-            "off" => return Some(Value::truth(false)),
-            _ => {}
-        }
-    }
     if method == "statements" && matches!(node.class, RakuAstClass::StatementList) {
         let items = node
             .fields
@@ -1693,33 +1684,23 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
     // Positional-leaf accessors: a node whose single positional field is its
     // payload exposes it under a class-specific name (`IntLiteral.value`,
     // `Var::Lexical.name`). The named-field loop above runs first, so a class
-    // with a *named* field of the same name (e.g. `Call::Name.name`) is unaffected.
-    let positional_name = match node.class {
-        RakuAstClass::IntLiteral | RakuAstClass::RatLiteral | RakuAstClass::StrLiteral => {
-            Some("value")
-        }
-        RakuAstClass::FunctionInfix => Some("function"),
-        RakuAstClass::VarLexical => Some("name"),
-        RakuAstClass::Blockoid => Some("statement-list"),
-        RakuAstClass::InitializerAssign => Some("expression"),
-        RakuAstClass::MetaInfixAssign => Some("infix"),
-        RakuAstClass::TypeSimple | RakuAstClass::TypeSetting | RakuAstClass::TypeCapture => {
-            Some("name")
-        }
-        RakuAstClass::TraitReturns | RakuAstClass::TraitOf => Some("type"),
-        RakuAstClass::RegexLiteral => Some("text"),
-        RakuAstClass::RegexQuote => Some("quoted"),
-        RakuAstClass::RegexSequence | RakuAstClass::RegexAlternation => Some("terms"),
-        RakuAstClass::RegexGroup | RakuAstClass::RegexWithWhitespace => Some("regex"),
-        _ => None,
-    };
-    if positional_name == Some(method)
+    // with a *named* field of the same name (e.g. `Call::Name.name`) is
+    // unaffected.
+    if fields::positional_accessor(node.class) == Some(method)
         && let Some(f) = node.fields.first()
         && f.name.is_none()
     {
         return Some(field_to_value(&f.value));
     }
-    None
+    // A field the class DECLARES but this node does not carry still answers:
+    // rakudo models every field as an attribute, so an absent optional clause
+    // reads as an undefined type object (or `()` / `False` / `0`) rather than
+    // dying. That is what makes `.defined` the way to test for one — see
+    // `fields::Absent`.
+    fields::model_fields(node.class)
+        .iter()
+        .find(|(name, _)| *name == method)
+        .and_then(|(_, absent)| absent.value())
 }
 
 /// Native methods currently exposed directly by a RakuAST model class.
@@ -1778,7 +1759,7 @@ pub fn inherited_method_names(class_name: &str) -> Option<Vec<&'static str>> {
 ///
 /// As with [`local_method_names`], these are mutsu's public model fields rather
 /// than Rakudo's backend storage slots.
-pub fn local_attribute_names(class_name: &str) -> Option<&'static [&'static str]> {
+pub fn local_attribute_names(class_name: &str) -> Option<Vec<&'static str>> {
     class_from_name(class_name).map(accessor_names)
 }
 
@@ -1841,52 +1822,14 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
     )
 }
 
-fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
-    use RakuAstClass::*;
-    match class {
-        StatementList => &["statements"],
-        StatementExpression => &["expression", "loop-modifier"],
-        IntLiteral | RatLiteral | StrLiteral => &["value"],
-        VarLexical => &["name"],
-        ApplyInfix => &["left", "infix", "right"],
-        FunctionInfix => &["function"],
-        ApplyPrefix => &["prefix", "operand"],
-        ApplyPostfix => &["operand", "postfix"],
-        Postfix => &["operator"],
-        Block => &["body"],
-        Blockoid => &["statement-list"],
-        Sub => &["name", "signature", "traits", "body"],
-        Signature => &["parameters", "returns"],
-        MetaInfixAssign => &["infix"],
-        MetaInfixHyper => &["dwim-left", "infix", "dwim-right"],
-        TraitReturns | TraitOf => &["type"],
-        Parameter => &[
-            "type",
-            "names",
-            "type-captures",
-            "target",
-            "optional",
-            "default",
-            "where",
-            "slurpy",
-            "sub-signature",
-        ],
-        ParameterTargetVar => &["name"],
-        VarDeclarationSimple => &["sigil", "desigilname", "initializer"],
-        InitializerAssign => &["expression"],
-        TypeSimple | TypeSetting | TypeCapture => &["name"],
-        TypeEnum => &["name", "term"],
-        QuotedRegex => &["match-immediately", "body", "adverbs"],
-        RegexSequence | RegexAlternation => &["terms"],
-        RegexLiteral => &["text"],
-        RegexQuote => &["quoted"],
-        RegexGroup | RegexWithWhitespace => &["regex"],
-        RegexQuantifiedAtom => &["atom", "quantifier", "separator", "trailing-separator"],
-        RegexDeclaration | TokenDeclaration | RuleDeclaration => &["name", "body"],
-        Grammar => &["name", "body"],
-        Pragma => &["name", "argument", "off"],
-        _ => &[],
-    }
+/// The accessor names a RakuAST class declares, in declaration order. Derived
+/// from [`fields::model_fields`] so introspection and dispatch cannot disagree
+/// about which accessors a class has.
+fn accessor_names(class: RakuAstClass) -> Vec<&'static str> {
+    fields::model_fields(class)
+        .iter()
+        .map(|(name, _)| *name)
+        .collect()
 }
 
 fn field_to_value(fv: &RakuAstFieldValue) -> Value {

--- a/t/rakuast/rakuast-absent-field-accessors.t
+++ b/t/rakuast/rakuast-absent-field-accessors.t
@@ -1,0 +1,85 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# An optional RakuAST field a node does NOT carry still answers (#8124).
+#
+# A node only stores the fields its source produced, but raku declares every
+# field as an attribute, so asking for an absent one is legal and yields an
+# undefined value of the field's declared type. That is what makes `.defined`
+# the natural way to test for an optional clause — without it, the only way to
+# ask "does this statement have a loop modifier?" is to match `.gist` against a
+# string, which is what `t/rakuast/rakuast-with-without-modifier.t` had to do.
+#
+# Measured against Rakudo 2026.07; every assertion passes under BOTH mutsu and
+# raku.
+
+plan 27;
+
+# --- an absent node-typed field is that field's type object -----------------
+
+my $with-mod = Q[say 1 with 2].AST.statements[0];
+is $with-mod.loop-modifier.^name, 'RakuAST::StatementModifier::Loop',
+    'an absent loop-modifier answers with its declared type object';
+nok $with-mod.loop-modifier.defined,
+    'and that type object is undefined, so .defined is the test for the slot';
+ok $with-mod.condition-modifier.defined,
+    'while the slot the with modifier DID fill is defined';
+
+my $plain = Q[say 1].AST.statements[0];
+is $plain.condition-modifier.^name, 'RakuAST::StatementModifier::Condition',
+    'an absent condition-modifier answers with its own declared type object';
+nok $plain.condition-modifier.defined, 'absent condition-modifier is undefined';
+nok $plain.loop-modifier.defined, 'absent loop-modifier is undefined';
+
+# The same holds across the conditional family the `with` block forms joined.
+my $if = Q[if 1 { 2 }].AST.statements[0];
+is $if.else.^name, 'RakuAST::Block', 'an absent else answers with (Block)';
+nok $if.else.defined, 'an if with no else has an undefined else';
+ok Q[if 1 { 2 } else { 3 }].AST.statements[0].else.defined,
+    'an if that HAS an else answers with a defined Block';
+
+my $with = Q[with 1 { 2 }].AST.statements[0];
+nok $with.else.defined, 'a with with no else has an undefined else';
+ok Q[with 1 { 2 } else { 3 }].AST.statements[0].else.defined,
+    'a with that HAS an else answers with a defined Block';
+
+# --- an absent List-typed field is an empty list, never undefined -----------
+
+ok $if.elsifs.defined, 'an absent elsifs list is defined, not a type object';
+is $if.elsifs.elems, 0, 'an absent elsifs list is empty';
+is Q[if 1 { 2 } elsif 3 { 4 }].AST.statements[0].elsifs.elems, 1,
+    'and a chain that has one reports it';
+ok $with.elsifs.defined, 'the same holds for a with with no orwith clauses';
+is $with.elsifs.elems, 0, 'an absent orwith chain is an empty list';
+
+# --- an absent declaration/initializer slot ---------------------------------
+
+my $decl = Q[my $x].AST.statements[0].expression;
+is $decl.initializer.^name, 'RakuAST::Initializer',
+    'an uninitialised declaration answers with the Initializer type object';
+nok $decl.initializer.defined, 'and it is undefined';
+ok Q[my $x = 1].AST.statements[0].expression.initializer.defined,
+    'an initialised declaration answers with a defined Initializer';
+
+# --- a field whose EMPTY value the renderer elides is still there -----------
+# `sub f { }` gists with no `signature`, but the signature is not absent: it is
+# an empty one, and rakudo answers with it.
+
+my $sub = Q[sub f { }].AST.statements[0].expression;
+ok $sub.signature.defined,
+    'a sub written without a signature still has one';
+is $sub.signature.^name, 'RakuAST::Signature', 'and it is a Signature';
+is $sub.signature.parameters.elems, 0, 'with no parameters';
+nok $sub.signature.returns.defined, 'and no return constraint';
+
+# --- every statement modifier exposes the expression it was written with ----
+
+is Q[say 1 with 2].AST.statements[0].condition-modifier.expression.^name,
+    'RakuAST::IntLiteral', 'StatementModifier::With exposes .expression';
+is Q[say 1 if 2].AST.statements[0].condition-modifier.expression.^name,
+    'RakuAST::IntLiteral', 'StatementModifier::If exposes .expression';
+is Q[say 1 unless 2].AST.statements[0].condition-modifier.expression.^name,
+    'RakuAST::IntLiteral', 'StatementModifier::Unless exposes .expression';
+is Q[(say 1 if $_.defined) given 2].AST.statements[0].loop-modifier.expression.^name,
+    'RakuAST::IntLiteral', 'StatementModifier::Given exposes .expression';

--- a/t/rakuast/rakuast-type-attributes.t
+++ b/t/rakuast/rakuast-type-attributes.t
@@ -28,7 +28,7 @@ is RakuAST::Var::Lexical.^attributes(:local).map(*.name).join(','),
 is RakuAST::StatementList.^attributes(:local).map(*.name).join(','),
     '$!statements', 'statement children are discoverable as a model field';
 is RakuAST::Statement::Expression.^attributes(:local).map(*.name).join(','),
-    '$!expression,$!loop-modifier',
-    'statement expression and modifier are discoverable as model fields';
+    '$!expression,$!condition-modifier,$!loop-modifier',
+    'statement expression and both modifier slots are discoverable as model fields';
 is RakuAST::Assignment.^attributes(:local).elems, 0,
     'a class without modeled fields reports no local attributes';

--- a/t/rakuast/rakuast-type-methods.t
+++ b/t/rakuast/rakuast-type-methods.t
@@ -26,7 +26,7 @@ is RakuAST::StatementList.^methods(:local).map(*.name).sort.join(','),
     'StatementList exposes construction, mutation, and its read accessor';
 
 is RakuAST::Statement::Expression.^methods(:local).map(*.name).sort.join(','),
-    'expression,loop-modifier,new',
+    'condition-modifier,expression,loop-modifier,new',
     'statement wrapper exposes constructor and accessors';
 
 is RakuAST::Postfix.^methods(:local).map(*.name).sort.join(','),

--- a/t/rakuast/rakuast-with-without-block.t
+++ b/t/rakuast/rakuast-with-without-block.t
@@ -70,9 +70,7 @@ unlike Q[with 1 { say 2 } elsif 0 { say 3 } else { say 4 }].AST.statements[0].el
 
 # --- a nested `with` statement is not a continuation clause ------------------
 
-# (spelled against `.gist` rather than `.elsifs`, which throws on mutsu when the
-# field is absent instead of returning an empty list -- see #8124)
-unlike Q[if 1 { say 1 } else { with 2 { say 2 } }].AST.statements[0].gist, /'elsifs'/,
+is Q[if 1 { say 1 } else { with 2 { say 2 } }].AST.statements[0].elsifs.elems, 0,
     'a with block inside an else is a statement, not an elsif clause';
 like Q[if 1 { say 1 } else { with 2 { say 2 } }].AST.statements[0].else.gist,
     /'Statement::With'/,

--- a/t/rakuast/rakuast-with-without-modifier.t
+++ b/t/rakuast/rakuast-with-without-modifier.t
@@ -26,9 +26,9 @@ is Q["nf" without Nil].AST.statements[0].condition-modifier.^name,
 
 # It is a *condition* modifier, not a loop modifier: `loop-modifier` is the
 # field a real `given` fills, and `with` must leave it out entirely.
-unlike Q[say 1 with 2].AST.gist, /'loop-modifier'/,
+nok Q[say 1 with 2].AST.statements[0].loop-modifier.defined,
     'with modifier does not occupy the loop-modifier slot';
-unlike Q[say 1 without Nil].AST.gist, /'loop-modifier'/,
+nok Q[say 1 without Nil].AST.statements[0].loop-modifier.defined,
     'without modifier does not occupy the loop-modifier slot';
 
 # The modified statement survives as the statement's own expression, with the
@@ -43,7 +43,7 @@ is Q[say 1 with 2].AST.statements[0].expression.^name,
 is Q[(say 1 if $_.defined) given 2].AST.statements[0].loop-modifier.^name,
     'RakuAST::StatementModifier::Given',
     'an explicit given modifier is still a Given, not mistaken for a with';
-like Q[(say 1 if $_.defined) given 2].AST.gist, /'loop-modifier'/,
+ok Q[(say 1 if $_.defined) given 2].AST.statements[0].loop-modifier.defined,
     'an explicit given modifier fills the loop-modifier slot instead';
 
 # A real `given` block is unaffected too.


### PR DESCRIPTION
A RakuAST node stores only the fields its source produced, and the accessor layer built a node's method set out of exactly those, so asking a statement for a modifier it did not have was a hard error:

```
$ mutsu -e 'say Q[say 1 with 2].AST.statements[0].loop-modifier.defined'
No such method 'loop-modifier' for invocant of type 'RakuAST::Statement::Expression'
```

Rakudo declares every field as an attribute, so the same call is legal there and answers with an undefined value — which is what makes `.defined` the natural way to test for an optional clause. Without it the only way to assert "this statement has no loop modifier" was to match `.gist` against a string, which is what two tests had to do.

## What changed

The declaration is now separate from what a node carries. `src/rakuast/fields.rs` (new) holds, per class, the fields that class declares together with what each answers when the node does not carry it; `node_accessor` consults it after its lookup over the node's own fields misses, and `.^attributes(:local)` / `.^methods(:local)` are derived from the same table, so introspection and dispatch can no longer disagree about which accessors exist.

Every answer is a measured rakudo shape rather than a uniform `Nil`:

- an absent node-typed field is its **declared type object** — `.else` on an `if` without one is `(Block)`, `.loop-modifier` is `(Loop)`, `.initializer` on `my $x` is `(Initializer)`;
- an absent `List` field is `()`, never undefined — an `if` with no `elsif` has `.elsifs.elems == 0`;
- an elided `Bool` flag is `False`, an `int` flag `0`;
- a field whose *empty* value the renderer elides answers with that empty node: `sub f { }` gists with no `signature`, but `.signature` is a defined, parameterless `RakuAST::Signature`, as on rakudo;
- `Parameter.optional` is tri-state on rakudo — `False` on a plain positional, unset when optionality follows from a default, a slurpy or a named parameter — so an absent one is an undefined `Bool`;
- a structurally required field (`ApplyInfix.left`) declares no absent answer and still falls through to ordinary "no such method" dispatch, rather than inventing a value for a malformed node.

Two ad-hoc special cases fold into the table, and both were answering with the wrong *type* while being right about truthiness: `Pragma.argument` handed back `Nil` where rakudo has `(Expression)`, and `Pragma.off` `False` where rakudo has `0`.

Alongside this, the five `StatementModifier::*` classes gain the `.expression` accessor they never exposed (part 2 of the issue), and `Statement::Expression` gains the `condition-modifier` slot it could fill but not declare.

## Verification

A sweep over 21 sample programs walked every node of each tree and called every declared accessor under both implementations: 289 lines of class/accessor/type/definedness, identical but for one line — `Parameter.slurpy`, a pre-existing converter difference unrelated to this change, filed as #8157.

`t/rakuast/rakuast-absent-field-accessors.t` (new, 27 assertions) pins the mechanism, and the two `.gist` string matches in `rakuast-with-without-modifier.t` / `rakuast-with-without-block.t` are now the structural checks they were standing in for. Every assertion passes under both mutsu and raku.

`cargo fmt --all`, `make lint`, `make test` (4112 files / 43778 tests, 0 failures) and `make roast` all run locally; roast's only red files are the three environment-only ones documented in `docs/agent-environments.md`, with exactly the shapes listed there (`6.c/S32-io/file-tests.t` 6-8/10, `S16-filehandles/filetest.t` 25 tests, `S32-io/IO-Socket-Async.t` exit 124).

Closes #8124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8)_