### PR TITLE
fix(parser): the dotted subscript honours its semilist, and `.&lt;&gt;` parses

### DIFF
--- a/news/2026-09/dotted-subscript-honours-its-semilist.md
+++ b/news/2026-09/dotted-subscript-honours-its-semilist.md
@@ -1,0 +1,52 @@
+# The dotted subscript `.[$i; $j]` honours its semilist, and `.<>` parses
+
+A subscript holds a **semilist**, so `@a[$i; $j]` is a multi-dimensional index.
+The bracket spelling knew that; the dotted postfix spelling did not, and the
+failure mode was worse than a parse error — it silently answered with the wrong
+value:
+
+```
+$ raku  -e 'my $c = [[1,2],[3,4]]; say $c.[0; 1];'
+2
+$ mutsu -e 'my $c = [[1,2],[3,4]]; say $c.[0; 1];'
+([1 2] [3 4])
+```
+
+`.[...]` and `.{...}` called `parse_bracket_indices`, the *wrapper* that exists
+for callers which cannot represent dimensions: it flattens them into a single
+`ArrayLiteral`. So `$c.[0; 1]` parsed as the slice `$c[(0, 1)]` — hence the
+whole container back — and `%h.{"a"; "b"}` as `%h{("a", "b")}`. Both dotted arms
+now go through `parse_bracket_indices_inner` and build the same `MultiDimIndex`
+the bracket loop builds, lowering a single remaining dimension back to a plain
+`Expr::Index`. The shared lowering lives in one helper
+(`dotted_subscript_expr`) so the two arms cannot drift apart again.
+
+The second half was a missing postfix entirely. `Game::Entities` — the
+distribution that motivated the ticket — writes `.[COMPONENTS; $i].<>`, and
+`.<>`, the dotted spelling of the decontainerizing zen angle subscript, had no
+arm at all: the `.<key>` arm requires a non-empty key, so the empty `<>` fell
+through every dotted postfix to a bare `Confused`. The issue attributed that
+parse failure to the leftover semilist, but it reproduces on its own
+(`my $x = 5; say $x.<>`) and is independent — the undotted `$x<>` has worked all
+along. It now lowers exactly as the undotted arm does.
+
+With both halves, `Game::Entities` 0.1.6 loads under mutsu, so its `ecosystem/`
+record leaves `blocked_load` at the next sweep. Its own test suite is still red
+on unrelated gaps, which belong to the `ecosystem-dist-fix` workflow.
+
+One divergence found alongside is deliberately *not* fixed here, because it
+lives in the bracket form too and predates this change: a `WhateverCode`
+dimension (`@m[*-1; 0]`) returns the bare element where rakudo returns a
+one-element `List`. Filed as
+[#8188](https://github.com/tokuhirom/mutsu/issues/8188); the new test does not
+assert that case, so the two spellings are now consistently wrong there rather
+than differently wrong.
+
+Pinned by `t/collections/subscript/dotted-subscript-semilist.t` — 21 assertions
+measured against rakudo, covering two and three dimensions in both the
+positional and associative spellings, the single-dimension and comma-slice
+non-regressions, a trailing `;`, assignment through the subscript, `:exists`,
+`.<>` on a scalar/array/hash/subscript, and the distribution's own
+`.[$i; $j].<>` chain.
+
+Closes [#8155](https://github.com/tokuhirom/mutsu/issues/8155).

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -8,9 +8,9 @@ use super::adverb::{
 };
 use super::call_method::{
     ParsedBracketIndex, QuotedMethodName, append_call_arg, auto_invoke_bareword_method_target,
-    has_ternary_else_after, is_postfix_operator_boundary, parse_bracket_indices,
-    parse_bracket_indices_inner, parse_custom_postfix_operator, parse_prefix_as_postfix,
-    parse_private_method_name, parse_quoted_method_name,
+    has_ternary_else_after, is_postfix_operator_boundary, parse_bracket_indices_inner,
+    parse_custom_postfix_operator, parse_prefix_as_postfix, parse_private_method_name,
+    parse_quoted_method_name,
 };
 use super::dot_assign::{atomic_var_name, parse_dot_assign};
 use super::helpers::{
@@ -759,6 +759,28 @@ fn brace_is_postcircumfix(expr: &Expr, term_ends_with_ws: bool) -> bool {
         && !matches!(expr, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. }))
 }
 
+/// Lower a parsed DOTTED subscript (`.[...]` / `.{...}`) onto `target`.
+///
+/// A semilist of two or more dimensions becomes a `MultiDimIndex`; a single
+/// dimension becomes a plain `Expr::Index`, which is what every downstream
+/// consumer of an ordinary one-dimensional subscript expects. Same shape as the
+/// undotted bracket loop's own `ParsedBracketIndex` match, extracted so the two
+/// dotted arms cannot drift from each other (GH #8155).
+fn dotted_subscript_expr(target: Expr, parsed: ParsedBracketIndex, is_positional: bool) -> Expr {
+    match parsed {
+        ParsedBracketIndex::MultiDim(dimensions) => Expr::MultiDimIndex {
+            target: Box::new(target),
+            is_positional,
+            dimensions,
+        },
+        ParsedBracketIndex::Single(index) => Expr::Index {
+            target: Box::new(target),
+            index: Box::new(index),
+            is_positional,
+        },
+    }
+}
+
 fn postfix_expr_loop(rest: &str, expr: Expr, allow_ws_dot: bool) -> PResult<'_, Expr> {
     postfix_expr_loop_from(rest, expr, allow_ws_dot, (false, false), false)
 }
@@ -1028,31 +1050,57 @@ fn postfix_expr_loop_from(
                 }
             }
             // Check for .[index] syntax: object.[expr] or .[expr1, expr2, ...]
+            //
+            // A subscript holds a SEMILIST, so `.[$i; $j]` is a
+            // multi-dimensional index exactly as the undotted `@a[$i; $j]` is.
+            // Both dotted arms therefore go through
+            // `parse_bracket_indices_inner` and build the same `MultiDimIndex`
+            // the bracket loop below builds, lowering a single remaining
+            // dimension back to a plain `Expr::Index`. They used to call the
+            // `parse_bracket_indices` WRAPPER, which flattens the dimensions
+            // into one `ArrayLiteral` for callers that cannot represent them --
+            // turning `$c.[0; 1]` into the slice `$c[(0, 1)]` and silently
+            // answering with the whole container (`([1 2] [3 4])` instead of
+            // `2`), and `%h.{"a"; "b"}` into `%h{("a", "b")}` (GH #8155).
             if let Some(r_inner) = r.strip_prefix('[') {
                 let (r_inner, _) = ws(r_inner)?;
-                let (r_inner, index) = parse_bracket_indices(r_inner)?;
+                let (r_inner, parsed) = parse_bracket_indices_inner(r_inner)?;
                 let (r_inner, _) = ws(r_inner)?;
                 let (r_inner, _) = parse_char(r_inner, ']')?;
-                expr = Expr::Index {
-                    target: Box::new(expr),
-                    index: Box::new(index),
-                    is_positional: true,
-                };
+                expr = dotted_subscript_expr(expr, parsed, true);
                 rest = r_inner;
                 continue;
             }
             // Check for .{index} syntax: object.{$expr}
             if let Some(r) = r.strip_prefix('{') {
                 let (r, _) = ws(r)?;
-                let (r, index) = parse_bracket_indices(r)?;
+                let (r, parsed) = parse_bracket_indices_inner(r)?;
                 let (r, _) = ws(r)?;
                 let (r, _) = parse_char(r, '}')?;
-                expr = Expr::Index {
-                    target: Box::new(expr),
-                    index: Box::new(index),
-                    is_positional: false,
-                };
+                expr = dotted_subscript_expr(expr, parsed, false);
                 rest = r;
+                continue;
+            }
+            // The dotted spelling of the DECONTAINERIZING zen angle subscript,
+            // `.<>`, which the undotted `$x<>` / `@a<>` arm below already
+            // handles and which lowers the same way. `Game::Entities` writes
+            // `.[COMPONENTS; $i].<>`, and without this arm the empty `<>` fell
+            // through every dotted postfix (the `.<key>` arm just below needs a
+            // non-empty key) to a bare "Confused" (GH #8155). Adverbs on the
+            // dotted form (`%h.<>:k`) are still unhandled, as they are for
+            // every other dotted subscript.
+            if let Some(r_zen) = r.strip_prefix("<>") {
+                expr = match &expr {
+                    Expr::HashVar(_) => expr.clone(),
+                    _ => Expr::MethodCall {
+                        target: Box::new(expr.clone()),
+                        name: Symbol::intern("__mutsu_zen_angle"),
+                        args: Vec::new(),
+                        modifier: None,
+                        quoted: false,
+                    },
+                };
+                rest = r_zen;
                 continue;
             }
             // Check for .<key> angle-bracket hash access: %h.<foo>, $obj.<bar>

--- a/t/collections/subscript/dotted-subscript-semilist.t
+++ b/t/collections/subscript/dotted-subscript-semilist.t
@@ -1,0 +1,87 @@
+use v6;
+use Test;
+
+# A subscript holds a SEMILIST, so `.[$i; $j]` is a multi-dimensional index
+# exactly as the undotted `@a[$i; $j]` is. The dotted postfix spelling went
+# through the wrapper that FLATTENS the dimensions into one `ArrayLiteral` for
+# callers that cannot represent them, so `$c.[0; 1]` silently became the slice
+# `$c[(0, 1)]` and answered with the whole container instead of the element --
+# a wrong value, not a parse error. `%h.{"a"; "b"}` had the same shape.
+#
+# `.<>`, the dotted decontainerizing zen angle subscript, was missing outright:
+# the `.<key>` arm needs a non-empty key, so the empty `<>` fell through every
+# dotted postfix to a bare "Confused". `Game::Entities` writes
+# `.[COMPONENTS; $i].<>`, which needs both halves (#8155).
+#
+# Every expectation below was measured against rakudo.
+
+plan 21;
+
+my @m = [[1, 2, 3], [4, 5, 6]];
+
+# The two spellings of a multi-dimensional index now agree.
+is @m.[0; 1], 2, '.[$i; $j] indexes the second dimension';
+is @m.[1; 2], 6, '.[$i; $j] again, other corner';
+is @m[0; 1],  2, 'the bracket spelling is unchanged';
+is @m.[0; 1], @m[0; 1], 'dotted and bracket subscripts agree';
+
+# Three dimensions, so the loop is exercised past one `;`.
+{
+    my @d = [[[7, 8], [9, 10]], [[11, 12], [13, 14]]];
+    is @d.[0; 1; 0], 9,  '.[$i; $j; $k] indexes three dimensions';
+    is @d.[1; 0; 1], 12, 'three dimensions again';
+}
+
+# A single dimension still lowers to a plain one-dimensional subscript, and a
+# comma list is still a slice rather than a second dimension.
+is @m.[0].gist, '[1 2 3]', '.[$i] is still a plain index';
+is @m.[0, 1].gist, '([1 2 3] [4 5 6])', '.[$i, $j] is still a slice, not two dimensions';
+
+# A trailing `;` terminates the last dimension rather than opening an empty one.
+is @m.[0; 1;], 2, 'a trailing semicolon does not add a dimension';
+
+# The associative dotted subscript takes a semilist too.
+{
+    my %h = a => { b => { c => 42 } };
+    is %h.{"a"; "b"}.gist, '({c => 42})', '.{...; ...} indexes the nested hash';
+    is %h.{"a"; "b"; "c"}.gist, '(42)', 'three associative dimensions';
+    is %h{"a"; "b"; "c"}.gist, '(42)', 'the brace spelling is unchanged';
+}
+
+# It is an lvalue, like the bracket form.
+{
+    my @w = [[1, 2], [3, 4]];
+    @w.[0; 1] = 99;
+    is @w.gist, '[[1 99] [3 4]]', '.[$i; $j] assigns through to the element';
+    @w[1; 0] = 55;
+    is @w.gist, '[[1 99] [55 4]]', 'the bracket spelling still assigns';
+}
+
+# `:exists` still reaches the adverb handling.
+{
+    my $s = [[1, 2], [3, 4]];
+    ok $s.[0; 1]:exists, '.[$i; $j]:exists';
+}
+
+# `.<>` is the dotted decontainerizing zen angle subscript.
+{
+    my $x = 5;
+    is $x.<>, 5, '.<> on a scalar yields the value';
+    my @a = 1, 2;
+    is @a.<>.gist, '[1 2]', '.<> on an array yields the array';
+    my %h = a => 1;
+    is %h.<>.gist, '{a => 1}', '.<> on a hash yields the hash';
+    my $c = [[1, 2], [3, 4]];
+    is $c.[0].<>.gist, '[1 2]', '.<> chains after a dotted subscript';
+}
+
+# The distribution's own spelling: a semilist subscript with `.<>` chained onto
+# it. Before the fix this was a hard parse error, which is what made
+# `Game::Entities` unloadable rather than merely wrong.
+{
+    my $c = [[1, 2], [3, 4]];
+    is $c.[0; 1].<>, 2, '.[$i; $j].<> parses and indexes (the Game::Entities shape)';
+    is @m.[0; 2].<>, 3, 'and again on an array variable';
+}
+
+done-testing;


### PR DESCRIPTION
## The gap

A subscript holds a **semilist**, so `@a[$i; $j]` is a multi-dimensional index. The bracket spelling knew that; the dotted postfix spelling did not, and the failure mode was worse than a parse error — it silently answered with the wrong value:

```
$ raku  -e 'my $c = [[1,2],[3,4]]; say $c.[0; 1];'
2
$ mutsu -e 'my $c = [[1,2],[3,4]]; say $c.[0; 1];'
([1 2] [3 4])
```

`.[...]` and `.{...}` called `parse_bracket_indices`, the **wrapper** that exists for callers which cannot represent dimensions: it flattens them into a single `ArrayLiteral`. So `$c.[0; 1]` parsed as the slice `$c[(0, 1)]` — hence the whole container back — and `%h.{"a"; "b"}` as `%h{("a", "b")}` (`({b => 7} (Any))` instead of `(7)`). Both dotted arms now go through `parse_bracket_indices_inner` and build the same `MultiDimIndex` the bracket loop builds, lowering a single remaining dimension back to a plain `Expr::Index`. The shared lowering lives in one helper (`dotted_subscript_expr`) so the two arms cannot drift apart again.

## The second half: `.<>` had no arm at all

`Game::Entities` — the distribution that motivated the ticket — writes `.[COMPONENTS; $i].<>`, and `.<>`, the dotted spelling of the decontainerizing zen angle subscript, was simply missing: the `.<key>` arm requires a non-empty key, so the empty `<>` fell through every dotted postfix to a bare `Confused`.

The issue attributes that parse failure to the leftover semilist. It is not that — it reproduces on its own, and the undotted `$x<>` has worked all along:

```
$ mutsu -e 'my $x = 5; say $x.<>;'
===SORRY!===   # raku: 5
$ mutsu -e 'my $x = 5; say $x<>;'
5              # already correct
```

So both halves were needed for the distribution's spelling. `.<>` now lowers exactly as the undotted arm does (the `HashVar` shortcut, otherwise `__mutsu_zen_angle`). Adverbs on the dotted form (`%h.<>:k`) remain unhandled, as they are for every other dotted subscript.

## Verification

All of the issue's repros, plus the `.{...}` case it asked to check, now match rakudo byte for byte, and the real distribution loads:

```
$ mutsu -I Game-Entities-0.1.6/lib -e 'use Game::Entities; say "ok"'
ok
```

so its `ecosystem/` record leaves `blocked_load` at the next sweep. Its own three test files are still red on unrelated gaps (a `Set` of method names differing in `namespace.t`, and two `subtest` failures) — the `ecosystem-dist-fix` workflow's business, not this ticket's, which scoped the test to the minimised case.

Pinned by `t/collections/subscript/dotted-subscript-semilist.t` — 21 assertions measured against rakudo first, covering two and three dimensions in both the positional and associative spellings, the single-dimension and comma-slice non-regressions, a trailing `;`, assignment through the subscript, `:exists`, `.<>` on a scalar/array/hash/subscript, and the distribution's own `.[$i; $j].<>` chain.

One divergence found alongside is deliberately **not** fixed here, because it lives in the bracket form too and predates this change: a `WhateverCode` dimension (`@m[*-1; 0]`) returns the bare element where rakudo returns a one-element `List`. Filed as #8188. The new test does not assert that case, so the two spellings are now consistently wrong there rather than differently wrong — which is itself an improvement on the previous state.

## Suites

- `cargo fmt --all`, `make lint` — clean (all four configurations).
- `make test` — PASS, 4136 files / 44031 tests.
- `make roast` — green apart from the three documented container-only files: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8 and 10), `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125), `roast/S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17) — matching `docs/agent-environments.md` by name and by subtest range.

Closes #8155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_