### PR TITLE
fix(types): accept an imported `constant` type alias as a type

### DIFF
--- a/news/2026-09/imported-constant-type-alias-is-a-type.md
+++ b/news/2026-09/imported-constant-type-alias-is-a-type.md
@@ -1,0 +1,78 @@
+# An imported `constant` type alias is accepted as a type again
+
+A `constant` bound to a bare type name is a **type alias**: it binds a type
+object into the lexical scope, and Raku accepts it anywhere a type name goes.
+C bindings lean on this heavily — `Gnome::N` writes
+`constant \GType is export = uint64` and then spells whole signatures in terms
+of it.
+
+mutsu imported such an alias correctly as a *value* (`MyInt.^name` was already
+`Int`) but lost its type-ness on the way, so every "is this name a type"
+validator rejected it ([#8131](https://github.com/tokuhirom/mutsu/issues/8131)):
+
+```raku
+# lib/GT3.rakumod
+unit module GT3;
+constant MyInt is export = Int;
+```
+
+| construct, with `use GT3` in scope | before |
+| --- | --- |
+| `sub f(MyInt $x)` | `Invalid typename 'MyInt' in parameter declaration.` |
+| the same inside a nested block | same |
+| `role R { method m(MyInt $x) }` | same |
+| `my MyInt $v = 3` | `Package 'MyInt' is insufficiently type-like to qualify a variable.` |
+| `class C { method m(MyInt $x) }` | **worked** |
+
+`raku` accepts all five. Declaring the alias in the same compilation unit
+worked, because the sub pre-pass accepts the name out of `declared_types` — the
+unit's statically gathered declarations — which is exactly what an import does
+not populate.
+
+## Three separate causes, one per validator
+
+**The compile-time sub pre-pass never saw the alias.** It runs before the
+mainline, so a `use`d module has not been loaded; `collect_use_declared_type_names`
+compensates by scanning the module's *source* for declaration keywords. Its list
+was `class`/`role`/`grammar`/`enum`/`subset` — `constant` was not on it, and
+could not simply be added: alias-ness is decided by the right-hand side, not by
+the keyword (`constant TAU = 6.28` names a value and must keep being rejected as
+a parameter type), and the name may be spelled sigillessly with traits in
+between (`constant \GType is export = uint64`). A companion scan now records
+exactly the aliases whose whole initializer is a single identifier the
+interpreter already recognises as a type — including one the same module
+declares, which the declarator scan has just collected.
+
+**`is_resolvable_type` had no alias-following step at all.** It resolves a
+lexical `my class`/`my role` through `resolve_bare_type_name`, but that helper
+insists the target be a class or role, so an alias to a builtin (`Int`) or a
+native type (`uint64`) did not survive it. It now follows the alias and answers
+for its target, which is what makes the role-method validator accept the name
+once the module is loaded. The walk is bounded, so a pathological
+`constant A = B; constant B = A` pair reports "not an alias" rather than
+spinning; `is_type_alias_constant` (which did a single step of the same walk)
+now shares it.
+
+**The variable-declaration validator asked the wrong question first.** At
+runtime `env` genuinely holds a `Package` under `MyInt`, so `is_declared_package`
+matched and produced the "insufficiently type-like" message before anything
+considered that this `Package` is an alias with a resolvable target. The
+constraint is now resolved to its target once, up front, so everything
+downstream sees `Int`: the known-type check runs, and the failure message names
+the target the way rakudo does (`expected Int but got Str ("x")`). Any smiley
+rides along (`my MyInt:D $v`), and the resolution is gated on the constraint not
+already being a known type, so the overwhelmingly common `my Int $x` pays a
+static `matches!` rather than an env lookup per typed declaration.
+
+## Deliberately unchanged
+
+`constant TAU = 6.28` used as a parameter type stays rejected. rakudo accepts it
+(any term may constrain a parameter, as a value smartmatch) and mutsu does not —
+a pre-existing divergence, and the in-unit collector draws the same line
+on purpose, so widening it here would have been a second change hiding inside
+this one.
+
+Pinned by `t/modules/import-export/imported-constant-type-alias.t` (12
+assertions, green under `raku` as written) with a `t/lib` fixture carrying all
+three shapes an alias comes in: to a builtin, to a native type spelled
+sigillessly, and to a class the same module declares.

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -69,6 +69,94 @@ fn collect_use_declared_type_names(
         }
         i = (i + kw.len()).max(j);
     }
+    collect_source_constant_type_aliases(interp, &bytes, out);
+}
+
+/// Record the `constant NAME = TypeName;` *type aliases* a used module's source
+/// declares.
+///
+/// A `constant` bound to a bare type name aliases that type and is usable
+/// wherever a type name is — `Gnome::N`'s `constant \GType is export = uint64`,
+/// named by `sub g_value_init(N-GValue $value, GType $g_type)`. A `constant`
+/// bound to a *value* (`constant TAU = 6.28`) is not a type and must keep being
+/// rejected in a parameter declaration, so only a single-identifier right-hand
+/// side the interpreter already recognises as a type is recorded — the same
+/// line the in-unit collector draws for a `Stmt::VarDecl` alias.
+///
+/// This cannot ride the declarator loop above: the alias-ness is decided by the
+/// right-hand side, not by the keyword, and the name may be spelled sigillessly
+/// (`\GType`) with traits (`is export`) in between.
+fn collect_source_constant_type_aliases(
+    interp: &Interpreter,
+    bytes: &[char],
+    out: &mut std::collections::HashSet<String>,
+) {
+    let is_ident = |c: char| c.is_alphanumeric() || c == '_' || c == '-';
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if (i > 0 && is_ident(bytes[i - 1]))
+            || !bytes[i..].starts_with(&['c', 'o', 'n', 's', 't', 'a', 'n', 't'])
+            || bytes.get(i + 8).is_some_and(|c| is_ident(*c))
+        {
+            i += 1;
+            continue;
+        }
+        let mut j = i + 8;
+        while bytes.get(j).is_some_and(|c| c.is_whitespace()) {
+            j += 1;
+        }
+        // A sigilless `constant \GType` names the same thing as `constant GType`.
+        if bytes.get(j) == Some(&'\\') {
+            j += 1;
+        }
+        let start = j;
+        while bytes.get(j).is_some_and(|c| is_ident(*c)) {
+            j += 1;
+        }
+        let name: String = bytes[start..j].iter().collect();
+        // Everything between the name and `=` is traits (`is export`); stop at
+        // the end of the statement so a runaway scan cannot pair a `constant`
+        // with a later statement's `=`.
+        while bytes
+            .get(j)
+            .is_some_and(|c| !matches!(c, '=' | ';' | '\n' | '{'))
+        {
+            j += 1;
+        }
+        if bytes.get(j) != Some(&'=') || bytes.get(j + 1) == Some(&'=') {
+            i = (i + 8).max(j);
+            continue;
+        }
+        j += 1;
+        while bytes.get(j).is_some_and(|c| c.is_whitespace()) {
+            j += 1;
+        }
+        let rhs_start = j;
+        while bytes.get(j).is_some_and(|c| is_ident(*c)) {
+            j += 1;
+        }
+        let target: String = bytes[rhs_start..j].iter().collect();
+        // The right-hand side must be the WHOLE initializer, or it is an
+        // expression (`constant K = Int.new`) rather than an alias.
+        let trailing_is_terminator = bytes[j..]
+            .iter()
+            .find(|c| !c.is_whitespace())
+            .is_none_or(|c| *c == ';');
+        if !name.is_empty()
+            && !target.is_empty()
+            && trailing_is_terminator
+            && (interp.is_resolvable_type(&target)
+                || interp.has_type(&target)
+                // A type the SAME module declares is not registered yet either
+                // -- the declarator scan above has just collected it into
+                // `out`, and that is the only record of it at this point.
+                || out.contains(&target)
+                || crate::runtime::nativecall::CType::from_type_name(&target).is_some())
+        {
+            out.insert(name);
+        }
+        i = (i + 8).max(j);
+    }
 }
 
 /// Locate `module`'s source under one of `dirs` (or its `lib/` subdirectory).

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -433,17 +433,12 @@ impl Interpreter {
     /// X::Parameter::BadType in Raku ("insufficiently type-like") — treating it
     /// as an alias here would swallow that error.
     pub(crate) fn is_type_alias_constant(&self, name: &str) -> bool {
-        let Some(value) = self.get_env_with_main_alias(name) else {
+        let Some(target) = self.resolve_type_alias_chain(name) else {
             return false;
         };
-        let ValueView::Package(target) = value.view() else {
-            return false;
-        };
-        let target = target.resolve();
-        target != name
-            && (self.is_resolvable_type(&target)
-                || self.has_type(&target)
-                || crate::runtime::nativecall::CType::from_type_name(&target).is_some())
+        self.is_resolvable_type(&target)
+            || self.has_type(&target)
+            || crate::runtime::nativecall::CType::from_type_name(&target).is_some()
     }
 
     /// Reject a sub return type (`--> NoSuchType` / `returns NoSuchType`) that

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -1157,9 +1157,67 @@ impl Interpreter {
         if self.resolve_bare_type_name(base).is_some() {
             return true;
         }
+        // A `constant` type alias stands for the type it names, wherever a type
+        // name goes. Answering for the alias's TARGET is what makes an imported
+        // alias usable in a role method's signature: the caller's own probes
+        // above all miss it, because the registry holds `Int`/`uint64`, not
+        // `MyInt`. `Gnome::N`'s `constant \GType is export = uint64` is the
+        // shape ([#8131]).
+        //
+        // [#8131]: https://github.com/tokuhirom/mutsu/issues/8131
+        if let Some(target) = self.resolve_type_alias_chain(base) {
+            return self.is_resolvable_type(&target)
+                || self.has_type(&target)
+                || crate::runtime::nativecall::CType::from_type_name(&target).is_some();
+        }
         // Check if it starts with uppercase (heuristic for type names)
         // This handles cases like user-defined enum types that may not be registered as classes
         false
+    }
+
+    /// Follow a `constant` type-alias binding from `name` to the type it
+    /// ultimately names, or `None` when `name` is not such an alias.
+    ///
+    /// `constant MyInt = Int;` / `constant \GType = uint64;` binds a *type
+    /// object* into the lexical scope, and Raku accepts the alias anywhere a
+    /// type name goes. The binding is held as a `Package` value, so a plain env
+    /// lookup identifies it — an ordinary `constant TAU = 6.28` holds its value
+    /// instead. A `package`/`module` binds its own name to itself and is
+    /// therefore NOT an alias: `my package A {}; my A $x` is
+    /// X::Syntax::Variable::BadType in Raku, and treating it as an alias here
+    /// would swallow that error.
+    ///
+    /// The walk is bounded, so a pathological cycle cannot spin; a chain that
+    /// has not settled within the bound is reported as "not an alias" rather
+    /// than followed further.
+    pub(crate) fn resolve_type_alias_chain(&self, name: &str) -> Option<String> {
+        // A type name is an identifier starting with a letter. Requiring that
+        // keeps the walk away from every magic env key that is not one -- the
+        // TOPIC above all, which is stored under the bare key `_` and usually
+        // holds a type object: without this, `my _ $x = 3` would take `_` for
+        // an alias of `Any` and be accepted, where rakudo (and
+        // `t/lang/eval-parse-failure-propagates-through-block-call.t`) requires
+        // it to die.
+        if !name.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        let mut current = name.to_string();
+        for _ in 0..16 {
+            let next =
+                self.get_env_with_main_alias(&current)
+                    .and_then(|value| match value.view() {
+                        crate::value::ValueView::Package(target) => Some(target.resolve()),
+                        _ => None,
+                    });
+            match next {
+                Some(target) if target != current => current = target,
+                // Settled: either the name is not bound to a type object at
+                // all, or it names itself (a package). Only report a chain that
+                // actually moved.
+                _ => return (current != name).then_some(current),
+            }
+        }
+        None
     }
 
     /// Resolve the ultimate base type of a constraint, following subset chains.

--- a/src/vm/vm_misc_typecheck.rs
+++ b/src/vm/vm_misc_typecheck.rs
@@ -13,6 +13,31 @@ impl Interpreter {
         let var_name: Option<&str> = var_name_idx.map(|idx| Self::const_str(code, idx));
         // Apply `use variables :D/:U` pragma to the constraint
         let effective_constraint = loan_env!(self, apply_variables_pragma(raw_constraint));
+        // A `constant` type alias stands for the type it names, so resolve it
+        // to that target once, here, before anything below reads the
+        // constraint. Everything downstream then sees `Int` rather than
+        // `MyInt`: the native/known-type check runs, and the type-check error
+        // names the target, which is what rakudo reports ("expected Int but got
+        // Str"). Without this the alias reached the unknown-type arm and, since
+        // env holds a `Package` under the alias, was reported as a package
+        // "insufficiently type-like to qualify a variable" (#8131).
+        //
+        // Gated on the constraint not already being a known type, so the
+        // overwhelmingly common `my Int $x` pays a static `matches!` here
+        // rather than an env lookup per typed declaration.
+        let effective_constraint = {
+            let (base, smiley) = crate::runtime::types::strip_type_smiley(&effective_constraint);
+            let resolved = if runtime::is_known_type_constraint(base) || is_core_raku_type(base) {
+                None
+            } else {
+                self.resolve_type_alias_chain(base)
+                    .map(|target| format!("{}{}", target, smiley.unwrap_or("")))
+            };
+            match resolved {
+                Some(target) => std::borrow::Cow::Owned(target),
+                None => effective_constraint,
+            }
+        };
         let constraint: &str = &effective_constraint;
         let (base_constraint, _) = crate::runtime::types::strip_type_smiley(constraint);
         let declared_constraint = base_constraint

--- a/t/lib/ConstantTypeAliasExport.rakumod
+++ b/t/lib/ConstantTypeAliasExport.rakumod
@@ -1,0 +1,11 @@
+use v6;
+unit module ConstantTypeAliasExport;
+
+class Shape is export { method sides { 3 } }
+
+# A `constant` bound to a bare type name is a TYPE ALIAS: usable wherever a
+# type name is. Both spellings appear in the wild -- `Gnome::N` writes the
+# sigilless one (`constant \GType is export = uint64`).
+constant AliasedInt is export = Int;
+constant \AliasedNative is export = uint64;
+constant AliasedShape is export = Shape;

--- a/t/modules/import-export/imported-constant-type-alias.t
+++ b/t/modules/import-export/imported-constant-type-alias.t
@@ -1,0 +1,67 @@
+use v6;
+use lib 't/lib';
+use Test;
+use ConstantTypeAliasExport;
+
+# A `constant` bound to a bare type name is a TYPE ALIAS -- it binds a type
+# object into the lexical scope, and Raku accepts it anywhere a type name goes.
+# mutsu imported the alias fine as a *value* (`AliasedInt.^name` was already
+# `Int`) but lost its type-ness on the way, so every "is this name a type"
+# validator rejected it: a sub parameter and a role-method parameter reported
+# `Invalid typename`, and a variable declaration reported the alias as a
+# package "insufficiently type-like to qualify a variable" (#8131).
+#
+# The class-method position was the odd one out and already worked, which is
+# why it is pinned here too: its validator runs late enough to see the import.
+#
+# `Gnome::N`'s `constant \GType is export = uint64` is the real site, so the
+# fixture carries all three shapes an alias comes in: to a builtin, to a native
+# type (sigil-lessly spelled), and to a class the same module declares.
+
+plan 12;
+
+# --- the alias still imports as a value, as it always did ---
+is AliasedInt.^name, 'Int', 'an imported alias to a builtin names its target';
+is AliasedNative.^name, 'uint64', 'a sigilless alias to a native type names its target';
+is AliasedShape.^name, 'ConstantTypeAliasExport::Shape', 'an alias to a class names its target';
+
+# --- sub parameter (compile-time pre-pass) ---
+sub takes-int(AliasedInt $x) { $x + 1 }
+is takes-int(3), 4, 'an imported alias types a sub parameter';
+
+sub takes-native(AliasedNative $x) { $x + 1 }
+is takes-native(7), 8, 'a native-typed alias types a sub parameter';
+
+sub takes-shape(AliasedShape $s) { $s.sides }
+is takes-shape(Shape.new), 3, 'a class alias types a sub parameter';
+
+# The pre-pass descends into nested blocks, so the alias has to survive there.
+{
+    sub nested(AliasedInt $x) { $x * 2 }
+    is nested(4), 8, 'an imported alias types a sub parameter inside a nested block';
+}
+
+# --- return type ---
+sub returns-int(--> AliasedInt) { 5 }
+is returns-int(), 5, 'an imported alias types a sub return';
+
+# --- role method, and the class method that already worked ---
+{
+    role R { method m(AliasedInt $x) { $x + 10 } }
+    class C does R { }
+    is C.new.m(1), 11, 'an imported alias types a role method parameter';
+
+    class D { method m(AliasedInt $x) { $x + 20 } }
+    is D.new.m(1), 21, 'an imported alias types a class method parameter';
+}
+
+# --- variable declaration: accepted, and still type-checked against the TARGET ---
+{
+    my AliasedInt $v = 3;
+    is $v.WHAT.^name, 'Int', 'an imported alias types a variable declaration';
+}
+
+# rakudo reports the resolved target in the failure ("expected Int"), not the
+# alias, which is what resolving the alias before the check gives.
+throws-like { my AliasedInt $bad = "x" }, X::TypeCheck::Assignment,
+    'and the declared variable is still type-checked against the target';


### PR DESCRIPTION
Closes #8131 — the `GType` member of the `invalid-typename` ecosystem cluster (#7993).

## The gap

A `constant` bound to a bare type name is a **type alias**: it binds a type object into the lexical scope, and Raku accepts it anywhere a type name goes. C bindings lean on this heavily — `Gnome::N` writes `constant \GType is export = uint64` and then spells whole signatures in terms of it.

mutsu imported such an alias correctly as a *value* (`MyInt.^name` was already `Int`) but lost its type-ness, so every "is this name a type" validator rejected it:

| construct, with `use GT3` in scope | before | after |
| --- | --- | --- |
| `sub f(MyInt $x)` | `Invalid typename 'MyInt' in parameter declaration.` | works |
| the same inside a nested block | same | works |
| `role R { method m(MyInt $x) }` | same | works |
| `my MyInt $v = 3` | `Package 'MyInt' is insufficiently type-like to qualify a variable.` | works, `$v.WHAT` is `(Int)` |
| `class C { method m(MyInt $x) }` | worked | works |

`raku` accepts all five.

## Three separate causes, one per validator

**1. The compile-time sub pre-pass never saw the alias.** It runs before the mainline, so a `use`d module is not loaded; `collect_use_declared_type_names` compensates by scanning the module's *source* for declaration keywords. Its list was `class`/`role`/`grammar`/`enum`/`subset`, and `constant` could not simply be added to it: alias-ness is decided by the right-hand side, not by the keyword (`constant TAU = 6.28` names a value), and the name may be spelled sigillessly with traits in between (`constant \GType is export = uint64`). A companion scan now records exactly the aliases whose whole initializer is a single identifier the interpreter already recognises as a type — including one the same module declares, which the declarator scan has just collected.

**2. `is_resolvable_type` had no alias-following step at all.** It resolves a lexical `my class`/`my role` through `resolve_bare_type_name`, but that helper insists the target be a class or role, so an alias to a builtin (`Int`) or a native type (`uint64`) did not survive it. It now follows the alias and answers for its target — which is what makes the role-method validator accept the name once the module is loaded. The walk is bounded, so a pathological `constant A = B; constant B = A` pair reports "not an alias" rather than spinning, and `is_type_alias_constant` (which did a single step of the same walk) now shares it.

**3. The variable-declaration validator asked the wrong question first.** At runtime `env` genuinely holds a `Package` under `MyInt`, so `is_declared_package` matched and produced the "insufficiently type-like" message before anything considered the target. The constraint is now resolved to its target once, up front, so everything downstream sees `Int`: the known-type check runs, and the failure names the target the way rakudo does — `Type check failed in assignment to $v; expected Int but got Str ("x")`, byte-identical to rakudo's. A smiley rides along (`my MyInt:D $v`).

## Two guards worth calling out

- **The topic is not an alias.** The alias walk requires the name to start with a letter. Without that, the topic — stored under the bare env key `_`, usually holding a type object — made `my _ $x = 3` resolve `_` to `Any` and be accepted. `t/lang/eval-parse-failure-propagates-through-block-call.t` caught exactly that in the first full `make test`, and now pins it.
- **`my Int $x` does not pay for this.** The resolution in `exec_type_check_op_inner` is gated on the constraint not already being a known/core type, so the common case is a static `matches!` rather than an env lookup per typed declaration.

## Deliberately unchanged

`constant TAU = 6.28` used as a parameter type stays rejected. rakudo accepts it (any term may constrain a parameter, as a value smartmatch) and mutsu does not — a pre-existing divergence, and the in-unit collector draws the same line on purpose, so widening it here would have been a second change hiding inside this one.

## Tests

`t/modules/import-export/imported-constant-type-alias.t` (12 assertions, green under `raku` as written), with a `t/lib` fixture carrying all three shapes an alias comes in: to a builtin, to a native type spelled sigillessly (`constant \AliasedNative is export = uint64`), and to a class the same module declares. It covers the sub parameter (top level and in a nested block), the return type, the role method, the class method that already worked, the variable declaration, and the type check still failing against the target.

## Pre-publication gates

- `cargo fmt --all`, `make check-t-layout`: clean.
- `make lint`: all four configurations green.
- `make test`: **PASS** — 4122 files, 43845 tests.
- `make roast`: three failures, all three exactly the container-specific known reds in `docs/agent-environments.md`, at their documented shapes — `roast/6.c/S32-io/file-tests.t` `Failed: 4` (tests 6-8, 10) and `roast/S16-filehandles/filetest.t` `Failed: 25` (57-64, 69-72, 77-80, 101, 103, 105, 107, 109, 111, 117, 121, 125), both from running as `uid 0`; `roast/S32-io/IO-Socket-Async.t` exit 124 from the sandboxed network. Nothing else in the whitelist failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK)_