### PR TITLE
docs: say what PLAN.md's "Semaphore / non-blocking await" axis actually is

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -219,7 +219,18 @@ from the real dispatch table (ADR-0019 F1/F2). The pool's one open follow-up: it
 of per-`start` cost, so whitelisting Digest's `t/ripemd.t` still needs per-call-site compile-cache
 levers — [#7571](https://github.com/tokuhirom/mutsu/issues/7571), actively worked.
 
-- [ ] Semaphore / non-blocking await / lock contention (S17; hard; separate axis).
+- [ ] **Non-blocking `await` — ADR-0020's rejected alternative (b), kept as a standing axis.**
+      mutsu's `await` is a blocking condvar wait (`SharedPromise::wait`,
+      `src/value/value_async.rs`), as are `Lock`/`Semaphore` critical sections, so a blocked frame
+      costs an OS thread and nested `await` of depth N materializes ~N of them.
+      [ADR-0020](docs/adr/0020-shared-worker-pool.md) §2 chose the elastic pool that makes this
+      correct rather than deadlocking; rakudo instead parks the frame on a continuation
+      (`$*AWAITER`) and returns the worker to a *capped* pool. Doing the same here means turning
+      every blocking point (`await`, channel receive, lock, sleep) into a suspension point and
+      teaching the VM to unwind and restore native Rust stack frames — VM-scale, hence still
+      deferred. **No roast pressure remains** (all 99 S17 files are whitelisted); the motive is
+      thread consumption under heavy concurrency, so start this only on a measured trigger and an
+      updated ADR.
 - [ ] Propagate Supply detached-worker panics to QUIT (currently swallowed) — [#8185](https://github.com/tokuhirom/mutsu/issues/8185).
 - [ ] Split out the roast fudge logic. File size (376 over 500 lines, 138 over 1000, still growing —
       `ANALYSIS.md` §6) is **not** a standalone campaign: split when a campaign opens the file and the


### PR DESCRIPTION
Follow-up to #8179, whose nine commits are already on `main`. This branch was
restarted from `main` and carries only the one commit that came after that PR was
closed — opening it as a new PR rather than reusing the closed one.

## Summary

PLAN.md §5 carried the line:

> - [ ] Semaphore / non-blocking await / lock contention (S17; hard; separate axis).

Nine words, no pointer, unreadable without already knowing what it meant. It turns
out to be the standing reference to **ADR-0020 §2's rejected alternative (b)** — the
ADR names it by exactly this phrase ("This is the 'Semaphore / non-blocking await'
axis PLAN.md §5"), but nothing pointed the other way.

Spelled out:

- mutsu's `await` is a **blocking condvar wait** (`SharedPromise::wait`,
  `src/value/value_async.rs`), and so are `Lock`/`Semaphore` critical sections. A
  blocked frame therefore costs an OS thread, and nested `await` of depth N
  materializes about N of them.
- rakudo instead parks the frame on a continuation via `$*AWAITER` and returns the
  worker to a **capped** pool, which is why 96 workers survive depth-500 nesting.
- ADR-0020 chose (a) — an elastic pool with blocking `await` — so the shape is
  correct rather than deadlocking. Matching rakudo means making every blocking point
  (`await`, channel receive, lock, sleep) a suspension point and teaching the VM to
  unwind and restore native Rust stack frames, i.e. VM-scale, hence still deferred.

It also drops a stale justification: `(S17)` implied roast pressure, but **all 99
S17 roast files are whitelisted** and `TODO_roast/BLOCKERS.md` records the S17
concurrency campaign as complete. The motive today is thread consumption under heavy
concurrency, not compatibility — which makes this a measured-trigger item like
ADR-0001's layer 3c, not an open task competing with the rest of §5.

## Test plan

- [x] Documentation-only change (`PLAN.md`), so CI's `changes` job classifies it as
      docs-only and the build jobs skip by design.
- [x] Claims verified against the tree: `SharedPromise::wait` is
      `gc::wait_until(lock, cvar, …)` in `src/value/value_async.rs`; ADR-0020 §2
      records the (a)/(b) fork and names this axis; all 99 files under `roast/S17-*`
      appear in `roast-whitelist.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY5aYEwfnfbQouXEYKWq6y

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY5aYEwfnfbQouXEYKWq6y)_