### PR TITLE
fix(regex): an aliased capture is one Match object on both parse paths

### DIFF
--- a/news/2026-09/aliased-capture-is-one-match-object.md
+++ b/news/2026-09/aliased-capture-is-one-match-object.md
@@ -1,0 +1,50 @@
+# An aliased capture is one Match object, on both parse paths
+
+A non-suppressing alias `<val=word>` files **one** capture under both names, so
+`$m<val>` and `$m<word>` are the same `Match` — `===` on them is `True` in
+rakudo. mutsu got that right only when an actions object was passed:
+
+```
+grammar A { token TOP { <val=word> }; token word { \w+ } }
+my $m = A.parse('abc');
+say $m<val> === $m<word>;                      # mutsu: False   raku: True
+my $n = A.parse('abc', :actions(class { }));
+say $n<val> === $n<word>;                      # mutsu: True    raku: True
+```
+
+The capture store was never the problem. #7576's round-10 fix already made such
+an alias store a single `Arc<CapNode>` under both slots
+(`build_named_candidates_from_inner`'s `shared_under_original`), and
+`t/grammar/grammar-alias-action-fires-once.t` pins it — but that test parses
+*with* `:actions(...)`, which is exactly the path that worked.
+
+The identity was lost on the way **out** of the store. The lazy-Match
+materialization built a child `Match` per *slot*: `named_slot_value` called
+`Value::lazy_match` for every entry it walked, and each call mints a fresh
+`MatchNode` with its own instance id. Two slots pointing at one node therefore
+became two objects with two `.WHICH`es. The action-driven path builds its Match
+objects through the reduce walk instead and kept the sharing, so the two paths
+disagreed about whether an aliased capture is one object or two — a latent trap
+for the engine's own invariants, not only for a program asking `===`.
+
+## The fix
+
+One memo per materialization, keyed by `Arc` identity, so a capture node that
+two slots share yields the child `Match` built for it once. It covers both axes
+(`.list` and `.hash`) because the positional and named loops of one
+`materialize_map` now share the memo. `pos_slot_value` / `named_slot_value` keep
+their old signatures as thin wrappers that pass a throwaway memo, so the regex
+engine's mid-match variable binding is untouched.
+
+The key is only ever compared while every `Arc` it came from is alive in the
+parent's `CapChildren`, and the memo never outlives the materialization, so
+there is no freed-address collision of the kind `WhichId` exists to prevent.
+
+Pinned by `t/grammar/grammar-alias-capture-identity.t`: 15 assertions measured
+against rakudo, covering the action-less and action-driven parses, `.WHICH` and
+`eqv`, `.hash` as well as subscript reads, the alias inside a non-capturing
+group / an alternation / a nested subrule, a quantified alias sharing per
+iteration, a *suppressing* alias still filing one name only, and a plain
+positional capture keeping a stable identity.
+
+Closes [#8167](https://github.com/tokuhirom/mutsu/issues/8167).

--- a/src/value/match_lazy.rs
+++ b/src/value/match_lazy.rs
@@ -143,10 +143,15 @@ impl MatchNode {
         }
         let kids = cap.kids();
 
+        // One memo for the whole materialization, so two slots that share a
+        // capture node share the child `Match` built for it. See
+        // [`SharedNodeValues`].
+        let mut shared = SharedNodeValues::new();
+
         let pos_vals: Vec<Value> = kids
             .positional
             .iter()
-            .map(|slot| Value::pos_slot_value(slot, &self.target))
+            .map(|slot| Value::pos_slot_value_shared(slot, &self.target, &mut shared))
             .collect();
 
         // Silent-action captures: hidden `<.foo>` subrule matches (stored
@@ -161,7 +166,10 @@ impl MatchNode {
                 }
                 continue;
             }
-            sub_named.insert(key.resolve(), Value::named_slot_value(slot, &self.target));
+            sub_named.insert(
+                key.resolve(),
+                Value::named_slot_value_shared(slot, &self.target, &mut shared),
+            );
         }
 
         let mut attrs = AttrMap::new();
@@ -243,6 +251,36 @@ fn span_leaf_match(from: usize, to: usize, target: &MatchTarget) -> Value {
     Value::make_instance(match_class_symbol(), attrs)
 }
 
+/// Memo of the lazy child `Match` already built for a given capture node,
+/// keyed by `Arc` identity.
+///
+/// Two capture slots of the SAME parent can share one `Arc<CapNode>`: a
+/// non-suppressing alias `<val=word>` files a single capture under both names
+/// (`build_named_candidates_from_inner`'s `shared_under_original`, #7576 round
+/// 10). Rakudo hands out one `Match` object for both, so `$m<val> === $m<word>`
+/// is `True` there; building the child per SLOT minted two `MatchNode`s with
+/// two instance ids and made it `False` on the action-less path, while the
+/// action-driven path -- which builds its Matches through the reduce walk --
+/// kept the sharing. Memoizing per node makes both paths agree (GH #8167).
+///
+/// The key is only ever compared while every `Arc` it came from is alive in the
+/// parent's `CapChildren`, so no freed-address collision is possible; the memo
+/// is per materialization and never outlives it.
+type SharedNodeValues = std::collections::HashMap<usize, Value>;
+
+/// The lazy child `Match` for `sc`, reusing the one already built for that same
+/// capture node. See [`SharedNodeValues`].
+fn shared_node_value(
+    shared: &mut SharedNodeValues,
+    sc: &Arc<CapNode>,
+    target: &MatchTarget,
+) -> Value {
+    shared
+        .entry(Arc::as_ptr(sc) as usize)
+        .or_insert_with(|| Value::lazy_match(Arc::clone(sc), target.clone()))
+        .clone()
+}
+
 impl Value {
     /// Render one positional capture slot exactly as a Match's `.list` exposes
     /// it: `Nil` for an unmatched optional, an Array for a quantified group,
@@ -255,6 +293,16 @@ impl Value {
     /// the bare string). Building the slot's value directly keeps the parent
     /// cursor lazy — the block may never look at `$/` at all.
     pub(crate) fn pos_slot_value(slot: &PosSlot, target: &MatchTarget) -> Value {
+        Value::pos_slot_value_shared(slot, target, &mut SharedNodeValues::new())
+    }
+
+    /// [`Self::pos_slot_value`] sharing one child `Match` per capture node with
+    /// the rest of a materialization. See [`SharedNodeValues`].
+    fn pos_slot_value_shared(
+        slot: &PosSlot,
+        target: &MatchTarget,
+        shared: &mut SharedNodeValues,
+    ) -> Value {
         // An unmatched optional capture (`(x)?` zero match) renders as Nil.
         if slot.nil {
             return Value::Nil;
@@ -263,14 +311,14 @@ impl Value {
             let arr: Vec<Value> = qlist
                 .iter()
                 .map(|(qfrom, qto, subcap)| match subcap {
-                    Some(sc) => Value::lazy_match(Arc::clone(sc), target.clone()),
+                    Some(sc) => shared_node_value(shared, sc, target),
                     None => span_leaf_match(*qfrom, *qto, target),
                 })
                 .collect();
             return Value::array(arr);
         }
         if let Some(subcap) = &slot.subcap {
-            return Value::lazy_match(Arc::clone(subcap), target.clone());
+            return shared_node_value(shared, subcap, target);
         }
         // ADR-0016 P4: every slot carries its span, so a subcap-less leaf
         // renders with its REAL offsets (pre-P4 this was the text-only
@@ -282,10 +330,20 @@ impl Value {
     /// a single Match, or an Array when the name was quantified or captured
     /// more than once. Companion of [`Self::pos_slot_value`].
     pub(crate) fn named_slot_value(slot: &NamedSlot, target: &MatchTarget) -> Value {
+        Value::named_slot_value_shared(slot, target, &mut SharedNodeValues::new())
+    }
+
+    /// [`Self::named_slot_value`] sharing one child `Match` per capture node
+    /// with the rest of a materialization. See [`SharedNodeValues`].
+    fn named_slot_value_shared(
+        slot: &NamedSlot,
+        target: &MatchTarget,
+        shared: &mut SharedNodeValues,
+    ) -> Value {
         let vals: Vec<Value> = slot
             .nodes
             .iter()
-            .map(|sc| Value::lazy_match(Arc::clone(sc), target.clone()))
+            .map(|sc| shared_node_value(shared, sc, target))
             .collect();
         if vals.len() == 1 && !slot.quantified {
             vals.into_iter().next().unwrap()

--- a/t/grammar/grammar-alias-capture-identity.t
+++ b/t/grammar/grammar-alias-capture-identity.t
@@ -1,0 +1,81 @@
+use v6;
+use Test;
+
+# A non-suppressing alias `<val=word>` files ONE capture under BOTH names, so
+# `$m<val>` and `$m<word>` are the same `Match` object -- `===` on them is True
+# in rakudo, and `.WHICH` agrees.
+#
+# The capture store already did that: #7576 round 10 made such an alias store a
+# single `Arc<CapNode>` under both slots. The identity was lost on the way OUT,
+# in the lazy-Match materialization, which minted a `MatchNode` (and so a fresh
+# instance id) per SLOT rather than per node. The action-driven path builds its
+# Match objects through the reduce walk and kept the sharing, so the bug showed
+# only on an action-less `.parse` -- the two paths disagreed about whether an
+# aliased capture is one object or two (#8167).
+#
+# Every expectation below was measured against rakudo.
+
+plan 15;
+
+grammar A { token TOP { <val=word> }; token word { \w+ } }
+class Act { }
+
+# The reported case: action-less and action-driven parses must agree.
+{
+    my $m = A.parse('abc');
+    ok $m<val> === $m<word>, 'an alias hands out ONE Match for both names';
+    ok $m<val>.WHICH eq $m<word>.WHICH, 'and their .WHICH agrees';
+    ok $m<val> eqv $m<word>, 'eqv agrees too (it always did)';
+    is $m.hash.keys.sort.join(','), 'val,word', 'both names are in .hash';
+    is $m<val>.Str, 'abc', 'the shared Match still carries its own span';
+
+    my $n = A.parse('abc', :actions(Act));
+    ok $n<val> === $n<word>, 'the action-driven path agrees (it always did)';
+}
+
+# Reading the same name twice was never broken; pin it so the memo cannot
+# regress in the other direction.
+{
+    my $m = A.parse('abc');
+    ok $m<word> === $m<word>, 'two reads of one name are the same object';
+    ok $m.hash<val> === $m.hash<word>, '.hash exposes the shared object too';
+}
+
+# The alias is shared wherever it appears, not only at the top level.
+{
+    grammar B { token TOP { [ <val=word> ] }; token word { \w+ } }
+    my $b = B.parse('xy');
+    ok $b<val> === $b<word>, 'inside a non-capturing group';
+
+    grammar C { token TOP { <val=word> | <num=digits> }; token word { \w+ }; token digits { \d+ } }
+    my $c = C.parse('zz');
+    ok $c<val> === $c<word>, 'inside an alternation';
+
+    grammar D { token TOP { <item> }; token item { <val=word> }; token word { \w+ } }
+    my $d = D.parse('abc');
+    ok $d<item><val> === $d<item><word>, 'through a nested subrule';
+}
+
+# A quantified alias shares per iteration.
+{
+    grammar F { token TOP { <val=word>+ }; token word { \w } }
+    my $f = F.parse('ab');
+    is $f<val>.elems, 2, 'a quantified alias captures each iteration';
+    ok $f<val>[0] === $f<word>[0], 'and shares the Match per iteration';
+}
+
+# A SUPPRESSING alias `<val=.word>` files one name only -- the sharing must not
+# invent the second.
+{
+    grammar E { token TOP { <val=.word> }; token word { \w+ } }
+    my $e = E.parse('q');
+    is $e.hash.keys.sort.join(','), 'val', 'a suppressing alias files one name';
+}
+
+# An ordinary positional capture is unaffected.
+{
+    my $g = 'abc' ~~ / (\w) (\w) /;
+    ok $g[0] === $g[0], 'a positional capture keeps a stable identity';
+}
+
+done-testing;


### PR DESCRIPTION
## The gap

A non-suppressing alias `<val=word>` files **one** capture under both names, so `$m<val>` and `$m<word>` are the same `Match` — `===` on them is `True` in rakudo. mutsu got that right only when an actions object was passed:

```raku
grammar A { token TOP { <val=word> }; token word { \w+ } }
my $m = A.parse('abc');
say $m<val> === $m<word>;                      # mutsu: False   raku: True
my $n = A.parse('abc', :actions(class { }));
say $n<val> === $n<word>;                      # mutsu: True    raku: True
```

## Root cause

The issue had this narrowed to the right half already, and the measurement confirms it: the capture store was never the problem. #7576's round-10 fix already makes such an alias store a single `Arc<CapNode>` under both slots (`build_named_candidates_from_inner`'s `shared_under_original`), and `t/grammar/grammar-alias-action-fires-once.t` pins it — but that test parses **with** `:actions(...)`, which is exactly the path that worked.

The identity was lost on the way **out** of the store. The lazy-Match materialization built a child `Match` per *slot*: `named_slot_value` called `Value::lazy_match` for every entry it walked, and each call mints a fresh `MatchNode` with its own instance id, so two slots pointing at one node became two objects with two `.WHICH`es. The action-driven path builds its Match objects through the reduce walk instead and kept the sharing — so the two paths disagreed about whether an aliased capture is one object or two, which is a latent trap for the engine's own invariants, not only for a program asking `===`.

Reading the *same* name twice was never broken (`$m<word> === $m<word>` was already `True`, because the parent's map is memoized), which is what localises the bug to the per-slot construction rather than to `AT-KEY`.

## The fix

One memo per materialization, keyed by `Arc` identity, so a capture node two slots share yields the child `Match` built for it once. It covers both axes because the positional and named loops of a single `materialize_map` share the memo. `pos_slot_value` / `named_slot_value` keep their signatures as thin wrappers that pass a throwaway memo, so the regex engine's mid-match variable binding (`$0` read from inside an embedded `{ … }` block) is untouched.

The key is only ever compared while every `Arc` it came from is alive in the parent's `CapChildren`, and the memo never outlives the materialization, so there is no freed-address collision of the kind `WhichId` exists to prevent. `src/value/match_view.rs` needed no change.

## Verification

Every shape the issue names now matches rakudo, and so do the ones it did not:

| | mutsu before | mutsu after | raku |
| --- | --- | --- | --- |
| `$m<val> === $m<word>` (no actions) | `False` | `True` | `True` |
| same, `:actions(...)` | `True` | `True` | `True` |
| `.WHICH` equal | `False` | `True` | `True` |
| `$m.hash<val> === $m.hash<word>` | `False` | `True` | `True` |
| inside `[ ... ]` / an alternation | `False` | `True` | `True` |
| `$d<item><val> === $d<item><word>` | `False` | `True` | `True` |
| quantified alias, per iteration | `True` | `True` | `True` |
| suppressing `<val=.word>` keys | `(val)` | `(val)` | `(val)` |

Pinned by `t/grammar/grammar-alias-capture-identity.t` — 15 assertions measured against rakudo first (15/15 under `raku` as well as under mutsu), including the suppressing-alias and positional-capture non-regressions so the memo cannot over-share. `t/grammar` + `t/regex` (340 files) pass.

## Suites

- `cargo fmt --all`, `make lint` — clean (all four configurations).
- `make test` — PASS, 4143 files / 44109 tests.
- `make roast` — green apart from the three documented container-only files: `roast/6.c/S32-io/file-tests.t` (`Failed: 4`, tests 6-8 and 10), `roast/S16-filehandles/filetest.t` (`Failed: 25`, tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125), `roast/S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17) — matching `docs/agent-environments.md` by name and by subtest range.

Closes #8167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_