### PR TITLE
fix: a bare Numeric method no longer provides .Str

### DIFF
--- a/news/2026-09/bare-numeric-method-no-longer-provides-str.md
+++ b/news/2026-09/bare-numeric-method-no-longer-provides-str.md
@@ -1,0 +1,22 @@
+# A bare Numeric method no longer provides .Str
+
+A class that defined a `Numeric` method (without `does Real`/`does
+Numeric`) got its `.Str` — and `~`, string interpolation, every
+stringifying context — routed through that method. In rakudo `Str` falls
+back to `Mu.Str` regardless; a `Numeric` method has no bearing on it. The
+same numeric-only class still bridges numeric-context coercion (`+1` etc.)
+to it, matching rakudo.
+
+The fallback chain in `methods_instance_ops.rs` gated numeric-bridge
+delegation on `has_user_method(..., "Numeric")` alone, which is true for
+any class merely declaring a method of that name. Stringify methods
+(`Str`/`Stringy`) now require the object to genuinely compose `Real` or
+`Numeric` — checked via `does_check` (mixin composition) and
+`class_does_role` (static class-level composition, e.g. `class P does
+Real { ... }`, which `does_check` alone cannot see since it has no
+interpreter/registry access) — before bridging to the number; numeric
+coercion methods keep the bare-method exception since that matches
+rakudo (`class P { method Numeric { 7 } }; P.new + 1` is `8` there too).
+
+See [#8153](https://github.com/tokuhirom/mutsu/issues/8153) and the
+regression test `t/oo/method/numeric-method-does-not-provide-str.t`.

--- a/news/2026-09/role-method-param-typo-revalidated-at-composition.md
+++ b/news/2026-09/role-method-param-typo-revalidated-at-composition.md
@@ -1,0 +1,20 @@
+# A role method's deferred param-type check is re-validated at composition
+
+`registration_role_method.rs`'s per-parameter type-constraint check accepts
+a role method's parameter type optimistically whenever the role body has
+an unloaded `use` — the not-yet-loaded module might supply the type. But
+nothing ever re-validated that guess once the module actually loaded, so a
+genuinely mistyped parameter type was accepted forever and its method
+silently vanished once the role was composed, instead of raising
+`X::Parameter::InvalidType` the way an immediately-unresolvable name
+already does.
+
+Each such deferred check is now recorded on the `RoleDef` (propagated when
+one role composes another) and re-run in `compose_role_into_class` once the
+role's deferred body — which runs its `use` statements — has executed,
+reusing `resolve_declared_type_name`'s indirect (env/stash) lookup so a
+type that legitimately resolves through the module's exports (#8023,
+#7993) is still accepted.
+
+See [#8083](https://github.com/tokuhirom/mutsu/issues/8083) and the
+regression test `t/oo/role/role-composed-method-param-typo.t`.

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1770,8 +1770,31 @@ impl Interpreter {
                 if self.has_user_method(&class_name.resolve(), "Str"));
             let is_numeric_coercion = matches!(method, "Numeric" | "Real" | "Bridge");
             let is_own_stringify = has_user_str && matches!(method, "Str" | "Stringy");
+            // A class that merely DECLARES a method named `Numeric` (without
+            // `does Real`/`does Numeric`) still gets numeric-context coercion
+            // bridged to it -- `P.new + 1` is 8 in rakudo too, with no role
+            // composition at all -- but stringification is NOT part of that
+            // deal: `Mu.Str` is the fallback there, and a `Numeric` method has
+            // no bearing on it (#8153). Gate the two kinds of coercion
+            // separately: numeric ops may ride the bare-method exception
+            // (`has_user_method(..., "Numeric"/"Bridge")` alone, checked by the
+            // outer `if` above), but `.Str`/`.Stringy` bridge to the number
+            // only when the object genuinely composes Real/Numeric.
+            let is_stringify_method = matches!(method, "Str" | "Stringy");
+            // `does_check` is a `Value`-only check (no interpreter access), so
+            // it sees a *mixin* role composition (`$x but Real`) but not a
+            // plain class's static `does Real` -- that lives in the class
+            // registry, reached through `class_does_role`. Check both: a
+            // class-composed role must count too (`class P does Real { ... }`
+            // is the exact case this branch's own comment documents keeping).
+            let genuinely_numeric = target.does_check("Real")
+                || target.does_check("Numeric")
+                || matches!(target.view(), ValueView::Instance { class_name, .. }
+                    if self.class_does_role(&class_name.resolve(), "Real")
+                        || self.class_does_role(&class_name.resolve(), "Numeric"));
             if !is_numeric_coercion
                 && !is_own_stringify
+                && (!is_stringify_method || genuinely_numeric)
                 && let Ok(coerced) = self
                     .call_method_with_values(target.clone(), "Numeric", vec![])
                     .or_else(|_| self.call_method_with_values(target.clone(), "Bridge", vec![]))

--- a/t/oo/method/numeric-method-does-not-provide-str.t
+++ b/t/oo/method/numeric-method-does-not-provide-str.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# #8153: a class that defines a `Numeric` method (but does not `does
+# Real`/`does Numeric`) got its `.Str` routed through that method instead of
+# falling back to `Mu.Str`. rakudo's `Mu.Str` renders `TypeName<id>`; mutsu's
+# own default instance repr is `TypeName()` (a pre-existing, unrelated
+# divergence -- both are "the default object stringification", neither is
+# the Numeric value). What matters here is that a bare `Numeric` method has
+# no bearing on `.Str`, `~`, string interpolation, matching rakudo, while
+# numeric-context coercion (`+`) still bridges through it.
+
+plan 7;
+
+class P { method Numeric { 7 } }
+
+isnt P.new.Str, '7', 'a bare Numeric method does not provide .Str';
+isnt ~P.new, '7', 'nor does it provide prefix ~ stringification';
+isnt "$(P.new)", '7', 'nor string interpolation';
+is P.new + 1, 8, 'but numeric-context coercion still bridges to it';
+
+# A class that genuinely composes Real/Numeric (not just a same-named method)
+# keeps the documented `.Str`/`.gist` bridging exception.
+class Q does Real {
+    method Bridge { 7 }
+}
+is Q.new.Str, '7', 'a class that does Real still bridges .Str to its number';
+is ~Q.new, '7', 'and prefix ~';
+is Q.new.gist, '7', 'and .gist';


### PR DESCRIPTION
## Summary

A class that defines a `Numeric` method (without `does Real`/`does
Numeric`) got its `.Str` — and `~`, string interpolation, every
stringifying context — routed through that method. In rakudo `Str` falls
back to `Mu.Str` regardless; a `Numeric` method has no bearing on it. The
same numeric-only class still bridges numeric-context coercion (`+1` etc.)
to it, matching rakudo (`class P { method Numeric { 7 } }; P.new + 1` is
`8` there too).

The fallback chain in `methods_instance_ops.rs` gated numeric-bridge
delegation on `has_user_method(..., "Numeric")` alone, which is true for
any class merely declaring a method of that name. Stringify methods
(`Str`/`Stringy`) now require the object to genuinely compose `Real` or
`Numeric` — checked via `does_check` (mixin composition, `$x but Real`)
and `class_does_role` (static class-level composition, e.g. `class P does
Real { ... }`, which `does_check` alone cannot see since it has no
interpreter/registry access) — before bridging to the number; numeric
coercion methods (`Numeric`/`Real`/`Bridge`, and anything that reaches
them, like `+`) keep the bare-method exception since that's genuine
rakudo behavior.

Closes #8153

(Also backfills the `news/` entry for #8083, merged via #8172 without one
at the time.)

## Test plan

- Added `t/oo/method/numeric-method-does-not-provide-str.t`: the issue's
  repro (`.Str`, `~`, interpolation all fall back correctly, `+` still
  bridges), plus a pin that `class Q does Real { method Bridge {...} }`
  keeps the documented `.Str`/`.gist`/`~` bridging exception.
- Ran the broader `t/oo` + `t/types` sweep (881 files, 9856 tests) to
  check for regressions in the numeric-coercion/Bridge machinery — all
  green.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run
  locally. `make roast` comes back with only the three environment-only
  failures documented in `docs/agent-environments.md` for a remote
  container (`roast/6.c/S32-io/file-tests.t`,
  `roast/S16-filehandles/filetest.t` — both `uid 0` chmod-based file tests
  — and `roast/S32-io/IO-Socket-Async.t`, sandboxed network); everything
  else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_