### PR TITLE
fix(oo): make `Enumeration` a composable core role, not just an enum constraint

### DIFF
--- a/news/2026-09/enumeration-is-a-composable-core-role.md
+++ b/news/2026-09/enumeration-is-a-composable-core-role.md
@@ -1,0 +1,62 @@
+# `Enumeration` is a composable core role, not just an enum-value constraint
+
+`class Foo does Enumeration { ... }` died as `X::InvalidType: Invalid typename
+'Enumeration'`. Every other natively-modelled core role composed — `Dateish`,
+`Positional`, `Associative`, `Numeric`, `Real`, `Callable`, `Stringy`,
+`Iterable` all accept a `does` — because `Enumeration` existed in mutsu only as
+a *type-check constraint* that enum values satisfy
+(`runtime/utils/type_constraints.rs`, `types/type_matching.rs`,
+`value/types_isa.rs`) and in neither list of composable core role names.
+
+That is not a cosmetic gap. Rakudo's `Enumeration` is a real role with state —
+`has $.key`, `has $.value` — and `raku-doc/doc/Type/Enumeration.rakudoc`
+documents composing it from an ordinary class as a supported way to build a
+constrained key/value pair (`class DNA does Enumeration`, whose `new` blesses
+`key`/`value` itself). `Logic::Ternary` 0.0.4 does exactly that, which is how
+the gap surfaced: its entry in the `invalid-typename` ecosystem cluster
+([#7993](https://github.com/tokuhirom/mutsu/issues/7993)) was never a
+typename-resolution problem at all.
+
+## What it took
+
+The role is now supplied as **real Raku source** (`ENUMERATION_ROLE_PRELUDE` in
+`src/runtime/run.rs`), parsed once and spliced into any compunit that names it,
+the way the `Rational`, `IO::Socket` and `Metamodel::Naming` roles already are.
+A composing class therefore gets the role's attributes, its generated
+accessors, `$!key`/`$!value` visibility inside its own method bodies, and the
+attribute-collision diagnostic, all from the ordinary role-composition path
+rather than from a second native implementation of behaviour mutsu already has
+for enum values.
+
+The method set is the part of `Enumeration.^methods` that actually *works* on a
+composing class in rakudo, measured there rather than transcribed from the
+role's source: `kv`, `pair`, `Numeric`, `Int`, `Real`, `gist`, `raku`. The rest
+(`enums`, `pred`, `succ`, `pick`, `roll`, `CALL-ME`) reach
+`self.^enum_values`, which a `ClassHOW` does not have — they die in rakudo too,
+so supplying them would have been a divergence, not a feature. `.Str` is absent
+for the same reason: rakudo's composing class falls back to `Mu.Str`, even
+though a real enum value stringifies to its key.
+
+Three smaller pieces went with it:
+
+- the prelude is injected for **modules** as well as the main program, because
+  the distribution that motivated this composes the role inside the module
+  while the program that loads it (`use Logic::Ternary;`) never names
+  `Enumeration` at all;
+- `Enumeration` joined `BUILTIN_ROLE_NAMES`, which one consumer needs *before*
+  any prelude is registered: the compiler qualifies a class header's `does`
+  parent with the enclosing package unless the name is a known core type, so
+  without the entry `unit module M; class C does Enumeration` compiled a parent
+  named `M::Enumeration`;
+- the two `constraint == "Enumeration"` fast paths (`type_matches_value` and
+  the `~~` handler in `seq_helpers/smart_match.rs`) returned `false` for
+  anything that was not an enum value or enum type object, pre-empting the
+  ordinary composed-role check. They now assert enum membership and otherwise
+  fall through, so `$instance ~~ Enumeration` is `True` for a class that has
+  composed the role and still `False` for one that has not.
+
+Pinned by `t/oo/role/class-does-enumeration-role.t`, whose 18 assertions were
+all measured against rakudo first — including the documented `DNA` example and
+the two enum-value non-regressions.
+
+Closes [#8115](https://github.com/tokuhirom/mutsu/issues/8115).

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -214,6 +214,40 @@ role GLOBAL::IO::Socket {
 }
 "#;
 
+/// Builtin `Enumeration` role. mutsu models the role's behaviour natively for
+/// *enum values* (they are their own `Value` shape, with native `key`/`value`/
+/// `kv`/`pair`/`Numeric` methods), but Rakudo's `Enumeration` is a real role
+/// with state — `has $.key`, `has $.value` — that an ordinary user class may
+/// compose to get a key/value pair with the enum API on top, and the
+/// documentation's own example does exactly that (`class DNA does Enumeration`
+/// in `raku-doc/doc/Type/Enumeration.rakudoc`; `Logic::Ternary` in the
+/// ecosystem). Supplying it as a real role rather than as a second native
+/// implementation is what makes a composing class get the state, the generated
+/// accessors, and the attribute-collision diagnostics for free.
+///
+/// The method set is exactly the part of `Enumeration.^methods` that WORKS on a
+/// composing class in Rakudo, measured there rather than copied from the role's
+/// source: `enums`, `pred`, `succ`, `pick`, `roll` and `CALL-ME` all reach
+/// `self.^enum_values`, which a `ClassHOW` does not have, so in Rakudo they die
+/// ("No such method 'enum_values' for invocant of type
+/// 'Perl6::Metamodel::ClassHOW'") and faking them here would be a divergence,
+/// not a feature. `.Str` is likewise absent deliberately: Rakudo's composing
+/// class falls back to `Mu.Str` (`Tern<4665716083224>`), even though a real
+/// enum value stringifies to its key.
+pub(super) const ENUMERATION_ROLE_PRELUDE: &str = r#"
+role GLOBAL::Enumeration {
+    has $.key;
+    has $.value;
+    method kv() { self.key, self.value }
+    method pair() { self.key => self.value }
+    method Numeric() { self.value }
+    method Int() { self.value.Int }
+    method Real() { self.value }
+    method gist() { self.key.Str }
+    method raku() { self.^name ~ '::' ~ self.key }
+}
+"#;
+
 /// `trait_mod:<does>` — CORE.setting's callable form of the `does` mixin
 /// operator, with the same three overloads Rakudo's `SETTING::src/core.c/
 /// traits.rakumod` declares (verified against real `raku`: calling it with a
@@ -602,6 +636,7 @@ impl Interpreter {
         Self::inject_trait_mod_does_prelude(&code, &mut stmts);
         Self::inject_trait_mod_is_prelude(&code, &mut stmts);
         Self::inject_metamodel_role_prelude(&code, &mut stmts);
+        Self::inject_enumeration_prelude(&code, &mut stmts);
         // Install EVERY END phaser this compunit declares — top-level, inside
         // a block, inside a sub or a method — before the VM runs a single
         // statement, in source order. That is what rakudo does (it installs at

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -572,6 +572,7 @@ impl Interpreter {
         Self::inject_iosocket_prelude(&code, &mut stmts);
         Self::inject_trait_mod_does_prelude(&code, &mut stmts);
         Self::inject_trait_mod_is_prelude(&code, &mut stmts);
+        Self::inject_enumeration_prelude(&code, &mut stmts);
 
         // Save to precompilation cache when the module is eligible.
         if precomp_eligible {

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -1,7 +1,7 @@
 use super::run::{
-    IO_SOCKET_ROLE_PRELUDE, METAMODEL_ROLE_PRELUDE, NATIVECALL_POINTER_PRELUDE,
-    NATIVECALL_SUB_PRELUDES, RATIONAL_ROLE_PRELUDE, TRAIT_MOD_DOES_PRELUDE,
-    TRAIT_MOD_IS_NATIVECALL_PRELUDE,
+    ENUMERATION_ROLE_PRELUDE, IO_SOCKET_ROLE_PRELUDE, METAMODEL_ROLE_PRELUDE,
+    NATIVECALL_POINTER_PRELUDE, NATIVECALL_SUB_PRELUDES, RATIONAL_ROLE_PRELUDE,
+    TRAIT_MOD_DOES_PRELUDE, TRAIT_MOD_IS_NATIVECALL_PRELUDE,
 };
 use super::source_code_text::CodeText;
 use super::*;
@@ -274,6 +274,35 @@ impl Interpreter {
         static METAMODEL_ROLE_STMTS: OnceLock<Vec<Stmt>> = OnceLock::new();
         let prelude = METAMODEL_ROLE_STMTS.get_or_init(|| {
             crate::parse_dispatch::parse_source(METAMODEL_ROLE_PRELUDE)
+                .map(|(s, _)| s)
+                .unwrap_or_default()
+        });
+        if prelude.is_empty() {
+            return;
+        }
+        let mut combined = prelude.clone();
+        combined.append(stmts);
+        *stmts = combined;
+    }
+
+    /// Prepend the builtin `Enumeration` role ([`ENUMERATION_ROLE_PRELUDE`]) to
+    /// a program (or module) that mentions it.
+    ///
+    /// Gated on the name like the other role preludes, and skipped when the
+    /// compunit declares its own `role Enumeration` (which the prelude would
+    /// collide with). Injected for MODULES too, not only the main program: the
+    /// distribution that motivated this is `Logic::Ternary`, whose
+    /// `class Logic::Ternary does Enumeration` lives in the module, while the
+    /// program that loads it (`use Logic::Ternary;`) never names `Enumeration`
+    /// at all — so gating on the main program's source alone would never fire.
+    pub(super) fn inject_enumeration_prelude(source: &CodeText<'_>, stmts: &mut Vec<Stmt>) {
+        if !source.contains("Enumeration") || source.contains("role Enumeration") {
+            return;
+        }
+        use std::sync::OnceLock;
+        static ENUMERATION_STMTS: OnceLock<Vec<Stmt>> = OnceLock::new();
+        let prelude = ENUMERATION_STMTS.get_or_init(|| {
+            crate::parse_dispatch::parse_source(ENUMERATION_ROLE_PRELUDE)
                 .map(|(s, _)| s)
                 .unwrap_or_default()
         });

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1529,17 +1529,17 @@ impl Interpreter {
 
                 // Every enum type object and every enum value does the
                 // `Enumeration` role (`E ~~ Enumeration`, `E.pick ~~ Enumeration`).
-                if base_type == "Enumeration" {
-                    let is_enum = match left.view() {
-                        ValueView::Enum { .. } => true,
-                        ValueView::Package(n) => {
-                            self.registry().enum_types.contains_key(&*n.resolve())
-                        }
-                        _ => false,
-                    };
-                    if !is_enum {
-                        return false;
-                    }
+                // A non-enum LHS falls through to the ordinary role check
+                // instead of failing here: an ordinary class may compose the
+                // role too (`ENUMERATION_ROLE_PRELUDE`, `class DNA does
+                // Enumeration`), and returning `False` outright made
+                // `$instance ~~ Enumeration` wrong for one that had.
+                let is_enum = match left.view() {
+                    ValueView::Enum { .. } => true,
+                    ValueView::Package(n) => self.registry().enum_types.contains_key(&*n.resolve()),
+                    _ => false,
+                };
+                if base_type == "Enumeration" && is_enum {
                     // An enum value is defined (:D); a bare enum type object is
                     // undefined (:U).
                     return match smiley {

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -438,15 +438,25 @@ impl Interpreter {
         {
             return true;
         }
+        // Every enum value and every enum type object does `Enumeration`: those
+        // are their own `Value` shapes, so no composed-role list mentions the
+        // role and the membership has to be asserted here. Anything else FALLS
+        // THROUGH to the ordinary role check rather than being denied — an
+        // ordinary class may compose `Enumeration` too (the role is supplied by
+        // `ENUMERATION_ROLE_PRELUDE`, as `raku-doc`'s own `class DNA does
+        // Enumeration` example and `Logic::Ternary` both do), and denying it
+        // here made `$instance ~~ Enumeration` `False` for a class that had
+        // just composed the role.
         if constraint == "Enumeration" {
-            // Every enum value and every enum type object does `Enumeration`.
-            return match value.view() {
-                ValueView::Enum { .. } => true,
-                ValueView::Package(name) => {
-                    self.registry().enum_types.contains_key(&*name.resolve())
+            match value.view() {
+                ValueView::Enum { .. } => return true,
+                ValueView::Package(name)
+                    if self.registry().enum_types.contains_key(&*name.resolve()) =>
+                {
+                    return true;
                 }
-                _ => false,
-            };
+                _ => {}
+            }
         }
         // The native socket classes (`IO::Socket::INET`, `IO::Socket::Async`)
         // do the built-in `IO::Socket` role in Raku, but mutsu implements them

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -40,6 +40,14 @@ pub(crate) const BUILTIN_ROLE_NAMES: &[&str] = &[
     "PositionalBindFailover",
     "Systemic",
     "Awaitable",
+    // Supplied as a real role with state by `ENUMERATION_ROLE_PRELUDE`, so
+    // most consumers see it through `has_role`. It is listed here too because
+    // one consumer runs BEFORE any prelude is registered: the compiler
+    // qualifies a class header's `does` parent with the enclosing package
+    // unless the name is a known core type, so without this entry
+    // `unit module M; class C does Enumeration` compiled a parent named
+    // `M::Enumeration` that nothing could ever resolve.
+    "Enumeration",
 ];
 
 /// Is `name` one of [`BUILTIN_ROLE_NAMES`]?

--- a/t/oo/role/class-does-enumeration-role.t
+++ b/t/oo/role/class-does-enumeration-role.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# `Enumeration` is not only the constraint every enum value satisfies -- it is a
+# real composable core role with state (`has $.key`, `has $.value`) that an
+# ordinary class may compose to get a key/value pair with the enum API on top.
+# `raku-doc/doc/Type/Enumeration.rakudoc` documents exactly that with its
+# `class DNA does Enumeration` example, and the `Logic::Ternary` distribution
+# does the same. mutsu had `Enumeration` as a type-check constraint only, so
+# `class Foo does Enumeration` died as `X::InvalidType: Invalid typename
+# 'Enumeration'` (#8115).
+#
+# Every expectation below was measured against rakudo. The methods that reach
+# `self.^enum_values` (`enums`, `pred`, `succ`, `pick`, `roll`, `CALL-ME`) are
+# deliberately NOT provided: a `ClassHOW` has no `enum_values`, so they die in
+# rakudo too, and faking them would be a divergence.
+
+plan 18;
+
+class Tern does Enumeration {
+    method new(Str:D $val) { self.bless: key => $val, value => 1 }
+}
+
+my $t = Tern.new('yes');
+
+# The role's state, reachable through the accessors it generates on the
+# composing class.
+is $t.key,   'yes', 'the composed role supplies a $.key accessor';
+is $t.value, 1,     'the composed role supplies a $.value accessor';
+
+# Role membership, from all three directions.
+ok $t ~~ Enumeration,      'an instance of the composing class ~~ Enumeration';
+ok $t.does(Enumeration),   '.does(Enumeration) on the instance';
+ok Tern ~~ Enumeration,    'the composing class type object ~~ Enumeration';
+is Tern.^roles.map(*.^name).join(','), 'Enumeration',
+    '.^roles lists the composed Enumeration role';
+
+# The derived API the role supplies on top of the two attributes.
+is $t.kv.join(' '), 'yes 1', '.kv is (key, value)';
+is $t.pair.gist,    'yes => 1', '.pair is key => value';
+is $t.Numeric,      1, '.Numeric is the value';
+is $t.Int,          1, '.Int is the value as an Int';
+is $t.Real,         1, '.Real is the value';
+is $t.gist,         'yes', '.gist is the key';
+is $t.raku,         'Tern::yes', '.raku is Name::key';
+
+# An `Enumeration` parameter binds an instance of the composing class, just as
+# it binds an enum value.
+{
+    sub takes-enumeration(Enumeration $x) { $x.key }
+    is takes-enumeration($t), 'yes', 'an Enumeration parameter binds the instance';
+}
+
+# The documented example: the composing class reads the role's attribute as
+# `$!key` from inside its own method, and may override `gist`.
+{
+    class DNA does Enumeration {
+        my %pairings = %( A => 'T', T => 'A', C => 'G', G => 'C' );
+        method new($base-pair where 'A' | 'C' | 'G' | 'T') {
+            self.bless(key => $base-pair, value => %pairings{$base-pair});
+        }
+        multi method gist(::?CLASS:D:) { "$!key -> $!value" }
+    }
+    my $b = DNA.new('A');
+    is $b.value, 'T', "the class's own new() blesses the role's attributes";
+    is $b.gist, 'A -> T',
+        'the class reads the role attributes as $!key/$!value and overrides gist';
+}
+
+# Composing the role does not disturb enum values, which are their own `Value`
+# shape and satisfy `Enumeration` natively rather than through a role list.
+{
+    enum E <a b>;
+    ok (a ~~ Enumeration), 'an enum value still ~~ Enumeration';
+    nok (42 ~~ Enumeration), 'a non-composing, non-enum value still does not';
+}
+
+done-testing;


### PR DESCRIPTION
## The gap

`class Foo does Enumeration { ... }` died as `X::InvalidType: Invalid typename 'Enumeration'`, while every other natively-modelled core role (`Dateish`, `Positional`, `Associative`, `Numeric`, `Real`, `Callable`, `Stringy`, `Iterable`) composed fine. `Enumeration` existed in mutsu only as a *type-check constraint* that enum values satisfy, and in neither list of composable core role names.

Rakudo's `Enumeration` is a real role with state — `has $.key`, `has $.value` — and `raku-doc/doc/Type/Enumeration.rakudoc` documents composing it from an ordinary class as a supported way to build a constrained key/value pair (`class DNA does Enumeration`, whose `new` blesses `key`/`value` itself). `Logic::Ternary` 0.0.4 does exactly that, which is how the gap surfaced: its entry in the `invalid-typename` ecosystem cluster (#7993) was never a typename-resolution problem at all.

## The fix

The role is now supplied as **real Raku source** (`ENUMERATION_ROLE_PRELUDE` in `src/runtime/run.rs`), parsed once and spliced into any compunit that names it, the way the `Rational`, `IO::Socket` and `Metamodel::Naming` roles already are. A composing class therefore gets the role's attributes, its generated accessors, `$!key`/`$!value` visibility inside its own method bodies, and the attribute-collision diagnostic, all from the ordinary role-composition path rather than from a second native implementation of behaviour mutsu already has for enum values.

The method set is the part of `Enumeration.^methods` that actually **works** on a composing class in rakudo, measured there rather than transcribed from the role's source: `kv`, `pair`, `Numeric`, `Int`, `Real`, `gist`, `raku`. The rest (`enums`, `pred`, `succ`, `pick`, `roll`, `CALL-ME`) reach `self.^enum_values`, which a `ClassHOW` does not have — they die in rakudo too (`No such method 'enum_values' for invocant of type 'Perl6::Metamodel::ClassHOW'`), so supplying them would be a divergence, not a feature. `.Str` is absent for the same reason: rakudo's composing class falls back to `Mu.Str`.

Three smaller pieces go with it:

- the prelude is injected for **modules** as well as the main program, because the motivating distribution composes the role inside the module while the program that loads it (`use Logic::Ternary;`) never names `Enumeration` at all, so gating on the main program's source alone would never fire;
- `Enumeration` joins `BUILTIN_ROLE_NAMES`, which one consumer needs *before* any prelude is registered: the compiler qualifies a class header's `does` parent with the enclosing package unless the name is a known core type, so without the entry `unit module M; class C does Enumeration` compiled a parent named `M::Enumeration`;
- the two `constraint == "Enumeration"` fast paths (`type_matches_value` and the `~~` handler in `seq_helpers/smart_match.rs`) returned `false` for anything that was not an enum value or enum type object, pre-empting the ordinary composed-role check. They now assert enum membership and otherwise fall through, so `$instance ~~ Enumeration` is `True` for a class that has composed the role and still `False` for one that has not.

## Verification

The whole minimised repro, and the documented `DNA` example, now produce byte-identical output under mutsu and rakudo. The real distribution loads too:

```
$ mutsu -I Logic-Ternary-0.0.4/lib -e 'use Logic::Ternary; say "ok"'
ok
```

which moves its `ecosystem/` record off `blocked_load`. Its own test suite is still red on unrelated gaps (an exported `infix:<not3>` invisible to the importer, a stack overflow in the operator file, an `ACCEPTS` multi-resolution failure, an `EXPORT` sub re-adding a method to `Any`, and a `Bool`-into-class coercion) — those belong to the `ecosystem-dist-fix` workflow and the next sweep's re-measure, not to this ticket, which scoped the test to the minimised case explicitly. The ledger record is left for that sweep to rewrite rather than hand-edited.

Pinned by `t/oo/role/class-does-enumeration-role.t`, whose 18 assertions were all measured against rakudo first, including the two enum-value non-regressions.

One finding outside the slice was filed rather than folded in: #8153 — `.Str` on an instance falls back to the class's own `Numeric` method instead of `Mu.Str` (`class P { method Numeric { 7 } }; say P.new.Str` gives `7`, rakudo gives `P<...>`). It is a pre-existing, general behaviour that composing `Enumeration` merely makes newly reachable.

## Suites

- `cargo fmt --all`, `make lint` — clean (all four configurations).
- `make test` — PASS, 4112 files / 43769 tests.
- `make roast` — the three documented container-only failures and nothing else: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8 and 10), `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125), `roast/S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17) — matching `docs/agent-environments.md` by name and by subtest range.

Closes #8115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_