### PR TITLE
fix: re-validate a role method's deferred param-type check at composition

### DIFF
--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -86,6 +86,37 @@ pub(crate) struct RoleDef {
     pub(crate) decl_file: Option<String>,
     /// Unknown lowercase trait names deferred for custom `trait_mod:<is>` dispatch.
     pub(crate) deferred_custom_traits: Vec<String>,
+    /// Role-method parameter type constraints that `role_body_method_decl`
+    /// accepted optimistically at registration time because the role body
+    /// has a `use` of a module not yet loaded (the module MIGHT supply the
+    /// type) -- see the long comment on that check in
+    /// `registration_role_method.rs`. Re-validated by
+    /// `compose_role_into_class` once this role's own deferred body (which
+    /// runs its `use` statements) has actually executed: a name that still
+    /// does not resolve is a genuine typo, not a not-yet-loaded type, and is
+    /// reported as `X::Parameter::InvalidType` instead of silently
+    /// vanishing along with the method that named it (#8083).
+    pub(crate) pending_param_type_checks: Vec<PendingRoleParamTypeCheck>,
+}
+
+/// One entry of [`RoleDef::pending_param_type_checks`]: a role-method
+/// parameter type constraint whose resolvability could not be decided at
+/// role-registration time because a module the role body `use`s had not
+/// loaded yet.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingRoleParamTypeCheck {
+    /// The constraint exactly as written (e.g. `TotallyBogusTypeName:U`),
+    /// used verbatim in the `X::Parameter::InvalidType` message if the
+    /// re-check still fails.
+    pub(crate) tc: String,
+    /// `tc` with any definedness smiley, coercion, and parameterization
+    /// stripped -- the name actually looked up in the type registry.
+    pub(crate) tc_base: String,
+    /// Enclosing-package prefixes of the declaring role, tried against
+    /// `tc_base` the same way `role_body_method_decl` tries them the first
+    /// time (a sibling type declared in an enclosing package may only now
+    /// be visible too).
+    pub(crate) enclosing_prefixes: Vec<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -56,6 +56,7 @@ pub(super) fn builtin_role_def() -> RoleDef {
         deferred_body: Vec::new(),
         decl_file: None,
         deferred_custom_traits: Vec::new(),
+        pending_param_type_checks: Vec::new(),
     }
 }
 

--- a/src/runtime/registration_class_compose.rs
+++ b/src/runtime/registration_class_compose.rs
@@ -521,6 +521,15 @@ impl Interpreter {
                 run?;
             }
         }
+        // #8083: re-validate every param-type check deferred at role
+        // registration because the role body's `use` had not loaded yet.
+        // By now that `use` has run -- either just above (a fresh
+        // composition) or during an earlier composition of the same role
+        // (the `composed_role_bodies` memo skipped re-running it, but the
+        // module it loaded is still loaded) -- so a name that still does
+        // not resolve is a genuine typo, not a type some `use`d module
+        // just hadn't supplied yet.
+        self.revalidate_pending_role_param_type_checks(&role.pending_param_type_checks)?;
         self.propagate_composed_role_parent_specs(cx, base_role_name, &role, &role_param_values);
         Ok(())
     }

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -416,6 +416,7 @@ impl Interpreter {
             // `RoleDef::decl_file`.
             decl_file: self.current_source_file(),
             deferred_custom_traits: Vec::new(),
+            pending_param_type_checks: Vec::new(),
         };
         let mut cx = RoleDeclCx {
             name,

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -418,6 +418,18 @@ impl Interpreter {
                 cx.role_def.attributes.push(attr.clone());
             }
         }
+        // Carry the parent role's own deferred param-type checks (#8083)
+        // forward so a bogus type in ONE of its methods is still caught once
+        // THIS role is eventually composed into a class -- `role.methods`
+        // below is merged into `cx.role_def.methods` verbatim, but the
+        // pending-check list living alongside it on the parent `RoleDef`
+        // would otherwise be left behind, and no later composition would
+        // ever revalidate it.
+        if !role.pending_param_type_checks.is_empty() {
+            cx.role_def
+                .pending_param_type_checks
+                .extend(role.pending_param_type_checks.iter().cloned());
+        }
         for (mname, overloads) in role.methods {
             // Skip methods declared with `my` scope -- role-private
             // Submethods (is_submethod=true) ARE composed even though

--- a/src/runtime/registration_role_method.rs
+++ b/src/runtime/registration_role_method.rs
@@ -93,7 +93,7 @@ impl Interpreter {
                 // the registry while its methods validate, so accept its
                 // own name (full or short) explicitly.
                 let self_short = name.rsplit_once("::").map(|(_, s)| s).unwrap_or(name);
-                let resolvable = tc_base == name
+                let resolvable_without_deferred = tc_base == name
                     || tc_base == self_short
                     // A role type parameter carrying a definiteness
                     // smiley (`role R[::T] { method f(T:D $x) }`,
@@ -132,12 +132,13 @@ impl Interpreter {
                     // short-name match still finds it, mirroring how the
                     // sub pre-pass accepts any type declared in the unit.
                     || (!tc.contains("::")
-                        && self.type_known_by_short_name(tc_base))
+                        && self.type_known_by_short_name(tc_base));
+                if !resolvable_without_deferred {
                     // A type supplied by a module `use`d within this role
                     // body is not yet loaded at registration time (the
                     // body's `use` runs after this validation), so accept
-                    // the constraint if a body import could still provide
-                    // it. Applies equally to a qualified name
+                    // the constraint optimistically if a body import could
+                    // still provide it. Applies equally to a qualified name
                     // (`Event::Test`) and a bare one (`Event`): nothing
                     // about either spelling predicts which `use`d module
                     // supplies it (`unit package Outer; class Event is
@@ -146,24 +147,41 @@ impl Interpreter {
                     // `Types1` that exports it, #8023), so a name-based match
                     // against the module name is unsound either way. Only a
                     // body `use` of a module that has NOT been loaded yet
-                    // defers — once every module this body names is loaded,
-                    // an unresolvable name really is a typo and still
-                    // reports X::Parameter::InvalidType.
-                    || cx
+                    // defers.
+                    //
+                    // The optimism is not unconditional, though (#8083): a
+                    // GENUINELY mistyped name is never supplied by any
+                    // module, and used to be accepted forever with no
+                    // re-check, silently dropping the method that named it
+                    // once the role composed. Record the pending check so
+                    // `compose_role_into_class` can re-run it once this
+                    // role's own deferred body -- which runs its `use`
+                    // statements -- has actually executed, and reject it
+                    // then if the name still does not resolve.
+                    if cx
                         .body_used_modules
                         .iter()
-                        .any(|m| !self.is_module_loaded(m));
-                if !resolvable {
-                    let mut attrs = std::collections::HashMap::new();
-                    attrs.insert("type".to_string(), Value::str(tc.to_string()));
-                    attrs.insert(
-                        "message".to_string(),
-                        Value::str(format!(
-                            "Invalid typename '{}' in parameter declaration.",
-                            tc
-                        )),
-                    );
-                    return Err(RuntimeError::typed("X::Parameter::InvalidType", attrs));
+                        .any(|m| !self.is_module_loaded(m))
+                    {
+                        cx.role_def
+                            .pending_param_type_checks
+                            .push(PendingRoleParamTypeCheck {
+                                tc: tc.to_string(),
+                                tc_base: tc_base.to_string(),
+                                enclosing_prefixes: enclosing_prefixes.clone(),
+                            });
+                    } else {
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("type".to_string(), Value::str(tc.to_string()));
+                        attrs.insert(
+                            "message".to_string(),
+                            Value::str(format!(
+                                "Invalid typename '{}' in parameter declaration.",
+                                tc
+                            )),
+                        );
+                        return Err(RuntimeError::typed("X::Parameter::InvalidType", attrs));
+                    }
                 }
             }
         }
@@ -334,6 +352,51 @@ impl Interpreter {
                     }
                     HandleSpec::Type(_) => {}
                 }
+            }
+        }
+        Ok(())
+    }
+
+    /// Re-run every param-type check `role_body_method_decl` deferred for
+    /// this role (#8083), once its deferred body -- and therefore its `use`
+    /// statements -- has actually executed. A name that still does not
+    /// resolve is a genuine typo, not a type some `use`d module just hadn't
+    /// loaded yet, and is reported the same way an immediately-unresolvable
+    /// one already was.
+    pub(super) fn revalidate_pending_role_param_type_checks(
+        &self,
+        pending: &[PendingRoleParamTypeCheck],
+    ) -> Result<(), RuntimeError> {
+        for check in pending {
+            // The role body's own `use` (which has now run) typically
+            // leaves its exports bound in `self.env` rather than registering
+            // the exact qualified spelling written in the parameter --
+            // `Event::Test` resolves through the freshly-bound `Event` ->
+            // `Outer::Event` and a package-stash lookup for `Test`, not
+            // through a literal `Event::Test` registry entry. This is
+            // exactly the indirect lookup `resolve_declared_type_name`
+            // already performs for a real reference to the type; reuse it
+            // here instead of re-deriving the same resolution.
+            let resolved_indirect = self.resolve_declared_type_name(&check.tc_base);
+            let resolvable = self.is_resolvable_type(&check.tc)
+                || check
+                    .enclosing_prefixes
+                    .iter()
+                    .any(|pfx| self.is_resolvable_type(&format!("{pfx}::{}", check.tc_base)))
+                || (!check.tc.contains("::") && self.type_known_by_short_name(&check.tc_base))
+                || (resolved_indirect != check.tc_base
+                    && self.is_resolvable_type(&resolved_indirect));
+            if !resolvable {
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("type".to_string(), Value::str(check.tc.clone()));
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!(
+                        "Invalid typename '{}' in parameter declaration.",
+                        check.tc
+                    )),
+                );
+                return Err(RuntimeError::typed("X::Parameter::InvalidType", attrs));
             }
         }
         Ok(())

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2647,6 +2647,7 @@ impl Interpreter {
                     deferred_body: Vec::new(),
                     decl_file: None,
                     deferred_custom_traits: Vec::new(),
+                    pending_param_type_checks: Vec::new(),
                 },
             );
             roles.insert(
@@ -2665,6 +2666,7 @@ impl Interpreter {
                     deferred_body: Vec::new(),
                     decl_file: None,
                     deferred_custom_traits: Vec::new(),
+                    pending_param_type_checks: Vec::new(),
                 },
             );
             roles.insert(
@@ -2683,6 +2685,7 @@ impl Interpreter {
                     deferred_body: Vec::new(),
                     decl_file: None,
                     deferred_custom_traits: Vec::new(),
+                    pending_param_type_checks: Vec::new(),
                 },
             );
             roles.insert(
@@ -2701,6 +2704,7 @@ impl Interpreter {
                     deferred_body: Vec::new(),
                     decl_file: None,
                     deferred_custom_traits: Vec::new(),
+                    pending_param_type_checks: Vec::new(),
                 },
             );
             roles.insert(
@@ -2719,6 +2723,7 @@ impl Interpreter {
                     deferred_body: Vec::new(),
                     decl_file: None,
                     deferred_custom_traits: Vec::new(),
+                    pending_param_type_checks: Vec::new(),
                 },
             );
             // ADR-0029: role-shaped `X::` exception "namespaces".
@@ -2789,6 +2794,7 @@ impl Interpreter {
                         deferred_body: Vec::new(),
                         decl_file: None,
                         deferred_custom_traits: Vec::new(),
+                        pending_param_type_checks: Vec::new(),
                     },
                 );
             }
@@ -2844,6 +2850,7 @@ impl Interpreter {
                         deferred_body: Vec::new(),
                         decl_file: None,
                         deferred_custom_traits: Vec::new(),
+                        pending_param_type_checks: Vec::new(),
                     },
                 );
             }
@@ -2901,6 +2908,7 @@ impl Interpreter {
                         deferred_body: Vec::new(),
                         decl_file: None,
                         deferred_custom_traits: Vec::new(),
+                        pending_param_type_checks: Vec::new(),
                     },
                 );
             }

--- a/t/lib/RolePendingTypo/Helper.rakumod
+++ b/t/lib/RolePendingTypo/Helper.rakumod
@@ -1,0 +1,7 @@
+unit module RolePendingTypo::Helper;
+
+# Any module the role body `use`s -- it only needs to still be unloaded at
+# the role's own registration time, so that `role_body_method_decl`'s
+# accept-optimistically branch (registration_role_method.rs) actually
+# defers the parameter's type check instead of rejecting it immediately.
+sub noop is export { }

--- a/t/lib/RolePendingTypo/R.rakumod
+++ b/t/lib/RolePendingTypo/R.rakumod
@@ -1,0 +1,13 @@
+unit role RolePendingTypo::R;
+
+# The `use` sits inside the role body (deferred to composition time, see
+# `RoleDef::deferred_body`), so the role's own param-type validation at
+# registration time cannot yet tell whether `RolePendingTypo::Helper` would
+# have supplied `TotallyBogusTypeName`. `role_body_method_decl` accepts the
+# parameter optimistically and records the check as pending (#8083); it
+# must be genuinely a typo (no module ever supplies this name), so
+# `compose_role_into_class` must reject it once the role is actually
+# composed and the `use` above has run.
+use RolePendingTypo::Helper;
+
+method m(TotallyBogusTypeName:U \x) { 1 }

--- a/t/oo/role/role-composed-method-param-typo.t
+++ b/t/oo/role/role-composed-method-param-typo.t
@@ -1,0 +1,22 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+plan 1;
+
+# #8083: a role method whose parameter names a GENUINELY mistyped type is
+# silently accepted at role-registration time whenever the role body has a
+# `use` of a module that has not loaded yet -- the not-yet-loaded module
+# MIGHT have supplied the type, so `role_body_method_decl` defers the check
+# optimistically. But nothing ever re-validates the deferred check once the
+# module actually loads, so a truly bogus name is accepted forever and the
+# method that names it silently disappears once the role is composed,
+# instead of raising X::Parameter::InvalidType the way an immediately
+# unresolvable name already does.
+
+use RolePendingTypo::R;
+
+throws-like
+    { class Consumer does RolePendingTypo::R { } },
+    X::Parameter::InvalidType,
+    'a genuinely mistyped role-method param type is still caught once the role body\'s use has run';


### PR DESCRIPTION
## Summary

`registration_role_method.rs`'s per-parameter type-constraint check accepts
a role method's parameter type optimistically whenever the role body has
an unloaded `use` — the not-yet-loaded module might supply the type. But
nothing ever re-validated that guess once the module actually loaded, so a
genuinely mistyped parameter type was accepted forever and its method
silently vanished once the role was composed, instead of raising
`X::Parameter::InvalidType` the way an immediately-unresolvable name
already does.

Record each such deferred check on the `RoleDef` (propagated when one role
composes another) and re-run it in `compose_role_into_class` once the
role's deferred body — which runs its `use` statements — has executed,
reusing `resolve_declared_type_name`'s indirect (env/stash) lookup so a
type that legitimately resolves through the module's exports (#8023,
#7993) is still accepted.

Closes #8083

## Test plan

- Added `t/oo/role/role-composed-method-param-typo.t` with a fixture role
  module (`t/lib/RolePendingTypo/`) that has an unloaded-at-registration
  `use` and a genuinely bogus parameter type name; composing it into a
  class now raises instead of silently dropping the method.
- Verified the issue's own manual repro (`R.rakumod` with `use SomeModule;
  method m(TotallyBogusTypeName:U \x) { 1 }`, composed via `class C does R
  {}`) now raises `X::Parameter::InvalidType` under mutsu, matching
  `raku`'s `===SORRY!===` compile-time diagnostic in spirit (mutsu's
  message includes the `:U` smiley rakudo's doesn't; both reject the
  declaration rather than silently dropping the method).
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run
  locally. `make roast` comes back with only the three environment-only
  failures documented in `docs/agent-environments.md` for a remote
  container (`roast/6.c/S32-io/file-tests.t`,
  `roast/S16-filehandles/filetest.t` — both `uid 0` chmod-based file tests
  — and `roast/S32-io/IO-Socket-Async.t`, sandboxed network); everything
  else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_