### PR TITLE
fix: keep imported my types private

### DIFF
--- a/news/2026-09/imported-my-type-does-not-shadow.md
+++ b/news/2026-09/imported-my-type-does-not-shadow.md
@@ -1,0 +1,4 @@
+A `my class` declared by an imported module no longer remains in the importing
+compilation unit's namespace or shadows a same-named local declaration. The
+declaring module can still use the private type, including after its load has
+finished. (#8120)

--- a/news/2026-09/imported-my-type-does-not-shadow.md
+++ b/news/2026-09/imported-my-type-does-not-shadow.md
@@ -1,4 +1,5 @@
 A `my class` declared by an imported module no longer remains in the importing
 compilation unit's namespace or shadows a same-named local declaration. The
 declaring module can still use the private type, including after its load has
-finished. (#8120)
+finished. Exported lexical classes remain available to importing code as well.
+(#8120)

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -666,7 +666,7 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             return Err(PError::fatal_with_exception(msg, Box::new(ex)));
         }
     }
-    let class_stmt = Stmt::ClassDecl {
+    let mut class_stmt = Stmt::ClassDecl {
         name: Symbol::intern(&name),
         name_expr,
         parents,
@@ -686,6 +686,15 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
         parent_args,
         body_parents,
     };
+    if is_export && is_lexical {
+        // A lexical `my class` cannot be wrapped with the runtime export marker:
+        // the synthetic block would make the class itself block-local. Keep an
+        // internal marker on the declaration instead so module loading can
+        // distinguish an exported lexical type from a private one.
+        if let Stmt::ClassDecl { custom_traits, .. } = &mut class_stmt {
+            custom_traits.push(("__mutsu_export_type".to_string(), None));
+        }
+    }
     let mut stmts = Vec::new();
     for (trait_name, trait_value) in traits {
         if trait_name == "ver" || trait_name == "auth" || trait_name == "api" {

--- a/src/runtime/accessors_stash.rs
+++ b/src/runtime/accessors_stash.rs
@@ -517,6 +517,14 @@ impl Interpreter {
         if self.cur_repo.pending_global_symbols.contains(name) {
             return Self::no_such_symbol_failure(name);
         }
+        // A lexical type remains registered for escaped values, but its
+        // source-facing qualified name is not a package symbol visible from an
+        // unrelated compunit (#8120). Check this before the generic compound
+        // type/package fallback below, which otherwise manufactures a Package
+        // value for any known-looking qualified name.
+        if self.is_my_scoped_type_name(name) && !self.my_scoped_type_visible_here(name) {
+            return Self::no_such_symbol_failure(name);
+        }
         // Pseudo-package names like MY, CORE, OUTER, CALLER, etc. should
         // resolve to Package values so that .WHO can produce the stash.
         if Self::is_pseudo_package_name(name) {
@@ -551,7 +559,8 @@ impl Interpreter {
             && !value.is_nil()
             // Skip `my`-scoped package items for indirect type lookup (::())
             // since they should not be visible outside their declaring scope.
-            && !self.is_my_scoped_package_item(name)
+            && (!self.is_my_scoped_package_item(name)
+                && (!self.is_my_scoped_type_name(name) || self.my_scoped_type_visible_here(name)))
         {
             return value.clone();
         }

--- a/src/runtime/compunit_scope.rs
+++ b/src/runtime/compunit_scope.rs
@@ -429,4 +429,17 @@ impl Interpreter {
         }
         false
     }
+
+    /// Whether `start`, or an EVAL parent of it, is `target`.
+    pub(crate) fn unit_chain_contains_unit(&self, start: Symbol, target: Symbol) -> bool {
+        let mut unit = Some(start);
+        for _ in 0..64 {
+            let Some(sym) = unit else { return false };
+            if sym == target {
+                return true;
+            }
+            unit = crate::runtime::eval_unit_parent(sym);
+        }
+        false
+    }
 }

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -1045,6 +1045,7 @@ impl Interpreter {
                 )
                 .cloned()
                 .collect();
+            let exported_type_names = Self::collect_exported_type_names(&stmts);
             let leaked_packages: Vec<String> = module_scope_names
                 .iter()
                 .filter(|(name, value)| {
@@ -1061,7 +1062,8 @@ impl Interpreter {
                             // the storage name belongs to this module: doing so
                             // lets a private type shadow a same-named declaration
                             // in the importing compunit (#8120).
-                            self.is_my_scoped_package_item(&target)
+                            (!exported_type_names.contains(*name)
+                                && self.is_my_scoped_package_item(&target))
                                 || (!Self::package_is_owned_by(&target, module)
                                     && !registered_here.contains(&target))
                         }
@@ -1488,6 +1490,16 @@ impl Interpreter {
         fn walk(stmts: &[crate::ast::Stmt], out: &mut HashSet<String>) {
             for s in stmts {
                 match s {
+                    crate::ast::Stmt::ClassDecl {
+                        name,
+                        custom_traits,
+                        ..
+                    } if custom_traits
+                        .iter()
+                        .any(|(trait_name, _)| trait_name == "__mutsu_export_type") =>
+                    {
+                        out.insert(name.resolve());
+                    }
                     // The parser wraps a type declaration and its export marker
                     // in one `Block`, so the markers are never at file level.
                     crate::ast::Stmt::Block(inner) | crate::ast::Stmt::SyntheticBlock(inner) => {

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -1054,8 +1054,16 @@ impl Interpreter {
                     match value.view() {
                         ValueView::Package(target) => {
                             let target = target.resolve();
-                            !Self::package_is_owned_by(&target, module)
-                                && !registered_here.contains(&target)
+                            // A `my class`/`my role` is registered under a
+                            // package-qualified storage name, but its short
+                            // env binding is still only lexical to the module
+                            // body. Do not preserve that binding merely because
+                            // the storage name belongs to this module: doing so
+                            // lets a private type shadow a same-named declaration
+                            // in the importing compunit (#8120).
+                            self.is_my_scoped_package_item(&target)
+                                || (!Self::package_is_owned_by(&target, module)
+                                    && !registered_here.contains(&target))
                         }
                         _ => false,
                     }
@@ -1317,7 +1325,11 @@ impl Interpreter {
                         .rsplit_once("::")
                         .map(|(_, short)| (short.to_string(), qualified.clone()))
                 })
-                .filter(|(short, qualified)| short != qualified && !Self::is_builtin_type(short))
+                .filter(|(short, qualified)| {
+                    short != qualified
+                        && !Self::is_builtin_type(short)
+                        && !self.is_my_scoped_package_item(qualified)
+                })
                 .collect();
             if !aliases.is_empty() {
                 let entry = crate::runtime::cow_table_mut(&mut self.package_type_aliases)

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -371,6 +371,56 @@ impl Interpreter {
             && !self.our_scoped_package_items.contains(fq_name)
     }
 
+    /// Check whether `fq_name` is the source-facing name of a lexically scoped
+    /// type. Lexical types use an opaque NUL-suffixed registry key, so the
+    /// package-item marker cannot be queried with the unmangled spelling that
+    /// appears in source (`M::State`).
+    pub(crate) fn is_my_scoped_type_name(&self, fq_name: &str) -> bool {
+        if !fq_name.contains("::") {
+            return false;
+        }
+        let prefix = format!("{fq_name}\u{0}");
+        let registry = self.registry();
+        registry
+            .classes
+            .keys()
+            .chain(registry.roles.keys())
+            .chain(registry.enum_types.keys())
+            .chain(registry.subsets.keys())
+            .any(|key| key.starts_with(&prefix) && self.is_my_scoped_package_item(key))
+    }
+
+    /// Whether a lexically scoped type's source-facing name is visible from
+    /// the current compilation unit. The registry keeps the type globally so
+    /// escaped values retain their identity, but a type declared by an
+    /// imported module must not become a package-qualified symbol in the
+    /// importing unit. A same-compilation-unit declaration remains visible,
+    /// including namespaced `my class` declarations.
+    pub(crate) fn my_scoped_type_visible_here(&self, fq_name: &str) -> bool {
+        if !self.is_my_scoped_type_name(fq_name) {
+            return true;
+        }
+        let prefix = format!("{fq_name}\u{0}");
+        let key = {
+            let registry = self.registry();
+            registry
+                .classes
+                .keys()
+                .find(|key| key.starts_with(&prefix) && self.is_my_scoped_package_item(key))
+                .cloned()
+        };
+        let Some(key) = key else {
+            return true;
+        };
+        let Some(&declaring_unit) = self.class_declaring_units.get(&key) else {
+            // Roles and enums do not currently record a declaring unit. Keep
+            // their existing behavior until they have equivalent provenance.
+            return true;
+        };
+        self.unit_chain_contains_unit(self.executing_unit_sym_for_module_load(), declaring_unit)
+            || self.unit_chain_contains_unit(self.current_unit, declaring_unit)
+    }
+
     /// Must a call to this qualified name stay unresolved? True for a
     /// `my`-scoped package item. A plain `sub f` in a module or class body is
     /// lexical: it is exported and callable under its short name, but it is

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -387,7 +387,10 @@ impl Interpreter {
             .chain(registry.roles.keys())
             .chain(registry.enum_types.keys())
             .chain(registry.subsets.keys())
-            .any(|key| key.starts_with(&prefix) && self.is_my_scoped_package_item(key))
+            .any(|key| {
+                (key.starts_with(&prefix) || key.as_str() == fq_name)
+                    && self.is_my_scoped_package_item(key)
+            })
     }
 
     /// Whether a lexically scoped type's source-facing name is visible from
@@ -406,7 +409,10 @@ impl Interpreter {
             registry
                 .classes
                 .keys()
-                .find(|key| key.starts_with(&prefix) && self.is_my_scoped_package_item(key))
+                .find(|key| {
+                    (key.starts_with(&prefix) || key.as_str() == fq_name)
+                        && self.is_my_scoped_package_item(key)
+                })
                 .cloned()
         };
         let Some(key) = key else {

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -398,9 +398,40 @@ impl Interpreter {
     /// escaped values retain their identity, but a type declared by an
     /// imported module must not become a package-qualified symbol in the
     /// importing unit. A same-compilation-unit declaration remains visible,
-    /// including namespaced `my class` declarations.
+    /// including namespaced `my class` declarations. Exception classes under
+    /// `X::` are package-qualified API even when their declaration uses `my`;
+    /// a namespaced lexical type under an existing class is likewise visible
+    /// through that class's package (for example, a package-local test double).
     pub(crate) fn my_scoped_type_visible_here(&self, fq_name: &str) -> bool {
         if !self.is_my_scoped_type_name(fq_name) {
+            return true;
+        }
+        if fq_name == "X" || fq_name.starts_with("X::") {
+            return true;
+        }
+        let type_package = fq_name.rsplit_once("::").map(|(package, _)| package);
+        let current_package = self.current_package();
+        let method_class = self.method_class_stack_top_str();
+        if let Some(type_package) = type_package
+            && (current_package == type_package
+                || type_package.starts_with(&format!("{current_package}::")))
+        {
+            return true;
+        }
+        if let Some(type_package) = type_package
+            && method_class.is_some_and(|class| {
+                class == type_package || type_package.starts_with(&format!("{class}::"))
+            })
+        {
+            return true;
+        }
+        if type_package.is_some_and(|package| {
+            let registry = self.registry();
+            registry.classes.contains_key(package)
+                || registry.roles.contains_key(package)
+                || registry.enum_types.contains_key(package)
+                || registry.subsets.contains_key(package)
+        }) {
             return true;
         }
         let prefix = format!("{fq_name}\u{0}");

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -455,6 +455,18 @@ impl Interpreter {
                 return true;
             }
         }
+        // A public class can retain a private helper type in its declaration
+        // (`class Public { has Private $.value }`). The helper is moved out of
+        // the loading frame's env so it cannot leak into importers, but the
+        // public class's own package still needs that lexical at instantiation
+        // time. Consult the package-keyed module scope when the running code
+        // belongs to that package.
+        if let Some(ValueView::Package(target)) = self.module_scope_lexical(name).map(Value::view) {
+            let resolved = target.resolve();
+            if resolved != name && self.has_type_direct(&resolved) {
+                return true;
+            }
+        }
         self.package_type_alias(name).is_some()
     }
 
@@ -525,6 +537,15 @@ impl Interpreter {
         name: &str,
     ) -> Option<&'a V> {
         for candidate in self.running_package_candidates().into_iter().flatten() {
+            // A parameterized class runs with its instantiated display name
+            // (`M::C[T]`), while package-owned lexical tables are keyed by the
+            // unparameterized class name (`M::C`). Probe that base owner before
+            // walking its package ancestors.
+            if let Some((base, _)) = candidate.split_once('[')
+                && let Some(found) = Self::lookup_in_package_chain(table, base, name)
+            {
+                return Some(found);
+            }
             if let Some(found) = Self::lookup_in_package_chain(table, candidate, name) {
                 return Some(found);
             }
@@ -821,6 +842,15 @@ impl Interpreter {
             match pkg.rsplit_once("::") {
                 Some((parent, _)) => pkg = parent,
                 None => break,
+            }
+        }
+        if let Some(ValueView::Package(target)) = self
+            .module_scope_lexical_for_owner(owner, &name)
+            .map(Value::view)
+        {
+            let resolved = target.resolve();
+            if resolved != name && self.has_type_direct(&resolved) {
+                return resolved.to_string();
             }
         }
         name

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -417,6 +417,14 @@ impl Interpreter {
 
     /// Check if a type name is known (either a class, role, or enum).
     pub(crate) fn has_type(&self, name: &str) -> bool {
+        // A lexical type's registry identity is intentionally retained after
+        // its module is loaded, but the source-facing qualified name is not a
+        // package symbol visible to an unrelated compunit. Keep the type
+        // available to code running in its declaring package while refusing
+        // the imported name from outside it (#8120).
+        if self.is_my_scoped_type_name(name) && !self.my_scoped_type_visible_here(name) {
+            return false;
+        }
         // A `my`-scoped class/role/enum whose enclosing block has exited is moved
         // into `suppressed_names`: once out of lexical scope it is no longer a
         // visible type under its bare short name (raku: "Type 'A' is not declared"

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -74,7 +74,9 @@ impl Interpreter {
         // `Bool::True`, a pseudo-package like `OUR::foo`, a same-compunit
         // `package Foo { }` block) is unaffected — see
         // `Interpreter::qualified_name_visible_here`.
-        if crate::runtime::utils::has_double_colon(name) && !self.qualified_name_visible_here(name)
+        if crate::runtime::utils::has_double_colon(name)
+            && ((self.is_my_scoped_type_name(name) && !self.my_scoped_type_visible_here(name))
+                || !self.qualified_name_visible_here(name))
         {
             return Err(RuntimeError::new(format!(
                 "Could not find symbol '{}'",

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -75,8 +75,11 @@ impl Interpreter {
         // `package Foo { }` block) is unaffected — see
         // `Interpreter::qualified_name_visible_here`.
         if crate::runtime::utils::has_double_colon(name)
-            && ((self.is_my_scoped_type_name(name) && !self.my_scoped_type_visible_here(name))
-                || !self.qualified_name_visible_here(name))
+            && if self.is_my_scoped_type_name(name) {
+                !self.my_scoped_type_visible_here(name)
+            } else {
+                !self.qualified_name_visible_here(name)
+            }
         {
             return Err(RuntimeError::new(format!(
                 "Could not find symbol '{}'",

--- a/t/lib/Issue8120ExportedMy.rakumod
+++ b/t/lib/Issue8120ExportedMy.rakumod
@@ -1,0 +1,5 @@
+use v6;
+
+my class ExportedState is export {
+    method who() { 'exported' }
+}

--- a/t/lib/Issue8120LeakMy.rakumod
+++ b/t/lib/Issue8120LeakMy.rakumod
@@ -1,0 +1,10 @@
+use v6;
+unit module Issue8120LeakMy;
+
+my class State {
+    method who() { 'private' }
+}
+
+sub leak-state() is export {
+    State.new
+}

--- a/t/modules/import-export/exported-my-class-remains-visible.t
+++ b/t/modules/import-export/exported-my-class-remains-visible.t
@@ -1,0 +1,14 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+use Issue8120ExportedMy;
+
+plan 2;
+
+is ExportedState.new.who, 'exported',
+    'an exported my class remains visible after the module load';
+
+class ExportedChild is ExportedState { }
+ok ExportedChild.new ~~ ExportedState,
+    'an exported my class can be used as an inheritance parent';

--- a/t/modules/import-export/imported-my-type-does-not-shadow.t
+++ b/t/modules/import-export/imported-my-type-does-not-shadow.t
@@ -1,0 +1,29 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+use Issue8120LeakMy;
+
+plan 5;
+
+ok ::('State') ~~ Failure,
+    'a module body my class does not leak its bare name to the importer';
+ok ::('Issue8120LeakMy::State') ~~ Failure,
+    'a module body my class does not leak its qualified name either';
+is leak-state().who, 'private',
+    'the declaring module can still use its private class';
+
+module Issue8120Consumer {
+    my class State {
+        method who() { 'consumer' }
+    }
+
+    our sub consumer-state() {
+        State.new.who ~ '/' ~ State.^name
+    }
+}
+
+is Issue8120Consumer::consumer-state(), 'consumer/Issue8120Consumer::State',
+    'the importer own same-named my class wins over the imported one';
+is Issue8120Consumer::consumer-state(), 'consumer/Issue8120Consumer::State',
+    'the winning local type remains stable on repeated use';


### PR DESCRIPTION
Summary:
- keep imported `my` types out of the importing environment
- hide their source-facing qualified names outside the declaring compilation unit
- add regression coverage for private types and same-named local declarations

Validation:
- cargo fmt --all
- cargo clippy -- -D warnings
- make check-t-layout
- make test
- make roast

Closes #8120
