### PR TITLE
fix: say gather {...} propagates an exception thrown by the body

### DIFF
--- a/news/2026-09/gather-lazy-say-propagates-exceptions.md
+++ b/news/2026-09/gather-lazy-say-propagates-exceptions.md
@@ -1,0 +1,27 @@
+# `say gather {...}` no longer swallows an exception thrown by the body
+
+An exception thrown inside a `gather { ... }` block propagated correctly
+when the resulting `Seq` was reified eagerly (`my @r = gather {...}; say
+@r`), but was silently discarded — printing an empty line and exiting 0 —
+when the `Seq` was consumed lazily and directly (`say gather {...}`).
+
+`say`'s `.gist` dispatch on a `LazyList` forces the gather body and
+re-dispatches onto the resulting `Seq`. `render_gist_value` treats a
+`X::Method::NotFound`/`X::Multi::NoMatch` error from that dispatch as "no
+`.gist` candidate exists" and falls back to the native placeholder gist —
+correct for a type that genuinely has no `.gist` method, but wrong here: a
+`LazyList` always has a `.gist` route (either the lazy placeholder or
+force-and-redispatch onto a `Seq`, which always has one), so an error
+surfacing at that point can only have come from running the gather body
+itself, e.g. `say gather { "u".nosuchmethod }` throwing because `Str` has
+no `nosuchmethod`. The fallback now excludes `LazyList` targets, so the
+underlying exception propagates instead of being mistaken for "no
+`.gist`".
+
+`put`/`print`/string interpolation on a lazily-consumed gather have the
+same underlying gap (tracked by a pre-existing `TODO` on
+`render_str_value`, which returns a plain `String` rather than a
+`Result` and cannot propagate at all) and are not fixed by this change.
+
+See [#8159](https://github.com/tokuhirom/mutsu/issues/8159) and the
+regression test `t/exceptions/gather-lazy-consume-propagates-exception.t`.

--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -529,7 +529,18 @@ impl Interpreter {
         match result {
             Ok(result) => Ok(result.to_string_value()),
             Err(e) if e.return_value.is_some() => Err(RuntimeError::controlflow_return(true)),
-            Err(e) if e.is_method_not_found() || e.is_multi_no_match() => {
+            // A `LazyList` always has a `.gist` route (either the lazy
+            // placeholder or force-and-redispatch onto the resulting `Seq`,
+            // which always has one) -- so a `X::Method::NotFound`/no-match
+            // error surfacing here did NOT come from ".gist itself has no
+            // candidate"; it came from running the gather body during the
+            // force, e.g. `say gather { "u".nosuchmethod }`. Swallowing it
+            // as "no .gist" printed an empty line instead of propagating
+            // the user's own exception (#8159).
+            Err(e)
+                if (e.is_method_not_found() || e.is_multi_no_match())
+                    && !matches!(value.view(), ValueView::LazyList(_)) =>
+            {
                 Ok(crate::runtime::gist_value(value))
             }
             Err(e) => Err(e),

--- a/t/exceptions/gather-lazy-consume-propagates-exception.t
+++ b/t/exceptions/gather-lazy-consume-propagates-exception.t
@@ -1,0 +1,39 @@
+use Test;
+
+# #8159: an exception thrown inside a `gather { ... }` body propagated when
+# the resulting Seq was reified EAGERLY (`my @r = gather {...}; say @r`), but
+# was silently swallowed -- printing an empty line and exiting 0 -- when the
+# Seq was consumed LAZILY (`say gather {...}` directly).
+#
+# Root cause: `say`'s `.gist` dispatch on a LazyList forces the gather body
+# and re-dispatches onto the resulting Seq. When the force itself threw
+# `X::Method::NotFound` (as it does here, from the body's own `.nosuchmethod`
+# call), the renderer mistook that for "no .gist candidate exists" -- the same
+# exception type a genuinely gist-less type would raise -- and fell back to
+# the native placeholder gist instead of propagating the user's exception.
+
+plan 6;
+
+throws-like 'say gather { "u".nosuchmethod }', X::Method::NotFound,
+    method => 'nosuchmethod', typename => 'Str',
+    'say gather {...} propagates a method-not-found thrown by the body';
+
+throws-like 'my @r = gather { "u".nosuchmethod }; say @r', X::Method::NotFound,
+    method => 'nosuchmethod', typename => 'Str',
+    'eager reification into an array still propagates the same exception';
+
+throws-like 'say gather { die "inner" }', X::AdHoc,
+    'a plain die inside a lazily-consumed gather still propagates';
+
+throws-like 'say gather { "u".take-rw }', X::Method::NotFound,
+    method => 'take-rw', typename => 'Str',
+    'take-rw on a value with no such method propagates too';
+
+throws-like 'say gather { 1.take; "u".nope }', X::Method::NotFound,
+    method => 'nope', typename => 'Str',
+    'a throw after some values were already taken still propagates, not ()';
+
+# A gather with no error still renders normally through the same lazy `say`
+# path (pin against a fix that overcorrects and breaks the happy path).
+is (gather { take 1; take 2; take 3 }).gist, '(1 2 3)',
+    'a successful gather still gists its taken elements';


### PR DESCRIPTION
## Summary

An exception thrown inside a `gather { ... }` block propagated correctly
when the resulting `Seq` was reified eagerly (`my @r = gather {...}; say
@r`), but was silently discarded — printing an empty line and exiting 0 —
when the `Seq` was consumed lazily and directly (`say gather {...}`).

`say`'s `.gist` dispatch on a `LazyList` forces the gather body and
re-dispatches onto the resulting `Seq`. `render_gist_value` treated any
`X::Method::NotFound`/`X::Multi::NoMatch` error surfacing from that
dispatch as "no `.gist` candidate exists" and fell back to the native
placeholder gist — correct for a type that genuinely has no `.gist`
method, but wrong here: a `LazyList` always has a `.gist` route (either
the lazy placeholder or force-and-redispatch onto a `Seq`, which always
has one), so an error at that point can only have come from running the
gather body itself (e.g. `say gather { "u".nosuchmethod }` throwing
because `Str` has no `nosuchmethod`).

The fallback now excludes `LazyList` targets, so the underlying exception
propagates instead of being mistaken for "no `.gist`".

`put`/`print`/string interpolation on a lazily-consumed gather have the
same underlying gap, tracked by a pre-existing `TODO` comment on
`render_str_value` (which returns a plain `String`, not a `Result`, and
cannot propagate at all) — out of scope here since the issue's repro is
specifically about `say`.

Closes #8159

## Test plan

- Added `t/exceptions/gather-lazy-consume-propagates-exception.t`: the
  issue's repro (`say gather { "u".nosuchmethod }`), the already-correct
  eager-reification case as a pin, a plain `die` inside the gather (also
  already correct), `take-rw` on a value with no such method, a throw
  after some values were already taken, and a successful gather still
  gisting correctly (guards against an overcorrection).
- Verified against a genuinely-infinite gather (`gather { loop { take 1 }
  }`) still doesn't touch this code path — confirmed a pre-existing,
  unrelated timeout there reproduces identically on `main` without this
  change (not something this PR needs to fix).
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run
  locally. `make roast` comes back with only the three environment-only
  failures documented in `docs/agent-environments.md` for a remote
  container (`roast/6.c/S32-io/file-tests.t`,
  `roast/S16-filehandles/filetest.t` — both `uid 0` chmod-based file
  tests — and `roast/S32-io/IO-Socket-Async.t`, sandboxed network);
  everything else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_