### PR TITLE
ci: key the claim-label concurrency group by issue, not globally

### DIFF
--- a/.github/workflows/claim-label.yml
+++ b/.github/workflows/claim-label.yml
@@ -44,10 +44,29 @@ permissions:
   contents: read
   issues: write
 
-# One run at a time: two concurrent runs would read the same log and issue the
-# same label edit twice.
+# One run at a time PER ISSUE: two concurrent runs over the same log would read
+# it identically and issue the same label edit twice.
+#
+# The group must be keyed by the issue, not global. `cancel-in-progress: false`
+# protects a run that is already executing, but GitHub allows only one PENDING
+# run per group -- queueing a new one cancels the previously pending one. Since
+# an `issue_comment` run reconciles only `github.event.issue.number` (see the
+# Reconcile step), a global group let a comment on issue B cancel the pending
+# run for issue A, and the run that replaced it then reconciled B instead: A's
+# claim or release was simply dropped. The 3-hourly schedule below caught it
+# eventually, but up to three hours late -- long enough for another agent to
+# take an issue somebody is on, which is the failure this workflow exists to
+# prevent. Observed on #7988: its `Releasing:` comment's run was cancelled one
+# second later by an unrelated issue's, and the label stayed on for an hour
+# until a manual dispatch cleared it.
+#
+# Collapsing two runs for the SAME issue stays correct and is the point of the
+# group: each run replays that issue's whole comment log, so it is idempotent,
+# and the surviving (newer) run sees strictly more comments than the one it
+# replaced. The whole-queue runs (`schedule`, and a dispatch with no `issue`)
+# share the `all` key and still serialise against each other.
 concurrency:
-  group: claim-label
+  group: claim-label-${{ github.event.issue.number || inputs.issue || 'all' }}
   cancel-in-progress: false
 
 jobs:

--- a/news/2026-09/the-claim-label-group-is-per-issue.md
+++ b/news/2026-09/the-claim-label-group-is-per-issue.md
@@ -1,0 +1,80 @@
+# The `working` label's concurrency group has to be per-issue
+
+[#8117](https://github.com/tokuhirom/mutsu/pull/8117) made the `working` label
+*derived* from the claim log so the two could no longer disagree. The parsing
+half of that worked. The delivery half had a hole, and it reintroduced exactly
+the failure the PR was written to eliminate — an issue that reads as free while
+somebody is on it — with the added insult that it struck hardest when the queue
+was busiest.
+
+## Caught in the act
+
+I released [#7988](https://github.com/tokuhirom/mutsu/issues/7988) at
+`12:59:07Z`. Both `Claiming:`/`Releasing:` pairs on it were then matched and
+nobody else had claimed it, yet an hour later it still carried `working`. A
+`workflow_dispatch` scoped to that one issue cleared it instantly — so the
+parser read the comment correctly and the run for it had simply never happened:
+
+```
+44  12:59:10Z  issue_comment  -> success
+43  12:59:09Z  issue_comment  -> cancelled     <-- the #7988 release
+42  12:58:59Z  issue_comment  -> success
+…
+39  12:52:16Z  issue_comment  -> cancelled     <-- the same thing, seven minutes earlier
+```
+
+## Why a global group loses events
+
+```yaml
+concurrency:
+  group: claim-label          # one constant, for every issue
+  cancel-in-progress: false
+```
+
+`cancel-in-progress: false` protects a run that is already *executing*. It says
+nothing about queueing, and GitHub allows only **one pending run per group**:
+queueing a new one cancels the previously pending one. With a single global
+key, a comment on issue B therefore cancels the still-pending run for issue A.
+
+That would be harmless if every run reconciled the whole queue — but an
+`issue_comment` run is scoped to its own event:
+
+```yaml
+ISSUE: ${{ github.event.issue.number || inputs.issue }}
+```
+
+So the run that supersedes a cancelled one reconciles a *different* issue, and
+the cancelled one's issue is skipped outright. Claims and releases are dropped
+in proportion to how much traffic the queue is carrying.
+
+The 3-hourly `schedule` run is the designed backstop — its own comment says it
+exists "to catch an event that was never delivered" — and it does self-heal
+this. But three hours is long enough for another agent to pick up an issue
+somebody is already working, which is the whole thing the label is for.
+
+## The fix
+
+Key the group by the issue the run is about:
+
+```yaml
+group: claim-label-${{ github.event.issue.number || inputs.issue || 'all' }}
+```
+
+Comments on different issues now never cancel one another. Collapsing two runs
+for the *same* issue stays correct and is the point of having a group at all:
+each run replays that issue's entire comment log, so it is idempotent, and the
+surviving (newer) run sees strictly more comments than the one it replaced. The
+whole-queue runs — `schedule`, and a dispatch with no `issue` — share the `all`
+key and still serialise against each other as before.
+
+## Verified before merging, not after
+
+A bad expression in a workflow-level `concurrency` key does not fail one run; it
+makes the workflow unparseable and takes down every run. Since the `inputs`
+context's availability there is the one thing this change depends on, it was
+checked by **dispatching the workflow from the PR branch** rather than by
+reading the docs: a `workflow_dispatch` on `claude/mutsu-issue-7996-41oc6h`
+reconciled #8165 and completed green, which proves the expression both parses
+and evaluates on a real event. The cheap checks came first — `yaml.safe_load`
+on the file, and the script's own 14-case `--self-test`, which is untouched
+here because this is delivery, not parsing.


### PR DESCRIPTION
Closes #8165.

#8117 made the `working` label *derived* from the claim log so the two could not disagree. The parsing half worked. The delivery half dropped events — reintroducing the exact failure that PR set out to prevent (an issue that reads as free while somebody is on it), and doing so in proportion to how busy the queue was.

## Caught in the act

I released #7988 at `12:59:07Z`. Both `Claiming:`/`Releasing:` pairs on it were matched and nobody else had claimed it, yet an hour later it still carried `working`. A dispatch scoped to that one issue cleared it instantly — so the parser read the comment correctly and the run for it had never happened:

```
44  12:59:10Z  issue_comment  -> success
43  12:59:09Z  issue_comment  -> cancelled     <-- the #7988 release
42  12:58:59Z  issue_comment  -> success
…
39  12:52:16Z  issue_comment  -> cancelled     <-- same shape, seven minutes earlier
```

## Root cause

`cancel-in-progress: false` protects a run that is already *executing*. It says nothing about queueing, and GitHub allows only **one pending run per concurrency group** — queueing a new one cancels the previously pending one. The group was a single global constant, so a comment on issue B cancelled the still-pending run for issue A.

That would be harmless if every run reconciled the whole queue, but an `issue_comment` run is scoped to its own event:

```yaml
ISSUE: ${{ github.event.issue.number || inputs.issue }}
```

so the run that superseded the cancelled one reconciled **B** instead, and A's claim or release was simply lost.

The 3-hourly `schedule` run is the designed backstop — its comment says it exists "to catch an event that was never delivered" — and it does self-heal this. But three hours is long enough for another agent to take an issue somebody is already working, which is what the label is for.

## The change

```yaml
group: claim-label-${{ github.event.issue.number || inputs.issue || 'all' }}
```

Comments on different issues no longer cancel one another. Collapsing two runs for the **same** issue stays correct and is the point of having a group: each run replays that issue's entire comment log, so it is idempotent, and the surviving (newer) run sees strictly more comments than the one it replaced. The whole-queue runs (`schedule`, and a dispatch with no `issue`) share the `all` key and still serialise against each other.

`.github/scripts/sync-working-label.sh` is untouched — this is delivery, not parsing.

## Verified before merging, not after

A bad expression in a workflow-level `concurrency` key does not fail one run: it makes the workflow unparseable and takes down **every** run. The `inputs` context's availability there is the one thing this change depends on, so it was checked against GitHub rather than against the docs — **`workflow_dispatch` on this PR's branch**, [run 77](https://github.com/tokuhirom/mutsu/actions/workflows/claim-label.yml) on `ccf503c7`, `issue: 8165`:

- **conclusion `success`** — the expression parses and evaluates on a real event;
- it reconciled #8165 and correctly **left `working` on**, because my claim on it is live — so the behaviour the group guards is unchanged.

Cheap checks first: `yaml.safe_load` on the file, and the script's 14-case `--self-test` (all pass, unchanged).

`scripts/ci-docs-only.sh --classify` returns `true` for this diff (`.github/**` except `ci.yml`, plus `news/`), so the build jobs are expected to report `skipped`. Controls: adding `src/value.rs` to the list returns `false`, and `.github/workflows/ci.yml` alone returns `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pz6URmTWmqMP41wKgpjkRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pz6URmTWmqMP41wKgpjkRo)_