### PR TITLE
fix(oo): an attribute initializer copies its container instead of aliasing it

### DIFF
--- a/news/2026-09/attribute-initializer-copies-its-container.md
+++ b/news/2026-09/attribute-initializer-copies-its-container.md
@@ -1,0 +1,66 @@
+# An attribute initializer copies its container instead of aliasing it
+
+An attribute initializer written with `=` is an **assignment**, so the attribute
+gets a copy of whatever container the right-hand side evaluated to. mutsu stored
+the evaluated value directly, so the attribute shared the very container on the
+right — exactly as if `:=` had been written:
+
+```
+$ raku  -e 'my @o = 1,2; class C { our @.x = @o; }; @o.push(3); say C.x'
+[1 2]
+$ mutsu -e 'my @o = 1,2; class C { our @.x = @o; }; @o.push(3); say C.x'
+[1 2 3]
+```
+
+On a class-level attribute that made `=` and `:=` indistinguishable, which is
+the actual defect: the two spellings mean different things and only one of them
+was implemented ([#8150](https://github.com/tokuhirom/mutsu/issues/8150)).
+
+## The per-instance half the ticket did not name
+
+The same measurement on `has` shows the ticket was describing one side of a
+wider gap — the per-instance initializer aliased too:
+
+```
+$ mutsu -e 'my @o = 1,2; class C { has @.x = @o }; my $c = C.new; @o.push(3); say $c.x'
+[1 2 3]     # raku: [1 2]
+```
+
+That one is worse than it first looks, because it also makes two instances built
+from the same default share one container: `C.new.x.push(99)` was visible
+through the next instance's `.x`, and wrote back into `@o` as well.
+
+Both are fixed, and each at the single place its path already funnels through:
+
+- **Per-instance** — `Interpreter::eval_attr_default_expr` is "the single
+  env-setup shape for evaluating an attribute default", shared by `dispatch_new`'s
+  pre-BUILD fill, the post-BUILD deferred pass, the native default-constructor
+  fast path and `dispatch_bless`. Detaching its result covers all four at once.
+- **Class-level** — `Interpreter::class_body_has_decl` stores into
+  `class_def.class_level_attrs`, and had nothing to tell `=` from `:=`. Both
+  role-header spellings of the declaration parsed into the same
+  `Stmt::HasDecl { default: Some(expr) }`, so the declarator is now carried on
+  it (`default_is_bind`, `#[serde(default)]`, mirrored onto
+  `CompiledAttrDecl`) — set only by the `my`/`our` class-level parser, since
+  `has @.x := ...` is "Cannot use := to initialize an attribute" in rakudo and
+  is refused before it gets here.
+
+Both sides reuse `Value::detach_shared_container`, the existing "Raku `=` copy
+semantics" primitive (`my @b = @a` yields `@b !=:= @a`, also used by `is copy`
+parameter binding). It returns a singly-owned `Gc` unchanged, so a default that
+built its own fresh container pays nothing.
+
+## Found on the way, filed not bundled
+
+[#8175](https://github.com/tokuhirom/mutsu/issues/8175): the class-level
+initializer is not a list assignment at all — `our @.x = 1, 2, 3` keeps only the
+first element (the parser stops at the first comma), and `our @.x = (1, 2, 3)`
+stays a `List` because that store never goes through
+`coerce_attr_value_by_sigil`. The ticket had assumed this spelling "looks right
+by accident"; it does not. Fixing either half alone leaves the other spelling
+wrong, so it is its own ticket rather than a rider here.
+
+Pinned by `t/oo/attribute/attribute-initializer-copies-its-container.t` (10
+assertions, green under `raku` as written), alongside the existing
+`class-level-attribute-bind.t`, which pins the `:=` aliasing this must not take
+away — one bind assertion is repeated in the new file for exactly that reason.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1638,6 +1638,14 @@ pub(crate) enum Stmt {
         /// to that sub at class registration; otherwise this causes an
         /// `X::Comp::Trait::Unknown` error.
         unknown_traits: Vec<(String, String, Option<Expr>)>,
+        /// `default` was written with `:=`, not `=`. Only a CLASS-LEVEL
+        /// attribute (`our @.x := @c` / `my @.x := @c`) can be bound —
+        /// `has @.x := ...` is "Cannot use := to initialize an attribute" in
+        /// rakudo — and the two spellings mean different things: a bind makes
+        /// the accessor hand back the very container on the right, while `=`
+        /// is an assignment and must copy it (#8150).
+        #[serde(default)]
+        default_is_bind: bool,
     },
     MethodDecl {
         name: Symbol,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -429,6 +429,11 @@ pub(crate) struct CompiledAttrDecl {
     /// the same `constant`/enum lookup a normal read would use is safe,
     /// unlike guessing. See `Interpreter::resolve_dynamic_attr_shape`.
     pub(crate) dynamic_shape: bool,
+    /// `default` was written with `:=` rather than `=` — only reachable for a
+    /// class-level attribute (`our @.x := @c`), and the reason the class-level
+    /// registration path stores the right-hand container itself instead of a
+    /// copy. See `Stmt::HasDecl::default_is_bind`.
+    pub(crate) default_is_bind: bool,
 }
 
 impl CompiledAttrDecl {
@@ -466,6 +471,7 @@ impl CompiledAttrDecl {
             deprecated_message,
             is_built,
             unknown_traits,
+            default_is_bind,
         } = stmt
         else {
             unreachable!("CompiledAttrDecl::from_stmt called on a non-HasDecl statement");
@@ -504,6 +510,7 @@ impl CompiledAttrDecl {
             unknown_traits: unknown_traits.clone(),
             declared_shape,
             dynamic_shape,
+            default_is_bind: *default_is_bind,
         }
     }
 }

--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -72,6 +72,9 @@ fn has_decl_list(
             deprecated_message: None,
             is_built: None,
             unknown_traits: Vec::new(),
+            // `has @.x := ...` is refused outright, so a `has` declaration's
+            // initializer is always an assignment.
+            default_is_bind: false,
         });
         let (r, _) = ws(rest)?;
         rest = r;
@@ -1106,6 +1109,8 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
             deprecated_message,
             is_built,
             unknown_traits,
+            // As above: only the `my`/`our` class-level spellings can bind.
+            default_is_bind: false,
         },
     ))
 }

--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -316,10 +316,11 @@ pub(super) fn try_dot_twigil_attr<'a>(
         // in rakudo ("Cannot use := to initialize an attribute"), which is why
         // this branch lives here -- only the `my`/`our` scoped spellings reach
         // it -- and not in `has_decl`, which rejects it outright.
-        let (after_name, default) = if let Some(r) = after_name.strip_prefix(":=") {
+        let (after_name, default, default_is_bind) = if let Some(r) = after_name.strip_prefix(":=")
+        {
             let (r, _) = ws(r)?;
             let (r, expr) = expression(r)?;
-            (r, Some(expr))
+            (r, Some(expr), true)
         } else if after_name.starts_with('=')
             && !after_name.starts_with("==")
             && !after_name.starts_with("=>")
@@ -327,9 +328,9 @@ pub(super) fn try_dot_twigil_attr<'a>(
             let r = &after_name[1..];
             let (r, _) = ws(r)?;
             let (r, expr) = expression(r)?;
-            (r, Some(expr))
+            (r, Some(expr), false)
         } else {
-            (after_name, None)
+            (after_name, None, false)
         };
         // `class C { our Int $.x }` is refused at compile time, like every
         // other `our TYPE` spelling -- see `our_type_constraint_error`. Raised
@@ -361,6 +362,7 @@ pub(super) fn try_dot_twigil_attr<'a>(
             deprecated_message: None,
             is_built: None,
             unknown_traits: Vec::new(),
+            default_is_bind,
         };
         if apply_modifier {
             return parse_statement_modifier(after_name, stmt).map(Some);

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1520,6 +1520,9 @@ fn lower_attribute(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         deprecated_message: None,
         is_built: None,
         unknown_traits: Vec::new(),
+        // RakuAST models an attribute's initializer as an assignment; rakudo
+        // has no `:=` attribute-declaration node to lower from.
+        default_is_bind: false,
     })
 }
 

--- a/src/runtime/attr_build_defaults.rs
+++ b/src/runtime/attr_build_defaults.rs
@@ -365,6 +365,15 @@ impl Interpreter {
         } else {
             self.env.remove("?CLASS");
         }
-        result
+        // An attribute initializer is an ASSIGNMENT, so the attribute gets a
+        // COPY of whatever container the default evaluated to, not that
+        // container itself: `my @c = 1,2; class C { has @.x = @c }` must not
+        // let a later `@c.push(3)` show through `.x`. Detaching here -- the
+        // single env-setup shape every construction path shares -- covers
+        // `dispatch_new`'s pre-BUILD fill, the post-BUILD deferred pass, the
+        // native default-constructor fast path and `dispatch_bless` at once.
+        // A default that built its own fresh container owns its `Gc` already,
+        // so this is free on the common path (#8150).
+        result.map(Value::detach_shared_container)
     }
 }

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -222,7 +222,22 @@ impl Interpreter {
         if decl.is_our || decl.is_my {
             // Evaluate the default value if present
             let initial_value = if let Some(arg) = &decl.default {
-                self.eval_decl_trait_arg(arg)?
+                let value = self.eval_decl_trait_arg(arg)?;
+                if decl.default_is_bind {
+                    // `our @.x := @c` BINDS: the accessor hands back the very
+                    // container on the right, so a later push to `@c` shows
+                    // through it (Math::Symbolic's `our @.operations :=
+                    // @operations`).
+                    value
+                } else {
+                    // `our @.x = @c` ASSIGNS, so the attribute gets a COPY.
+                    // Storing the evaluated value made the two spellings
+                    // indistinguishable, which is the actual bug: `=` aliased
+                    // whatever container it was given (#8150). A default that
+                    // built its own fresh container owns its `Gc` already, so
+                    // this is free on the common path.
+                    value.detach_shared_container()
+                }
             } else {
                 Value::NIL
             };

--- a/t/oo/attribute/attribute-initializer-copies-its-container.t
+++ b/t/oo/attribute/attribute-initializer-copies-its-container.t
@@ -1,0 +1,95 @@
+use v6;
+use Test;
+
+# An attribute initializer written with `=` is an ASSIGNMENT, so the attribute
+# gets a COPY of whatever container the right-hand side evaluated to. mutsu
+# stored the evaluated value directly, so the attribute shared the very
+# container on the right -- exactly as if `:=` had been written, which made the
+# two spellings indistinguishable on a class-level attribute (#8150).
+#
+# The `:=` half is pinned by `class-level-attribute-bind.t`; this file is the
+# copy side, and re-asserts one bind case so a future "just always copy" cannot
+# quietly take the binding away.
+#
+# It only ever showed for an `@`/`%` attribute initialized from ANOTHER
+# container: `our @.x = 1, 2, 3` builds a fresh list and looked right by
+# accident. Every assertion below was checked against rakudo.
+
+plan 10;
+
+# --- class-level (`our` / `my`), the shape the ticket was filed for ---
+{
+    my @source = 1, 2;
+    class OurArray { our @.x = @source; }
+    @source.push(3);
+    is OurArray.x, [1, 2], 'our @.x = @c copies the list, so a later push is invisible';
+}
+
+{
+    my %source = a => 1;
+    class OurHash { our %.h = %source; }
+    %source<b> = 2;
+    is OurHash.h.keys.sort.join(','), 'a', 'our %.h = %c copies the hash';
+}
+
+{
+    my @source = 1, 2;
+    class MyArray { my @.x = @source; }
+    @source.push(3);
+    is MyArray.x, [1, 2], 'my @.x = @c copies the same way `our` does';
+}
+
+# The bind spelling must keep aliasing.
+{
+    my @source = 1, 2;
+    class BoundArray { our @.x := @source; }
+    @source.push(3);
+    is BoundArray.x, [1, 2, 3], 'our @.x := @c still binds the container itself';
+}
+
+# A literal initializer builds its own container, so it was always right and
+# stays right. Spelled with brackets on purpose: the bare comma-list spelling
+# (`our @.x = 1, 2, 3`) is a SEPARATE, pre-existing bug in the class-level
+# initializer -- it keeps only the first element, and a parenthesized list
+# stays a List instead of coercing to the attribute's `@` sigil. See #8175;
+# neither is about the copy this file pins.
+{
+    class Literal { our @.x = [1, 2, 3]; }
+    is Literal.x, [1, 2, 3], 'our @.x = [1, 2, 3] still initializes from the list';
+}
+
+# --- per-instance (`has`), which had the same defect ---
+{
+    my @source = 1, 2;
+    class HasArray { has @.x = @source; }
+    my $o = HasArray.new;
+    @source.push(3);
+    is $o.x, [1, 2], 'has @.x = @c copies the list into the instance';
+}
+
+{
+    my %source = a => 1;
+    class HasHash { has %.h = %source; }
+    my $o = HasHash.new;
+    %source<b> = 2;
+    is $o.h.keys.sort.join(','), 'a', 'has %.h = %c copies the hash into the instance';
+}
+
+# Two instances built from the same default must not share one container --
+# the same aliasing seen from the other side.
+{
+    my @source = 1, 2;
+    class TwoInstances { has @.x = @source; }
+    my $a = TwoInstances.new;
+    my $b = TwoInstances.new;
+    $a.x.push(99);
+    is $b.x, [1, 2], 'two instances do not share the container their default came from';
+    is @source, [1, 2], 'and neither of them wrote back into the source';
+}
+
+# A `$` attribute is not a list assignment either way, and is unaffected.
+{
+    my $source = 5;
+    class ScalarAttr { our $.n = $source; }
+    is ScalarAttr.n, 5, 'our $.n = $c is unaffected';
+}


### PR DESCRIPTION
Closes #8150.

## The gap

An attribute initializer written with `=` is an **assignment**, so the attribute gets a copy of whatever container the right-hand side evaluated to. mutsu stored the evaluated value directly, so the attribute shared the very container on the right:

```
$ raku  -e 'my @o = 1,2; class C { our @.x = @o; }; @o.push(3); say C.x'
[1 2]
$ mutsu -e 'my @o = 1,2; class C { our @.x = @o; }; @o.push(3); say C.x'
[1 2 3]
```

On a class-level attribute that made `=` and `:=` indistinguishable, which is the actual defect: the two spellings mean different things and only one of them was implemented.

## The per-instance half the ticket did not name

The same measurement on `has` shows the ticket was describing one side of a wider gap — the per-instance initializer aliased too:

```
$ mutsu -e 'my @o = 1,2; class C { has @.x = @o }; my $c = C.new; @o.push(3); say $c.x'
[1 2 3]     # raku: [1 2]
```

That one is worse than it first looks: it also made **two instances built from the same default share one container**. `C.new.x.push(99)` was visible through the next instance's `.x`, and wrote back into the source array as well. Both new assertions for that are in the test.

## The fix, one place per path

- **Per-instance** — `Interpreter::eval_attr_default_expr` is "the single env-setup shape for evaluating an attribute default", shared by `dispatch_new`'s pre-BUILD fill, the post-BUILD deferred pass, the native default-constructor fast path and `dispatch_bless`. Detaching its result covers all four at once, rather than patching the eight `coerce_attr_value_by_sigil` call sites individually.
- **Class-level** — `Interpreter::class_body_has_decl` had nothing to tell `=` from `:=`: both spellings parse into the same `Stmt::HasDecl { default: Some(expr) }`. The declarator is now carried on it — `default_is_bind`, `#[serde(default)]`, mirrored onto `CompiledAttrDecl` — and set only by the `my`/`our` class-level parser, since `has @.x := ...` is "Cannot use := to initialize an attribute" in rakudo and is refused before it gets here. Four construction sites; the ticket's estimate of ~30 was high.

Both sides reuse `Value::detach_shared_container`, the existing "Raku `=` copy semantics" primitive (`my @b = @a` yields `@b !=:= @a`; also used by `is copy` parameter binding). It returns a singly-owned `Gc` unchanged, so a default that built its own fresh container pays nothing.

## Measured against `raku`

| | mutsu before | mutsu after | raku |
|---|---|---|---|
| `our @.x = @c`, then `@c.push` | `[1 2 3]` | `[1 2]` | `[1 2]` |
| `our %.h = %c`, then `%c<b>=2` | `(a b)` | `(a)` | `(a)` |
| `my @.x = @c`, then `@c.push` | `[1 2 3]` | `[1 2]` | `[1 2]` |
| `our @.x := @c`, then `@c.push` | `[1 2 3]` | `[1 2 3]` | `[1 2 3]` |
| `has @.x = @c`, then `@c.push` | `[1 2 3]` | `[1 2]` | `[1 2]` |
| two instances from one `has @.x = @c` | shared | independent | independent |
| `our $.n = $c` | `5` | `5` | `5` |

## Found on the way, filed not bundled

#8175: the class-level initializer is not a list assignment at all — `our @.x = 1, 2, 3` keeps only the first element (the parser stops at the first comma), and `our @.x = (1, 2, 3)` stays a `List` because that store never goes through `coerce_attr_value_by_sigil`. The ticket had assumed this spelling "looks right by accident"; it does not. Fixing either half alone leaves the other spelling wrong, so it is its own ticket rather than a rider here — the test's literal case is spelled `= [1, 2, 3]` with a comment pointing at it.

## Tests

`t/oo/attribute/attribute-initializer-copies-its-container.t` (10 assertions, green under `raku` as written): the class-level `our`/`my` array and hash copies, the per-instance `has` copies, the two-instances-do-not-share pair, the `$` attribute that is unaffected, and one repeated `:=` assertion so a future "just always copy" cannot quietly take the binding away. The existing `t/oo/attribute/class-level-attribute-bind.t` (the `:=` pin) stays green, as does the rest of `t/oo/attribute/`.

## Pre-publication gates

- `cargo fmt --all`, `make check-t-layout`: clean.
- `make lint`: all four configurations green.
- `make test`: **PASS** — 4131 files, 43964 tests.
- `make roast`: three failures, all three exactly the container-specific known reds in `docs/agent-environments.md`, at their documented shapes — `roast/6.c/S32-io/file-tests.t` `Failed: 4` (tests 6-8, 10) and `roast/S16-filehandles/filetest.t` `Failed: 25` (57-64, 69-72, 77-80, 101, 103, 105, 107, 109, 111, 117, 121, 125), both from running as `uid 0`; `roast/S32-io/IO-Socket-Async.t` exit 124 from the sandboxed network. Nothing else in the whitelist failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK)_