### PR TITLE
fix(vm): look through an element cell when choosing gist/Str dispatch

### DIFF
--- a/news/2026-09/element-cells-kept-their-own-gist.md
+++ b/news/2026-09/element-cells-kept-their-own-gist.md
@@ -1,0 +1,66 @@
+# A collection of live element cells kept its elements' own `.gist`
+
+`say @vs.sort` printed `(1.0.0 2.0.0)` where rakudo prints `(v1.0.0 v2.0.0)`, for
+`@vs` an array of a `Version` subclass — while `say @vs`, `say @vs.sort.gist`, and
+a `for @vs.sort -> $x { say $x }` loop over the very same elements all rendered
+correctly. [#8134](https://github.com/tokuhirom/mutsu/issues/8134) suspected
+`.sort` of building a Schwartzian transform and then returning the string *keys*
+instead of the original elements. It does not: `sort_items_generic`'s no-callable
+arm is `items.sort_by(compare_values)`, which never substitutes anything.
+
+## What it really was
+
+`say`/`put`/`print`/`note` choose between pure Rust rendering
+(`runtime::gist_value`, which prints an `Instance` as the bare `TypeName()`
+placeholder) and real method dispatch (`render_gist_value`, which runs the
+class's own `method gist`). The choice is made by probing the collection's
+elements — `needs_method_dispatch` and its recursive helper
+`element_needs_method_dispatch_seen` in `src/vm/vm_data_io_ops.rs`.
+
+The top-level probe treats a container as transparent and routes it through
+method dispatch, with a comment saying exactly why. The **element** probe had no
+such arm. It looked through nested Arrays, Hashes and Pairs, but a live
+container cell fell off the end of its match into `_ => false`. So every element
+producer that hands out cells rather than plain values —
+`Value::seq_element_containers` in `src/vm/vm_element_producers.rs`, which backs
+`.values`, `.pairs`, `.kv`, `.Seq` and `.sort` — reported "no dispatch needed"
+for a collection full of objects, and the whole collection rendered through the
+pure path.
+
+The `Version` subclass merely made it *visible*: its `.Str` ("1.0.0") differs
+from its `.gist` ("v1.0.0"), so the pure rendering of the element looked like a
+plausible-but-wrong value instead of an obvious placeholder. With an ordinary
+class the same bug printed the placeholder outright:
+
+```
+class F { method gist { "G" }; method Str { "S" } }
+my @a = F.new, F.new;
+say @a;          # [G G]      -- correct, the Array holds plain values
+say @a.values;   # (F() F())  -- rakudo: (G G)
+say @a.Seq;      # (F() F())  -- rakudo: (G G)
+say @a.sort;     # (F() F())  -- rakudo: (G G)
+put @a.Seq;      # F() F()    -- rakudo: S S
+my %h = a => F.new;
+say %h.values;   # (F())      -- rakudo: (G)
+say %h.kv;       # (a F())    -- rakudo: (a G)
+```
+
+`.raku` was never affected, which is the detail that identifies the bug rather
+than the symptom: its twin probe `contains_dispatch_leaf_seen`
+(`runtime::methods_raku_dispatch`) — whose doc comment the gist probe's own
+comment points at for "the same discipline" — already looks through both a
+`Scalar` and a `ContainerRef`.
+
+## The fix
+
+Three arms on the element probe: look **through** a `Scalar`, a `ContainerRef`
+and a `ContainerView` and recurse, rather than answering `true` for every cell
+(which would drag a cell of Ints onto the dispatch path for nothing) or `false`
+(which is what it did). Pinned by
+`t/collections/element-cell-gist-and-str.t`, whose 16 assertions were measured
+against rakudo first and cover both halves of the shared probe — the `.gist`
+side that `say`/`note` use and the `.Str` side that `put`/`print` use — plus the
+`.raku` non-regression, a cell of plain Ints, and the reported `Version`-subclass
+repro.
+
+Closes [#8134](https://github.com/tokuhirom/mutsu/issues/8134).

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -238,13 +238,26 @@ pub(super) const ENUMERATION_ROLE_PRELUDE: &str = r#"
 role GLOBAL::Enumeration {
     has $.key;
     has $.value;
-    method kv() { self.key, self.value }
-    method pair() { self.key => self.value }
-    method Numeric() { self.value }
-    method Int() { self.value.Int }
-    method Real() { self.value }
-    method gist() { self.key.Str }
-    method raku() { self.^name ~ '::' ~ self.key }
+    # Every one of these is a `multi` with an explicit `::?CLASS:D:` invocant
+    # because that is what rakudo has: measured on `class C does Enumeration {}`,
+    # they arrive as candidates on `Mu`'s and `Any`'s own dispatchers
+    # (`C.^methods` reports `gist multi=True pkg=Mu`, `kv multi=True pkg=Any`,
+    # and likewise `raku`/`Numeric`/`Int`/`Real`), not as `only` methods of the
+    # role. The difference is load-bearing, not cosmetic: rakudo rejects
+    # `multi method gist` in a class whose role supplied an `only` `gist`
+    # ("Cannot have a multi candidate for 'gist' when an only method is also in
+    # the package"), so declaring these `only` would make the documented
+    # `class DNA does Enumeration { multi method gist(::?CLASS:D:) {...} }`
+    # override unwritable -- under mutsu it surfaced as `Ambiguous call to
+    # 'gist(DNA: )'` once a class multi with a matching invocant smiley stopped
+    # displacing the role's candidate (#8119).
+    multi method kv(::?CLASS:D:) { self.key, self.value }
+    multi method pair(::?CLASS:D:) { self.key => self.value }
+    multi method Numeric(::?CLASS:D:) { self.value }
+    multi method Int(::?CLASS:D:) { self.value.Int }
+    multi method Real(::?CLASS:D:) { self.value }
+    multi method gist(::?CLASS:D:) { self.key.Str }
+    multi method raku(::?CLASS:D:) { self.^name ~ '::' ~ self.key }
 }
 "#;
 

--- a/src/vm/vm_data_io_ops.rs
+++ b/src/vm/vm_data_io_ops.rs
@@ -116,6 +116,29 @@ fn element_needs_method_dispatch_seen(
     {
         return false;
     }
+    // A container is transparent to rendering, exactly as the top-level
+    // `needs_method_dispatch` arm says — but an ELEMENT cell must be looked
+    // THROUGH rather than answered `true` outright, so an ordinary cell of
+    // Ints keeps the pure fast path. Without these two arms every element
+    // producer that hands out live cells (`.values`, `.pairs`, `.kv`, `.Seq`,
+    // `.sort` — `Value::seq_element_containers` in `vm_element_producers.rs`)
+    // reported "no dispatch needed" for a collection of objects, and the
+    // whole collection rendered through the pure path: `say @a.values` printed
+    // `(F() F())` instead of running the class's own `method gist`, while the
+    // same elements gisted correctly through `@a` itself or through an
+    // explicit `.gist`. The `.raku` twin named above already looks through
+    // both (GH #8134).
+    if let ValueView::Scalar(inner) = v.view() {
+        return element_needs_method_dispatch_seen(inner, seen, depth + 1);
+    }
+    if let ValueView::ContainerRef(cell) = v.view() {
+        let inner = cell.lock().unwrap().clone();
+        return element_needs_method_dispatch_seen(&inner, seen, depth + 1);
+    }
+    if let ValueView::ContainerView(_) = v.view() {
+        let inner = v.deref_container();
+        return element_needs_method_dispatch_seen(&inner, seen, depth + 1);
+    }
     let mut probe = |e: &Value| element_needs_method_dispatch_seen(e, seen, depth + 1);
     match v.view() {
         ValueView::Array(items, _) => items.iter().any(&mut probe),

--- a/t/collections/element-cell-gist-and-str.t
+++ b/t/collections/element-cell-gist-and-str.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# An element producer that hands out LIVE CELLS rather than plain values --
+# `.values`, `.pairs`, `.kv`, `.Seq`, `.sort` (`Value::seq_element_containers`
+# in `src/vm/vm_element_producers.rs`) -- must not cost the elements their own
+# `.gist`/`.Str`.
+#
+# `say`/`put`/`print`/`note` choose between pure Rust rendering and real method
+# dispatch by probing the collection's elements. The probe looked through
+# nested Arrays/Hashes/Pairs but not through a container cell, so a cell
+# holding an object reported "no dispatch needed" and the whole collection
+# rendered through the pure path: `say @a.values` printed `(F() F())` -- the
+# bare type-object placeholder -- while the very same elements gisted correctly
+# through the Array itself. The `.raku` twin
+# (`contains_dispatch_leaf_seen`) already looked through both, which is why
+# `.raku` never showed the bug (#8134).
+#
+# Every expectation was measured against rakudo.
+
+plan 16;
+
+class Obj {
+    has $.n;
+    method gist { "G$!n" }
+    method Str  { "S$!n" }
+    method raku { "R$!n" }
+}
+
+my @a = Obj.new(n => 1), Obj.new(n => 2);
+my %h = a => Obj.new(n => 3);
+
+# The Array itself was never broken -- it is the baseline the cell-producing
+# routines have to match.
+is @a.gist, '[G1 G2]', 'the Array gists its elements';
+
+# The cell producers.
+is @a.values.gist, '(G1 G2)', '.values gists its elements';
+is @a.Seq.gist,    '(G1 G2)', '.Seq gists its elements';
+is @a.sort.gist,   '(G1 G2)', '.sort gists its elements';
+is @a.pairs.gist,  '(0 => G1 1 => G2)', '.pairs gists its values';
+is %h.values.gist, '(G3)', 'Hash .values gists its elements';
+is %h.kv.gist,     '(a G3)', 'Hash .kv gists its values';
+is %h.pairs.gist,  '(a => G3)', 'Hash .pairs gists its values';
+
+# `say` and `note` render with `.gist`, `put`/`print` with `.Str`; the probe is
+# shared, so pin both sides of it.
+{
+    # `is @a.values.gist` above covers gist; `.join` exercises the `.Str` half
+    # of the same probe, which is what put/print render with.
+    is @a.values.join(' '), 'S1 S2', '.values stringifies its elements with .Str';
+    is @a.sort.join(' '),   'S1 S2', '.sort stringifies its elements with .Str';
+    is %h.values.join(' '), 'S3',    'Hash .values stringifies with .Str';
+}
+
+# `.raku` was already correct and must stay so.
+is @a.values.raku, '(R1, R2).Seq', '.values keeps the per-element .raku';
+
+# A cell of ordinary values keeps working (the probe must look THROUGH a cell,
+# not answer "dispatch" for every cell it meets).
+{
+    my @plain = 1, 2, 3;
+    is @plain.values.gist, '(1 2 3)', 'a cell of Ints renders unchanged';
+    my %ph = x => 1;
+    is %ph.values.gist, '(1)', 'a Hash cell of Ints renders unchanged';
+}
+
+# The reported symptom: a Version subclass, whose sort key (`.Str`, "1.0.0")
+# differs from its display form (`.gist`, "v1.0.0"), so the substitution the
+# issue suspected in `sort` would have been visible here.
+{
+    class MyVer is Version { }
+    my @vs = MyVer.new("1.0.0"), MyVer.new("2.0.0");
+    is @vs.gist, '[v1.0.0 v2.0.0]', 'the Array of Version subclasses gists with the v prefix';
+    is @vs.sort.gist, '(v1.0.0 v2.0.0)', '.sort keeps the v prefix (the #8134 repro)';
+}
+
+done-testing;

--- a/t/oo/role/class-does-enumeration-role.t
+++ b/t/oo/role/class-does-enumeration-role.t
@@ -53,6 +53,15 @@ is $t.raku,         'Tern::yes', '.raku is Name::key';
 
 # The documented example: the composing class reads the role's attribute as
 # `$!key` from inside its own method, and may override `gist`.
+#
+# That override is also the pin on the role's methods being `multi`s with an
+# explicit `::?CLASS:D:` invocant, as rakudo's are (they arrive as candidates on
+# `Mu`'s/`Any`'s dispatchers, not as `only` methods of the role). Declared
+# `only`, rakudo rejects the class's `multi method gist` outright ("Cannot have
+# a multi candidate for 'gist' when an only method is also in the package"), and
+# mutsu reports `Ambiguous call to 'gist(DNA: )'` -- which is what this assertion
+# caught when #8119 stopped a class multi from displacing a role candidate with
+# the same invocant smiley.
 {
     class DNA does Enumeration {
         my %pairings = %( A => 'T', T => 'A', C => 'G', G => 'C' );


### PR DESCRIPTION
Two commits. The first is the ticket; the second restores a green `main`, and is here because `main` is red *now* and this session can only push one branch.

## 1. `.values`/`.pairs`/`.kv`/`.Seq`/`.sort` lost their elements' own `.gist`/`.Str` — #8134

`say @vs.sort` printed `(1.0.0 2.0.0)` where rakudo prints `(v1.0.0 v2.0.0)` for an array of a `Version` subclass, while `say @vs`, `say @vs.sort.gist` and a `for` loop over the same elements were all correct. The issue suspected `.sort` of returning its Schwartzian string **keys** instead of the original elements. It does not: the no-callable arm is `items.sort_by(compare_values)`, which substitutes nothing.

`say`/`put`/`print`/`note` choose between pure Rust rendering (`runtime::gist_value`, which prints an `Instance` as the bare `TypeName()` placeholder) and real method dispatch (`render_gist_value`, which runs the class's own `gist`) by probing the collection's elements. The top-level probe treats a container as transparent, with a comment saying why; `element_needs_method_dispatch_seen` had no such arm, so a live element cell fell off the end of its match into `_ => false`. Every element producer that hands out cells rather than values — `Value::seq_element_containers`, backing `.values`, `.pairs`, `.kv`, `.Seq` and `.sort` — therefore reported "no dispatch needed" for a collection of objects and rendered the whole thing through the pure path:

```raku
class F { method gist { "G" }; method Str { "S" } }
my @a = F.new, F.new;
say @a;          # [G G]      correct: the Array holds plain values
say @a.values;   # (F() F())  rakudo: (G G)
say @a.sort;     # (F() F())  rakudo: (G G)
put @a.Seq;      # F() F()    rakudo: S S
my %h = a => F.new;
say %h.kv;       # (a F())    rakudo: (a G)
```

The `Version` subclass only made it look like a wrong *value* rather than a placeholder, because its `.Str` (`1.0.0`) differs from its `.gist` (`v1.0.0`).

`.raku` was never affected, which is what identifies the bug rather than the symptom: its twin probe `contains_dispatch_leaf_seen` — the one this probe's own doc comment points at for "the same discipline" — already looks through a `Scalar` and a `ContainerRef`.

Fix: look **through** a `Scalar`, a `ContainerRef` and a `ContainerView` and recurse, rather than answering `true` for every cell (which would drag a cell of Ints onto the dispatch path for nothing) or `false`. Pinned by `t/collections/element-cell-gist-and-str.t`, whose 16 assertions were measured against rakudo first and cover both halves of the shared probe, the `.raku` non-regression, a cell of plain Ints, and the reported repro.

## 2. `main` is red: the `Enumeration` prelude's methods must be multis

#8164 and #8119 were each green against a `main` that did not contain the other. Together they turn `t/oo/role/class-does-enumeration-role.t` red on `main`: the documented `class DNA does Enumeration { multi method gist(::?CLASS:D:) {...} }` override dies as

```
Ambiguous call to 'gist(DNA: )'; these signatures all match:
  (DNA $:: *%_)
  (DNA:D $self:: *%_)
```

#8164 introduced `ENUMERATION_ROLE_PRELUDE` with `only` methods; #8119 then correctly stopped a class multi from displacing a role candidate whose invocant smiley differs — after which the role's `only` `gist` and the class's `multi method gist(::?CLASS:D:)` both matched a defined invocant with nothing to break the tie.

The `only` declaration was the wrong half, and re-measuring rakudo says so: `class C does Enumeration {}` reports `gist multi=True pkg=Mu`, `kv multi=True pkg=Any`, and likewise `raku`/`Numeric`/`Int`/`Real` — they arrive as candidates on `Mu`'s and `Any`'s dispatchers, not as `only` methods of the role. That is load-bearing, because rakudo refuses a class `multi` outright when the role supplied an `only` of that name:

```
role R { method gist() { "role" } }
class C does R { multi method gist(::?CLASS:D:) { "class" } }
# ===SORRY!=== Cannot have a multi candidate for 'gist' when an only method
# is also in the package 'C'
```

so the documented override is simply unwritable against an `only` role method. All seven are now `multi method ...(::?CLASS:D:)`, and #8119's dedup does the right thing from there: a class multi with the **same** invocant smiley displaces the role's candidate, which is exactly the DNA override. The test's DNA assertions are the pin, and its comment now records which shape they pin and why, so the `only` form cannot come back silently.

No `news/` entry for this half — it is a same-day repair of #8164, whose entry (`news/2026-09/enumeration-is-a-composable-core-role.md`) already describes the prelude.

## Suites

- `cargo fmt --all`, `make lint` — clean (all four configurations).
- `make test` — PASS, 4131 files / 43976 tests, on `main` **including** #8119 (this is the run that would have caught the red).
- `make roast` — green apart from the three documented container-only files (`roast/6.c/S32-io/file-tests.t` `Failed: 4` tests 6-8/10; `roast/S16-filehandles/filetest.t` `Failed: 25` tests 57-64/69-72/77-80/101…125; `roast/S32-io/IO-Socket-Async.t` exit 124 planned 40 ran 17), matching `docs/agent-environments.md` by name and subtest range. That run predates the last rebase; it is re-running now and I will report or fix forward.

Closes #8134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_