### PR TITLE
fix(rakuast): a slurpy marker is a type object, not a node

### DIFF
--- a/news/2026-09/rakuast-slurpy-marker-is-a-type-object.md
+++ b/news/2026-09/rakuast-slurpy-marker-is-a-type-object.md
@@ -1,0 +1,56 @@
+# A RakuAST slurpy marker is a type object, not a node
+
+Rakudo builds **no node** for a slurpy parameter's marker: the
+`RakuAST::Parameter::Slurpy::*` type object itself is what `$!slurpy` holds.
+mutsu normalized the other way round — it took the type object on the way in
+and stored an empty node of that class. The two render identically inside the
+parent's gist, so `.gist` of a whole tree matched byte for byte and the
+difference hid on the field itself:
+
+```
+my $p = Q[sub f(*@c) { }].AST.statements[0].expression.signature.parameters[0];
+say $p.slurpy.defined;   # mutsu: True    raku: False
+say $p.slurpy.gist;       # mutsu: RakuAST::Parameter::Slurpy::Flattened
+                          #  raku: (Flattened)
+say $p.slurpy === RakuAST::Parameter::Slurpy::Flattened;
+                          # mutsu: False   raku: True
+```
+
+The `.defined` answer was the damaging one. On rakudo the question "is this
+parameter slurpy?" is *which class of type object the field holds*
+(`$p.slurpy !=== RakuAST::Parameter::Slurpy`), never definedness — so mutsu
+answered `True` for every parameter carrying a marker where rakudo answers
+`False` for all of them, which is the exact opposite of useful. The identity
+comparison that rakudo's own idiom relies on could not work at all, because a
+node is never identical to a class.
+
+## The fix
+
+`normalize_slurpy_marker` now normalizes **to** the type object rather than away
+from it, and the two constructing sites (`convert.rs`'s `slurpy_parameter`, and
+`formatter.rs`'s synthesised `-> *@args` block) store that value directly. Both
+input spellings are still accepted: rakudo's `.new` takes only the type object,
+which is what `t/rakuast/rakuast-construct-rich-parameters.t` already passes,
+but a node of the same class names the same marker unambiguously and there was
+nothing to gain from rejecting it. `slurpy_marker_class` is the one place that
+reads either spelling, so the lowerer no longer matches on a node class.
+
+Because the field's value is now the same `Package` the bareword
+`RakuAST::Parameter::Slurpy::Flattened` already evaluated to, `.defined`,
+`.gist`, `.raku`, `===`, `=:=` and `~~` all came out right with no per-method
+work — mutsu's type-object surface was already correct, the field just was not
+holding one.
+
+One renderer change went with it: a type-object field value renders as its bare
+class name. That is genuinely different from how a type object gists alone —
+rakudo's `Parameter` gist shows
+`slurpy => RakuAST::Parameter::Slurpy::Flattened` while `.slurpy.gist` is
+`(Flattened)` — so the two spellings had to be kept apart rather than unified.
+
+Pinned by `t/rakuast/rakuast-slurpy-marker-type-object.t`: 19 assertions
+measured against rakudo, covering both markers and the base class, `.defined`,
+`.gist`, `.raku`, `===`/`=:=` in both directions, the documented base-class
+idiom, `~~` membership, the parent's gist rendering, and a hand-built parameter
+keeping the type object it was given.
+
+Closes [#8157](https://github.com/tokuhirom/mutsu/issues/8157).

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2934,7 +2934,8 @@ fn type_captures_field(type_capture: RakuAstNode) -> RakuAstField {
 
 /// A slurpy parameter `*@a` / `**@a` -> `Parameter(target => …, slurpy =>
 /// RakuAST::Parameter::Slurpy::{Flattened,Unflattened})`. A slurpy carries no
-/// `type`/`optional` field.
+/// `type`/`optional` field, and the marker is a type object rather than a node
+/// (see `slurpy_marker_value`).
 fn slurpy_parameter(sigil: &str, desigil: &str, double: bool) -> Result<RakuAstNode, RuntimeError> {
     let target = RakuAstNode {
         class: RakuAstClass::ParameterTargetVar,
@@ -2943,19 +2944,18 @@ fn slurpy_parameter(sigil: &str, desigil: &str, double: bool) -> Result<RakuAstN
             Value::str(format!("{sigil}{desigil}")),
         )],
     };
-    let slurpy = RakuAstNode {
-        class: if double {
-            RakuAstClass::ParameterSlurpyUnflattened
-        } else {
-            RakuAstClass::ParameterSlurpyFlattened
-        },
-        fields: Vec::new(),
-    };
+    // The marker is the `RakuAST::Parameter::Slurpy::*` TYPE OBJECT, as it is in
+    // rakudo -- see `slurpy_marker_value`.
+    let slurpy = super::slurpy_marker_value(if double {
+        RakuAstClass::ParameterSlurpyUnflattened
+    } else {
+        RakuAstClass::ParameterSlurpyFlattened
+    });
     Ok(RakuAstNode {
         class: RakuAstClass::Parameter,
         fields: vec![
             node_field(Some("target"), target),
-            node_field(Some("slurpy"), slurpy),
+            leaf_field(Some("slurpy"), slurpy),
         ],
     })
 }

--- a/src/rakuast/formatter.rs
+++ b/src/rakuast/formatter.rs
@@ -45,7 +45,8 @@ pub fn formatter_ast(format: &str) -> Value {
         RakuAstClass::ParameterTargetVar,
         vec![named("name", Value::str("@args".to_string()))],
     );
-    let slurpy = node(RakuAstClass::ParameterSlurpyFlattened, vec![]);
+    // The type object, not a node of that class -- see `slurpy_marker_value`.
+    let slurpy = super::slurpy_marker_value(RakuAstClass::ParameterSlurpyFlattened);
     let parameter = node(
         RakuAstClass::Parameter,
         vec![named("target", target), named("slurpy", slurpy)],

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1115,20 +1115,19 @@ fn lower_parameter(parameter: &RakuAstNode, owner: &RakuAstNode) -> Result<Param
         def.required = !is_optional;
         def.optional_marker = is_optional;
     }
-    // A slurpy parameter `*@a` / `**@a` carries a `slurpy` marker node.
+    // A slurpy parameter `*@a` / `**@a` carries a `slurpy` marker: the
+    // `RakuAST::Parameter::Slurpy::*` type object, as rakudo stores it (a node
+    // of the same class is accepted too -- see `slurpy_marker_class`).
     if let Some(s) = parameter.fields.iter().find(|f| f.name == Some("slurpy")) {
-        if let RakuAstFieldValue::Node(val) = &s.value
-            && let ValueView::RakuAst(marker) = val.view()
-        {
-            match marker.class {
-                RakuAstClass::ParameterSlurpyFlattened => def.slurpy = true,
-                RakuAstClass::ParameterSlurpyUnflattened => def.double_slurpy = true,
-                _ => return Err(unsupported(owner)),
-            }
-            def.required = false;
-        } else {
+        let RakuAstFieldValue::Node(val) = &s.value else {
             return Err(unsupported(owner));
+        };
+        match super::slurpy_marker_class(val) {
+            Some(RakuAstClass::ParameterSlurpyFlattened) => def.slurpy = true,
+            Some(RakuAstClass::ParameterSlurpyUnflattened) => def.double_slurpy = true,
+            _ => return Err(unsupported(owner)),
         }
+        def.required = false;
     }
     // `Int $x` -> a type constraint. `Type::Simple` (a plain type name) is
     // handled; the implicit `Type::Setting(Any)` on an untyped param is

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -1558,35 +1558,55 @@ fn require_rakuast_type(value: &Value, constructor: &str) -> Result<(), RuntimeE
     }
 }
 
-fn normalize_slurpy_marker(value: Value) -> Result<Value, RuntimeError> {
-    let class = match value.view() {
+/// The value a `Parameter`'s `slurpy` field holds: the
+/// `RakuAST::Parameter::Slurpy::*` **TYPE OBJECT**, not a node of that class.
+///
+/// Rakudo builds no node for a slurpy marker -- the type object itself is
+/// stored in `$!slurpy` -- and the difference is visible on the field even
+/// though the two render identically inside the parent's gist. mutsu used to
+/// normalize the other way (type object in, empty node out), which made
+/// `$p.slurpy.defined` answer `True` for every slurpy parameter where rakudo
+/// answers `False`, `$p.slurpy.gist` the full class name where rakudo gists
+/// `(Flattened)`, and `$p.slurpy === RakuAST::Parameter::Slurpy::Flattened`
+/// `False` where rakudo says `True`. On rakudo the test for "is this parameter
+/// slurpy?" is which CLASS of type object the field holds, never definedness
+/// (GH #8157).
+///
+/// Both spellings are accepted on the way in: rakudo's `.new` takes only the
+/// type object, and that is what `t/rakuast/rakuast-construct-rich-parameters.t`
+/// passes, but a node of the same class is an unambiguous way to name the same
+/// marker and there is nothing to gain from rejecting it.
+pub(crate) fn slurpy_marker_value(class: RakuAstClass) -> Value {
+    Value::package(crate::symbol::Symbol::intern(class.printed_name()))
+}
+
+/// The slurpy class a field's value names, whichever of the two spellings it
+/// uses. `None` for anything that is not a slurpy marker.
+pub(crate) fn slurpy_marker_class(value: &Value) -> Option<RakuAstClass> {
+    match value.view() {
         ValueView::RakuAst(node)
             if matches!(
                 node.class,
                 RakuAstClass::ParameterSlurpyFlattened | RakuAstClass::ParameterSlurpyUnflattened
             ) =>
         {
-            return Ok(value);
+            Some(node.class)
         }
         ValueView::Package(name) => match name.resolve().as_str() {
-            "RakuAST::Parameter::Slurpy::Flattened" => RakuAstClass::ParameterSlurpyFlattened,
-            "RakuAST::Parameter::Slurpy::Unflattened" => RakuAstClass::ParameterSlurpyUnflattened,
-            _ => {
-                return Err(RuntimeError::new(
-                    "RakuAST::Parameter.new expects a RakuAST slurpy marker",
-                ));
+            "RakuAST::Parameter::Slurpy::Flattened" => Some(RakuAstClass::ParameterSlurpyFlattened),
+            "RakuAST::Parameter::Slurpy::Unflattened" => {
+                Some(RakuAstClass::ParameterSlurpyUnflattened)
             }
+            _ => None,
         },
-        _ => {
-            return Err(RuntimeError::new(
-                "RakuAST::Parameter.new expects a RakuAST slurpy marker",
-            ));
-        }
-    };
-    Ok(Value::rakuast(Box::new(RakuAstNode {
-        class,
-        fields: Vec::new(),
-    })))
+        _ => None,
+    }
+}
+
+fn normalize_slurpy_marker(value: Value) -> Result<Value, RuntimeError> {
+    slurpy_marker_class(&value)
+        .map(slurpy_marker_value)
+        .ok_or_else(|| RuntimeError::new("RakuAST::Parameter.new expects a RakuAST slurpy marker"))
 }
 
 /// The class for a single-positional-argument constructor, or `None`.

--- a/src/rakuast/render.rs
+++ b/src/rakuast/render.rs
@@ -174,6 +174,12 @@ fn render_paren_list(items: &[Value], indent: usize) -> String {
 fn render_leaf(v: &Value) -> String {
     match v.view() {
         ValueView::Str(s) => render_str_literal(&s),
+        // A TYPE OBJECT field value renders as its bare class name, not as the
+        // `(Name)` form `Mu.gist` gives a type object on its own: rakudo's
+        // `Parameter` gist shows `slurpy => RakuAST::Parameter::Slurpy::Flattened`
+        // while `.slurpy.gist` alone is `(Flattened)`. See `slurpy_marker_value`
+        // for why the field holds a type object at all (GH #8157).
+        ValueView::Package(name) => name.resolve().to_string(),
         _ => v.to_string_value(),
     }
 }

--- a/t/rakuast/rakuast-slurpy-marker-type-object.t
+++ b/t/rakuast/rakuast-slurpy-marker-type-object.t
@@ -1,0 +1,77 @@
+use v6;
+use experimental :rakuast;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# Rakudo builds NO node for a slurpy marker: the
+# `RakuAST::Parameter::Slurpy::*` type object itself is what `$!slurpy` holds.
+# mutsu normalized the other way -- type object in, empty node out -- so the two
+# rendered identically inside the parent's gist but the field itself read as
+# defined, gisted as the full class name, and compared unequal to the very class
+# it named. On rakudo the test for "is this parameter slurpy?" is which CLASS of
+# type object the field holds, never definedness, so mutsu's `True` was the
+# opposite of useful (#8157).
+#
+# Every expectation below was measured against rakudo.
+
+plan 19;
+
+my $flat = Q[sub f(*@c) { }].AST.statements[0].expression.signature.parameters[0];
+my $unflat = Q[sub h(**@c) { }].AST.statements[0].expression.signature.parameters[0];
+my $plain = Q[sub g($x) { }].AST.statements[0].expression.signature.parameters[0];
+
+# The field holds a type object, so it is undefined.
+nok $flat.slurpy.defined, 'a slurpy marker is a type object, so it is not defined';
+nok $unflat.slurpy.defined, 'the same for **@c';
+nok $plain.slurpy.defined, 'and for a parameter with no marker at all';
+
+# Its name identifies which marker it is.
+is $flat.slurpy.^name, 'RakuAST::Parameter::Slurpy::Flattened',
+    '*@c carries the Flattened marker';
+is $unflat.slurpy.^name, 'RakuAST::Parameter::Slurpy::Unflattened',
+    '**@c carries the Unflattened marker';
+is $plain.slurpy.^name, 'RakuAST::Parameter::Slurpy',
+    'a non-slurpy parameter carries the base class';
+
+# `.gist` of a type object on its own is the short `(Name)` form.
+is $flat.slurpy.gist, '(Flattened)', '.gist of the marker alone is (Flattened)';
+is $unflat.slurpy.gist, '(Unflattened)', 'and (Unflattened)';
+is $plain.slurpy.gist, '(Slurpy)', 'and (Slurpy) for the base class';
+
+# `.raku` is the full class name, unlike `.gist`.
+is $flat.slurpy.raku, 'RakuAST::Parameter::Slurpy::Flattened',
+    '.raku of the marker is its full class name';
+
+# Identity against the class is how rakudo asks which marker this is.
+ok $flat.slurpy === RakuAST::Parameter::Slurpy::Flattened,
+    'the marker is identical to the class it names';
+ok $flat.slurpy =:= RakuAST::Parameter::Slurpy::Flattened,
+    '=:= agrees with ===';
+ok $unflat.slurpy === RakuAST::Parameter::Slurpy::Unflattened,
+    'and for the Unflattened marker';
+nok $flat.slurpy === RakuAST::Parameter::Slurpy::Unflattened,
+    'the two markers are not identical to each other';
+
+# The documented idiom: compare against the BASE class, not `.defined`.
+ok $flat.slurpy !=== RakuAST::Parameter::Slurpy, '*@c is slurpy by the base-class test';
+nok $plain.slurpy !=== RakuAST::Parameter::Slurpy, '$x is not';
+
+# Type-check membership is unchanged.
+ok $flat.slurpy ~~ RakuAST::Parameter::Slurpy, 'the marker does the base class';
+
+# The parent's gist still shows the marker as its bare class name -- a type
+# object renders differently inside a node's gist than it does alone.
+ok Q[sub f(*@c) { }].AST.gist.contains('slurpy => RakuAST::Parameter::Slurpy::Flattened'),
+    "the parent's gist renders the marker as its bare class name";
+
+# A hand-built parameter keeps the type object it was given, and still lowers.
+{
+    my $built = RakuAST::Parameter.new(
+        target => RakuAST::ParameterTarget::Var.new(name => '@values'),
+        slurpy => RakuAST::Parameter::Slurpy::Flattened,
+    );
+    ok $built.slurpy === RakuAST::Parameter::Slurpy::Flattened,
+        '.new keeps the type object it was handed';
+}
+
+done-testing;


### PR DESCRIPTION
## The gap

Rakudo builds **no node** for a slurpy parameter's marker: the `RakuAST::Parameter::Slurpy::*` type object itself is what `$!slurpy` holds. mutsu normalized the other way round — it took the type object on the way in and stored an empty node of that class. The two render identically inside the parent's gist, so `.gist` of a whole tree matched byte for byte and the difference hid on the field itself:

```raku
my $p = Q[sub f(*@c) { }].AST.statements[0].expression.signature.parameters[0];
say $p.slurpy.defined;   # mutsu: True   raku: False
say $p.slurpy.gist;      # mutsu: RakuAST::Parameter::Slurpy::Flattened
                         #  raku: (Flattened)
say $p.slurpy === RakuAST::Parameter::Slurpy::Flattened;
                         # mutsu: False  raku: True
```

The `.defined` answer was the damaging one. On rakudo the question "is this parameter slurpy?" is **which class** of type object the field holds (`$p.slurpy !=== RakuAST::Parameter::Slurpy`), never definedness — so mutsu answered `True` for every parameter carrying a marker where rakudo answers `False` for all of them, the exact opposite of useful. The identity comparison rakudo's own idiom relies on could not work at all, because a node is never identical to a class.

## The fix

`normalize_slurpy_marker` now normalizes **to** the type object rather than away from it, and the two constructing sites (`convert.rs`'s `slurpy_parameter`, `formatter.rs`'s synthesised `-> *@args` block) store that value directly. Both input spellings are still accepted: rakudo's `.new` takes only the type object, which is what `t/rakuast/rakuast-construct-rich-parameters.t` already passes, but a node of the same class names the same marker unambiguously and there was nothing to gain from rejecting it. `slurpy_marker_class` is the single place that reads either spelling, so the lowerer no longer matches on a node class.

Because the field now holds the same `Package` the bareword `RakuAST::Parameter::Slurpy::Flattened` already evaluated to, `.defined`, `.gist`, `.raku`, `===`, `=:=` and `~~` all came out right with no per-method work — mutsu's type-object surface was already correct, the field just was not holding one.

One renderer change goes with it: a type-object field value renders as its bare class name. That is genuinely different from how a type object gists alone — rakudo's `Parameter` gist shows `slurpy => RakuAST::Parameter::Slurpy::Flattened` while `.slurpy.gist` is `(Flattened)` — so the two spellings had to be kept apart rather than unified.

`src/rakuast/fields.rs` needed nothing: its declared absent value was already the type object `RakuAST::Parameter::Slurpy`, which is why the *non-slurpy* case (`sub g($x)`) reported `.defined` `False` and gisted `(Slurpy)` correctly all along — the inconsistency was only between a present marker and an absent one.

## Verification

The issue's whole repro script, extended to cover the identity comparisons, both markers, and the non-slurpy parameter, is now byte-identical between mutsu and rakudo. Pinned by `t/rakuast/rakuast-slurpy-marker-type-object.t` — 19 assertions measured against rakudo first (19/19 under `raku` as well as under mutsu), covering both markers and the base class, `.defined`, `.gist`, `.raku`, `===`/`=:=` in both directions, the documented base-class idiom, `~~` membership, the parent's gist rendering, and a hand-built parameter keeping the type object it was given.

`t/rakuast` (123 files) passes, including the two named pins.

## Suites

- `cargo fmt --all`, `make lint` — clean (all four configurations).
- `make test` — PASS, 4137 files / 44050 tests.
- `make roast` — green apart from the three documented container-only files: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8 and 10), `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125), `roast/S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17) — matching `docs/agent-environments.md` by name and by subtest range.

Closes #8157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_