### PR TITLE
fix(roles): qualify parameterised package parents

### DIFF
--- a/news/2026-09/parametric-role-qualifies-package-parent.md
+++ b/news/2026-09/parametric-role-qualifies-package-parent.md
@@ -1,0 +1,3 @@
+Parameterised roles composed by classes in a package now resolve their
+package-local role base even when the role's method refers to a lexical class
+and its type parameter is constrained by a lexical enum.

--- a/news/2026-09/role-multi-default-override.md
+++ b/news/2026-09/role-multi-default-override.md
@@ -1,0 +1,2 @@
+Class `multi` methods now correctly override same-signature non-`multi` methods
+provided by a composed role without leaving an ambiguous dispatch candidate.

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -162,7 +162,10 @@ impl Interpreter {
     /// `:D:`-invocant candidate must both survive composition.
     fn method_signatures_match_with_invocant(required: &MethodDef, candidate: &MethodDef) -> bool {
         Self::method_signatures_match(required, candidate)
-            && Self::invocant_type_constraint(required) == Self::invocant_type_constraint(candidate)
+            && (!required.is_multi
+                || !candidate.is_multi
+                || Self::invocant_type_constraint(required)
+                    == Self::invocant_type_constraint(candidate))
     }
 
     fn stub_is_nullary(def: &MethodDef) -> bool {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -653,22 +653,25 @@ impl Interpreter {
     /// MRO links `X::Decode` to the built-in namespace (an unknown parent, so it
     /// falls back to `Any`) instead of the module-local `M::X`.
     ///
-    /// Only rewrites a name (no type args) when `{current_package}::{name}` names
-    /// a registered class/role. A module-local class lexically shadows any
-    /// same-named outer or built-in type, so the package-qualified sibling is
-    /// preferred even when a bare built-in of that name also exists (e.g. `X`,
-    /// which is registered as the built-in `X::` exception namespace class);
-    /// genuine built-in and cross-package parents, which have no
-    /// current-package-qualified sibling, are left untouched.
+    /// Rewrites a name when `{current_package}::{name}` names a registered
+    /// class/role. Type arguments, when present, are kept on the qualified
+    /// base (`Packet[Type::Connect]` becomes `M::Packet[Type::Connect]`). A
+    /// module-local class lexically shadows any same-named outer or built-in
+    /// type, so the package-qualified sibling is preferred even when a bare
+    /// built-in of that name also exists (e.g. `X`, which is registered as the
+    /// built-in `X::` exception namespace class); genuine built-in and
+    /// cross-package parents, which have no current-package-qualified sibling,
+    /// are left untouched.
     ///
     /// A *nested* parent name is qualified the same way — the third link of
     /// `class X {}; class X::Decode is X {}; class X::Decode::Length is X::Decode {}`
     /// inside a module has to reach `M::X::Decode`, not a bare `X::Decode` that
     /// nothing declared.
     pub(crate) fn qualify_sibling_parent_name(&self, parent: &str) -> String {
-        if parent.contains('[') {
-            return parent.to_string();
-        }
+        let (base, suffix) = parent
+            .find('[')
+            .map(|start| (&parent[..start], &parent[start..]))
+            .unwrap_or((parent, ""));
         // The `Grammar` metatype, when it appears as an inheritance parent, is the
         // implicit default parent the parser auto-adds to every grammar. In Raku a
         // grammar with no explicit `is` clause always inherits the *core* `Grammar`
@@ -679,20 +682,20 @@ impl Interpreter {
         // tokens/actions/`parse` override (the YAMLish `Schema::*` reduce bug).
         // Direct references (`Grammar.parse`) still resolve to the module-local
         // grammar via bare-word resolution, so the module-local shadow is intact.
-        if parent == "Grammar" {
+        if base == "Grammar" {
             return parent.to_string();
         }
         let pkg = self.current_package();
         if pkg.is_empty() || pkg == "GLOBAL" {
             return parent.to_string();
         }
-        let qualified = format!("{}::{}", pkg, parent);
+        let qualified = format!("{}::{}", pkg, base);
         let registered = {
             let reg = self.registry();
             reg.classes.contains_key(&qualified) || reg.roles.contains_key(&qualified)
         };
         if registered {
-            qualified
+            format!("{qualified}{suffix}")
         } else {
             parent.to_string()
         }

--- a/t/oo/role/issue-8145-parametric-role-my-enum.t
+++ b/t/oo/role/issue-8145-parametric-role-my-enum.t
@@ -1,0 +1,23 @@
+use v6;
+use Test;
+
+plan 2;
+
+# A parameterised role in a unit package must resolve its package-local base
+# when a class composes it. The lexical `my class` in the role method makes the
+# bare role alias unavailable at that point, exposing the missing qualification
+# of `Packet[Type::Connect]`.
+my $result;
+lives-ok {
+    $result = EVAL q:to/CODE/;
+    unit package Issue8145;
+    my enum Type (Connect => 1);
+    my class EncodeBuffer { }
+    our role Packet[Type $type] {
+        method encode(EncodeBuffer $buffer) { 1 }
+    }
+    our class Packet::Connect does Packet[Type::Connect] { }
+    Packet::Connect.new.encode(EncodeBuffer.new).Int
+    CODE
+}, 'a parameterised role with a my enum and my class composes';
+is $result, 1, 'the composed role method sees its enum argument';

--- a/t/oo/role/role-nonmulti-class-multi-override.t
+++ b/t/oo/role/role-nonmulti-class-multi-override.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+plan 2;
+
+# A class multi method should replace a same-signature non-multi method
+# composed from a role. Invocant smiley differences distinguish two multi
+# candidates, but do not make a role default method coexist with its class
+# override.
+role RoleDefault {
+    method describe() { 'role' }
+}
+
+class ClassOverride does RoleDefault {
+    multi method describe(::?CLASS:D:) { 'class' }
+}
+
+is ClassOverride.new.describe, 'class',
+    'the class multi method overrides the role default';
+is ClassOverride.^find_method('describe').candidates.elems, 1,
+    'the replaced role method is not left as an ambiguous candidate';


### PR DESCRIPTION
Closes #8145

Parameterised role parents now preserve type arguments when qualifying package-local sibling names. This lets the reported unit-package role composition resolve the correct role.

Validation:
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast
- make check-t-layout