### PR TITLE
fix: dispatch the listop invocant colon as a method everywhere

### DIFF
--- a/news/2026-09/listop-invocant-colon-dispatches-a-method.md
+++ b/news/2026-09/listop-invocant-colon-dispatches-a-method.md
@@ -1,0 +1,51 @@
+# The listop invocant colon now dispatches a method everywhere
+
+Raku's listop invocant colon makes the first argument the invocant: `foo $x:
+@args` means `$x.foo(@args)`. mutsu's parser already built the right AST node
+for this (`CallArg::Invocant`, `Expr::MethodCall`) for the *non-tail*
+statement-level case, but several other places that compile a `Stmt::Call`
+either dropped the invocant marker and called the listop as a plain function,
+or hit `unreachable!()`:
+
+- `compile_tail_stmt_call_value` (shared by several tail-position call sites,
+  including a block/closure whose last statement is a call) panicked, because
+  its positional/named-pairs split has no arm for `CallArg::Invocant`.
+- `compile_routine_body_stmts` (a named `sub`'s own tail statement) and
+  `compile_closure_body_with_routine_flag`'s value-producing branch both
+  converted `CallArg::Invocant` into a plain positional argument, silently
+  dropping the colon.
+
+`die`/`fail` additionally had their own statement parser (`die_stmt`) and
+their own expression-position arm in `identifier_call.rs`, neither of which
+looked for a trailing `:` at all — `die "boom":` was a hard parse error
+(`fail`, `warn`, `say`, `sort`, `return` all *parsed*, since they go through
+the general listop-argument parser, but only the non-tail-statement case
+dispatched correctly).
+
+Fixed by adding one shared helper,
+`Compiler::invocant_colon_method_call`, that turns `(name, args)` into the
+equivalent `Expr::MethodCall` when `args` opens with an invocant, and wiring
+it into the three compiler call sites above; and by teaching `die_stmt` (and
+`die`/`fail`'s expression-position arm) to try the same no-paren
+invocant-colon parse `say`/`print`/`put`/`note` already use
+(`parse_io_colon_invocant_stmt`, renamed from an I/O-specific name since it is
+the general no-paren invocant-colon shape) before falling back to their own
+statement form.
+
+`say $x:`, `sort $x:` and `return $x:` already produced the right answer by
+coincidence — `Str`/`Array` really do have `.say`/`.sort` methods, and `.return`
+is a real control-flow method mutsu already implements, so dropping the colon
+and dispatching the method happened to agree. `warn $x:`/`die $x:` disagreed,
+because `Str` has no such method: mutsu warned/died with the string instead of
+raising `X::Method::NotFound` the way rakudo does. This let
+`Math::FractionalPart`'s
+`die "FATAL: ...; please report this issue":` load at all (previously a hard
+parse error), which also unblocks `Astro::Utils` and `DateTime::Julian`
+(both reach the construct through `Math::FractionalPart`).
+
+`t/routines/call/call-invocant-colon-listop.t` pins all five listops from the
+issue's table — the three that already matched rakudo by coincidence keep
+matching for the *right* reason, and `warn`/`die` now raise
+`X::Method::NotFound` like rakudo does.
+
+Closes #8141.

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -1234,6 +1234,15 @@ impl Compiler {
         name: crate::symbol::Symbol,
         args: &[CallArg],
     ) {
+        // An invocant-colon call (`die $x:`) becomes the equivalent
+        // MethodCall — see `invocant_colon_method_call`. Must run before the
+        // positional/pairs split below, which has no representation for
+        // `CallArg::Invocant` and previously hit the `unreachable!()` in the
+        // pairs loop (tokuhirom/mutsu#8141).
+        if let Some(method_call) = Self::invocant_colon_method_call(name, args) {
+            self.compile_expr(&method_call);
+            return;
+        }
         let rewritten_args = Self::rewrite_stmt_call_args(&name.resolve(), args);
         let positional_only = rewritten_args
             .iter()

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -132,6 +132,45 @@ impl Compiler {
             .collect()
     }
 
+    /// If `args` opens with an invocant colon (`CallArg::Invocant`), build the
+    /// equivalent `Expr::MethodCall` dispatching `name` as a method on that
+    /// invocant: `foo($obj: @rest)` / no-paren `foo $obj: @rest` both mean
+    /// `$obj.foo(@rest)` (see `try_parse_no_paren_invocant_colon_call` in
+    /// `parser/primary/ident/listop.rs`, which builds the same shape for the
+    /// expression-position spelling). Returns `None` when there is no
+    /// invocant, so callers fall back to their normal `Stmt::Call` handling.
+    ///
+    /// Every tail-position `Stmt::Call` compiler (the sub/closure body
+    /// compilers and `compile_tail_stmt_call_value`) must consult this before
+    /// dropping to a positional-args fast path — otherwise the invocant
+    /// marker is silently discarded and `die $x:`/`warn $x:` call the
+    /// builtin instead of dispatching `$x.die`/`$x.warn`
+    /// (tokuhirom/mutsu#8141). Named/slip args after the invocant are
+    /// dropped, matching the non-tail `Stmt::Call` handling in
+    /// `compile_stmt`.
+    pub(super) fn invocant_colon_method_call(
+        name: crate::symbol::Symbol,
+        args: &[crate::ast::CallArg],
+    ) -> Option<Expr> {
+        let crate::ast::CallArg::Invocant(invocant_expr) = args.first()? else {
+            return None;
+        };
+        let method_args: Vec<Expr> = args[1..]
+            .iter()
+            .filter_map(|arg| match arg {
+                crate::ast::CallArg::Positional(e) => Some(e.clone()),
+                _ => None,
+            })
+            .collect();
+        Some(Expr::MethodCall {
+            target: Box::new(invocant_expr.clone()),
+            name,
+            args: method_args,
+            modifier: None,
+            quoted: false,
+        })
+    }
+
     /// Thread the `&`-sigiled lexicals visible at this point (own `&` locals —
     /// params like `&x1`, `my &f` — plus everything inherited from enclosing
     /// scopes) down to a child sub/closure compiler. `compute_free_vars` uses
@@ -735,13 +774,16 @@ impl Compiler {
                         continue;
                     }
                     // Stmt::Call as last statement: convert to expression-level
-                    // Expr::Call so the return value is left on the stack.
+                    // Expr::Call so the return value is left on the stack. An
+                    // invocant-colon call (`die $x:`) instead becomes the
+                    // equivalent MethodCall — see `invocant_colon_method_call`.
                     Stmt::Call { name, args } => {
-                        let expr_args: Vec<Expr> = Self::call_args_to_expr_args(args);
-                        sub_compiler.compile_expr(&Expr::Call {
-                            name: *name,
-                            args: expr_args,
-                        });
+                        let call_expr = Self::invocant_colon_method_call(*name, args)
+                            .unwrap_or_else(|| Expr::Call {
+                                name: *name,
+                                args: Self::call_args_to_expr_args(args),
+                            });
+                        sub_compiler.compile_expr(&call_expr);
                         continue;
                     }
                     Stmt::If {
@@ -1262,6 +1304,12 @@ impl Compiler {
                     continue;
                 }
                 if is_value && let Stmt::Call { name, args } = stmt {
+                    // An invocant-colon call (`die $x:`) becomes the
+                    // equivalent MethodCall — see `invocant_colon_method_call`.
+                    if let Some(method_call) = Self::invocant_colon_method_call(*name, args) {
+                        sub_compiler.compile_expr(&method_call);
+                        continue;
+                    }
                     let positional: Option<Vec<Expr>> = args
                         .iter()
                         .map(|arg| match arg {

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1185,6 +1185,16 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 ));
             }
             let (r, arg) = expression(r)?;
+            // Invocant-colon form (`die $x: "extra"` == `$x.die("extra")`,
+            // tokuhirom/mutsu#8141) reaches this expression-position arm when
+            // `die`/`fail` is not the whole statement (e.g. `my $x = die
+            // "boom":`); the statement-position form is handled by
+            // `control_stmts.rs`'s `die_stmt` via the same helper.
+            let (r, invocant_colon_call) =
+                try_parse_no_paren_invocant_colon_call(&name, arg.clone(), r)?;
+            if let Some(method_call) = invocant_colon_call {
+                return Ok((r, method_call));
+            }
             return Ok((
                 r,
                 Expr::Call {

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -143,6 +143,16 @@ pub(crate) fn die_stmt(input: &str) -> PResult<'_, Stmt> {
         (r, false)
     };
     let (rest, _) = ws(rest)?;
+    // Invocant-colon form (`die $x: "extra"` == `$x.die("extra")`,
+    // tokuhirom/mutsu#8141): the listop invocant colon dispatches a method on
+    // the first argument rather than calling `die`/`fail` itself. Neither
+    // `Stmt::Die` nor `Stmt::Fail` has a slot for that, so this becomes a
+    // plain method-call expression statement instead — same shape `say`/
+    // `print`/`put`/`note` already use for their own invocant colon.
+    let method_name = if is_fail { "fail" } else { "die" };
+    if let Ok((rest, stmt)) = super::io_stmts::parse_io_colon_invocant_stmt(rest, method_name) {
+        return parse_statement_modifier(rest, stmt);
+    }
     // `die`/`fail` with no argument: followed by `;`, end, `}`, or a statement modifier
     let no_arg = rest.starts_with(';')
         || rest.is_empty()

--- a/src/parser/stmt/simple/io_stmts.rs
+++ b/src/parser/stmt/simple/io_stmts.rs
@@ -262,7 +262,16 @@ fn parse_io_expr_list(input: &str) -> PResult<'_, Vec<Expr>> {
     }
 }
 
-fn parse_io_colon_invocant_stmt<'a>(input: &'a str, method_name: &str) -> PResult<'a, Stmt> {
+/// Parse `EXPR: [args...]` after a listop keyword's own bare form has
+/// already failed — the invocant-colon form (`say $x: "y"` == `$x.say("y")`).
+/// Shared with `die`/`fail` in `control_stmts.rs`, whose own dedicated
+/// statement parsers do not otherwise see this syntax
+/// (tokuhirom/mutsu#8141): despite the name, this is the general no-paren
+/// invocant-colon-to-MethodCall shape, not something specific to I/O.
+pub(super) fn parse_io_colon_invocant_stmt<'a>(
+    input: &'a str,
+    method_name: &str,
+) -> PResult<'a, Stmt> {
     let (rest_after_target, target) = expression(input)?;
     let (rest_after_target, _) = ws(rest_after_target)?;
     if !rest_after_target.starts_with(':') || rest_after_target.starts_with("::") {

--- a/t/routines/call/call-invocant-colon-listop.t
+++ b/t/routines/call/call-invocant-colon-listop.t
@@ -1,0 +1,30 @@
+use Test;
+
+# The listop invocant colon (`foo $x: @args`) dispatches a method on the
+# first argument instead of calling the listop as a plain function:
+# `foo $x: @args` means `$x.foo(@args)`. tokuhirom/mutsu#8141.
+
+plan 7;
+
+is do { say "hello": }, True, 'say EXPR: dispatches .say, which returns True';
+
+my @a = 3, 1, 2;
+is-deeply (sort @a:), (1, 2, 3), 'sort @a: dispatches Array.sort';
+
+sub tail-return() { return "r": }
+is tail-return(), 'r', 'return EXPR: as a sub tail dispatches .return';
+
+sub mid-return() { return "r":; 'unreachable' }
+is mid-return(), 'r', 'return EXPR: mid-body dispatches .return';
+
+throws-like { my sub w() { warn "w": }; w() },
+    X::Method::NotFound,
+    'warn EXPR: as a sub tail has no .warn method on Str';
+
+throws-like { my sub d() { die "boom": }; d() },
+    X::Method::NotFound,
+    'die EXPR: as a sub tail has no .die method on Str';
+
+throws-like { die "boom":; 'unreachable' },
+    X::Method::NotFound,
+    'die EXPR: as a bare statement has no .die method on Str';


### PR DESCRIPTION
## Summary

Raku's listop invocant colon (`foo $x: @args` == `$x.foo(@args)`) already parsed and compiled correctly for a non-tail statement-level call, but several other compiler paths either dropped the invocant marker and called the listop as a plain function, or hit `unreachable!()`:

- `compile_tail_stmt_call_value` (shared by several tail-position call sites) panicked on `CallArg::Invocant` in its positional/named-pairs split.
- `compile_routine_body_stmts` (a named `sub`'s own tail statement) and `compile_closure_body_with_routine_flag`'s value-producing branch both silently converted the invocant into a plain positional argument, dropping the colon.

`die`/`fail` additionally had their own dedicated statement parser and expression-position arm, neither of which recognized a trailing invocant colon at all — `die "boom":` was a hard parse error instead of dispatching `.die`.

### Fix

- Added `Compiler::invocant_colon_method_call`, a shared helper that turns `(name, args)` into the equivalent `Expr::MethodCall` when `args` opens with an invocant, wired into the three tail-position compiler sites that previously mishandled it.
- Taught `die_stmt` and `die`/`fail`'s expression-position arm to try the same no-paren invocant-colon parse `say`/`print`/`put`/`note` already use (`parse_io_colon_invocant_stmt`, made `pub(super)` and documented as the general shape it always was, not something I/O-specific) before falling back to their own statement form.

`say $x:` / `sort $x:` / `return $x:` already matched rakudo by coincidence — `Str`/`Array` really do have `.say`/`.sort` methods, and `.return` is a real control-flow method mutsu already implements, so dropping the colon and dispatching the method happened to agree. `warn $x:` / `die $x:` did not, since `Str` has no such method: mutsu warned/died with the string instead of raising `X::Method::NotFound` like rakudo does.

This also lets `Math::FractionalPart`'s `die "FATAL: ...; please report this issue":` load at all (previously a hard parse error), which unblocks `Astro::Utils` and `DateTime::Julian` too (both reach the construct through `Math::FractionalPart`).

Closes #8141.

## Test plan

- [x] Added `t/routines/call/call-invocant-colon-listop.t`, pinning all five listops from the issue's table against expected behavior (verified against `raku` first).
- [x] `cargo fmt --all`
- [x] `make lint`
- [x] `make test` (4121 files, all green)
- [x] `make roast` — only the three documented container-environment failures (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t` — both `uid 0` chmod issues, and `roast/S32-io/IO-Socket-Async.t` — sandboxed network), matching `docs/agent-environments.md`'s known exceptions exactly.
- [x] Manually verified `Math::FractionalPart` now loads via `scripts/ecosystem-sweep.py --only Math::FractionalPart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsSEWrwCvPpagBfNjR5hFc


---
_Generated by [Claude Code](https://claude.ai/code/session_01SsSEWrwCvPpagBfNjR5hFc)_