### PR TITLE
fix: preserve regex capturing groups in the shared tree

### DIFF
--- a/docs/adr/0088-rakuast-regex-boundary-tree.md
+++ b/docs/adr/0088-rakuast-regex-boundary-tree.md
@@ -1,8 +1,9 @@
 # ADR-0088: RakuAST and execution share a source-level regex tree
 
-- Status: Accepted (static source-tree, RakuAST, execution-lowering, and
-  static-value-provenance slices implemented 2026-09-12; dynamic contents and
-  the complete execution-tree migration remain)
+- Status: Accepted (static source-tree, RakuAST, execution-lowering,
+  static-value-provenance, declaration-provenance, and positional-capture
+  slices implemented 2026-09-12; dynamic contents and the complete
+  execution-tree migration remain)
 - Date: 2026-09-12
 - Related: [ADR-0011](0011-rakuast-model-layer-and-phasing.md) (the RakuAST
   model layer and its bidirectional conversion),
@@ -431,3 +432,21 @@ The focused regressions are in `t/rakuast/rakuast-regex.t`,
 `t/regex/regex-tree-value-provenance.t`. They pin AST parity for adjacent
 groups, an EVAL'd rule's execution boundary, and repeated named-rule
 smartmatches.
+
+## 11. Positional capture-group source and execution slice (2026-09-12)
+
+The shared tree now retains ordinary positional capture groups as
+`CapturingGroup`, distinct from the non-capturing `Group` used for square
+brackets. The read direction emits `RakuAST::Regex::CapturingGroup`, and the
+write direction accepts that node and lowers it to the existing
+`RegexAtom::CaptureGroup` path. Nested source trees and quantified capture
+slots therefore keep the matcher's established sub-Match and positional
+numbering semantics without executing user code during conversion.
+
+This slice intentionally covers only the ordinary `( ... )` form. Named
+capture aliases, subrule assertions, variable interpolation, code
+assertions, and other runtime-valued regex nodes remain explicit follow-up
+boundaries. The focused regressions are in
+`t/rakuast/rakuast-regex.t` and `t/regex/regex-tree-captures.t`; they pin the
+model shape, constructor/EVAL lowering, capture spans, and quantified capture
+iteration values.

--- a/news/2026-09/rakuast-regex-capturing-groups.md
+++ b/news/2026-09/rakuast-regex-capturing-groups.md
@@ -1,0 +1,7 @@
+# Regex capturing groups retain their RakuAST and execution shape
+
+Parser-created and constructed regexes now retain ordinary positional capture
+groups in the shared `RegexTree`. RakuAST exposes them as
+`RakuAST::Regex::CapturingGroup`, while execution lowers them to the existing
+capture-aware matcher without changing capture numbering or quantified
+sub-Match values.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2309,6 +2309,10 @@ fn regex_node(node: &RegexNode) -> Result<RakuAstNode, RuntimeError> {
             RakuAstClass::RegexGroup,
             vec![node_field(None, regex_node(child)?)],
         ),
+        RegexNode::CapturingGroup(child) => (
+            RakuAstClass::RegexCapturingGroup,
+            vec![node_field(None, regex_node(child)?)],
+        ),
         RegexNode::Quantified { atom, quantifier } => {
             let quantifier = match quantifier {
                 RegexQuantifier::ZeroOrMore => RakuAstClass::RegexQuantifierZeroOrMore,

--- a/src/rakuast/fields.rs
+++ b/src/rakuast/fields.rs
@@ -151,7 +151,7 @@ pub(super) fn model_fields(class: RakuAstClass) -> &'static [(&'static str, Abse
         RegexSequence | RegexAlternation => &[("terms", Absent::EmptyList)],
         RegexLiteral => &[("text", Absent::Required)],
         RegexQuote => &[("quoted", Absent::Required)],
-        RegexGroup | RegexWithWhitespace => &[("regex", Absent::Required)],
+        RegexGroup | RegexCapturingGroup | RegexWithWhitespace => &[("regex", Absent::Required)],
         RegexQuantifiedAtom => &[
             ("atom", Absent::Required),
             ("quantifier", Absent::Required),
@@ -212,7 +212,7 @@ pub(super) fn positional_accessor(class: RakuAstClass) -> Option<&'static str> {
         RegexLiteral => "text",
         RegexQuote => "quoted",
         RegexSequence | RegexAlternation => "terms",
-        RegexGroup | RegexWithWhitespace => "regex",
+        RegexGroup | RegexCapturingGroup | RegexWithWhitespace => "regex",
         StatementModifierGiven
         | StatementModifierIf
         | StatementModifierUnless

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1592,6 +1592,9 @@ fn lower_regex_node(node: &RakuAstNode) -> Result<RegexNode, RuntimeError> {
         RakuAstClass::RegexGroup => Ok(RegexNode::Group(Box::new(lower_regex_node(
             named_child_or_positional(node)?,
         )?))),
+        RakuAstClass::RegexCapturingGroup => Ok(RegexNode::CapturingGroup(Box::new(
+            lower_regex_node(named_child_or_positional(node)?)?,
+        ))),
         RakuAstClass::RegexWithWhitespace => Ok(RegexNode::WithWhitespace(Box::new(
             lower_regex_node(named_child_or_positional(node)?)?,
         ))),

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -63,6 +63,7 @@ pub enum RakuAstClass {
     RegexQuote,
     RegexWithWhitespace,
     RegexGroup,
+    RegexCapturingGroup,
     RegexAlternation,
     RegexQuantifiedAtom,
     RegexQuantifierZeroOrMore,
@@ -265,6 +266,7 @@ impl RakuAstClass {
             RegexQuote => "RakuAST::Regex::Quote",
             RegexWithWhitespace => "RakuAST::Regex::WithWhitespace",
             RegexGroup => "RakuAST::Regex::Group",
+            RegexCapturingGroup => "RakuAST::Regex::CapturingGroup",
             RegexAlternation => "RakuAST::Regex::Alternation",
             RegexQuantifiedAtom => "RakuAST::Regex::QuantifiedAtom",
             RegexQuantifierZeroOrMore => "RakuAST::Regex::Quantifier::ZeroOrMore",
@@ -474,7 +476,7 @@ impl RakuAstClass {
             // through this list.
             | TermSelf => TERM,
             ApplyInfix | ApplyPrefix | ApplyPostfix | ApplyListInfix | Ternary => EXPR,
-            RegexLiteral | RegexQuote | RegexGroup | RegexWithWhitespace => &[
+            RegexLiteral | RegexQuote | RegexGroup | RegexCapturingGroup | RegexWithWhitespace => &[
                 "RakuAST::Regex::Atom",
                 "RakuAST::Regex::Term",
                 "RakuAST::Regex",
@@ -604,6 +606,7 @@ fn semantic_type_object_ancestors(class_name: &str) -> &'static [&'static str] {
         "RakuAST::Regex::Literal"
         | "RakuAST::Regex::Quote"
         | "RakuAST::Regex::Group"
+        | "RakuAST::Regex::CapturingGroup"
         | "RakuAST::Regex::WithWhitespace" => &[
             "RakuAST::Regex::Atom",
             "RakuAST::Regex::Term",
@@ -687,6 +690,7 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::RegexQuote,
     RakuAstClass::RegexWithWhitespace,
     RakuAstClass::RegexGroup,
+    RakuAstClass::RegexCapturingGroup,
     RakuAstClass::RegexAlternation,
     RakuAstClass::RegexQuantifiedAtom,
     RakuAstClass::RegexQuantifierZeroOrMore,
@@ -1524,6 +1528,7 @@ fn require_regex_node(value: &Value, constructor: &str) -> Result<(), RuntimeErr
                     | RakuAstClass::RegexQuote
                     | RakuAstClass::RegexWithWhitespace
                     | RakuAstClass::RegexGroup
+                    | RakuAstClass::RegexCapturingGroup
                     | RakuAstClass::RegexAlternation
                     | RakuAstClass::RegexQuantifiedAtom
                     | RakuAstClass::RegexCharClassDigit
@@ -1631,6 +1636,7 @@ fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClas
         ("RakuAST::Regex::Literal", "new") => RakuAstClass::RegexLiteral,
         ("RakuAST::Regex::Quote", "new") => RakuAstClass::RegexQuote,
         ("RakuAST::Regex::Group", "new") => RakuAstClass::RegexGroup,
+        ("RakuAST::Regex::CapturingGroup", "new") => RakuAstClass::RegexCapturingGroup,
         ("RakuAST::Regex::WithWhitespace", "new") => RakuAstClass::RegexWithWhitespace,
         ("RakuAST::ColonPair::True", "new") => RakuAstClass::ColonPairTrue,
         _ => return None,
@@ -1828,6 +1834,7 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::RegexQuote
             | RakuAstClass::RegexWithWhitespace
             | RakuAstClass::RegexGroup
+            | RakuAstClass::RegexCapturingGroup
             | RakuAstClass::RegexQuantifiedAtom
             | RakuAstClass::RegexQuantifierZeroOrMore
             | RakuAstClass::RegexQuantifierOneOrMore

--- a/src/regex_tree.rs
+++ b/src/regex_tree.rs
@@ -44,6 +44,7 @@ pub(crate) enum RegexNode {
     Sequence(Vec<RegexNode>),
     Alternation(Vec<RegexNode>),
     Group(Box<RegexNode>),
+    CapturingGroup(Box<RegexNode>),
     Quantified {
         atom: Box<RegexNode>,
         quantifier: RegexQuantifier,
@@ -258,6 +259,19 @@ impl RegexTree {
                         ratchet,
                     )])
                 }
+                RegexNode::CapturingGroup(child) => {
+                    let tokens =
+                        lower_node(child, ratchet, ignore_case, ignore_mark, rule_sigspace)?;
+                    Some(vec![token(
+                        crate::runtime::RegexAtom::CaptureGroup(pattern(
+                            tokens,
+                            ignore_case,
+                            ignore_mark,
+                        )),
+                        crate::runtime::RegexQuant::One,
+                        ratchet,
+                    )])
+                }
                 RegexNode::Quantified { atom, quantifier } => {
                     let quant = match quantifier {
                         RegexQuantifier::ZeroOrMore => crate::runtime::RegexQuant::ZeroOrMore,
@@ -344,6 +358,7 @@ impl RegexNode {
                     })
             }
             Self::Group(child) => format!("[{}]", child.to_source()),
+            Self::CapturingGroup(child) => format!("({})", child.to_source()),
             Self::Quantified { atom, quantifier } => {
                 let suffix = match quantifier {
                     RegexQuantifier::ZeroOrMore => '*',
@@ -485,11 +500,16 @@ impl Parser {
                     inner,
                 ))))
             }
-            // Parentheses are capture groups in regex slang.  Captures need
-            // runtime slot metadata, which this source tree does not retain;
-            // leave them on the established execution parser instead of
-            // silently turning them into a non-capturing `RegexGroup`.
-            '(' => None,
+            '(' => {
+                self.pos += 1;
+                let inner = self.parse_alternation(&[')'], false)?;
+                if !self.consume_if(')') {
+                    return None;
+                }
+                Some(RegexNode::CapturingGroup(Box::new(
+                    sequence_for_multichar_literal(inner),
+                )))
+            }
             ')' | ']' if stops.contains(&ch) => None,
             '|' | '+' | '*' | '?' | '.' | '^' | '$' | '<' | '>' => None,
             _ => self.parse_literal(),

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -1615,7 +1615,15 @@ mod static_execution_tests {
         assert!(lower_static_execution_pattern(":s a b").is_none());
         assert!(lower_static_execution_pattern("a.b").is_none());
         assert!(lower_static_execution_pattern("[ab]+ %% ','").is_none());
-        assert!(lower_static_execution_pattern("(a)").is_none());
+        let capture = lower_static_execution_pattern("(a)").expect("capture group");
+        assert!(matches!(
+            capture.tokens.as_slice(),
+            [RegexToken {
+                atom: RegexAtom::CaptureGroup(_),
+                quant: RegexQuant::One,
+                ..
+            }]
+        ));
         assert!(lower_static_execution_pattern(r#""\x20""#).is_none());
         assert!(lower_static_execution_pattern("\u{1}42\u{1}").is_none());
     }

--- a/t/rakuast/rakuast-regex.t
+++ b/t/rakuast/rakuast-regex.t
@@ -8,7 +8,7 @@ use Test;
 # shapes Rakudo exposes. These examples are intentionally static: dynamic
 # assertions and interpolations remain explicit follow-up boundaries.
 
-plan 16;
+plan 17;
 
 is Q[/a/].AST.gist, q:to/END/.chomp, 'a regex literal has a Literal body';
     RakuAST::StatementList.new(
@@ -71,6 +71,18 @@ is Q[/\d+/].AST.gist, q:to/END/.chomp, 'a digit class and quantifier remain stru
           body => RakuAST::Regex::QuantifiedAtom.new(
             atom       => RakuAST::Regex::CharClass::Digit.new,
             quantifier => RakuAST::Regex::Quantifier::OneOrMore.new
+          )
+        )
+      )
+    )
+    END
+
+is Q[/(a)/].AST.gist, q:to/END/.chomp, 'a capture group remains a CapturingGroup';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedRegex.new(
+          body => RakuAST::Regex::CapturingGroup.new(
+            RakuAST::Regex::Literal.new("a")
           )
         )
       )

--- a/t/regex/match/regex-tree-captures.t
+++ b/t/regex/match/regex-tree-captures.t
@@ -1,0 +1,50 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# ADR-0088 issue #8033: positional capture groups are retained in the shared
+# source tree and lower to the existing capture-aware RegexPattern matcher.
+
+plan 14;
+
+is Q[/(a)/].AST.gist, q:to/END/.chomp, 'the parser exposes a capturing group instead of an opaque regex value';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedRegex.new(
+          body => RakuAST::Regex::CapturingGroup.new(
+            RakuAST::Regex::Literal.new("a")
+          )
+        )
+      )
+    )
+    END
+
+my $parsed = / (a) /;
+my $parsed-match = 'a' ~~ $parsed;
+ok $parsed-match, 'a parser-produced capture group matches';
+is $parsed-match[0].Str, 'a', 'a parser-produced capture stores its text';
+is $parsed-match[0].from, 0, 'a parser-produced capture stores its start';
+is $parsed-match[0].to, 1, 'a parser-produced capture stores its end';
+
+my $constructed-group = RakuAST::Regex::CapturingGroup.new(
+    RakuAST::Regex::Literal.new("a"),
+);
+is $constructed-group.regex.text, 'a', 'a capturing group exposes its regex accessor';
+ok $constructed-group ~~ RakuAST::Regex::Atom,
+    'a capturing group retains the regex atom semantic type';
+
+my $constructed = RakuAST::QuotedRegex.new(
+    body => $constructed-group,
+);
+my $constructed-value = EVAL($constructed);
+my $constructed-match = 'a' ~~ $constructed-value;
+ok $constructed-match, 'a constructed capture group lowers through EVAL';
+is $constructed-match[0].Str, 'a', 'the lowered capture keeps its text';
+is $constructed-match[0].from, 0, 'the lowered capture keeps its start';
+is $constructed-match[0].to, 1, 'the lowered capture keeps its end';
+
+my $quantified = 'aaa' ~~ /(a)+/;
+is $quantified[0].elems, 3, 'a quantified capture retains one slot per iteration';
+is $quantified[0][2].Str, 'a', 'the final quantified capture retains its value';
+is ('aaa' ~~ /(a)+/)[0].elems, 3, 'a captured tree can be lowered again';


### PR DESCRIPTION
## Summary

- Preserve ordinary positional capture groups in the shared RegexTree and lower them through the existing capture-aware matcher.
- Add `RakuAST::Regex::CapturingGroup` conversion, construction, and lowering support.
- Add parser, constructed-RakuAST, quantified-capture, ADR, and news coverage.

This is a bounded slice of #8033; dynamic interpolation, named aliases, subrules, code assertions, and other matcher boundaries remain follow-up work.

## Validation

- `make lint`
- `make test` — 4,151 files / 44,191 tests, PASS
- `make roast` — 1,437 files / 219,658 tests, PASS
- `scripts/run-t-test.sh t/rakuast/rakuast-regex.t` — 17/17, PASS
- `scripts/run-t-test.sh t/regex/match/regex-tree-captures.t` — 14/14, PASS
