### PR TITLE
fix(oo): a role multi candidate survives a class override with a different invocant smiley

### DIFF
--- a/news/2026-09/role-multi-invocant-smiley-dedup.md
+++ b/news/2026-09/role-multi-invocant-smiley-dedup.md
@@ -1,0 +1,41 @@
+# A role's multi candidate survives a class's same-named override with a different invocant smiley
+
+A role's `multi method f(::?CLASS:U: Str:D $s) { ... }` candidate disappeared from a composing
+class the moment that class also declared its own `multi method f(::?CLASS:D: Str:D $s) { ... }`:
+
+```raku
+role R {
+    proto method f(|) { * };
+    multi method f(::?CLASS:U: Str:D $s) { "U-invocant: $s" }
+}
+class C does R {
+    multi method f(::?CLASS:D: Str:D $s) { "D-invocant: $s" }
+}
+C.f('x');   # rakudo: U-invocant: x   mutsu (before): Cannot resolve caller f(C:U: Str:D); ...
+```
+
+`resolve_class_stub_requirements` (`src/runtime/registration.rs`) has a legitimate rule: "when a
+class provides a multi candidate matching a role candidate, the class version takes priority —
+remove the role duplicate," for the case where a class re-declares an identical multi candidate
+to override a role's. Whether two candidates "match" reused `method_signatures_match`, which in
+turn uses `method_positional_signature` — a function whose whole point (for its *other*, original
+use: deciding whether a class's concrete method satisfies a role's stub requirement) is to strip
+the invocant out of the comparison entirely, since a typed invocant marker is advisory for stub
+satisfaction. Reused unchanged for the "class multi replaces role multi" dedup, it made
+`f(::?CLASS:U: Str:D)` and `f(::?CLASS:D: Str:D)` compare equal (both reduce to just `["Str:D"]`),
+so the role's `:U:`-invocant candidate was wrongly treated as a duplicate of the class's
+`:D:`-invocant one and dropped — even though the two are genuinely different, coexisting multi
+dispatch candidates in Raku.
+
+Added `method_signatures_match_with_invocant`, used only at this one dedup site, which additionally
+requires the invocant's own type constraint to match. The stub-satisfaction use of
+`method_signatures_match` (unrelated to this bug) is untouched. A class multi that genuinely
+re-declares the *same* invocant smiley as the role's still correctly replaces it — no duplicate
+candidate is left behind.
+
+This was blocking `TAP` (`t/source-file.rakutest`): `TAP::SourceHandler`'s
+`multi method make-source(::?CLASS:U: Str:D $name, *%args) { self.new.make-source($name, |%args) }`
+re-dispatch pattern needs exactly this shape, and `SourceHandler::File`'s own `:D:`-invocant
+override was silently eating the role's `:U:` candidate.
+
+Fixes #8119.

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -140,6 +140,31 @@ impl Interpreter {
             && required.is_private == candidate.is_private
     }
 
+    /// The invocant parameter's type constraint (`::?CLASS:U`, `Foo:D`, ...),
+    /// already resolved to a concrete class name by composition time. `None`
+    /// when the method declares no explicit invocant type (the common case).
+    fn invocant_type_constraint(def: &MethodDef) -> Option<&str> {
+        def.param_defs
+            .iter()
+            .find(|pd| pd.is_invocant || pd.traits.iter().any(|t| t == "invocant"))
+            .and_then(|pd| pd.type_constraint.as_deref())
+    }
+
+    /// [`Self::method_signatures_match`], but ALSO requires the invocant's own
+    /// type constraint to match. Used only to decide whether a class's own
+    /// multi candidate genuinely re-declares (and so should replace) a
+    /// same-named multi candidate composed from a role — unlike stub
+    /// satisfaction, where an invocant type marker is deliberately ignored,
+    /// two multi candidates that differ only in an invocant definedness
+    /// smiley (`::?CLASS:U:` vs `::?CLASS:D:`) are distinct dispatch
+    /// candidates, not the same one under a different spelling (#8119): a
+    /// role's `:U:`-invocant candidate and a composing class's own
+    /// `:D:`-invocant candidate must both survive composition.
+    fn method_signatures_match_with_invocant(required: &MethodDef, candidate: &MethodDef) -> bool {
+        Self::method_signatures_match(required, candidate)
+            && Self::invocant_type_constraint(required) == Self::invocant_type_constraint(candidate)
+    }
+
     fn stub_is_nullary(def: &MethodDef) -> bool {
         def.param_defs.iter().all(|pd| pd.named || pd.slurpy)
     }
@@ -367,10 +392,13 @@ impl Interpreter {
                     if m.role_origin.is_none() {
                         return true; // keep class methods
                     }
-                    // Keep role method only if no class method has matching signature
+                    // Keep role method only if no class method has matching
+                    // signature -- including the invocant's own type, so a
+                    // role's `:U:`-invocant candidate is not mistaken for a
+                    // duplicate of the class's `:D:`-invocant one (#8119).
                     !class_methods
                         .iter()
-                        .any(|cm| Self::method_signatures_match(m, cm))
+                        .any(|cm| Self::method_signatures_match_with_invocant(m, cm))
                 });
             }
             // ADR-0019 F4c-3: dual-write, see class_body_method_decl's own

--- a/t/oo/role/role-multi-invocant-smiley-across-composition.t
+++ b/t/oo/role/role-multi-invocant-smiley-across-composition.t
@@ -1,0 +1,55 @@
+use Test;
+
+# A role's `multi method f(::?CLASS:U: ...)` candidate must survive class
+# composition even when the CONSUMING CLASS declares its own multi candidate
+# of the same name with a DIFFERENT invocant definedness (`::?CLASS:D:`)
+# (GH #8119). `resolve_class_stub_requirements`'s "a class multi wins over a
+# matching role multi" dedup (`src/runtime/registration.rs`) compared
+# candidates by `method_positional_signature`, which deliberately strips the
+# invocant entirely (for a separate, correct reason: role-stub satisfaction
+# ignores an invocant type marker). Reused unchanged for this dedup, it made
+# `f(::?CLASS:U: Str:D)` and `f(::?CLASS:D: Str:D)` look identical, so the
+# role's `:U:` candidate was wrongly dropped as "the class already provides
+# this" the moment BOTH conditions held: the role declares a `:U:`-invocant
+# candidate, and the class ALSO declares a same-named multi, of ANY
+# definedness. `t/oo/role/role-ud-multi-dispatch.t` covers the sibling shape
+# where both candidates live in the role itself; this covers the class
+# overriding one of them.
+
+plan 6;
+
+role R {
+    proto method f(|) { * };
+    multi method f(::?CLASS:U: Str:D $s) { "U-invocant: $s" }
+}
+class C does R {
+    multi method f(::?CLASS:D: Str:D $s) { "D-invocant: $s" }
+}
+is C.f('x'), 'U-invocant: x', "the role's :U: candidate survives a class :D: override";
+is C.new.f('y'), 'D-invocant: y', "the class's own :D: candidate still dispatches";
+is C.^find_method('f').candidates.elems, 2, 'both candidates are registered';
+
+# The motivating real shape (TAP::SourceHandler): the role's :U: candidate
+# re-dispatches through `self.new`, landing on the class's own :D: candidate.
+role SourceHandler {
+    proto method make-source(|) { * };
+    multi method make-source(::?CLASS:U: Str:D $name) {
+        self.new.make-source($name);
+    }
+}
+class SourceHandler::File does SourceHandler {
+    multi method make-source(::?CLASS:D: Str:D $name) { "opened: $name" }
+}
+is SourceHandler::File.make-source('foo.tap'), 'opened: foo.tap',
+    'a :U: role candidate re-dispatching through self.new reaches the class :D: candidate';
+
+# A class multi that genuinely re-declares the SAME invocant smiley as the
+# role's still replaces it (no duplicate-candidate regression).
+role G {
+    multi method g(Int $x) { "role: $x" }
+}
+class D does G {
+    multi method g(Int $x) { "class: $x" }
+}
+is D.new.g(5), 'class: 5', "a same-invocant class override still wins over the role's";
+is D.^find_method('g').candidates.elems, 1, 'and does not leave a stale duplicate candidate';


### PR DESCRIPTION
## Summary

A role's `multi method f(::?CLASS:U: Str:D $s) { ... }` candidate disappeared from a composing
class the moment that class also declared its own `multi method f(::?CLASS:D: Str:D $s) { ... }`.

## Repro

```raku
role R {
    proto method f(|) { * };
    multi method f(::?CLASS:U: Str:D $s) { "U-invocant: $s" }
}
class C does R {
    multi method f(::?CLASS:D: Str:D $s) { "D-invocant: $s" }
}
say C.f('x');
say C.new.f('y');
```
| | rakudo | mutsu (before) |
|---|---|---|
| `C.f('x')` | `U-invocant: x` | `Cannot resolve caller f(C:U: Str:D); none of these signatures matches: (C:D $self:: Str:D $s, *%_)` |

## Root cause (traced with `rust-gdb`)

`resolve_class_stub_requirements` (`src/runtime/registration.rs`) has a legitimate rule: "when a
class provides a multi candidate matching a role candidate, the class version takes priority —
remove the role duplicate." Whether two candidates "match" reused `method_signatures_match`, built
on `method_positional_signature` — a function whose whole point, for its *other*, original use
(deciding whether a class's concrete method satisfies a role's stub requirement), is to strip the
invocant out of the comparison entirely. Reused unchanged for the "class multi replaces role multi"
dedup, it made `f(::?CLASS:U: Str:D)` and `f(::?CLASS:D: Str:D)` compare equal (both reduce to just
`["Str:D"]`), so the role's `:U:`-invocant candidate was wrongly treated as a duplicate of the
class's `:D:`-invocant one and dropped — confirmed by breaking on the composition push site, which
showed both candidates genuinely get pushed into the method table before this dedup step removes one.

## Fix

Added `method_signatures_match_with_invocant`, used only at this one dedup site, which additionally
requires the invocant's own type constraint to match. `method_signatures_match`'s stub-satisfaction
use (unrelated to this bug) is untouched, and a class multi that genuinely re-declares the *same*
invocant smiley as the role's still correctly replaces it — no duplicate candidate left behind.

## Why it matters

This was blocking `TAP` (`t/source-file.rakutest`): `TAP::SourceHandler`'s
`multi method make-source(::?CLASS:U: Str:D $name, *%args) { self.new.make-source($name, |%args) }`
re-dispatch pattern needs exactly this shape, and `SourceHandler::File`'s own `:D:`-invocant
override was silently eating the role's `:U:` candidate.

Closes #8119

## Testing

- `t/oo/role/role-multi-invocant-smiley-across-composition.t` — new: the reported repro, both
  candidates registered, the real `TAP::SourceHandler`-shaped re-dispatch case, and a regression
  check that a genuine same-invocant class override still correctly replaces the role's (no stale
  duplicate left).
- `cargo fmt --all`, `make lint` — green (all four configurations).
- `make test` — green, `Files=4121, Tests=43829, Result: PASS`.
- `make roast` — the only failures are the documented container-only entries in
  `docs/agent-environments.md` (`6.c/S32-io/file-tests.t`, `S16-filehandles/filetest.t` — this
  container runs as `uid 0`); both pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgfeutFHT5ZhakKNVXXoV7)_