### PR TITLE
fix(async): wire Awaitable into native handles

### DIFF
--- a/news/2026-09/awaitable-connects-native-and-custom-handles.md
+++ b/news/2026-09/awaitable-connects-native-and-custom-handles.md
@@ -1,0 +1,4 @@
+`Promise` and `Channel` now report their `Awaitable` membership from the
+builtin type catalog, and `await` invokes `get-await-handle` for user-defined
+`Awaitable` objects. This brings native membership introspection and custom
+awaitable values in line with Rakudo.

--- a/src/builtins/builtin_type_catalog.rs
+++ b/src/builtins/builtin_type_catalog.rs
@@ -620,6 +620,31 @@ pub(crate) fn builtin_type_info(name: &str) -> Option<&'static BuiltinTypeInfo> 
     interned_catalog().get(name).map(|row| row.info)
 }
 
+/// Whether a catalog type composes `role`, including roles inherited through
+/// the catalog MRO. Keeping this query beside the catalog lets type matching
+/// and runtime introspection share the Rakudo-adjudicated role data.
+pub(crate) fn builtin_type_has_role(type_name: &str, role: &str) -> bool {
+    let base_type = type_name
+        .split_once('[')
+        .map(|(base, _)| base)
+        .unwrap_or(type_name);
+    let role_base = role.split_once('[').map(|(base, _)| base).unwrap_or(role);
+    let Some(info) = builtin_type_info(base_type) else {
+        return false;
+    };
+    info.mro.iter().any(|ancestor| {
+        builtin_type_info(ancestor).is_some_and(|ancestor_info| {
+            ancestor_info.roles.iter().any(|candidate| {
+                candidate
+                    .split_once('[')
+                    .map(|(base, _)| base)
+                    .unwrap_or(candidate)
+                    == role_base
+            })
+        })
+    })
+}
+
 /// `builtin_type_info(name).mro`, interned to `Symbol`s once per process.
 ///
 /// The `Arc` is cloned, not rebuilt: a caller that hands the chain straight back

--- a/src/runtime/builtins_system_async.rs
+++ b/src/runtime/builtins_system_async.rs
@@ -255,13 +255,23 @@ impl Interpreter {
 
     /// Normalize a single `await` target. A `Supply` is awaited via its
     /// `.Promise` (kept with the last emitted value when the supply completes,
-    /// broken if it quits) — `await $supply` ≡ `await $supply.Promise`. All other
-    /// values pass through unchanged (Promises and Channels are handled inline).
+    /// broken if it quits) — `await $supply` ≡ `await $supply.Promise`. Other
+    /// `Awaitable` objects hand back the native Promise/Channel handle from
+    /// `get-await-handle`; native Promise and Channel values remain leaves for
+    /// the specialized wait/receive paths below.
     fn await_normalize(&mut self, v: Value) -> Result<Value, RuntimeError> {
         if let ValueView::Instance { class_name, .. } = v.view()
             && class_name == "Supply"
         {
             return self.call_method_with_values(v, "Promise", vec![]);
+        }
+        let native_await_target = matches!(v.view(), ValueView::Promise(_) | ValueView::Channel(_))
+            || matches!(
+                v.view(),
+                ValueView::Instance { class_name, .. } if class_name == "Promise"
+            );
+        if !native_await_target && self.type_matches_value("Awaitable", &v) {
+            return self.call_method_with_values(v, "get-await-handle", vec![]);
         }
         Ok(v)
     }

--- a/src/runtime/methods_classhow_parents.rs
+++ b/src/runtime/methods_classhow_parents.rs
@@ -140,6 +140,11 @@ impl Interpreter {
         if class_name == role {
             return true;
         }
+        if role == "Awaitable"
+            && crate::builtins::builtin_type_catalog::builtin_type_has_role(class_name, role)
+        {
+            return true;
+        }
         self.collect_roles_for_class(class_name, false, false, false)
             .iter()
             .any(|r| r.split_once('[').map(|(b, _)| b).unwrap_or(r) == role)
@@ -281,10 +286,17 @@ impl Interpreter {
             return result;
         }
         if local_only {
-            if let Some(roles) = self.registry().class_composed_roles.get(class_name) {
+            let roles = self
+                .registry()
+                .class_composed_roles
+                .get(class_name)
+                .cloned()
+                .filter(|roles| !roles.is_empty())
+                .unwrap_or_else(|| self.catalog_roles(class_name));
+            if !roles.is_empty() {
                 for r in roles {
                     if seen.insert(r.clone()) {
-                        result.push(r.clone());
+                        result.push(r);
                     }
                 }
             }
@@ -303,8 +315,14 @@ impl Interpreter {
                 // Clone out before the recursive call so no registry read guard is
                 // held across `collect_transitive_roles` (avoids a same-thread
                 // recursive read lock).
-                let roles = self.registry().class_composed_roles.get(cn).cloned();
-                if let Some(roles) = roles {
+                let roles = self
+                    .registry()
+                    .class_composed_roles
+                    .get(cn)
+                    .cloned()
+                    .filter(|roles| !roles.is_empty())
+                    .unwrap_or_else(|| self.catalog_roles(cn));
+                if !roles.is_empty() {
                     for r in &roles {
                         if seen.insert(r.clone()) {
                             result.push(r.clone());
@@ -327,7 +345,9 @@ impl Interpreter {
     /// `Rat`'s direct list kept `Real`. Otherwise directness is derived, by
     /// dropping every entry reachable from another entry's own `does`.
     fn direct_composed_roles(&self, class_name: &str) -> Vec<String> {
-        if let Some(direct) = self.registry().class_direct_composed_roles.get(class_name) {
+        if let Some(direct) = self.registry().class_direct_composed_roles.get(class_name)
+            && !direct.is_empty()
+        {
             return direct.clone();
         }
         let Some(all) = self
@@ -336,8 +356,11 @@ impl Interpreter {
             .get(class_name)
             .cloned()
         else {
-            return Vec::new();
+            return self.catalog_roles(class_name);
         };
+        if all.is_empty() {
+            return self.catalog_roles(class_name);
+        }
         let mut transitive = std::collections::HashSet::new();
         for r in &all {
             let base = r.split_once('[').map(|(b, _)| b).unwrap_or(r.as_str());
@@ -349,6 +372,19 @@ impl Interpreter {
         all.into_iter()
             .filter(|r| !transitive.contains(r))
             .collect()
+    }
+
+    fn catalog_roles(&self, class_name: &str) -> Vec<String> {
+        let base = class_name
+            .split_once('[')
+            .map(|(base, _)| base)
+            .unwrap_or(class_name);
+        if !matches!(base, "Promise" | "Channel") {
+            return Vec::new();
+        }
+        crate::builtins::builtin_type_catalog::builtin_type_info(base)
+            .map(|info| info.roles.iter().map(|role| (*role).to_string()).collect())
+            .unwrap_or_default()
     }
 
     /// Collect all transitively reachable roles into a set (for filtering).

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -132,6 +132,10 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         shared.mark_observed();
         match method {
+            // Promise and Channel are the native Awaitable handles themselves.
+            // Exposing the protocol method lets user-defined Awaitable classes
+            // delegate to a native handle just as they do on Rakudo.
+            "get-await-handle" => Ok(Value::promise(shared.clone())),
             "result" => {
                 // Wait for the promise to resolve (blocks if Planned)
                 let (result, _, _) = shared.wait();
@@ -357,6 +361,7 @@ impl Interpreter {
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
         match method {
+            "get-await-handle" => Ok(Value::channel(ch.clone())),
             "send" => {
                 if !ch.can_send() {
                     return Err(Self::channel_send_closed_error());

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -1193,6 +1193,13 @@ impl Interpreter {
         if resolved_constraint.is_some() && value.does_check(effective_constraint) {
             return true;
         }
+        // Builtin roles such as Awaitable are represented by the builtin type
+        // catalog rather than a registered RoleDef. Let the value-level role
+        // check consume that same catalog for builtin type objects and native
+        // Promise/Channel values.
+        if effective_constraint == "Awaitable" && value.does_check(effective_constraint) {
+            return true;
+        }
         // Type-object checks: Package values should respect declared class/role ancestry.
         if let ValueView::Package(package_name) = value.view() {
             if Self::type_matches(constraint, &package_name.resolve()) {

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -424,6 +424,22 @@ impl Value {
     /// wrapper views (Scalar, ContainerRef, forced LazyThunk, HashEntryRef,
     /// VarRef), so these arms match `self.view()` directly.
     fn does_role_hierarchy(&self, role_name: &str) -> bool {
+        let catalog_type = match self.view() {
+            ValueView::Package(name) => Some(name.resolve()),
+            ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
+            ValueView::Promise(_) => Some("Promise".to_string()),
+            ValueView::Channel(_) => Some("Channel".to_string()),
+            _ => None,
+        };
+        if role_name == "Awaitable"
+            && let Some(catalog_type) = catalog_type
+            && crate::builtins::builtin_type_catalog::builtin_type_has_role(
+                &catalog_type,
+                role_name,
+            )
+        {
+            return true;
+        }
         match role_name {
             "Numeric" => matches!(
                 self.view(),

--- a/t/concurrency/promise/awaitable-role-composition.t
+++ b/t/concurrency/promise/awaitable-role-composition.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 6;
+plan 11;
 
 # `Awaitable` is a core role — `raku -e 'say Awaitable.^name'` resolves it with
 # no `use` — and real code composes it onto its own classes (`TAP.rakumod`:
@@ -20,3 +20,8 @@ ok Handler ~~ Awaitable, 'a class that composes it does it';
 ok Handler.new ~~ Awaitable, 'and so does an instance';
 is Handler.^roles.map(*.^name).sort.join(','), 'Awaitable', 'it shows up in .^roles';
 nok Int ~~ Awaitable, 'an unrelated type does not do it';
+ok Promise ~~ Awaitable, 'Promise composes Awaitable';
+ok Channel ~~ Awaitable, 'Channel composes Awaitable';
+is Promise.^roles.map(*.^name).sort.join(','), 'Awaitable', 'Promise exposes Awaitable in .^roles';
+is Channel.^roles.map(*.^name).sort.join(','), 'Awaitable', 'Channel exposes Awaitable in .^roles';
+is await(Handler.new), 42, 'await dispatches through get-await-handle';


### PR DESCRIPTION
Closes #8118

- expose the catalog-defined Awaitable role for Promise and Channel membership and introspection
- route custom Awaitable values through get-await-handle during await
- add native Promise and Channel get-await-handle dispatch
- add regression coverage and a news entry

Validation:
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast