### PR TITLE
perf(regex): intern the capture-alias map and stop three futile map probes

### DIFF
--- a/news/2026-09/a-qualified-class-name-skips-a-futile-registry-scan.md
+++ b/news/2026-09/a-qualified-class-name-skips-a-futile-registry-scan.md
@@ -1,0 +1,32 @@
+# A qualified class name stops scanning the whole class registry
+
+Every `.new` of a user class asks `seed_quanthash_storage` whether the class
+inherits a QuantHash base, which resolves the class — and each of its declared
+parents — through `resolved_class_parents`. That lookup tries the registry key
+verbatim, and on a miss falls back to scanning the class table for a key whose
+`::`-tail short name matches, so a bare `Bar` can still find a registered
+`Foo::Bar`.
+
+The fallback cannot match a name that is already qualified. A key's `::`-tail is
+by construction everything after the *last* `::`, so it never contains one
+itself; `short == name` is therefore impossible the moment `name` does. Every
+such call scanned the entire table — a `rsplit_once` substring search per entry
+— to arrive at the `None` it was always going to return.
+
+That is not a rare shape. A class declared in a module composes its roles by
+qualified name, so parsing YAML with the bundled `YAMLish` battery reached here
+148 times for names like `YAMLish::Single` and `YAMLish::Quoted`, at about
+**97,000 instructions each**: **1.0% of the whole program**, 32,792 substring
+searches, to answer a question with no possible answer.
+
+One `name.contains("::")` guard before the fallback removes it:
+14,354,235 -> 987,214 Ir for `resolved_class_parents` on a 60-row YAML document.
+The short-name fallback itself is untouched, and a bare name still resolves to
+its qualified registry entry.
+
+Pinned by `t/collections/set-bag-mix/quanthash-subclass-qualified-name.t`
+(verified against rakudo 2026.07): a `BagHash` subclass declared in a module
+keeps its mutable backing store, a `Bag` subclass keeps the immutable one, and
+a bare parent name still finds the class it was declared as.
+
+Refs [#7576](https://github.com/tokuhirom/mutsu/issues/7576).

--- a/news/2026-09/capture-alias-map-is-interned.md
+++ b/news/2026-09/capture-alias-map-is-interned.md
@@ -1,0 +1,34 @@
+# The capture-alias map stops cloning two strings per candidate
+
+A non-suppressing alias — `<val=word>`, `<tags=tag-directive>` — files its match
+under both names, and the engine records the alias-to-original mapping in the
+capture accumulator so the Match builder can reproduce it. That map was
+`HashMap<String, String>`.
+
+Nothing about it wanted owned strings. Both halves of an entry are capture
+names the memoized lookup spec already holds as interned `Symbol`s
+(`spec.capture_sym`, `spec.lookup_sym`), and the only consumers are the two
+places that turn the finished map into a Match attribute, which resolve the
+names back to text once. In between sat the regex engine, which clones a whole
+`RegexCaptures` per accepted candidate and merges a delta per matched atom —
+so every alias cost two `String` allocations on each of those, plus a third for
+the undo record the trail keeps so a backtrack can restore it.
+
+Keying it by `Symbol` removes all of them. On a 60-row YAML document under
+callgrind, `String::clone` calls go **235,346 -> 144,469 (-39%)**, and
+instructions retired **1,317,486,807 -> 1,275,306,641 (-3.20%)** — the largest
+single item of the round, for a type change with an eleven-error blast radius
+that the compiler enumerated.
+
+The undo record (`Undo::AliasRestore`) carries symbols now too, which also
+shrinks it: a backtrack over an aliased capture used to allocate and free two
+strings just to put the previous entry back.
+
+Pinned by `t/grammar/grammar-capture-alias-across-backtracking.t` (verified
+against rakudo 2026.07): an alias inside an alternation under a separated
+quantifier, so the engine builds, merges and rewinds the alias record several
+times per item before the parse commits — both names resolve, the rejected
+branch leaves nothing behind, and a quantified alias still collects the whole
+list under each name.
+
+Refs [#7576](https://github.com/tokuhirom/mutsu/issues/7576).

--- a/news/2026-09/the-matcher-asks-each-map-once.md
+++ b/news/2026-09/the-matcher-asks-each-map-once.md
@@ -1,0 +1,40 @@
+# Two matcher hot paths ask their map once instead of twice
+
+Two places in the regex engine hashed and probed the same key twice in a row to
+answer one question.
+
+**Merging a capture delta.** `CapStore::merge_delta` pushed an undo record for
+each named key and then took an `entry` on the same map to append the delta's
+nodes. The record wants exactly the slot state the `entry` is about to hand out,
+so taking the entry first and reading the record off it is the same work minus
+one hash and one search per merged capture — about 57,000 of them on a 60-row
+YAML document.
+
+The same function also merged three maps that live in the accumulator's cold
+payload (`RareCaps`): capture aliases, hash captures and `:my` lexicals. A delta
+that never wrote one — the overwhelming majority — still paid three `take_*`
+calls, each of which built an empty map, iterated it, and pruned an absent
+payload. One `delta.has_rare()` branch answers all three at once. Together:
+`merge_delta` **93,006,964 -> 82,107,307 Ir (-0.81% of the program)**.
+
+**Starting a left-recursion activation.** Every `<subrule>` call asked
+`lr_key_is_active` and then, on either answer, took an `entry` on the same
+thread-local map — either to read the seed (a left-recursive re-entry) or to
+begin the activation. `lr_begin_or_reenter` does both in one map operation and
+returns which happened. The two spellings were otherwise identical: the separate
+`lr_key_is_active` declined to create a vacant entry, but the
+`lr_begin_activation` that always followed it created one anyway. That removes
+87,211 probes on the same document, none of whose rules are left-recursive at
+all.
+
+**What is still there.** The left-recursion bookkeeping remains the largest
+identified avoidable cluster in the profile: 224,644 map `entry` operations for
+112,322 activations, plus the seed-consulted reads, at roughly 2% of the run on
+a grammar with no left recursion anywhere. Removing it wants a gate on the
+call-graph reachability analysis `regex_call_graph::reenter_decline` already
+computes — which is not a slice, because the LR key deliberately carries no
+package and the analysis is per-package, so skipping an activation changes what
+a same-named rule in another grammar sees. It is recorded on the ticket rather
+than guessed at here.
+
+Refs [#7576](https://github.com/tokuhirom/mutsu/issues/7576).

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -773,7 +773,7 @@ impl Interpreter {
                 if !alias_map.is_empty() {
                     let alias_hash: HashMap<String, Value> = alias_map
                         .iter()
-                        .map(|(k, v)| (k.clone(), Value::str(v.clone())))
+                        .map(|(k, v)| (k.as_str().to_string(), Value::str(v.as_str().to_string())))
                         .collect();
                     updates.push(("capture_alias_map", Value::hash_bare_values(alias_hash)));
                 }

--- a/src/runtime/regex/regex_lr_state.rs
+++ b/src/runtime/regex/regex_lr_state.rs
@@ -108,6 +108,41 @@ pub(super) fn lr_begin_activation(key: &LrKey) -> bool {
     })
 }
 
+/// What a `<subrule>` call found when it asked to start an activation.
+pub(super) enum LrBegin {
+    /// The key is already under evaluation further up the stack: this call is
+    /// a left-recursive re-entry and gets the seed grown so far (highest
+    /// priority first, raw inner matches at absolute positions) instead of
+    /// recursing. Asking for it is what records the key as genuinely
+    /// left-recursive, so the owner keeps growing the seed.
+    Reentry(Vec<(usize, RegexCaptures)>),
+    /// The activation was started; the payload is the enclosing activation's
+    /// "seed was consulted" flag for [`lr_end_activation`] to restore.
+    Began(bool),
+}
+
+/// [`lr_key_is_active`] + the seed read / [`lr_begin_activation`] as ONE map
+/// operation.
+///
+/// Every `<subrule>` call asks both questions back to back and acts on exactly
+/// one of them, so asking them separately hashed and probed the same key twice
+/// per call — 87k redundant probes on a 60-row YAMLish parse, none of whose
+/// rules are left-recursive at all. The two spellings are otherwise identical:
+/// the separate `lr_key_is_active` declined to create a vacant entry, but the
+/// `lr_begin_activation` that always followed it created one anyway.
+pub(super) fn lr_begin_or_reenter(key: &LrKey) -> LrBegin {
+    LR_STATE.with(|s| {
+        let mut s = s.borrow_mut();
+        let entry = s.entry(key.clone()).or_default();
+        if let Some(seed) = entry.seed.as_ref() {
+            entry.seed_read = true;
+            return LrBegin::Reentry(seed.clone());
+        }
+        entry.seed = Some(Vec::new());
+        LrBegin::Began(std::mem::take(&mut entry.seed_read))
+    })
+}
+
 /// Undo [`lr_begin_activation`], reporting whether anything re-entered `key`
 /// and read its seed while it was active.
 pub(super) fn lr_end_activation(key: &LrKey, outer_seed_read: bool) -> bool {
@@ -134,17 +169,6 @@ pub(super) fn lr_end_activation(key: &LrKey, outer_seed_read: bool) -> bool {
                 false
             }
         }
-    })
-}
-
-/// Read the seed grown so far for an active `key`, recording that it was
-/// consulted (which is what makes this key genuinely left-recursive).
-pub(super) fn lr_read_seed(key: &LrKey) -> Vec<(usize, RegexCaptures)> {
-    LR_STATE.with(|s| {
-        let mut s = s.borrow_mut();
-        let entry = s.entry(key.clone()).or_default();
-        entry.seed_read = true;
-        entry.seed.clone().unwrap_or_default()
     })
 }
 
@@ -186,7 +210,7 @@ mod tests {
         let k = key("lr_seed_read", 3);
         // Outer activation, re-entered and consulted.
         let outer = lr_begin_activation(&k);
-        assert!(lr_read_seed(&k).is_empty());
+        assert!(matches!(lr_begin_or_reenter(&k), LrBegin::Reentry(seed) if seed.is_empty()));
         assert!(lr_seed_was_consulted(&k));
         // A nested activation of the same key starts un-consulted, and hands
         // the outer flag back on the way out.
@@ -207,12 +231,16 @@ mod tests {
         let k = key("lr_stored_seed", 5);
         let outer = lr_begin_activation(&k);
         lr_store_seed(&k, vec![(9, RegexCaptures::default())]);
-        let seed = lr_read_seed(&k);
+        let LrBegin::Reentry(seed) = lr_begin_or_reenter(&k) else {
+            panic!("an active key re-enters rather than beginning again");
+        };
         assert_eq!(seed.len(), 1);
         assert_eq!(seed[0].0, 9);
         lr_end_activation(&k, outer);
-        // The seed dies with the activation.
-        assert!(lr_read_seed(&k).is_empty());
+        // The seed dies with the activation: the next call BEGINS one rather
+        // than re-entering, and what it then hands a re-entry is empty again.
+        assert!(matches!(lr_begin_or_reenter(&k), LrBegin::Began(_)));
+        assert!(matches!(lr_begin_or_reenter(&k), LrBegin::Reentry(seed) if seed.is_empty()));
         lr_end_activation(&k, false);
         LR_STATE.with(|s| assert!(!s.borrow().contains_key(&k)));
     }

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -3,10 +3,7 @@ use super::regex_helpers::{
     LTM_DECLARATIVE_MODE, LTM_PREFIX_TERMINATED, NamedRegexLookupSpec, alternation_capture_slots,
     merge_regex_captures,
 };
-use super::regex_lr_state::{
-    LrKey, lr_begin_activation, lr_end_activation, lr_read_seed, lr_seed_was_consulted,
-    lr_store_seed,
-};
+use super::regex_lr_state::{LrKey, lr_end_activation, lr_seed_was_consulted, lr_store_seed};
 use super::regex_ltm_rank::{LtmAtomMode, ltm_atom_mode};
 
 /// ADR-0022 §4.4(a): one `|` branch's rank key (prefix_len, litlen) paired
@@ -569,37 +566,33 @@ impl Interpreter {
                 });
                 let lr_key = LrKey::new(spec.lookup_sym, lr_args, chars.len() - pos);
 
-                // Check if this call is currently active (left recursion detected).
-                let is_active = super::regex_lr_state::lr_key_is_active(&lr_key);
-                if is_active {
-                    // Genuine left recursion: this key's evaluation depends on
-                    // its own seed, so the owner must keep growing it. Reading
-                    // the seed is what records that.
-                    // The seed is stored in HIGHEST FIRST order (raw inner
-                    // matches, absolute positions).
-                    let seed = lr_read_seed(&lr_key);
-                    // Wrap seed into outer captures. build_named_candidates_from_inner
-                    // returns items in the same order as input (HIGHEST FIRST).
-                    // Caller expects LOWEST FIRST, so reverse.
-                    let mut result = Self::build_named_candidates_from_inner(
-                        seed, pos, &spec, None, // no sym_key for seed
-                    );
-                    result.reverse();
-                    return result;
-                }
-
-                // Not currently active: run the growing-seed algorithm.
+                // Is this call already active (left recursion), and if not,
+                // start its activation — one map operation for both, since
+                // exactly one of the two answers is acted on.
                 //
-                // Seed storage: raw (un-wrapped) inner matches in HIGHEST FIRST
-                // order, with absolute positions.
-                // When is_active branch reads the seed, it passes them to
-                // build_named_candidates_from_inner which adds the outer wrapping.
+                // Active: genuine left recursion. This key's evaluation depends
+                // on its own seed, so the owner must keep growing it; asking for
+                // the seed is what records that. The seed is stored in HIGHEST
+                // FIRST order (raw inner matches, absolute positions).
                 //
-                // Initialize with empty seed (= no match yet). This key starts
-                // out un-consulted for THIS activation; a stale entry from an
-                // earlier activation at the same key must not be read as
-                // "left-recursive" here.
-                let outer_seed_read = lr_begin_activation(&lr_key);
+                // Not active: run the growing-seed algorithm from an empty seed
+                // (= no match yet). This key starts out un-consulted for THIS
+                // activation; a stale entry from an earlier activation at the
+                // same key must not be read as "left-recursive" here.
+                let outer_seed_read = match super::regex_lr_state::lr_begin_or_reenter(&lr_key) {
+                    super::regex_lr_state::LrBegin::Reentry(seed) => {
+                        // Wrap seed into outer captures.
+                        // build_named_candidates_from_inner returns items in the
+                        // same order as input (HIGHEST FIRST). Caller expects
+                        // LOWEST FIRST, so reverse.
+                        let mut result = Self::build_named_candidates_from_inner(
+                            seed, pos, &spec, None, // no sym_key for seed
+                        );
+                        result.reverse();
+                        return result;
+                    }
+                    super::regex_lr_state::LrBegin::Began(outer_seed_read) => outer_seed_read,
+                };
 
                 // best_inner_max: max inner_end seen so far (None = nothing matched yet).
                 let mut best_inner_max: Option<usize> = None;
@@ -1075,7 +1068,7 @@ impl Interpreter {
                 if is_alias {
                     new_caps
                         .capture_alias_map_mut()
-                        .insert(capture_name.to_string(), spec.lookup_name.clone());
+                        .insert(capture_sym, spec.lookup_sym);
                 }
                 if let Some(orig_subcap) = shared_under_original {
                     new_caps

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -950,7 +950,7 @@ impl Interpreter {
                     {
                         new_caps
                             .capture_alias_map_mut()
-                            .insert(capture_name.to_string(), spec.lookup_name.clone());
+                            .insert(Symbol::intern(capture_name), spec.lookup_sym);
                         new_caps
                             .named
                             .entry(Symbol::intern(&spec.lookup_name))

--- a/src/runtime/regex/regex_trail.rs
+++ b/src/runtime/regex/regex_trail.rs
@@ -16,6 +16,7 @@
 //! and goal failures persist across backtracks by design.
 
 use super::super::*;
+use std::collections::hash_map::Entry;
 
 /// Saved tail for a positional truncation (slots moved out, moved back on
 /// rewind). Boxed to keep `Undo` small.
@@ -51,8 +52,8 @@ pub(super) enum Undo {
     },
     /// Restore a `capture_alias_map` entry (None = remove).
     AliasRestore {
-        key: String,
-        prev: Option<String>,
+        key: crate::symbol::Symbol,
+        prev: Option<crate::symbol::Symbol>,
     },
     /// Restore a `regex_vars` entry (None = remove).
     RegexVarRestore {
@@ -208,29 +209,60 @@ impl CapStore {
     /// per-level metadata (from/to/match_from) are intentionally NOT merged.
     pub(super) fn merge_delta(&mut self, mut delta: RegexCaptures) {
         for (k, v) in delta.named.drain() {
-            self.record_named_key(k);
-            let slot = self.caps.named.entry(k).or_default();
+            // One probe of `named`, not two: the undo record wants exactly the
+            // slot state the `entry` below is about to hand out, so recording it
+            // through a separate `get` (what `record_named_key` does for callers
+            // that have no entry in hand) hashed and searched for the same key
+            // twice per merged capture.
+            let slot = match self.caps.named.entry(k) {
+                Entry::Occupied(occupied) => {
+                    let slot = occupied.into_mut();
+                    self.trail.push(Undo::NamedTrunc {
+                        key: k,
+                        len: slot.nodes.len(),
+                        present: true,
+                        quantified: slot.quantified,
+                    });
+                    slot
+                }
+                Entry::Vacant(vacant) => {
+                    self.trail.push(Undo::NamedTrunc {
+                        key: k,
+                        len: 0,
+                        present: false,
+                        quantified: false,
+                    });
+                    vacant.insert(NamedSlot::default())
+                }
+            };
             slot.nodes.extend(v.nodes);
             slot.quantified |= v.quantified;
-        }
-        for (k, v) in delta.take_capture_alias_map() {
-            self.insert_alias(k, v);
         }
         if !delta.positional.is_empty() {
             self.record_pos_lens();
             self.caps.positional.append(&mut delta.positional);
         }
-        for (k, v) in delta.take_hash_captures() {
-            self.record_hash_cap_key(&k);
-            self.caps
-                .hash_captures_mut()
-                .entry(k)
-                .or_default()
-                .extend(v);
-        }
-        for (k, v) in delta.take_regex_vars() {
-            let prev = self.caps.regex_vars_mut().insert(k.clone(), v);
-            self.trail.push(Undo::RegexVarRestore { key: k, prev });
+        // Aliases, hash captures and `:my` lexicals all live in the delta's cold
+        // payload (`RareCaps`), allocated on first write. A delta that never
+        // wrote one has nothing to merge, and the three `take_*` calls below
+        // would each build an empty map, iterate it and prune the absent payload
+        // — per merged candidate, on the hottest path in the matcher.
+        if delta.has_rare() {
+            for (k, v) in delta.take_capture_alias_map() {
+                self.insert_alias(k, v);
+            }
+            for (k, v) in delta.take_hash_captures() {
+                self.record_hash_cap_key(&k);
+                self.caps
+                    .hash_captures_mut()
+                    .entry(k)
+                    .or_default()
+                    .extend(v);
+            }
+            for (k, v) in delta.take_regex_vars() {
+                let prev = self.caps.regex_vars_mut().insert(k.clone(), v);
+                self.trail.push(Undo::RegexVarRestore { key: k, prev });
+            }
         }
         if delta.capture_start.is_some() {
             self.trail.push(Undo::CaptureStart(self.caps.capture_start));
@@ -270,8 +302,8 @@ impl CapStore {
         }
     }
 
-    pub(super) fn insert_alias(&mut self, key: String, val: String) {
-        let prev = self.caps.capture_alias_map_mut().insert(key.clone(), val);
+    pub(super) fn insert_alias(&mut self, key: crate::symbol::Symbol, val: crate::symbol::Symbol) {
+        let prev = self.caps.capture_alias_map_mut().insert(key, val);
         self.trail.push(Undo::AliasRestore { key, prev });
     }
 

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -218,7 +218,7 @@ pub(crate) struct CapChildren {
     /// Capture names stay interned throughout matching and backtracking; only
     /// Match `.hash` materialization resolves them back to user-facing strings.
     pub(crate) named: NamedCaptureMap,
-    pub(crate) capture_alias_map: HashMap<String, String>,
+    pub(crate) capture_alias_map: CaptureAliasMap,
     /// Positional captures as span-bearing slots (ADR-0016 P4). Unlike the
     /// pre-P4 parallel vectors, the span survives onto the stored node — the
     /// text-only leaf fallback (fabricated `0..len` offsets) is gone.
@@ -316,7 +316,12 @@ impl RegexCaptures {
 pub(crate) type HashCaptureMap = HashMap<String, Vec<(String, Option<String>)>>;
 
 /// The capture-alias map shape (`<str=.str_escape>` → original rule name).
-pub(crate) type CaptureAliasMap = HashMap<String, String>;
+///
+/// Interned, like [`NamedCaptureMap`]: both halves of an entry are capture
+/// names the (memoized) lookup spec already holds as `Symbol`s, and the map is
+/// deep-cloned with every `RegexCaptures` the engine clones. Owned `String`s
+/// made that clone allocate two per alias per candidate.
+pub(crate) type CaptureAliasMap = HashMap<Symbol, Symbol>;
 
 /// The cold half of [`RegexCaptures`], behind one allocation that most
 /// accumulators never make.
@@ -430,6 +435,15 @@ impl RegexCaptures {
         self.rare.as_deref()
     }
 
+    /// Did this accumulator ever write a cold payload? A `false` answers every
+    /// `take_*`/`*_mut` question about [`RareCaps`] at once, so a caller that
+    /// would otherwise build, iterate and discard three empty maps can skip
+    /// them in one branch.
+    #[inline]
+    pub(crate) fn has_rare(&self) -> bool {
+        self.rare.is_some()
+    }
+
     /// The cold payload, allocating it on first use. Prefer the read-only
     /// accessors on a path that only inspects — this is what turns a
     /// few-word accumulator back into an allocating one.
@@ -514,7 +528,7 @@ impl RegexCaptures {
 
     /// Merge another accumulator's capture aliases into this one, without
     /// allocating a payload when there is nothing to merge.
-    pub(crate) fn extend_capture_alias_map<I: IntoIterator<Item = (String, String)>>(
+    pub(crate) fn extend_capture_alias_map<I: IntoIterator<Item = (Symbol, Symbol)>>(
         &mut self,
         aliases: I,
     ) {

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -206,6 +206,17 @@ impl Interpreter {
         if let Some(cd) = reg.classes.get(name) {
             return Some((name.to_string(), cd.parents.clone()));
         }
+        // The fallback below compares `name` against a registry key's `::`-tail,
+        // which is by construction everything after the LAST `::` and so never
+        // contains one itself. A qualified `name` therefore cannot match any
+        // key, and scanning the whole class table to discover that is provably
+        // futile — it was measured at 1.0% of a YAMLish parse (148 scans of
+        // ~220 entries, each one a `rsplit_once` substring search), because a
+        // role name like `YAMLish::Single` reaches here on every `.new` of a
+        // class that composes it (`seed_quanthash_storage`).
+        if name.contains("::") {
+            return None;
+        }
         reg.classes
             .iter()
             .find(|(k, _)| k.rsplit_once("::").is_some_and(|(_, short)| short == name))

--- a/src/value/match_lazy.rs
+++ b/src/value/match_lazy.rs
@@ -210,7 +210,7 @@ impl MatchNode {
             let alias_hash: HashMap<String, Value> = kids
                 .capture_alias_map
                 .iter()
-                .map(|(k, v)| (k.clone(), Value::str(v.clone())))
+                .map(|(k, v)| (k.as_str().to_string(), Value::str(v.as_str().to_string())))
                 .collect();
             attrs.insert("capture_alias_map", Value::hash_bare_values(alias_hash));
         }

--- a/t/collections/set-bag-mix/quanthash-subclass-qualified-name.t
+++ b/t/collections/set-bag-mix/quanthash-subclass-qualified-name.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A QuantHash subclass declared inside a `module` is constructed by its
+# package-qualified name, so `seed_quanthash_storage` asks the class registry
+# for `M::Tally`'s declared parents on every `.new`. That lookup has a
+# short-name fallback (a bare `Bar` finds a registered `Foo::Bar`) whose scan
+# cannot match a name that is already qualified — skipping it for such a name
+# must not change which base the subclass is backed by.
+plan 9;
+
+module M {
+    role Tagged { method tag() { 'tagged' } }
+    class Tally is BagHash does Tagged { }
+    class Frozen is Bag does Tagged { }
+    our sub build-tally() { Tally.new(<a b a>) }
+    our sub build-frozen() { Frozen.new(<a b a>) }
+}
+
+my $t = M::build-tally();
+is $t<a>, 2, 'a mutable QuantHash subclass counts its constructor arguments';
+is $t.tag, 'tagged', 'the composed role is still there';
+$t<a> = 5;
+is $t<a>, 5, 'a BagHash subclass is backed by a MUTABLE bag';
+is $t.elems, 2, 'and keeps its element count';
+ok $t ~~ M::Tally, 'the instance is of the subclass';
+
+my $f = M::build-frozen();
+is $f<a>, 2, 'an immutable QuantHash subclass counts its arguments too';
+is $f.tag, 'tagged', 'the composed role is there as well';
+ok !(try { $f<a> = 5; True }), 'a Bag subclass keeps the immutable backing store';
+
+# The short-name fallback itself: a bare parent name still resolves to the
+# package-qualified registry entry it was declared under.
+module N {
+    class Base { method kind() { 'base' } }
+    class Derived is Base { }
+    our sub build() { Derived.new }
+}
+is N::build().kind, 'base', 'a bare parent name still resolves to its qualified class';

--- a/t/grammar/grammar-capture-alias-across-backtracking.t
+++ b/t/grammar/grammar-capture-alias-across-backtracking.t
@@ -1,0 +1,41 @@
+use Test;
+
+# A non-suppressing alias `<val=word>` files its match under BOTH names, and
+# the engine records the alias in a capture-alias map that every candidate
+# clones, merges and rewinds. Putting the alias inside an alternation under a
+# separated quantifier makes the matcher build and undo those records several
+# times per item before the parse commits, so an alias that leaked across a
+# rewind — or one merged under the wrong name — shows up here.
+plan 12;
+
+grammar G {
+    token TOP { <item>+ %% ',' }
+    token item { [ <val=word> '!' | <val=digits> ';' ] }
+    token word { \w+ }
+    token digits { \d+ }
+}
+
+my $m = G.parse('abc!,12;,x!');
+ok $m.defined, 'the alternation parse succeeds';
+is $m<item>.elems, 3, 'every separated item matched';
+
+is ~$m<item>[0]<val>, 'abc', 'the first item captures under the alias';
+is ~$m<item>[0]<word>, 'abc', 'and under the aliased rule name';
+nok $m<item>[0]<digits>.defined, 'the rejected branch leaves no capture behind';
+
+is ~$m<item>[1]<val>, '12', 'the second item captures under the alias';
+is ~$m<item>[1]<digits>, '12', 'and under its own branch rule name';
+nok $m<item>[1]<word>.defined, 'the branch that backtracked left nothing';
+
+is ~$m<item>[2]<word>, 'x', 'the third item is unaffected by the two before it';
+
+nok G.parse('abc?').defined, 'a parse that fails overall still fails';
+
+# A quantified alias collects the whole list under both names.
+grammar H {
+    token TOP { <n=num>+ }
+    token num { \d }
+}
+my $h = H.parse('123');
+is $h<n>.map(~*).join(','), '1,2,3', 'a quantified alias collects every match';
+is $h<num>.map(~*).join(','), '1,2,3', 'and so does the aliased rule name';


### PR DESCRIPTION
Round 19 of the YAMLish parse profile ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).

Instructions retired on the 60-row document go **1,346,619,420 -> 1,274,829,698 (-5.33%)** — callgrind `Ir`, deterministic and load-independent, precompilation cache warmed first per round 14's note.

All three changes are behaviour-preserving.

## (a) The capture-alias map is interned (-3.20%)

A non-suppressing alias — `<val=word>`, `<tags=tag-directive>` — files its match under both names, and the engine records the alias-to-original mapping in the capture accumulator so the Match builder can reproduce it. That map was `HashMap<String, String>`.

Nothing about it wanted owned strings. Both halves of an entry are capture names the memoized lookup spec already holds as interned `Symbol`s (`spec.capture_sym`, `spec.lookup_sym`), and the only consumers are the two places that turn the finished map into a Match attribute, which resolve the names back to text once. In between sits the regex engine, which clones a whole `RegexCaptures` per accepted candidate and merges a delta per matched atom — so every alias cost two `String` allocations on each of those, plus a third for the undo record the trail keeps so a backtrack can restore it.

`String::clone` calls over the whole program: **235,346 -> 144,469 (-39%)**. The blast radius was eleven compile errors, all of which the compiler enumerated.

## (b) A qualified class name skips a provably futile registry scan (-1.0%)

Every `.new` of a user class asks `seed_quanthash_storage` whether the class inherits a QuantHash base, which resolves the class — and each of its declared parents — through `resolved_class_parents`. That lookup tries the registry key verbatim and, on a miss, falls back to scanning the class table for a key whose `::`-tail short name matches, so a bare `Bar` can still find a registered `Foo::Bar`.

The fallback cannot match a name that is already qualified: a key's `::`-tail is by construction everything after the *last* `::`, so it never contains one itself. Every such call scanned the entire table — a `rsplit_once` substring search per entry — to arrive at the `None` it was always going to return.

A class declared in a module composes its roles by qualified name, so parsing YAML reached here 148 times for names like `YAMLish::Single`, at about **97,000 instructions each**: 32,792 substring searches to answer a question with no possible answer. One `name.contains("::")` guard removes it (`resolved_class_parents` 14,354,235 -> 987,214 Ir). The short-name fallback itself is untouched.

## (c) Two matcher hot paths ask their map once instead of twice (-1.1%)

- **`CapStore::merge_delta`** pushed an undo record for each named key through a separate `get`, then took an `entry` on the same map — the record wants exactly the slot state the `entry` is about to hand out. It also merged three maps that live in the accumulator's cold payload (`RareCaps`); a delta that never wrote one still paid three `take_*` calls that each built an empty map, iterated it and pruned an absent payload. One `has_rare()` branch answers all three. `merge_delta` 93,006,964 -> 82,107,307 Ir.
- **`lr_begin_or_reenter`** folds `lr_key_is_active` and the seed read / activation start into one thread-local map operation. The two spellings were otherwise identical: the separate `lr_key_is_active` declined to create a vacant entry, but the `lr_begin_activation` that always followed it created one anyway. 87,211 redundant probes removed, on a grammar with no left recursion at all.

## Tests

Two new pins, both verified against rakudo 2026.07:

- `t/grammar/grammar-capture-alias-across-backtracking.t` — an alias inside an alternation under a separated quantifier, so the engine builds, merges and rewinds the alias record several times per item before the parse commits. Both names resolve, the rejected branch leaves nothing behind, and a quantified alias still collects the whole list under each name.
- `t/collections/set-bag-mix/quanthash-subclass-qualified-name.t` — a `BagHash` subclass declared in a module keeps its mutable backing store, a `Bag` subclass keeps the immutable one, and a bare parent name still resolves to its qualified class.

The left-recursion module's own unit tests are ported to the merged entry point.

## Verification

- `cargo fmt --all`, `make lint` (all four configurations) clean.
- `make test`: 4113 files, 43772 tests, **PASS**.
- `make roast`: 1437 files, 219,635 tests. The only failures are the three documented container artifacts — `6.c/S32-io/file-tests.t` (Failed: 4, tests 6-8/10), `S16-filehandles/filetest.t` (Failed: 25, exactly the documented subtest set) and `S32-io/IO-Socket-Async.t` (exit 124, ran 17) — all three running as `uid 0` / under the network sandbox, per `docs/agent-environments.md`.

## Also found, filed separately

[#8167](https://github.com/tokuhirom/mutsu/issues/8167): `$<alias> === $<rule>` answers `False` on an action-less `.parse` and `True` with `:actions`. Pre-existing (confirmed against a pre-round-19 binary), not touched here.

Refs #7576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_