### PR TITLE
perf(regex): the subrule atom answers its own questions

### DIFF
--- a/news/2026-09/the-subrule-atom-answers-its-own-questions.md
+++ b/news/2026-09/the-subrule-atom-answers-its-own-questions.md
@@ -1,0 +1,92 @@
+# The subrule atom answers its own questions
+
+Round 20 of [#7576](https://github.com/tokuhirom/mutsu/issues/7576). Instructions
+on the 60-row YAMLish document go **1,277,410,693 -> 1,239,208,554 (-2.99%)**.
+Attribution is callgrind `Ir` throughout, cache warmed first.
+
+Both items are the same shape: a question whose answer was already fixed before
+the matcher started, asked again on every atom match.
+
+## (a) 402,202 calls to arm a seed that nothing reads (-1.63%)
+
+Every atom match calls `arm_inline_vars_seed`, which publishes two things to the
+nested walks the atom is about to run: the enclosing regex's `:my`/`:let`
+lexicals, and the enclosing level's captures for a backreference to resolve
+against. Both are real mechanisms with real tests behind them — and on this
+workload both are inert. The function ran **402,202 times and touched a
+thread-local in 507 of them**.
+
+It still cost 1.63% of the whole program: 20.2 M `Ir` in the call itself (a
+seven-way `matches!` over the atom, two seed constructions, an out-of-line call
+and return) plus 6.0 M more in `drop_in_place<(InlineVarsSeed, OuterCapsSeed)>`,
+the out-of-line drop glue for two guards that each immediately found `armed:
+false`.
+
+Neither "is anything published" question needs to look at the atom at all:
+`any_regex_backref_lowered()` is a process-global `AtomicBool` the parser sets
+the first time it lowers a backreference anywhere, and "is a lexical published"
+is a thread-local `Cell<bool>` plus `current_caps.regex_vars_shared()`. When all
+three say no, whichever branch the function would have taken arms
+`InlineVarsSeed::arm(None)` against an empty slot (inert) and
+`OuterCapsSeed::inert()` — so the fast path returns exactly the pair the slow
+path would have built. It is `#[inline]` now, with the real work behind
+`#[inline(never)] arm_inline_vars_seed_cold`, and the two `Drop` impls are
+`#[inline]` so the inert case leaves no drop glue to call. In the profile the
+function disappears and the cold path is left at 40,597 `Ir`.
+
+The cold path is unchanged and stays pinned by
+`t/regex/regex-backref-in-group.t` (the capture-scope rules, all fourteen
+verified against raku) and `t/regex/regex-my-var-in-subpattern.t` (a `:my`
+lexical reaching every flavour of inline sub-pattern).
+
+## (b) A `<subrule>` atom's lookup spec, re-derived per call (-1.35%)
+
+`parse_named_regex_lookup_spec` turns the text between the angle brackets into
+the spec the matcher acts on: silent or not, token-lookup or not, the alias and
+whether it replaces the original, the interned lookup and capture names, the
+argument expressions. It is a pure function of the text, and the text is fixed
+once the pattern is parsed. It was memoized — on a process-wide
+`FxHashMap<String, Arc<NamedRegexLookupSpec>>`, probed **113,590 times** on this
+parse for 17.2 M `Ir`, every probe hashing the same atom text again to hand back
+the same `Arc`.
+
+`RegexAtom::Named` carries a `NamedAtom` now: the text, plus a `OnceLock` for
+the spec derived from it. The callers all hold that node — they matched on it to
+get the `&str` they were passing — so they ask it directly. The first ask still
+goes through the global memo, so two atoms spelled the same still share one
+`Arc` exactly as before; every later one is an initialized `OnceLock` read. The
+compiler enumerated the change: 16 construction sites take `.into()`, and 14 of
+the 18 spec lookups became `name.spec()` where the node was in hand (the four that
+work from a runtime-built string — `<::(EXPR)>` indirection, an interpolated
+pattern, the call-graph walk's memo miss — keep the global entry point).
+
+Pinned by `t/regex/regex-named-atom-spec-forms.t`: one of each atom shape the
+spec distinguishes (plain, `<.silent>`, `<al=word>` under both names,
+`<dot=.word>`, `<rule(args)>`, a quantified subrule) plus two grammars whose
+identical atom text must resolve to their own rules — the spec is shared per
+text, the resolution is not. Verified against rakudo 2026.07.
+
+## Where the next round starts
+
+Re-measured after this round, not carried forward from round 19 (see round 12's
+note — round 19's own winner was not on round 18's list):
+
+- **Left-recursion bookkeeping is now the largest single cluster, ~3.6%.** The
+  two biggest remaining thread-local clients are `for_each_atom_candidate`
+  (22.2 M, 134,850 calls) and `regex_match_atom_all_with_capture_in_pkg_inner`
+  (22.0 M, 130,045), and in both it is the inlined `lr_begin_or_reenter` /
+  `lr_seed_was_consulted` / `lr_end_activation` trio — three hash-map operations
+  per `<subrule>` call on a grammar with no left recursion at all. The gate
+  (`regex_call_graph::reenter_decline`) already exists; what makes it not a
+  slice is that `LrKey` carries no package while the analysis is per-package,
+  and a wrong `None` fails as unbounded recursion rather than a wrong answer.
+- `Symbol::intern` at 2.34% (209,401 interns, diffuse callers).
+- `subrule_call_stream_decline` at 0.61% — 46,677 probes of a
+  `(pkg, atom text)` memo, now that the atom is a node that could hold the
+  verdict itself; needs a `Sync` cache, since the verdict is keyed by token
+  generation and package rather than once-only.
+- The capture store (`CapStore::merge_delta` 1.79% self, `RegexCaptures::clone`,
+  `rewind`) is unchanged and still wants a design pass rather than a slice.
+
+Cumulative over rounds 11-20 on the 60-row document: **8.130 Bn -> 1.239 Bn `Ir`
+(-84.8%)**.

--- a/src/runtime/regex/regex_call_graph.rs
+++ b/src/runtime/regex/regex_call_graph.rs
@@ -479,7 +479,7 @@ fn collect_atom_calls(atom: &RegexAtom, pkg: Symbol, out: &mut Vec<RuleNode>) ->
             true
         }
         RegexAtom::Named(name) => {
-            let spec = Interpreter::parse_named_regex_lookup_spec(name);
+            let spec = name.spec();
             // `<::(EXPR)>` names its target at runtime, and a rule call with
             // arguments resolves per argument list — neither is a static edge.
             if spec.lookup_name == "::" || !spec.arg_exprs.is_empty() {

--- a/src/runtime/regex/regex_casefold.rs
+++ b/src/runtime/regex/regex_casefold.rs
@@ -175,7 +175,7 @@ fn casefold_atom(atom: &RegexAtom) -> CasefoldedAtom {
         RegexAtom::Named(name) => {
             // Case-fold the literal name text
             let folded: String = name.chars().flat_map(casefold_char).collect();
-            CasefoldedAtom::Single(RegexAtom::Named(folded))
+            CasefoldedAtom::Single(RegexAtom::Named(folded.into()))
         }
         RegexAtom::Group(p) => CasefoldedAtom::Single(RegexAtom::Group(casefold_pattern(p))),
         RegexAtom::CaptureGroup(p) => {

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -135,6 +135,7 @@ impl OuterCapsSeed {
     }
 
     /// Leave the enclosing atom's seed in place untouched.
+    #[inline]
     pub(crate) fn inert() -> Self {
         OuterCapsSeed {
             prev: None,
@@ -144,6 +145,7 @@ impl OuterCapsSeed {
 }
 
 impl Drop for OuterCapsSeed {
+    #[inline]
     fn drop(&mut self) {
         if !self.armed {
             return;
@@ -188,6 +190,14 @@ pub(crate) fn atom_contains_backref(atom: &RegexAtom) -> bool {
     }
 }
 
+/// Is anything published in [`INLINE_REGEX_VARS_SEED`] right now? A `false`
+/// means an atom that has no lexicals of its own to publish cannot change what
+/// any nested store would see, so it need not arm the seed at all.
+#[inline]
+pub(crate) fn inline_regex_vars_active() -> bool {
+    INLINE_REGEX_VARS_ACTIVE.with(Cell::get)
+}
+
 /// Arms the [`INLINE_REGEX_VARS_SEED`] for the duration of one atom match,
 /// restoring the enclosing atom's seed on drop. An atom that is an inline
 /// sub-pattern arms it with the lexicals in scope; every other atom — a subrule
@@ -202,6 +212,7 @@ impl InlineVarsSeed {
     /// Publish `vars` (already a shared handle — `None` means "publish
     /// nothing", which is what a subrule reference arms) for the duration of
     /// one atom match.
+    #[inline]
     pub(crate) fn arm(vars: Option<&std::sync::Arc<crate::runtime::RegexVarMap>>) -> Self {
         let active = INLINE_REGEX_VARS_ACTIVE.with(Cell::get);
         if vars.is_none() && !active {
@@ -217,9 +228,21 @@ impl InlineVarsSeed {
         let prev = INLINE_REGEX_VARS_SEED.with(|s| std::mem::replace(&mut *s.borrow_mut(), next));
         InlineVarsSeed { prev, armed: true }
     }
+
+    /// Leave the enclosing atom's seed in place untouched. Equivalent to
+    /// [`Self::arm`]`(None)` when nothing is published, without asking the
+    /// thread-local whether anything is.
+    #[inline]
+    pub(crate) fn inert() -> Self {
+        InlineVarsSeed {
+            prev: None,
+            armed: false,
+        }
+    }
 }
 
 impl Drop for InlineVarsSeed {
+    #[inline]
     fn drop(&mut self) {
         if !self.armed {
             return;
@@ -640,7 +663,7 @@ fn strip_marks_atom(atom: &RegexAtom) -> RegexAtom {
         RegexAtom::Named(name) => {
             // Named subrule / literal string match — strip marks from the name
             let stripped: String = name.nfd().filter(|c| !is_combining_mark(*c)).collect();
-            RegexAtom::Named(stripped)
+            RegexAtom::Named(stripped.into())
         }
         RegexAtom::Group(p) => RegexAtom::Group(strip_marks_pattern(p)),
         RegexAtom::CaptureGroup(p) => RegexAtom::CaptureGroup(strip_marks_pattern(p)),
@@ -886,28 +909,28 @@ impl Iterator for CaseFoldIter {
     }
 }
 
-pub(super) struct NamedRegexLookupSpec {
-    pub(super) silent: bool,
-    pub(super) token_lookup: bool,
-    pub(super) lookup_name: String,
+pub(crate) struct NamedRegexLookupSpec {
+    pub(crate) silent: bool,
+    pub(crate) token_lookup: bool,
+    pub(crate) lookup_name: String,
     /// [`Self::lookup_name`] interned. The spec itself is memoized per atom
     /// text, so this interns once per distinct `<subrule>` atom in the program
     /// rather than once per call — the left-recursion key is built from it on
     /// every subrule call at every position
     /// ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
-    pub(super) lookup_sym: crate::symbol::Symbol,
-    pub(super) capture_name: Option<String>,
+    pub(crate) lookup_sym: crate::symbol::Symbol,
+    pub(crate) capture_name: Option<String>,
     /// [`Self::capture_name`] interned, `None` when the atom carries no alias.
     /// Interned with the spec (once per distinct `<subrule>` atom) rather than
     /// per candidate: `build_named_candidates_from_inner` files every matched
     /// subrule under this name, so interning it there re-hashed the same string
     /// once per capture -- 37,012 interns on a 60-row YAML parse
     /// ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
-    pub(super) capture_sym: Option<crate::symbol::Symbol>,
-    pub(super) arg_exprs: Vec<String>,
+    pub(crate) capture_sym: Option<crate::symbol::Symbol>,
+    pub(crate) arg_exprs: Vec<String>,
     /// When true, the alias replaces the original capture name (dot-call alias).
     /// `<foo=.alpha>` sets this to true; `<foo=alpha>` leaves it false.
-    pub(super) alias_replaces_original: bool,
+    pub(crate) alias_replaces_original: bool,
 }
 
 /// Check if a character is a "word" character for word boundary purposes.

--- a/src/runtime/regex/regex_ltm_rank.rs
+++ b/src/runtime/regex/regex_ltm_rank.rs
@@ -324,18 +324,18 @@ impl Interpreter {
                     }
                 }
                 RegexAtom::Named(name) => {
-                    if depth >= LTM_LITLEN_MAX_DEPTH || seen.contains(name) {
+                    if depth >= LTM_LITLEN_MAX_DEPTH || seen.contains(name.text()) {
                         return (acc, false);
                     }
-                    let spec = Self::parse_named_regex_lookup_spec(name);
+                    let spec = name.spec();
                     if !spec.arg_exprs.is_empty() {
                         return (acc, false);
                     }
-                    let (candidates, raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &[]);
+                    let (candidates, raw_empty) = self.parsed_subrule_candidates(spec, pkg, &[]);
                     if raw_empty {
                         return (acc, false);
                     }
-                    seen.insert(name.clone());
+                    seen.insert(name.text().to_string());
                     let mut best = 0usize;
                     let mut all_full = true;
                     for (cand_pattern, cand_pkg, _sym) in candidates.iter() {
@@ -350,7 +350,7 @@ impl Interpreter {
                         best = best.max(len);
                         all_full &= full;
                     }
-                    seen.remove(name);
+                    seen.remove(name.text());
                     acc += best;
                     if !all_full {
                         return (acc, false);

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -480,7 +480,7 @@ impl Interpreter {
             }
             out
         } else if let RegexAtom::Named(name) = atom {
-            let spec = Self::parse_named_regex_lookup_spec(name);
+            let spec = name.spec().clone();
             // Symbolic indirect subrule `<::(EXPR)>`: evaluate EXPR to obtain
             // the rule name dynamically, then dispatch as if it were `<NAME>`.
             // This must resolve through the same path as a literal subrule so
@@ -491,7 +491,7 @@ impl Interpreter {
                     return Vec::new();
                 };
                 let dyn_name = val.to_string_value();
-                let dyn_atom = RegexAtom::Named(dyn_name);
+                let dyn_atom = RegexAtom::Named(dyn_name.into());
                 return self.regex_match_atom_all_with_capture_opts(
                     &dyn_atom,
                     chars,

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -510,7 +510,7 @@ impl Interpreter {
             _ => {}
         }
         if let RegexAtom::Named(name) = atom {
-            let spec = Self::parse_named_regex_lookup_spec(name);
+            let spec = name.spec();
             let default_caps = RegexCaptures::default();
             let arg_values = if spec.arg_exprs.is_empty() {
                 Vec::new()
@@ -520,7 +520,7 @@ impl Interpreter {
             // Establish the subrule's `$*`-twigil parameters for the whole
             // resolve-and-match (see `regex_dynparams`); the wrapper restores.
             *dyn_saved = self.install_subrule_dynamic_params(&spec.lookup_name, pkg, &arg_values);
-            let candidates = self.resolve_named_regex_candidates_in_pkg(&spec, pkg, &arg_values);
+            let candidates = self.resolve_named_regex_candidates_in_pkg(spec, pkg, &arg_values);
             if !candidates.is_empty() {
                 let remaining: String = chars[pos..].iter().collect();
                 let mut best_len: Option<usize> = None;
@@ -666,7 +666,7 @@ impl Interpreter {
                 }
             }
             RegexAtom::Named(name) => {
-                let spec = Self::parse_named_regex_lookup_spec(name);
+                let spec = name.spec();
                 if spec.token_lookup || !spec.arg_exprs.is_empty() {
                     return None;
                 }
@@ -844,7 +844,7 @@ impl Interpreter {
         if matched {
             match atom {
                 RegexAtom::Named(name) => {
-                    let spec = Self::parse_named_regex_lookup_spec(name);
+                    let spec = name.spec();
                     Some(pos + spec.lookup_name.chars().count())
                 }
                 // Literal matches advance by exactly 1 codepoint — they do

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -27,7 +27,41 @@ impl Interpreter {
     /// enclosing level's captures for the sub-pattern matches this atom is
     /// about to run. See [`super::regex_helpers::INLINE_REGEX_VARS_SEED`] and
     /// [`super::regex_helpers::INLINE_OUTER_CAPS_SEED`].
+    ///
+    /// Every atom match calls this, and on a grammar that publishes neither
+    /// mechanism every call is a no-op: on a 60-row YAMLish parse it ran
+    /// 402,202 times and touched a thread-local 507 of them, for 1.63% of the
+    /// program between the call, the two seed constructions and their drop glue
+    /// ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)). Both "is
+    /// anything published" questions are answered without looking at the atom
+    /// at all, so they gate an inlined early-out and the real work moves to an
+    /// out-of-line cold path.
+    #[inline]
     pub(super) fn arm_inline_vars_seed(
+        atom: &RegexAtom,
+        current_caps: &RegexCaptures,
+    ) -> (
+        super::regex_helpers::InlineVarsSeed,
+        super::regex_helpers::OuterCapsSeed,
+    ) {
+        use super::regex_helpers::{
+            InlineVarsSeed, OuterCapsSeed, any_regex_backref_lowered, inline_regex_vars_active,
+        };
+        // Nothing published and nothing to publish: whichever branch the cold
+        // path would take, it arms `InlineVarsSeed::arm(None)` with the slot
+        // already empty (inert) and, with no backreference lowered anywhere in
+        // the process, `OuterCapsSeed::inert()`.
+        if !any_regex_backref_lowered()
+            && !inline_regex_vars_active()
+            && current_caps.regex_vars_shared().is_none()
+        {
+            return (InlineVarsSeed::inert(), OuterCapsSeed::inert());
+        }
+        Self::arm_inline_vars_seed_cold(atom, current_caps)
+    }
+
+    #[inline(never)]
+    fn arm_inline_vars_seed_cold(
         atom: &RegexAtom,
         current_caps: &RegexCaptures,
     ) -> (
@@ -785,13 +819,13 @@ impl Interpreter {
             _ => {}
         }
         if let RegexAtom::Named(name) = atom {
-            let spec = Self::parse_named_regex_lookup_spec(name);
+            let spec = name.spec().clone();
             // Symbolic indirect subrule `<::(EXPR)>`: evaluate EXPR to obtain the
             // dynamic rule name, then dispatch as if it were `<NAME>` so that
             // builtin character classes and user-defined tokens both resolve.
             if spec.lookup_name == "::" && spec.arg_exprs.len() == 1 {
                 let val = self.eval_regex_expr_value(&spec.arg_exprs[0], current_caps)?;
-                let dyn_atom = RegexAtom::Named(val.to_string_value());
+                let dyn_atom = RegexAtom::Named(val.to_string_value().into());
                 return self
                     .regex_match_atom_all_with_capture_in_pkg(
                         &dyn_atom,
@@ -1043,7 +1077,7 @@ impl Interpreter {
         }
         match atom {
             RegexAtom::Named(name) => {
-                let spec = Self::parse_named_regex_lookup_spec(name);
+                let spec = name.spec();
                 if spec.token_lookup {
                     return None;
                 }

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -84,7 +84,7 @@ impl Interpreter {
     fn collect_named_captures_in_atom(atom: &RegexAtom, out: &mut HashSet<String>) {
         match atom {
             RegexAtom::Named(name) => {
-                let spec = Self::parse_named_regex_lookup_spec(name);
+                let spec = name.spec();
                 if !spec.silent {
                     // A non-suppressing alias captures under BOTH names (see
                     // `also_under_original` in `regex_match_atom.rs`), so both are
@@ -413,7 +413,7 @@ impl Interpreter {
         let subrule_subcap = if group_subcap.is_none()
             && let RegexAtom::Named(atom_name) = &token.atom
         {
-            let spec = Self::parse_named_regex_lookup_spec(atom_name);
+            let spec = atom_name.spec();
             let own_key = spec
                 .capture_name
                 .clone()
@@ -454,7 +454,7 @@ impl Interpreter {
         // never be dispatched. Preserve the original rule name on the alias
         // node, just as the `<alias=.subrule>` spelling does in the matcher.
         if let RegexAtom::Named(atom_name) = &token.atom {
-            let spec = Self::parse_named_regex_lookup_spec(atom_name);
+            let spec = atom_name.spec();
             if spec.silent && !spec.lookup_name.is_empty() {
                 std::sync::Arc::make_mut(&mut sub).action_name = Some(spec.lookup_name.clone());
             }
@@ -467,7 +467,7 @@ impl Interpreter {
         // per node: one alias name can select different rules in different
         // alternatives (`$<part> = <text> || $<part> = <code>`).
         if let RegexAtom::Named(atom_name) = &token.atom {
-            let spec = Self::parse_named_regex_lookup_spec(atom_name);
+            let spec = atom_name.spec();
             if !spec.silent
                 && !spec.lookup_name.is_empty()
                 && name != &spec.lookup_name

--- a/src/runtime/regex/regex_match_lazy_subrule.rs
+++ b/src/runtime/regex/regex_match_lazy_subrule.rs
@@ -50,7 +50,7 @@ impl Interpreter {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn drive_named_subrule_candidates(
         &mut self,
-        name: &str,
+        name: &crate::runtime::regex_types::NamedAtom,
         chars: &[char],
         pos: usize,
         store: &mut CapStore,
@@ -78,7 +78,7 @@ impl Interpreter {
         if let Some(reason) = self.subrule_call_stream_decline(name, pkg) {
             return decline(reason);
         }
-        let spec = Self::parse_named_regex_lookup_spec(name);
+        let spec = name.spec();
         let lr_key = super::regex_lr_state::LrKey::new(spec.lookup_sym, None, chars.len() - pos);
         if super::regex_lr_state::lr_key_is_active(&lr_key) {
             return decline(StreamDecline::LrKeyActive);
@@ -86,7 +86,7 @@ impl Interpreter {
         // Same resolution the eager arm performs (memoized for a static body,
         // per-call otherwise). The shape was settled above, but a body that is
         // re-parsed per call is re-checked rather than assumed.
-        let (candidates, _) = self.parsed_subrule_candidates(&spec, pkg, &[]);
+        let (candidates, _) = self.parsed_subrule_candidates(spec, pkg, &[]);
         let [(parsed, sub_pkg, sym_key)] = &candidates[..] else {
             return decline(StreamDecline::SeveralCandidates);
         };
@@ -116,7 +116,7 @@ impl Interpreter {
                 let wrapped = Interpreter::build_named_candidates_from_inner(
                     vec![(end, inner)],
                     pos,
-                    &spec,
+                    spec,
                     None,
                 );
                 let Some((end, delta)) = wrapped.into_iter().next() else {

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -131,14 +131,14 @@ impl Interpreter {
         let RegexAtom::Named(name) = atom else {
             return None;
         };
-        let spec = Self::parse_named_regex_lookup_spec(name);
+        let spec = name.spec();
         if !spec.arg_exprs.is_empty() {
             return None;
         }
         // Memoized resolution+parse (PARSED_TOKEN_CANDIDATES); this fast path
         // runs per quantifier iteration, so the per-call registry walk it used
         // to do was pure overhead. None (non-static pattern) → no fast path.
-        let (candidates, _raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &[]);
+        let (candidates, _raw_empty) = self.parsed_subrule_candidates(spec, pkg, &[]);
         if candidates.len() != 1 {
             return None;
         }

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -543,7 +543,7 @@ impl Interpreter {
     /// [`crate::runtime::regex_parse::REGEX_PARSE_CACHE`] — this memo needs no
     /// generation key: a rule (re)definition cannot change how its *reference*
     /// spells itself.
-    pub(super) fn parse_named_regex_lookup_spec(
+    pub(crate) fn parse_named_regex_lookup_spec(
         name: &str,
     ) -> std::sync::Arc<NamedRegexLookupSpec> {
         if let Some(hit) = NAMED_LOOKUP_SPEC_CACHE.with(|c| c.borrow().get(name).cloned()) {

--- a/src/runtime/regex_parse_charclass.rs
+++ b/src/runtime/regex_parse_charclass.rs
@@ -1047,7 +1047,7 @@ impl Interpreter {
             .into_iter()
             // Prefix with `.` so the subrule is matched *silently* (no named
             // capture) — a character class never captures.
-            .map(|name| guard_pattern(make_pattern(RegexAtom::Named(format!(".{name}")))))
+            .map(|name| guard_pattern(make_pattern(RegexAtom::Named(format!(".{name}").into()))))
             .collect();
         // Statically-folded token bodies join the alternation directly (they
         // are closed patterns: no captures, no runtime resolution).

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -455,7 +455,7 @@ impl Interpreter {
     ) -> RegexAtom {
         let inner_pattern = RegexPattern {
             tokens: vec![RegexToken {
-                atom: RegexAtom::Named(subrule.to_string()),
+                atom: RegexAtom::Named(subrule.to_string().into()),
                 quant: RegexQuant::One,
                 named_capture: None,
                 hash_capture: None,
@@ -2793,7 +2793,7 @@ impl Interpreter {
                                     && mode == RegexParseMode::Validate
                                 {
                                     // <?@var> / <!@var> lookahead — opaque at parse time.
-                                    RegexAtom::Named(name.clone())
+                                    RegexAtom::Named(name.clone().into())
                                 } else if trimmed.starts_with("?@") || trimmed.starts_with("!@") {
                                     // <?@var> / <!@var> — zero-width lookahead asserting the
                                     // position matches (or, negated, does not match) any
@@ -2840,7 +2840,7 @@ impl Interpreter {
                                 } else if let Some(negated_name) = trimmed.strip_prefix('!') {
                                     if negated_name.is_empty() {
                                         // <!> — always-fail (handled as Named("!") downstream)
-                                        RegexAtom::Named(name)
+                                        RegexAtom::Named(name.into())
                                     } else if negated_name == "same" || negated_name == ".same" {
                                         // <!same> — zero-width assertion: next two chars are different
                                         RegexAtom::SameAssertion { negated: true }
@@ -2998,7 +2998,7 @@ impl Interpreter {
                                             }
                                         } else {
                                             // Not a known builtin — pass through as Named
-                                            RegexAtom::Named(name)
+                                            RegexAtom::Named(name.into())
                                         }
                                     } // close else (non-empty negated_name)
                                 } else if trimmed.starts_with("::") {
@@ -3006,7 +3006,7 @@ impl Interpreter {
                                     // double colon distinguishes it from a `<:PropName>`
                                     // Unicode-property assertion; keep it as a Named atom
                                     // so the dynamic name is resolved at match time.
-                                    RegexAtom::Named(name)
+                                    RegexAtom::Named(name.into())
                                 } else if trimmed.starts_with(":!") || trimmed.starts_with("-:") {
                                     // <:!PropName> or <-:PropName> — negated Unicode property
                                     let prop_name = &trimmed[2..];
@@ -3101,7 +3101,7 @@ impl Interpreter {
                                     // <$var> interpolation — opaque at parse time (the variable's
                                     // value is unavailable). Accept it as a syntactically-valid
                                     // assertion; the runtime `Match` path below resolves it.
-                                    RegexAtom::Named(name.clone())
+                                    RegexAtom::Named(name.clone().into())
                                 } else if let Some(var_name) = trimmed.strip_prefix('$') {
                                     // <$var> — look up scalar variable and compile as regex.
                                     // The `${name}` fallback and `.into_deref()` mirror the
@@ -3233,7 +3233,7 @@ impl Interpreter {
                                     && mode == RegexParseMode::Validate
                                 {
                                     // <@var> interpolation — opaque at parse time.
-                                    RegexAtom::Named(name.clone())
+                                    RegexAtom::Named(name.clone().into())
                                 } else if trimmed.starts_with('@') {
                                     // <@var> — look up array variable and compile
                                     // each element as a regex pattern (alternation).
@@ -3402,7 +3402,7 @@ impl Interpreter {
                                     match crate::runtime::regex_parse::TopLevelSourceScope::current(
                                     ) {
                                         Some(src) => RegexAtom::RecurseSelf(Box::from(&*src)),
-                                        None => RegexAtom::Named(name),
+                                        None => RegexAtom::Named(name.into()),
                                     }
                                 } else if trimmed == "|w" {
                                     // <|w> — zero-width assertion at a boundary of the
@@ -3415,7 +3415,7 @@ impl Interpreter {
                                     if let Ok(pos) = inner.trim().parse::<usize>() {
                                         RegexAtom::AtPosition(pos)
                                     } else {
-                                        RegexAtom::Named(name)
+                                        RegexAtom::Named(name.into())
                                     }
                                 } else if let Some(sub) = trimmed
                                     .strip_prefix('?')
@@ -3462,7 +3462,7 @@ impl Interpreter {
                                         && !self.current_package().is_empty()
                                         && self.resolve_token_defs(class_name).is_some();
                                     if grammar_overrides_builtin {
-                                        RegexAtom::Named(name)
+                                        RegexAtom::Named(name.into())
                                     } else {
                                         // Check for named character classes
                                         match class_name {
@@ -3574,7 +3574,7 @@ impl Interpreter {
                                                     });
                                                     return None;
                                                 }
-                                                RegexAtom::Named(name)
+                                                RegexAtom::Named(name.into())
                                             }
                                         }
                                     } // close else of grammar_overrides_builtin

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -793,10 +793,87 @@ pub(crate) struct RegexSeparatorSpec {
     pub(crate) allow_trailing: bool,
 }
 
+/// A `<subrule>` atom's written text, with its parsed lookup spec memoized
+/// alongside it.
+///
+/// The spec (silent/token flavour, alias, interned names, argument
+/// expressions) is a pure function of the text, and the text is fixed once the
+/// pattern is parsed — but the matcher asked for it per *call*, through a
+/// process-wide `text -> spec` map: 113,480 probes and 1.35% of a 60-row
+/// YAMLish parse, all of them re-deriving what one node had already answered
+/// ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)). Answering it from
+/// the node costs one already-initialized `OnceLock` read.
+///
+/// The first read still goes through
+/// [`Interpreter::parse_named_regex_lookup_spec`](crate::runtime::Interpreter),
+/// so two atoms spelled the same share one `Arc` exactly as before.
+#[derive(Clone, Default)]
+pub(crate) struct NamedAtom {
+    text: String,
+    spec: std::sync::OnceLock<Arc<crate::runtime::regex::regex_helpers::NamedRegexLookupSpec>>,
+}
+
+impl NamedAtom {
+    /// The atom exactly as written between the angle brackets.
+    #[inline]
+    pub(crate) fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// This atom's parsed lookup spec, derived once.
+    #[inline]
+    pub(crate) fn spec(&self) -> &Arc<crate::runtime::regex::regex_helpers::NamedRegexLookupSpec> {
+        self.spec
+            .get_or_init(|| crate::runtime::Interpreter::parse_named_regex_lookup_spec(&self.text))
+    }
+}
+
+impl From<String> for NamedAtom {
+    fn from(text: String) -> Self {
+        NamedAtom {
+            text,
+            spec: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl From<&str> for NamedAtom {
+    fn from(text: &str) -> Self {
+        NamedAtom::from(text.to_string())
+    }
+}
+
+impl std::ops::Deref for NamedAtom {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        &self.text
+    }
+}
+
+impl std::fmt::Display for NamedAtom {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.text)
+    }
+}
+
+impl PartialEq<str> for NamedAtom {
+    fn eq(&self, other: &str) -> bool {
+        self.text == other
+    }
+}
+
+impl PartialEq<&str> for NamedAtom {
+    fn eq(&self, other: &&str) -> bool {
+        self.text == *other
+    }
+}
+
 #[derive(Clone)]
 pub(crate) enum RegexAtom {
     Literal(char),
-    Named(String),
+    Named(NamedAtom),
     Any,
     CharClass(CharClass),
     /// `<.ws>` — Raku's word-boundary-aware whitespace rule:

--- a/t/regex/regex-named-atom-spec-forms.t
+++ b/t/regex/regex-named-atom-spec-forms.t
@@ -1,0 +1,51 @@
+use Test;
+
+# A `<subrule>` atom's lookup spec — silent or not, aliased or not, with or
+# without arguments — is a pure function of the atom text, and the matcher used
+# to re-derive it per call through a process-wide `text -> spec` map. It is
+# memoized on the atom node now (`NamedAtom::spec`), so the derivation happens
+# once per written atom instead of once per call
+# (https://github.com/tokuhirom/mutsu/issues/7576).
+#
+# The spec is what decides the capture NAME and visibility of every one of these
+# forms, so this file pins one of each: a wrong or stale spec on a node shows up
+# directly as a capture filed under the wrong key (or not at all). Verified
+# against rakudo 2026.07.
+
+plan 10;
+
+grammar G {
+    token TOP     { <plain> ' ' <.silent> ' ' <al=word> ' ' <dot=.word> }
+    token plain   { \w+ }
+    token silent  { \w+ }
+    token word    { \w+ }
+}
+
+my $m = G.parse('aa bb cc dd');
+ok $m.defined, 'the whole mixture of subrule forms parses';
+is $m<plain>.Str, 'aa', 'a plain <subrule> captures under its own name';
+nok ($m<silent>:exists), 'a silent <.subrule> captures nothing';
+is $m<al>.Str, 'cc', 'a non-suppressing alias <al=word> captures under the alias';
+is $m<word>.Str, 'cc', '...and under the original rule name too';
+is $m<dot>.Str, 'dd', 'a dot alias <dot=.word> captures under the alias only';
+nok ($m<TOP>:exists), 'no stray capture leaked in';
+
+grammar Args {
+    token TOP     { <rep(3)> }
+    token rep($n) { \w ** {$n} }
+}
+is Args.parse('xyz')<rep>.Str, 'xyz', 'a parameterized <rule(args)> call keeps its own name';
+
+grammar Q {
+    token TOP  { <item>+ % ',' }
+    token item { \w+ }
+}
+is Q.parse('a,b,c')<item>».Str.join('|'), 'a|b|c',
+    'a quantified subrule files every iteration under the one name';
+
+# The same atom text in two grammars resolves to each grammar's own rule: the
+# spec is shared per text, the RESOLUTION is not.
+grammar A { token TOP { <v> }; token v { 'a' } }
+grammar B { token TOP { <v> }; token v { 'b' } }
+ok A.parse('a').defined && B.parse('b').defined && !A.parse('b').defined,
+    'one atom text, two grammars, each resolving to its own rule';


### PR DESCRIPTION
Round 20 of #7576. Instructions on the 60-row YAMLish document go
**1,277,410,693 -> 1,239,208,554 (-2.99%)**. Attribution is callgrind `Ir`
throughout, cache warmed first (`tmp/prof60.sh`, the round-15 harness).

Both items are the same shape: a question whose answer was fixed before the
matcher started, asked again on every atom match.

## (a) 402,202 calls to arm a seed that nothing reads (-1.63%)

`arm_inline_vars_seed` publishes two things to the nested walks an atom is about
to run: the enclosing regex's `:my`/`:let` lexicals, and the enclosing level's
captures for a backreference to resolve against. Both are real mechanisms with
real tests behind them — and on this workload both are inert. It ran **402,202
times and touched a thread-local in 507 of them**, for 1.63% of the program:
20.2 M `Ir` in the call itself (a seven-way `matches!` over the atom, two seed
constructions, an out-of-line call and return) plus 6.0 M in
`drop_in_place<(InlineVarsSeed, OuterCapsSeed)>`, the out-of-line drop glue for
two guards that each immediately found `armed: false`.

Neither "is anything published" question needs to look at the atom:
`any_regex_backref_lowered()` is a process-global `AtomicBool` the parser sets
the first time it lowers a backreference anywhere, and the lexical side is a
thread-local `Cell<bool>` plus `current_caps.regex_vars_shared()`. When all
three say no, whichever branch the slow path would take arms
`InlineVarsSeed::arm(None)` against an empty slot (inert) and
`OuterCapsSeed::inert()` — so the fast path returns exactly the pair the slow
path would have built. It is `#[inline]` now with the real work behind
`#[inline(never)] arm_inline_vars_seed_cold`, and the two `Drop` impls are
`#[inline]` so the inert case leaves no glue to call. In the profile the
function disappears and the cold path is left at 40,597 `Ir`.

The cold path is unchanged and stays pinned by the existing
`t/regex/regex-backref-in-group.t` (the capture-scope rules, all fourteen
verified against raku) and `t/regex/regex-my-var-in-subpattern.t` (a `:my`
lexical reaching every flavour of inline sub-pattern).

## (b) A `<subrule>` atom's lookup spec, re-derived per call (-1.35%)

`parse_named_regex_lookup_spec` turns the text between the angle brackets into
the spec the matcher acts on: silent or not, token-lookup or not, the alias and
whether it replaces the original, the interned lookup and capture names, the
argument expressions. It is a pure function of the text, and the text is fixed
once the pattern is parsed. It was memoized on a process-wide
`FxHashMap<String, Arc<NamedRegexLookupSpec>>`, probed **113,590 times** on this
parse for 17.2 M `Ir`, every probe hashing the same atom text again to hand back
the same `Arc`.

`RegexAtom::Named` carries a `NamedAtom` now: the text plus a `OnceLock` for the
spec derived from it. The callers all hold that node — they matched on it to get
the `&str` they were passing — so they ask it directly. The first ask still goes
through the global memo, so two atoms spelled the same still share one `Arc`
exactly as before; every later one is an initialized `OnceLock` read. The
compiler enumerated the change: 16 construction sites take `.into()`, and 14 of
the 18 spec lookups became `name.spec()`; the four that work from a
runtime-built string (`<::(EXPR)>` indirection, an interpolated pattern, the
call-graph walk's memo miss) keep the global entry point.

Pinned by `t/regex/regex-named-atom-spec-forms.t`: one of each atom shape the
spec distinguishes (plain, `<.silent>`, `<al=word>` under both names,
`<dot=.word>`, `<rule(args)>`, a quantified subrule) plus two grammars whose
identical atom text must resolve to their own rules — the spec is shared per
text, the resolution is not. Verified against rakudo 2026.07.

## Verification

- `make test` — **PASS**, 4142 files / 44085 tests, on the rebased tree.
- `make lint` — green (default clippy, `jit` off, wasm32 lib, rustdoc).
- `make roast` — 1437 files / 219635 tests, failing only the three
  container-only files `docs/agent-environments.md` documents:
  `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t`
  (`chmod` tests meaningless as uid 0) and `roast/S32-io/IO-Socket-Async.t`
  (sandboxed network), each with exactly the failure shape recorded there.

## What the next round starts from

Re-measured after this round rather than carried forward: left-recursion
bookkeeping is now the largest single cluster (~3.6%, three hash-map operations
per `<subrule>` call on a grammar with no left recursion), then
`Symbol::intern` at 2.34% and `subrule_call_stream_decline` at 0.61%. The
capture store still wants a design pass rather than a slice. Written up in
`news/2026-09/the-subrule-atom-answers-its-own-questions.md`.

The ticket stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_