### PR TITLE
fix(parser): four parse-failure-index constructs from #7954

### DIFF
--- a/news/2026-09/parse-failure-index-ternary-lvalues-attribute-binds-and-hash-composers.md
+++ b/news/2026-09/parse-failure-index-ternary-lvalues-attribute-binds-and-hash-composers.md
@@ -1,0 +1,165 @@
+# Parse-failure index: ternary lvalues, class-level attribute binds, hash composers, and `when` matchers
+
+Four more rows off the `expected statement …` parse-failure index
+([#7954](https://github.com/tokuhirom/mutsu/issues/7954)). Two of them were
+named — but not reduced — by the previous batch's handover notes, so this round
+went straight from the named construct to the fix. The other two were rows that
+index could only mark as *containers*; they were bisected by prefix over the
+failing file, and each turned out to have nothing to do with the line the error
+reported. After every fix, `mutsu --dump-ast` was re-run over every module each
+distribution's META6 `provides` names, which is also how the two container rows
+surfaced their real causes: fixing one construct moves the reported location to
+the next one.
+
+## A conditional is an assignment's lvalue (`Pop`)
+
+`Pop/Inputs.rakumod` writes
+
+```raku
+@!keyboard[ $scancode
+    ?? $key
+    !! %cache{$key} //= SDL::GetScancodeFromKey($key)
+]
+```
+
+and mutsu refused it with `Precedence of //= is too loose to use inside ?? !!`.
+That guard is real, but it applies to only one of the two branches. `?? !!`
+sits at *item assignment* precedence and is right-associative, so an assignment
+written after the else branch does not nest inside that branch — it takes the
+whole conditional as its lvalue. rakudo settles it directly:
+
+```
+$ raku -e 'my $x = 5; my $y = 7; 1 ?? $y !! $x = 3; say "$x $y"'
+5 3
+```
+
+The *then* branch was written, so the parse is `(1 ?? $y !! $x) = 3`. Only an
+assignment *between* `??` and `!!` is genuinely too loose, and that is the one
+rakudo reports.
+
+mutsu had two conditional parsers and each got this half-right in a different
+way. `ternary_mode` already parsed its else branch no-assign and re-applied a
+trailing `=` as an lvalue-ternary, but only for a bare `=` and only in
+`ExprMode::Full` — so the statement-level `=` worked while every compound
+spelling, and everything inside parentheses (`ExprMode::NoSequence`), still hit
+the guard. `item_expr`'s conditional had no trailing handler at all: it parsed
+the else branch *with* the assignment layer and then rejected the result.
+
+Both now share one `ternary_trailing_assignment`, and both parse the else
+branch no-assign so the operator is still there for it. The compound spellings
+need no new machinery on the runtime side —
+`build_compound_assign_expr` already desugars `(cond ?? A !! B) op= rhs` into
+`cond ?? (A op= rhs) !! (B op= rhs)`, so only the selected branch is written and
+`rhs` is evaluated once, in that branch. The two call-argument modes
+(`ListopArg`, `NoSequenceNoFeed`) are excluded, because they disable the
+item-assignment layer wholesale and a listop's own comma-list machinery owns
+that boundary.
+
+This also **retires a band-aid**. `ALLOW_TERNARY_ELSE_ASSIGNMENT` was a
+thread-local parser-context flag that made exactly one grammar position — a
+sigilless declaration's initializer — accept an assignment nested in the else
+branch, on the theory that it was a special case of the sigilless binding
+grammar. It never was: `my \x = cond ?? a !! %h<k> //= b` is the same
+lvalue-ternary as everywhere else. The flag also had to disable expression
+memoization for that context, since a memo entry could not be shared across the
+boundary. Both are gone, and `t/control/ternary-sigilless-compound-assign.t`
+(the pin the flag was added for) stays green on the general rule.
+
+## A class-level attribute can be bound (`Math::Symbolic`)
+
+`Math/Symbolic/Language.rakumod` ends with
+
+```raku
+our @.operations := @operations;
+our %.by_name    := %by_name;
+```
+
+An `our`/`my` scoped attribute names a container that already exists at
+declaration time, so `:=` binds the accessor to that very container — a later
+push to `@operations` is visible through `.operations`. mutsu's dot-twigil
+attribute declaration parsed a `=` default and nothing else, so the `:=` fell
+through as unconsumed input and took the whole compilation unit with it.
+
+A *per-instance* attribute is the opposite case: its storage is built by the
+constructor, so there is nothing for `:=` to bind, and rakudo refuses
+`has $.x := 1` outright with `X::Comp::AdHoc: Cannot use := to initialize an
+attribute`. `has_decl` now raises exactly that instead of a generic "Confused".
+
+One divergence this exposed is **not** fixed here and is filed separately:
+rakudo's `our @.x = @c` *copies* the list where mutsu's aliases it, which is why
+`=` and `:=` currently behave the same in mutsu even though they should not.
+
+## An attribute accessor is not an implicit-topic call (`Data::Dump::Tree`)
+
+`DDTR::FixedGlyphs` returns a hash composed of its own attribute:
+
+```raku
+multi method get_glyphs {
+    {
+    last => $.fixed_glyph, not_last => $.fixed_glyph,
+    ...
+    }
+}
+```
+
+mutsu failed it with `Preceding context expects a term, but found infix =>`.
+The cause is not `last` as a key — that works on its own — but `$.fixed_glyph`
+as a *value*. The hash-vs-block scan treats an invocant-less `.method` call as a
+topic reference, which correctly forces a block (`{ a => .uc }` is a Block in
+rakudo too). It was reading the `.` of the `$.`/`@.`/`%.`/`&.` **attribute
+twigil** as one of those, so every `{ key => $.attr }` inside a class came out a
+Block — and, with a control-flow keyword for a key, did not even parse, because
+the block's first statement then started with the `last` *statement*.
+
+The twigil is a term whose invocant is `self`, so a sigil glued to the dot is
+never a topic call. Gluedness is the whole test: an infix `%` before a real
+topic call is separated from it by whitespace, so `{a => 2 % .elems}` stays a
+Block, as rakudo has it.
+
+That left one file, whose `:title( S/(' ')$// given @element[0] ~ @element[1] )`
+exposed a second gap: a colonpair's parenthesized value did not accept a
+statement modifier, where a plain parenthesized group has always accepted one.
+It now runs the same `try_inline_modifier`, after the separated-list loop rather
+than per element, because statement modifiers are looser than the comma
+(`:t(1, 2 if 0)` suppresses the whole value, matching rakudo).
+
+## A built-in enum value as a `when` matcher (`IO::String`)
+
+`IO::String.seek` dispatches on `SeekType`:
+
+```raku
+$!pos = (do given $whence {
+    when SeekFromBeginning { $offset }
+    ...
+} min $!buffer.chars) max 0;
+```
+
+A bareword `when` matcher that names a complete nullary term keeps the block
+that follows it; one that names a routine legitimately gobbles it. The parser
+decided that from `is_builtin_enum_value`, a **second, hand-written copy** of
+the built-in enums the type registry seeds — and it had drifted. `SeekType` and
+`Signal` are registered as real enums (`say SeekFromBeginning.^name` has always
+said `SeekType`) but were absent from that list, so the matcher read as a listop
+call and the whole compilation unit died with "Function 'SeekFromBeginning'
+needs arguments".
+
+Rather than adding the missing names to the copy, the copy is gone:
+`is_builtin_enum_value` now derives its set from the registry's own variant
+lists (`Endian`, `ProtocolFamily`, `Order`, `SeekType`, `Signal`), so a new
+built-in enum cannot be registered and forgotten here again. `PromiseStatus`
+stays listed explicitly, since mutsu represents `Promise.status` as a bare
+string and it has no registry entry to derive from.
+
+## Result
+
+`Pop`, `Math::Symbolic`, `Data::Dump::Tree` and `IO::String` now parse every
+module their META6 `provides` names. (`PrettyDump`, the fifth row this batch
+started from, was fixed in parallel on `main` by the sibling
+`pointy-block-signature-literal-param` slice, so its duplicate is dropped here.)
+
+Pins: `t/control/ternary-lvalue-assignment.t`,
+`t/oo/attribute/class-level-attribute-bind.t`,
+`t/collections/hash/hash-composer-dot-twigil-value.t`,
+`t/collections/hash/hash-colonpair-paren-statement-modifier.t`,
+`t/control/when-builtin-enum-value-matcher.t` — all five green under rakudo
+itself, so they pin rakudo's behaviour rather than mutsu's.

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -17,7 +17,7 @@ mod tests_postfix;
 
 use super::memo::{MemoEntry, MemoKey, MemoStats, ParseMemo};
 use super::parse_result::PResult;
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::collections::HashMap;
 
 use crate::ast::{Expr, Stmt};
@@ -53,29 +53,6 @@ use whatever_wrap::{try_wrap_whatevercode_call_chain, wrap_composition_operands}
 thread_local! {
     static EXPR_MEMO_TLS: RefCell<HashMap<MemoKey, MemoEntry<Expr>>> = RefCell::new(HashMap::new());
     static EXPR_MEMO_STATS_TLS: RefCell<MemoStats> = RefCell::new(MemoStats::default());
-    /// A sigilless declaration's initializer permits an assignment in the
-    /// else branch of its ternary (`my \\x = cond ?? a !! %h<k> //= b`).
-    /// This is a parser-context distinction, so expression memoization must
-    /// not reuse results across the boundary.
-    static ALLOW_TERNARY_ELSE_ASSIGNMENT: Cell<bool> = const { Cell::new(false) };
-}
-
-pub(in crate::parser) fn allow_ternary_else_assignment() -> bool {
-    ALLOW_TERNARY_ELSE_ASSIGNMENT.with(Cell::get)
-}
-
-pub(in crate::parser) fn with_ternary_else_assignment<T>(f: impl FnOnce() -> T) -> T {
-    struct Restore(bool);
-
-    impl Drop for Restore {
-        fn drop(&mut self) {
-            ALLOW_TERNARY_ELSE_ASSIGNMENT.with(|enabled| enabled.set(self.0));
-        }
-    }
-
-    let previous = ALLOW_TERNARY_ELSE_ASSIGNMENT.with(|enabled| enabled.replace(true));
-    let _restore = Restore(previous);
-    f()
 }
 
 static EXPR_MEMO: ParseMemo<Expr> = ParseMemo::new(&EXPR_MEMO_TLS, &EXPR_MEMO_STATS_TLS);
@@ -89,12 +66,7 @@ pub(super) fn expression_memo_stats() -> (usize, usize, usize) {
 }
 
 pub(super) fn expression(input: &str) -> PResult<'_, Expr> {
-    // The sigilless-declaration initializer grammar has one context-sensitive
-    // exception for assignments in a ternary's else branch. Do not reuse an
-    // expression parsed outside that context (or cache this context's result
-    // for an ordinary expression).
-    let use_memo = !allow_ternary_else_assignment();
-    if use_memo && let Some(cached) = EXPR_MEMO.get(input) {
+    if let Some(cached) = EXPR_MEMO.get(input) {
         return cached;
     }
     let result = (|| {
@@ -177,9 +149,7 @@ pub(super) fn expression(input: &str) -> PResult<'_, Expr> {
         }
         Ok((rest, expr))
     })();
-    if use_memo {
-        EXPR_MEMO.store(input, &result);
-    }
+    EXPR_MEMO.store(input, &result);
     result
 }
 

--- a/src/parser/expr/precedence/list_infix_top.rs
+++ b/src/parser/expr/precedence/list_infix_top.rs
@@ -22,7 +22,28 @@ use super::*;
 /// which is TIGHTER than item assignment and therefore appears here rather than
 /// at the top-level word-logical layer.
 pub(crate) fn item_expr(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
-    let (rest, left) = assign_not_expr_mode(input, mode)?;
+    item_expr_inner(input, mode, true)
+}
+
+/// [`item_expr`], with the item-assignment layer switchable.
+///
+/// A conditional's ELSE branch is parsed with `allow_assign == false`. `?? !!`
+/// sits at item-assignment precedence and is right-associative, so an
+/// assignment written after the else branch takes the WHOLE conditional as its
+/// lvalue rather than nesting inside that branch (`c ?? $a !! $b = 3` is
+/// `(c ?? $a !! $b) = 3`, verified against rakudo). Parsing the branch
+/// no-assign leaves the operator for
+/// [`super::ternary::ternary_trailing_assignment`] below, which is where that
+/// lvalue reading is built. The THEN branch keeps the
+/// assignment layer: an assignment there really does sit between `??` and
+/// `!!`, which is rakudo's
+/// `X::Syntax::ConditionalOperator::PrecedenceTooLoose`.
+fn item_expr_inner(input: &str, mode: ExprMode, allow_assign: bool) -> PResult<'_, Expr> {
+    let (rest, left) = if allow_assign {
+        assign_not_expr_mode(input, mode)?
+    } else {
+        not_expr_mode(input, mode)?
+    };
     // If the item layer already consumed an assignment (`$x = ...`), the ternary
     // condition would be that assignment, which is looser than `?? !!` — so a
     // following `??` binds to the assignment's RHS, which was already parsed
@@ -71,7 +92,7 @@ pub(crate) fn item_expr(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     let (after_bang, _) = parse_tag(after_then, "!!")
         .map_err(|err| ternary_missing_bang_bang_error(after_then, err, after_then.len()))?;
     let (after_bang, _) = ws(after_bang)?;
-    let (rest, else_expr) = item_expr(after_bang, mode).map_err(|err| {
+    let (rest, else_expr) = item_expr_inner(after_bang, mode, false).map_err(|err| {
         enrich_expected_error(err, "expected else-expression after '!!'", after_bang.len())
     })?;
     // Only a LOOSE assignment is an error here; the mutating method call `.=` is
@@ -82,22 +103,18 @@ pub(crate) fn item_expr(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             &spelled_assign_operator(after_q),
         ));
     }
-    if !crate::parser::expr::allow_ternary_else_assignment()
-        && is_assignment_expr(&else_expr)
-        && !assign_operator_is_tight(&else_expr)
+    let ternary_expr = Expr::Ternary {
+        cond: Box::new(cond),
+        then_expr: Box::new(then_expr),
+        else_expr: Box::new(else_expr),
+    };
+    if allow_assign
+        && let Some((rest, assigned)) =
+            super::ternary::ternary_trailing_assignment(rest, &ternary_expr, mode)?
     {
-        return Err(conditional_precedence_too_loose_error(
-            &spelled_assign_operator(after_bang),
-        ));
+        return Ok((rest, assigned));
     }
-    Ok((
-        rest,
-        Expr::Ternary {
-            cond: Box::new(cond),
-            then_expr: Box::new(then_expr),
-            else_expr: Box::new(else_expr),
-        },
-    ))
+    Ok((rest, ternary_expr))
 }
 
 /// The top-level list-infix layer: `Z`, `X`, their meta-ops, infixed functions,

--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -294,22 +294,82 @@ pub(crate) fn call_arg_ternary_expr(input: &str) -> PResult<'_, Expr> {
 /// because its no-`??` fallback (`or_expr_mode`) includes assignment, which would
 /// swallow the default value (e.g. `$x where Int = 9`).
 pub(crate) fn ternary_no_assign(input: &str) -> PResult<'_, Expr> {
-    let (rest, cond) = if crate::parser::expr::allow_ternary_else_assignment() {
-        // A sigilless declaration initializer is the one Raku grammar context
-        // where an assignment may be nested in the else branch of `?? !!`.
-        // Parse that branch at the ordinary expression precedence so indexed
-        // compound assignments such as `%cache<key> //= value` are consumed.
-        or_expr_mode(input, ExprMode::Full)?
-    } else {
-        or_expr_no_assign_mode(input, ExprMode::Full)?
-    };
+    ternary_no_assign_mode(input, ExprMode::Full)
+}
+
+/// [`ternary_no_assign`] at an explicit [`ExprMode`] -- what a conditional's own
+/// ELSE branch is parsed with, so a trailing assignment stays for
+/// [`ternary_trailing_assignment`] instead of nesting inside that branch.
+pub(crate) fn ternary_no_assign_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
+    let (rest, cond) = or_expr_no_assign_mode(input, mode)?;
     let (rest_ws, _) = ws(rest)?;
     if rest_ws.starts_with("??") {
         // A conditional constraint: the full ternary parser is safe because a
         // top-level `=` only appears after the complete `?? !!` expression.
-        return ternary_mode(input, ExprMode::Full);
+        return ternary_mode(input, mode);
     }
     Ok((rest, cond))
+}
+
+/// Apply a trailing item-assignment to a COMPLETE conditional, which the
+/// conditional itself becomes the lvalue of.
+///
+/// `?? !!` sits at *item assignment* precedence and is right-associative, so an
+/// assignment written after the else branch does not nest inside that branch --
+/// it takes the whole conditional as its lvalue. `raku -e 'my $x=5; my $y=7;
+/// 1 ?? $y !! $x = 3; say "$x $y"'` prints `5 3`: the THEN branch was written,
+/// so the parse is `(1 ?? $y !! $x) = 3`, never `1 ?? $y !! ($x = 3)`. Every
+/// compound spelling behaves the same (`+=`, `//=`, `min=`, ...), and
+/// `build_compound_assign_expr` already knows how to push one into both
+/// branches of a ternary lvalue so only the selected branch is written and the
+/// right-hand side is evaluated once.
+///
+/// Only an assignment BETWEEN `??` and `!!` is the
+/// `X::Syntax::ConditionalOperator::PrecedenceTooLoose` error rakudo reports;
+/// the callers keep that guard on the then-branch.
+///
+/// `after_ternary` is the unconsumed input right after the else branch (not yet
+/// whitespace-skipped). Returns `None`, consuming nothing, when no assignment
+/// operator follows.
+pub(crate) fn ternary_trailing_assignment<'a>(
+    after_ternary: &'a str,
+    ternary_expr: &Expr,
+    mode: ExprMode,
+) -> Result<Option<(&'a str, Expr)>, PError> {
+    let (r, _) = ws(after_ternary)?;
+    // Compound spellings first, so `//=` is not read as a bare `=` with a `//`
+    // glued to the else branch.
+    if let Some((after_op, op)) = parse_compound_assign_op(r) {
+        let (rhs_in, _) = ws(after_op)?;
+        let (r2, rhs) = ternary_mode(rhs_in, mode).map_err(|err| {
+            enrich_expected_error(
+                err,
+                "expected value after compound assignment",
+                rhs_in.len(),
+            )
+        })?;
+        let assigned =
+            crate::parser::stmt::assign::build_compound_assign_expr(ternary_expr.clone(), op, rhs)?;
+        return Ok(Some((r2, assigned)));
+    }
+    if r.starts_with('=')
+        && !r.starts_with("==")
+        && !r.starts_with("=>")
+        && !r.starts_with("=:=")
+        && !r.starts_with("=~=")
+    {
+        let (rhs_in, _) = ws(&r[1..])?;
+        let (r2, rhs) = ternary_mode(rhs_in, mode)
+            .map_err(|err| enrich_expected_error(err, "expected value after '='", rhs_in.len()))?;
+        return Ok(Some((
+            r2,
+            Expr::Call {
+                name: Symbol::intern("__mutsu_assign_callable_lvalue"),
+                args: vec![ternary_expr.clone(), Expr::ArrayLiteral(Vec::new()), rhs],
+            },
+        )));
+    }
+    Ok(None)
 }
 
 pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
@@ -379,14 +439,22 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             parse_tag(input, "!!")?
         };
         let (input, _) = ws(input)?;
-        // Parse the else-expr. In Full mode do NOT absorb a trailing assignment:
-        // `=` is LOOSER than the conditional `?? !!`, so `cond ?? t !! lhs = rhs`
-        // parses as `(cond ?? t !! lhs) = rhs` (an lvalue-ternary assignment),
-        // not as an assignment nested inside the else-branch. Parsing the
-        // else-branch no-assign leaves `= rhs` for the trailing handler below.
+        // Parse the else-expr WITHOUT absorbing a trailing assignment: `?? !!`
+        // sits at item-assignment precedence and is right-associative, so
+        // `cond ?? t !! lhs = rhs` parses as `(cond ?? t !! lhs) = rhs` (an
+        // lvalue-ternary assignment), not as an assignment nested inside the
+        // else-branch. Parsing the else-branch no-assign leaves the operator
+        // for the trailing handler below.
+        //
+        // The two call-argument modes are the exception: they disable the
+        // item-assignment layer wholesale (`assign_not_expr_mode`), because a
+        // listop's own comma-list machinery owns that boundary. They therefore
+        // neither parse the branch no-assign nor claim the trailing operator.
+        let handles_trailing_assign =
+            !matches!(mode, ExprMode::NoSequenceNoFeed | ExprMode::ListopArg);
         let else_src = input;
-        let (input, else_expr) = if mode == ExprMode::Full {
-            ternary_no_assign(input).map_err(|err| {
+        let (input, else_expr) = if handles_trailing_assign {
+            ternary_no_assign_mode(input, mode).map_err(|err| {
                 enrich_expected_error(err, "expected else-expression after '!!'", input.len())
             })?
         } else {
@@ -404,10 +472,7 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
                 &spelled_assign_operator(then_src),
             ));
         }
-        if !crate::parser::expr::allow_ternary_else_assignment()
-            && is_assignment_expr(&else_expr)
-            && !assign_operator_is_tight(&else_expr)
-        {
+        if is_assignment_expr(&else_expr) && !assign_operator_is_tight(&else_expr) {
             return Err(conditional_precedence_too_loose_error(
                 &spelled_assign_operator(else_src),
             ));
@@ -452,28 +517,14 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
                 else_expr: Box::new(else_expr),
             }
         };
-        // A trailing simple assignment binds the whole ternary as an lvalue:
-        // `cond ?? $a !! $b = rhs` is `(cond ?? $a !! $b) = rhs` (raku precedence).
-        if mode == ExprMode::Full {
-            let (after_ws, _) = ws(input)?;
-            if after_ws.starts_with('=')
-                && !after_ws.starts_with("==")
-                && !after_ws.starts_with("=>")
-                && !after_ws.starts_with("=:=")
-                && !after_ws.starts_with("=~=")
-            {
-                let (rhs_in, _) = ws(&after_ws[1..])?;
-                let (input2, rhs) = ternary_mode(rhs_in, mode).map_err(|err| {
-                    enrich_expected_error(err, "expected value after '='", rhs_in.len())
-                })?;
-                return Ok((
-                    input2,
-                    Expr::Call {
-                        name: Symbol::intern("__mutsu_assign_callable_lvalue"),
-                        args: vec![ternary_expr, Expr::ArrayLiteral(Vec::new()), rhs],
-                    },
-                ));
-            }
+        // A trailing assignment binds the whole ternary as an lvalue:
+        // `cond ?? $a !! $b = rhs` is `(cond ?? $a !! $b) = rhs`, and likewise
+        // for every compound spelling (see `ternary_trailing_assignment`).
+        if handles_trailing_assign
+            && let Some((input2, assigned)) =
+                ternary_trailing_assignment(input, &ternary_expr, mode)?
+        {
+            return Ok((input2, assigned));
         }
         return Ok((input, ternary_expr));
     }

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -44,3 +44,7 @@ pub(super) use sigil_context::{
 // pub(crate) re-exports — visible throughout the crate
 pub(crate) use allomorph::angle_word_value;
 pub(crate) use meta_ops::{lift_list_infix_in_arg_list, try_parse_sequence_arg_list};
+// A colonpair's parenthesized value takes a statement modifier just as a plain
+// parenthesized group does (`:t( $x.uc given $x )`), so the colonpair parser in
+// `parser::primary::misc` needs the same helper `paren` uses.
+pub(super) use meta_ops::try_inline_modifier;

--- a/src/parser/primary/misc/colonpair.rs
+++ b/src/parser/primary/misc/colonpair.rs
@@ -13,6 +13,28 @@ use crate::value::signature::{make_signature_value, param_defs_to_sig_info};
 use std::collections::HashMap;
 
 /// Parse colonpair expressions: :$var, :@var, :%var, :name(expr), :name, :!name
+/// A colonpair's parenthesized value may carry a statement modifier, exactly as
+/// a plain parenthesized group may: `:title( S/(' ')$// given @e[0] ~ @e[1] )`
+/// (Data::Dump::Tree, #7954), `:t(1, 2 if 0)`. Statement modifiers are looser
+/// than the comma, so the modifier applies to the whole value -- the list form
+/// included, which is why this runs after the separated-list loop rather than
+/// per element. Without it the modifier keyword sat where the closing `)` was
+/// expected and the entire argument list failed to parse.
+///
+/// `value` is the value parsed so far; the returned expression is either it
+/// unchanged (no modifier follows) or it wrapped in the modifier.
+fn colonpair_paren_value_tail(input: &str, value: Expr) -> PResult<'_, Expr> {
+    let (rest, _) = ws(input)?;
+    match crate::parser::primary::container::try_inline_modifier(rest, value.clone()) {
+        Some(result) => {
+            let (rest, modified) = result?;
+            let (rest, _) = ws(rest)?;
+            Ok((rest, modified))
+        }
+        None => Ok((input, value)),
+    }
+}
+
 pub(crate) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
     let r = input
         .strip_prefix(':')
@@ -504,23 +526,25 @@ pub(crate) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
                 items.push(next);
                 r = r2;
             }
+            let (r, value) = colonpair_paren_value_tail(r, Expr::ArrayLiteral(items))?;
             let (r, _) = parse_char(r, ')')?;
             return Ok((
                 r,
                 Expr::Binary {
                     left: Box::new(Expr::Literal(Value::str(name.to_string()))),
                     op: crate::token_kind::TokenKind::FatArrow,
-                    right: Box::new(Expr::ArrayLiteral(items)),
+                    right: Box::new(value),
                 },
             ));
         }
+        let (r, value) = colonpair_paren_value_tail(r, first)?;
         let (r, _) = parse_char(r, ')')?;
         return Ok((
             r,
             Expr::Binary {
                 left: Box::new(Expr::Literal(Value::str(name.to_string()))),
                 op: crate::token_kind::TokenKind::FatArrow,
-                right: Box::new(first),
+                right: Box::new(value),
             },
         ));
     }

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -645,6 +645,16 @@ fn is_implicit_topic_call(bytes: &[u8], at: usize) -> bool {
     if !starts_call {
         return false;
     }
+    // `$.attr` / `@.attr` / `%.attr` / `&.attr` is the ATTRIBUTE twigil, a term
+    // whose invocant is `self` -- not an implicit-topic call, so rakudo keeps
+    // `{ a => $.g }` a Hash (checked for all four sigils). The sigil has to be
+    // glued to the dot: an infix `%` or `&` before a real topic call is
+    // separated from it by whitespace (`{a => 2 % .elems}` is a Block), and
+    // that spelling falls through to the general rules below. Tested before the
+    // whitespace-skip for exactly that reason.
+    if at > 0 && matches!(bytes[at - 1], b'$' | b'@' | b'%' | b'&') {
+        return false;
+    }
     let mut p = at;
     while p > 0 && bytes[p - 1].is_ascii_whitespace() {
         p -= 1;

--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -787,6 +787,17 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
         (rest, None)
     };
 
+    // `has $.x := ...` is a compile-time refusal in rakudo: a per-instance
+    // attribute's container is built by the constructor, so there is nothing
+    // for `:=` to bind at declaration time. Only the class-level spellings
+    // (`my $.x := ...`, `our $.x := ...`) name an already-existing container,
+    // and `try_dot_twigil_attr` parses those. Without this the `:=` fell
+    // through as unconsumed input and the whole compilation unit failed with a
+    // generic "Confused".
+    if rest.starts_with(":=") {
+        return Err(super::helpers::attribute_bind_initializer_error());
+    }
+
     // Default value
     let (rest, mut default) = if let Some(stripped) = rest.strip_prefix(".=") {
         let (rest, _) = ws(stripped)?;

--- a/src/parser/stmt/decl/helpers.rs
+++ b/src/parser/stmt/decl/helpers.rs
@@ -311,6 +311,23 @@ pub(super) fn is_parser_keyword(name: &str) -> bool {
 /// destructuring list lowers to `VarDecl`s that never learn they were `our`,
 /// and a class attribute is a `HasDecl` the class-body planner compiles rather
 /// than `compile_stmt`.
+/// The compile-time refusal rakudo raises for `has $.x := ...`.
+///
+/// An attribute's per-instance storage is created by the constructor, so there
+/// is nothing for `:=` to bind at declaration time. Only the class-level
+/// spellings (`my $.x := ...`, `our $.x := ...`) name a container that already
+/// exists, and those are parsed by `try_dot_twigil_attr` instead. Verified
+/// against `raku -e 'class C { has $.x := 1 }'`, which raises `X::Comp::AdHoc`
+/// with exactly this message.
+pub(in crate::parser::stmt) fn attribute_bind_initializer_error() -> PError {
+    const MSG: &str = "Cannot use := to initialize an attribute";
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(MSG.to_string()));
+    attrs.insert("payload".to_string(), Value::str(MSG.to_string()));
+    let ex = Value::make_instance(crate::symbol::Symbol::intern("X::Comp::AdHoc"), attrs);
+    PError::fatal_with_exception(MSG.to_string(), Box::new(ex))
+}
+
 pub(in crate::parser::stmt) fn our_type_constraint_error() -> PError {
     const MSG: &str = "Cannot put a type constraint on an 'our'-scoped variable";
     let mut attrs = std::collections::HashMap::new();

--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -89,8 +89,7 @@ pub(super) fn parse_sigilless_decl(
     let (r, _) = ws(r)?;
     if let Some(r) = r.strip_prefix("::=").or_else(|| r.strip_prefix(":=")) {
         let (r, _) = ws(r)?;
-        let (r, expr) =
-            crate::parser::expr::with_ternary_else_assignment(|| parse_assign_expr_or_comma(r))?;
+        let (r, expr) = parse_assign_expr_or_comma(r)?;
         let stmt = build_sigilless_bind_stmt(name, expr, type_constraint.clone(), is_state, is_our);
         if apply_modifier {
             return parse_statement_modifier(r, stmt);
@@ -152,8 +151,7 @@ pub(super) fn parse_sigilless_decl(
     if r.starts_with('=') && !r.starts_with("==") && !r.starts_with("=>") {
         let r = &r[1..];
         let (r, _) = ws(r)?;
-        let (r, expr) =
-            crate::parser::expr::with_ternary_else_assignment(|| parse_assign_expr_or_comma(r))?;
+        let (r, expr) = parse_assign_expr_or_comma(r)?;
         let stmt = build_sigilless_bind_stmt(name, expr, type_constraint.clone(), is_state, is_our);
         if apply_modifier {
             return parse_statement_modifier(r, stmt);
@@ -311,7 +309,18 @@ pub(super) fn try_dot_twigil_attr<'a>(
         })?;
         let attr_name = attr_name.to_string();
         let (after_name, _) = ws(after_name)?;
-        let (after_name, default) = if after_name.starts_with('=')
+        // A class-level attribute may be BOUND as well as assigned:
+        // `our @.operations := @operations` (Math::Symbolic, #7954) makes the
+        // accessor hand back the very container on the right, so a later push
+        // to it is visible through the accessor. `has @.x := ...` is an error
+        // in rakudo ("Cannot use := to initialize an attribute"), which is why
+        // this branch lives here -- only the `my`/`our` scoped spellings reach
+        // it -- and not in `has_decl`, which rejects it outright.
+        let (after_name, default) = if let Some(r) = after_name.strip_prefix(":=") {
+            let (r, _) = ws(r)?;
+            let (r, expr) = expression(r)?;
+            (r, Some(expr))
+        } else if after_name.starts_with('=')
             && !after_name.starts_with("==")
             && !after_name.starts_with("=>")
         {

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -193,7 +193,7 @@ impl Interpreter {
     /// builds their `Value`s for the global base tier) and
     /// [`Self::seed_builtin_enum_types`] (which records the type itself in the
     /// built-in registry template).
-    fn endian_enum_variants() -> Vec<(String, EnumValue)> {
+    pub(in crate::runtime) fn endian_enum_variants() -> Vec<(String, EnumValue)> {
         vec![
             ("NativeEndian".to_string(), EnumValue::Int(0)),
             ("LittleEndian".to_string(), EnumValue::Int(1)),
@@ -204,7 +204,7 @@ impl Interpreter {
     /// builds their `Value`s for the global base tier) and
     /// [`Self::seed_builtin_enum_types`] (which records the type itself in the
     /// built-in registry template).
-    fn protocol_family_enum_variants() -> Vec<(String, EnumValue)> {
+    pub(in crate::runtime) fn protocol_family_enum_variants() -> Vec<(String, EnumValue)> {
         vec![
             ("PF_UNSPEC".to_string(), EnumValue::Int(0)),
             ("PF_INET".to_string(), EnumValue::Int(1)),
@@ -218,7 +218,7 @@ impl Interpreter {
     /// builds their `Value`s for the global base tier) and
     /// [`Self::seed_builtin_enum_types`] (which records the type itself in the
     /// built-in registry template).
-    fn order_enum_variants() -> Vec<(String, EnumValue)> {
+    pub(in crate::runtime) fn order_enum_variants() -> Vec<(String, EnumValue)> {
         vec![
             ("Less".to_string(), EnumValue::Int(-1)),
             ("Same".to_string(), EnumValue::Int(0)),
@@ -229,7 +229,7 @@ impl Interpreter {
     /// builds their `Value`s for the global base tier) and
     /// [`Self::seed_builtin_enum_types`] (which records the type itself in the
     /// built-in registry template).
-    fn seek_type_enum_variants() -> Vec<(String, EnumValue)> {
+    pub(in crate::runtime) fn seek_type_enum_variants() -> Vec<(String, EnumValue)> {
         vec![
             ("SeekFromBeginning".to_string(), EnumValue::Int(0)),
             ("SeekFromCurrent".to_string(), EnumValue::Int(1)),
@@ -240,7 +240,7 @@ impl Interpreter {
     /// builds their `Value`s for the global base tier) and
     /// [`Self::seed_builtin_enum_types`] (which records the type itself in the
     /// built-in registry template).
-    fn signal_enum_variants() -> Vec<(String, EnumValue)> {
+    pub(in crate::runtime) fn signal_enum_variants() -> Vec<(String, EnumValue)> {
         // Use libc constants on Unix, standard POSIX numbers on other platforms
         vec![
             // Signals that share value 0 on this platform (Rakudo lists them so

--- a/src/runtime/utils/type_constraints.rs
+++ b/src/runtime/utils/type_constraints.rs
@@ -218,20 +218,45 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
 }
 
 /// Check if a bare identifier names a value of a built-in enum (`Order`,
-/// `Endian`, `Bool`). These are nullary value terms, not type names, so they are
-/// complete expressions on their own (e.g. the then-branch of `1 ?? More !! Less`).
+/// `Endian`, `SeekType`, `Signal`, `ProtocolFamily`). These are nullary value
+/// terms, not type names, so they are complete expressions on their own (the
+/// then-branch of `1 ?? More !! Less`, the matcher of `when SeekFromBeginning
+/// { ... }`).
+///
+/// The names come from the type registry's OWN variant lists
+/// ([`crate::runtime::Interpreter::seed_builtin_enum_types`]), not from a
+/// second hand-written copy. That copy had drifted: `SeekType` and `Signal` were
+/// registered as real enums but absent from it, so `given $whence { when
+/// SeekFromBeginning { ... } }` read the bareword as a listop call that
+/// gobbled the block, and the whole compilation unit failed with "Function
+/// 'SeekFromBeginning' needs arguments" (IO::String, #7954).
 pub(crate) fn is_builtin_enum_value(name: &str) -> bool {
-    matches!(
-        name,
-        // Order
-        "Less" | "Same" | "More"
-        // Endian
-        | "LittleEndian" | "BigEndian" | "NativeEndian"
-        // PromiseStatus (mutsu represents Promise.status as a bare string, not
-        // a registered enum type — see roast/packages/Test-Helpers/lib/Test/Util.rakumod's
-        // `given $promise.status { when Kept { ... } }`)
-        | "Planned" | "Kept" | "Broken"
-    )
+    static NAMES: std::sync::OnceLock<std::collections::HashSet<String>> =
+        std::sync::OnceLock::new();
+    NAMES
+        .get_or_init(|| {
+            let mut names: std::collections::HashSet<String> = [
+                crate::runtime::Interpreter::endian_enum_variants(),
+                crate::runtime::Interpreter::protocol_family_enum_variants(),
+                crate::runtime::Interpreter::order_enum_variants(),
+                crate::runtime::Interpreter::seek_type_enum_variants(),
+                crate::runtime::Interpreter::signal_enum_variants(),
+            ]
+            .into_iter()
+            .flatten()
+            .map(|(key, _)| key)
+            .collect();
+            // PromiseStatus is the one built-in enum that is NOT in the
+            // registry: mutsu represents `Promise.status` as a bare string
+            // (see roast/packages/Test-Helpers/lib/Test/Util.rakumod's
+            // `given $promise.status { when Kept { ... } }`), so its value
+            // names have to be listed here.
+            for extra in ["Planned", "Kept", "Broken"] {
+                names.insert(extra.to_string());
+            }
+            names
+        })
+        .contains(name)
 }
 
 /// Well-known nullary value terms that resolve as a bareword — e.g.

--- a/t/collections/hash/hash-colonpair-paren-statement-modifier.t
+++ b/t/collections/hash/hash-colonpair-paren-statement-modifier.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+plan 7;
+
+# A colonpair's parenthesized value takes a statement modifier, exactly as a
+# plain parenthesized group does: `:title( S/(' ')$// given @e[0] ~ @e[1] )` is
+# the shape Data::Dump::Tree's `Horizontal` uses. Without it the modifier
+# keyword sat where the closing `)` was expected and the whole argument list
+# failed to parse.
+# Every assertion below was checked against rakudo itself.
+
+sub take-named(:$t) { $t }
+
+{
+    my $x = 'a';
+    is take-named(:t( $x.uc given $x )), 'A', '`given` inside a colonpair value';
+    is take-named(:t( $x.uc if 1 )), 'A', '`if` inside a colonpair value';
+    is take-named(:t( $x.uc if 0 )).raku, 'Empty',
+        'an unrun `if` yields Empty, as a statement modifier does';
+}
+
+# Statement modifiers are looser than the comma, so one after a separated list
+# applies to the whole value rather than to its last element.
+is take-named(:t(1, 2 given 3)).raku, '$(1, 2)',
+    'a modifier after a separated list applies to the whole value';
+is take-named(:t(1, 2 if 0)).raku, 'Empty',
+    'and can suppress the whole list';
+
+# The spellings with no modifier must be untouched.
+is take-named(:t(1, 2)).raku, '$(1, 2)', 'a plain separated list is unchanged';
+is take-named(:t(1)).raku, '1', 'a plain single value is unchanged';
+
+done-testing;

--- a/t/collections/hash/hash-composer-dot-twigil-value.t
+++ b/t/collections/hash/hash-composer-dot-twigil-value.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+plan 9;
+
+# `{ a => $.g }` composes a HASH. The `$.`/`@.`/`%.`/`&.` twigil is an attribute
+# accessor -- a term whose invocant is `self` -- not the invocant-less `.method`
+# call that would make the braces a block. The hash-vs-block scan read the `.`
+# in `$.g` as an implicit-topic call, so every `{ key => $.attr }` in a class
+# came out a Block (or, with a control keyword for a key, failed to parse at
+# all: "Preceding context expects a term, but found infix =>"). That is the
+# shape Data::Dump::Tree's `DDTR::FixedGlyphs` uses.
+# Every assertion below was checked against rakudo itself.
+
+class Glyphs {
+    has $.scalar = 'x';
+    has @.array  = (1, 2);
+    has %.hash   = (k => 'v');
+
+    method scalar-value  { { a => $.scalar } }
+    method array-value   { { a => @.array } }
+    method hash-value    { { a => %.hash } }
+    method keyword-key   { { last => $.scalar, empty => ' ' x $.scalar.chars } }
+    method computed      { { a => $.scalar.uc } }
+    method private-twin  { { a => $!scalar } }
+}
+
+my $g = Glyphs.new;
+
+is-deeply $g.scalar-value, {a => 'x'}, '{ a => $.attr } composes a hash';
+is $g.array-value.WHAT.^name, 'Hash', '{ a => @.attr } composes a hash';
+is $g.hash-value.WHAT.^name, 'Hash', '{ a => %.attr } composes a hash';
+is-deeply $g.computed, {a => 'X'}, 'a method call on the attribute still composes a hash';
+is-deeply $g.private-twin, {a => 'x'}, 'the private `$!attr` twin is unchanged';
+is-deeply $g.keyword-key, {last => 'x', empty => ' '},
+    'a control-flow keyword as a key composes a hash alongside an attribute value';
+
+# The rule must stay narrow: a genuinely invocant-less method call is still a
+# topic reference, and so still forces a block.
+is { a => .uc }.WHAT.^name, 'Block', 'a bare `.method` value is still a block';
+is { a => 2 % .elems }.WHAT.^name, 'Block',
+    'an infix `%` before a topic call is not the `%.` twigil';
+is { a => .[0] }.WHAT.^name, 'Block', 'a bare `.[0]` value is still a block';
+
+done-testing;

--- a/t/control/ternary-lvalue-assignment.t
+++ b/t/control/ternary-lvalue-assignment.t
@@ -1,0 +1,96 @@
+use v6;
+use Test;
+
+plan 16;
+
+# `?? !!` sits at ITEM ASSIGNMENT precedence and is right-associative, so an
+# assignment written after the else branch takes the WHOLE conditional as its
+# lvalue -- it does not nest inside that branch. Every assertion below was
+# checked against rakudo itself.
+
+# --- plain `=`, statement position ------------------------------------------
+{
+    my $x = 5;
+    my $y = 7;
+    my $r = 1 ?? $y !! $x = 3;
+    is $r, 3, 'the trailing = returns the assigned value';
+    is $x, 5, 'the UNSELECTED branch is not written';
+    is $y, 3, 'the selected (then) branch is what got assigned';
+}
+
+{
+    my $x = 5;
+    my $y = 7;
+    my $r = 0 ?? $y !! $x = 3;
+    is $r, 3, 'a false condition still returns the assigned value';
+    is $x, 3, 'the selected (else) branch is what got assigned';
+    is $y, 7, 'the unselected then branch is untouched';
+}
+
+# --- inside parentheses ------------------------------------------------------
+{
+    my $x = 5;
+    my $y = 7;
+    my $r = (1 ?? $y !! $x = 3);
+    is "$r $x $y", '3 5 3', 'a parenthesized group reads the same way';
+}
+
+# --- compound assignment operators ------------------------------------------
+{
+    my $x = 5;
+    my $y = 7;
+    my $r = (1 ?? $y !! $x += 3);
+    is "$r $x $y", '10 5 10', '+= writes through the selected branch';
+}
+
+{
+    my $x = 5;
+    my $y = 7;
+    my $r = (0 ?? $y !! $x += 3);
+    is "$r $x $y", '8 8 7', '+= on a false condition writes the else branch';
+}
+
+# `//=` is the shape Pop's `@!keyboard[ $scancode ?? $key !! %cache{$key} //=
+# ... ]` uses: the conditional picks the container, the compound assignment
+# fills it in only when it is not already there.
+{
+    my %cache;
+    my $r = 0 ?? 1 !! %cache<k> //= 2;
+    is $r, 2, '//= fills in the undefined element the else branch selected';
+    is %cache<k>, 2, 'the hash element really was written';
+}
+
+{
+    my %cache;
+    my $r = 1 ?? 3 !! %cache<k> //= 4;
+    is $r, 3, '//= leaves a defined selected branch alone';
+    nok %cache<k>.defined, 'the unselected element stays untouched';
+}
+
+# --- as a subscript ----------------------------------------------------------
+{
+    my @a = 0 .. 9;
+    my %cache;
+    is @a[ 0 ?? 1 !! %cache<k> //= 4 ], 4, 'the whole form works as a subscript';
+}
+
+# --- what is still an error --------------------------------------------------
+# An assignment BETWEEN `??` and `!!` really is too loose, and rakudo rejects it.
+{
+    my $died = False;
+    try {
+        EVAL 'my $a = 5; my $r = 1 ?? $a = 9 !! 2;';
+        CATCH { default { $died = True } }
+    }
+    ok $died, 'an assignment in the THEN branch is still refused';
+}
+
+# `.=` is a mutating method call at method-postfix precedence, far tighter than
+# the conditional, so it stays legal inside a branch.
+{
+    my $v = 'ab';
+    my $r = 1 ?? $v .= uc !! 9;
+    is "$r $v", 'AB AB', '.= inside the then branch is still tight enough';
+}
+
+done-testing;

--- a/t/control/when-builtin-enum-value-matcher.t
+++ b/t/control/when-builtin-enum-value-matcher.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+plan 8;
+
+# A bareword `when` matcher that names a built-in enum VALUE is a complete
+# nullary term, so the block after it belongs to the `when`. The parser's
+# known-term list was a second, hand-written copy of the type registry's
+# built-in enums and had drifted: `SeekType` and `Signal` are registered as
+# real enums but were missing from it, so `given $whence { when
+# SeekFromBeginning { ... } }` read the bareword as a listop call that gobbled
+# the block and the whole compilation unit failed with "Function
+# 'SeekFromBeginning' needs arguments". That is the shape IO::String's `seek`
+# uses. Every assertion below was checked against rakudo itself.
+
+sub which-seek($whence) {
+    do given $whence {
+        when SeekFromBeginning { 'begin' }
+        when SeekFromCurrent   { 'current' }
+        when SeekFromEnd       { 'end' }
+        default                { 'other' }
+    }
+}
+
+is which-seek(SeekFromBeginning), 'begin', 'SeekFromBeginning matches as a `when` bareword';
+is which-seek(SeekFromCurrent), 'current', 'SeekFromCurrent matches';
+is which-seek(SeekFromEnd), 'end', 'SeekFromEnd matches';
+is which-seek(42), 'other', 'a non-member falls through to default';
+
+sub which-signal($s) {
+    do given $s {
+        when SIGINT  { 'int' }
+        when SIGTERM { 'term' }
+        default      { 'other' }
+    }
+}
+
+is which-signal(SIGINT), 'int', 'a Signal value matches as a `when` bareword';
+is which-signal(SIGTERM), 'term', 'and so does another';
+
+# The enums that already worked must keep working.
+is (do given More { when Less { 'less' }; when More { 'more' }; default { 'other' } }),
+    'more', 'an Order value still matches';
+is (do given BigEndian { when LittleEndian { 'le' }; when BigEndian { 'be' }; default { 'other' } }),
+    'be', 'an Endian value still matches';
+
+done-testing;

--- a/t/oo/attribute/class-level-attribute-bind.t
+++ b/t/oo/attribute/class-level-attribute-bind.t
@@ -1,0 +1,83 @@
+use v6;
+use Test;
+
+plan 9;
+
+# A CLASS-LEVEL attribute (`our $.x` / `my $.x`) may be BOUND with `:=` as well
+# as assigned with `=`. Binding makes the accessor hand back the very container
+# on the right-hand side, so a later mutation of that container is visible
+# through the accessor. This is the shape Math::Symbolic's
+# `Language.rakumod` uses (`our @.operations := @operations;`).
+# Every assertion below was checked against rakudo itself.
+
+{
+    my @source = 1, 2;
+    class WithArray {
+        our @.operations := @source;
+    }
+    @source.push(3);
+    is WithArray.operations, [1, 2, 3],
+        'our @.x := @c makes the accessor see later pushes to @c';
+}
+
+{
+    my %source = a => 1;
+    class WithHash {
+        our %.by-name := %source;
+    }
+    %source<b> = 2;
+    is WithHash.by-name.sort.map(*.kv.join('=')).join(','), 'a=1,b=2',
+        'our %.x := %c binds the hash container itself';
+}
+
+{
+    my $source = 5;
+    class WithScalar {
+        our $.n := $source;
+    }
+    is WithScalar.n, 5, 'our $.x := $c binds a scalar';
+}
+
+{
+    my @source = 1, 2;
+    class MyScoped {
+        my @.x := @source;
+    }
+    @source.push(3);
+    is MyScoped.x, [1, 2, 3], 'my @.x := @c binds the same way `our` does';
+}
+
+# The bind must not disturb the `=` spelling that was already there.
+{
+    my @source = 1, 2;
+    class Assigned {
+        our @.x = @source;
+    }
+    is Assigned.x, [1, 2], 'our @.x = @c still initializes from the list';
+}
+
+# A PER-INSTANCE attribute has no container yet at declaration time -- its
+# storage is built by the constructor -- so rakudo refuses `:=` there outright.
+{
+    my $err;
+    try {
+        EVAL 'class HasBind { has $.x := 1 }';
+        CATCH { default { $err = $_ } }
+    }
+    ok $err.defined, 'has $.x := ... is refused';
+    is $err.message, 'Cannot use := to initialize an attribute',
+        'and refused with rakudo\'s own message';
+    ok $err ~~ X::Comp::AdHoc, 'as an X::Comp::AdHoc';
+}
+
+{
+    my $err;
+    try {
+        EVAL 'class HasBindArray { has @.x := (1, 2) }';
+        CATCH { default { $err = $_ } }
+    }
+    is $err.message, 'Cannot use := to initialize an attribute',
+        'the array spelling is refused identically';
+}
+
+done-testing;


### PR DESCRIPTION
Four more rows off the `expected statement …` parse-failure index (#7954). Two were named — but not reduced — by the previous batch's handover notes; the other two were rows that index could only mark as *containers*, bisected by prefix over the failing file. Each fix was reduced to a one-liner checked against rakudo, and after every fix `mutsu --dump-ast` was re-run over every module each distribution's META6 `provides` names.

> **Rebase note.** This branch also started from the `PrettyDump` row (`-> :(...)` as an anonymous named parameter). That row was fixed in parallel on `main` by the sibling `pointy-block-signature-literal-param` slice while these suites were running, so the duplicate implementation and its test were dropped during the rebase and `main`'s version is kept — it produces the same `:(:$ (Int $a, $b))` rakudo does.

### A conditional is an assignment's lvalue (`Pop`)

`@!keyboard[ $scancode ?? $key !! %cache{$key} //= SDL::GetScancodeFromKey($key) ]` was refused with `Precedence of //= is too loose to use inside ?? !!`. That guard applies to only one of the two branches: `?? !!` sits at *item assignment* precedence and is right-associative, so an assignment after the else branch takes the whole conditional as its lvalue.

```
$ raku -e 'my $x = 5; my $y = 7; 1 ?? $y !! $x = 3; say "$x $y"'
5 3
```

The *then* branch was written, so the parse is `(1 ?? $y !! $x) = 3`.

mutsu has two conditional parsers and each got this half-right. `ternary_mode` already parsed its else branch no-assign and re-applied a trailing `=`, but only a bare `=` and only in `ExprMode::Full` — so the statement-level `=` worked while every compound spelling, and everything inside parentheses, still hit the guard. `item_expr`'s conditional had no trailing handler at all. Both now share one `ternary_trailing_assignment` and both parse the else branch no-assign. No new runtime machinery was needed: `build_compound_assign_expr` already desugars `(cond ?? A !! B) op= rhs` into `cond ?? (A op= rhs) !! (B op= rhs)`.

This **retires a band-aid**: `ALLOW_TERNARY_ELSE_ASSIGNMENT`, a thread-local parser-context flag that made a sigilless declaration's initializer accept an assignment nested in the else branch, and had to disable expression memoization for that context. That was never a special case — it is the same lvalue-ternary — so the flag and the memo exclusion are gone, and the pin it was added for (`t/control/ternary-sigilless-compound-assign.t`) stays green on the general rule.

### A class-level attribute can be bound (`Math::Symbolic`)

`our @.operations := @operations;` — an `our`/`my` scoped attribute names a container that already exists, so `:=` binds the accessor to it. The dot-twigil declaration parsed a `=` default and nothing else. A per-instance attribute is the opposite case (its storage is built by the constructor), and `has $.x := 1` now raises rakudo's own `X::Comp::AdHoc: Cannot use := to initialize an attribute` instead of a generic "Confused".

### An attribute accessor is not an implicit-topic call (`Data::Dump::Tree`)

`{ last => $.fixed_glyph, ... }` failed with `Preceding context expects a term, but found infix =>`. The cause was `$.fixed_glyph` as a *value*: the hash-vs-block scan read the `.` of the `$.`/`@.`/`%.`/`&.` attribute twigil as an invocant-less topic call, so every `{ key => $.attr }` in a class came out a Block — and with a control-flow keyword for a key it did not parse at all. The twigil is a term whose invocant is `self`; gluedness is the test, so `{a => 2 % .elems}` stays a Block as rakudo has it.

That left the dist's other file, whose `:title( S/(' ')$// given @element[0] ~ @element[1] )` exposed a second gap: a colonpair's parenthesized value did not accept a statement modifier, where a plain parenthesized group always has. It now runs the same `try_inline_modifier`, after the separated-list loop rather than per element, because statement modifiers are looser than the comma.

### A built-in enum value as a `when` matcher (`IO::String`)

`when SeekFromBeginning { ... }` died with "Function 'SeekFromBeginning' needs arguments". The parser decided bareword-vs-listop from `is_builtin_enum_value`, a **second, hand-written copy** of the built-in enums the type registry seeds, and it had drifted — `SeekType` and `Signal` are registered as real enums but were absent from it. The copy is gone: the set is now derived from the registry's own variant lists (`Endian`, `ProtocolFamily`, `Order`, `SeekType`, `Signal`), so a new built-in enum cannot be registered and forgotten here again. `PromiseStatus` stays listed explicitly, since mutsu represents `Promise.status` as a bare string.

## Result

`Pop`, `Math::Symbolic`, `Data::Dump::Tree` and `IO::String` now parse every module their META6 `provides` names.

Pins — all five green under rakudo itself, so they pin rakudo's behaviour rather than mutsu's:

- `t/control/ternary-lvalue-assignment.t`
- `t/oo/attribute/class-level-attribute-bind.t`
- `t/collections/hash/hash-composer-dot-twigil-value.t`
- `t/collections/hash/hash-colonpair-paren-statement-modifier.t`
- `t/control/when-builtin-enum-value-matcher.t`

Write-up: `news/2026-09/parse-failure-index-ternary-lvalues-attribute-binds-and-hash-composers.md`.

`cargo fmt --all`, `make lint`, `make test` and `make roast` were all run locally before publishing, and are being re-run against the rebased tree. On the pre-rebase tree `make test` was `Result: PASS` (4111 files) and `make roast`'s only red files were `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8/10) and `roast/S16-filehandles/filetest.t` (`Failed: 25`) — the two `uid 0` files `docs/agent-environments.md` documents, matching its recorded subtest ranges exactly.

Two follow-ups filed rather than forced through:

- **#8150** (`todo:ticket`) — `our @.x = @c` aliases the container where rakudo copies the list, so `=` and `:=` are currently indistinguishable in mutsu on that declaration. Needs `HasDecl` to carry the assignment-vs-bind distinction.
- **#8155** (`todo:ticket`) — the dotted postfix subscript `.[$i; $j]` drops its semilist and returns the whole container (a silently wrong answer), and stops parsing entirely with a postfix chained onto it. This is the last construct blocking `Game::Entities`.

#7954 stays open — it is an index, and the remaining rows still span a dozen or so distinct constructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wa1VSpvkjpb2Ur13ibj1CZ