### PR TITLE
fix: a class-level @/% attribute initializer behaves like a list assignment

### DIFF
--- a/news/2026-09/class-level-attribute-comma-list-initializer.md
+++ b/news/2026-09/class-level-attribute-comma-list-initializer.md
@@ -1,0 +1,22 @@
+# A class-level `@`/`%` attribute initializer now behaves like a list assignment
+
+`our @.x = 1, 2, 3` (and `my @.x = ...`) kept only the first element, and
+`our @.x = (1, 2, 3)` stayed a bare `List` instead of coercing to an `Array`.
+Both were specific to the class-level (`our`/`my`) attribute spelling — the
+per-instance `has @.x = ...` spelling already got this right.
+
+Two independent causes:
+
+1. `try_dot_twigil_attr` parsed the initializer with `expression`, which
+   stops at the first comma, so the rest of a bare comma list was silently
+   dropped. An `@`/`%` sigil initializer now parses the whole comma list via
+   `parse_comma_or_expr`, mirroring `has_decl`'s `=` branch.
+2. `class_body_has_decl` stored the evaluated value as-is, skipping
+   `coerce_attr_value_by_sigil` — the rule every other attribute-store path
+   goes through, and the reason `has @.x = (1, 2, 3)` was already an
+   `Array`. The class-level `=` branch now coerces before detaching its
+   copy (the `:=` bind and the `=` copy semantics from #8150 are both
+   preserved).
+
+See [#8175](https://github.com/tokuhirom/mutsu/issues/8175) and the
+regression test `t/oo/attribute/class-level-attribute-list-initializer.t`.

--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -11,6 +11,7 @@ use crate::symbol::Symbol;
 use crate::value::Value;
 
 use super::parse_assign_expr_or_comma;
+use super::parse_comma_or_expr;
 
 /// Build the statement for a sigilless bind/declaration (`my \name := expr`,
 /// `my \name ::= expr`, or `my \name = expr` — all three bind the sigilless
@@ -327,7 +328,16 @@ pub(super) fn try_dot_twigil_attr<'a>(
         {
             let r = &after_name[1..];
             let (r, _) = ws(r)?;
-            let (r, expr) = expression(r)?;
+            // An `@`/`%` sigil initializer is a LIST assignment, so it must
+            // consume the whole comma list here rather than stopping at the
+            // first comma (#8175) -- mirrors `has_decl`'s `=` branch, which
+            // the per-instance `has @.x = 1, 2, 3` spelling already goes
+            // through.
+            let (r, expr) = if is_array || is_hash {
+                parse_comma_or_expr(r)?
+            } else {
+                expression(r)?
+            };
             (r, Some(expr), false)
         } else {
             (after_name, None, false)

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -236,7 +236,17 @@ impl Interpreter {
                     // whatever container it was given (#8150). A default that
                     // built its own fresh container owns its `Gc` already, so
                     // this is free on the common path.
-                    value.detach_shared_container()
+                    //
+                    // Coerce to the attribute's sigil FIRST (#8175): every
+                    // other attribute-store path runs the evaluated value
+                    // through `coerce_attr_value_by_sigil` -- the ONE
+                    // list-assignment rule -- which is why `our @.x = (1, 2,
+                    // 3)` becomes an `Array` (matching `has @.x = ...`)
+                    // instead of staying a bare `List`. Detach after
+                    // coercing, since a same-sigil `Array` source shares its
+                    // `Gc` through the coercion (the common, cheap path) and
+                    // still needs its own copy.
+                    Self::coerce_attr_value_by_sigil(value, decl.sigil).detach_shared_container()
                 }
             } else {
                 Value::NIL

--- a/t/oo/attribute/class-level-attribute-list-initializer.t
+++ b/t/oo/attribute/class-level-attribute-list-initializer.t
@@ -1,0 +1,92 @@
+use v6;
+use Test;
+
+# #8175: a class-level `@`/`%` attribute initializer written as a bare comma
+# list, or a parenthesized list, did not behave like a list assignment.
+#
+# Two independent causes, both fixed here:
+#
+# 1. The parser stopped at the first comma (`try_dot_twigil_attr` used
+#    `expression`, which does not consume a comma list), so `our @.x = 1, 2,
+#    3` kept only `1` and silently dropped the rest.
+# 2. The evaluated value was stored as-is, skipping
+#    `coerce_attr_value_by_sigil` -- the rule every other attribute-store path
+#    goes through -- so a parenthesized `(1, 2, 3)` stayed a `List` instead of
+#    becoming an `Array` like `has @.x = (1, 2, 3)` already does.
+#
+# The bracketed spelling (`our @.x = [1, 2, 3]`) and the per-instance `has`
+# spelling were already correct and are pinned here too, as a guard against a
+# fix that only handles the comma-list/parenthesized cases.
+
+plan 12;
+
+# --- our, comma list and parenthesized list ---
+{
+    class OurCommaList { our @.x = 1, 2, 3; }
+    is OurCommaList.x, [1, 2, 3], 'our @.x = 1, 2, 3 keeps every element';
+}
+
+{
+    class OurParenList { our @.x = (1, 2, 3); }
+    is OurParenList.x, [1, 2, 3], 'our @.x = (1, 2, 3) coerces to an Array';
+}
+
+{
+    class OurHashCommaList { our %.h = a => 1, b => 2; }
+    is OurHashCommaList.h.keys.sort.join(','), 'a,b',
+        'our %.h = a => 1, b => 2 keeps every pair';
+}
+
+# --- my, same as our for a class-level attribute ---
+{
+    class MyCommaList { my @.x = 1, 2, 3; }
+    is MyCommaList.x, [1, 2, 3], 'my @.x = 1, 2, 3 keeps every element';
+}
+
+{
+    class MyParenList { my @.x = (1, 2, 3); }
+    is MyParenList.x, [1, 2, 3], 'my @.x = (1, 2, 3) coerces to an Array';
+}
+
+# --- already-correct spellings, pinned against a partial fix ---
+{
+    class OurBracket { our @.x = [1, 2, 3]; }
+    is OurBracket.x, [1, 2, 3], 'our @.x = [1, 2, 3] is unaffected';
+}
+
+{
+    class HasCommaList { has @.x = 1, 2, 3; }
+    is HasCommaList.new.x, [1, 2, 3], 'has @.x = 1, 2, 3 is unaffected';
+}
+
+{
+    class HasParenList { has @.x = (1, 2, 3); }
+    is HasParenList.new.x, [1, 2, 3], 'has @.x = (1, 2, 3) is unaffected';
+}
+
+# --- the := bind and #8150's = copy must still hold on the fixed paths ---
+{
+    my @source = 1, 2, 3;
+    class BoundCommaSource { our @.x := @source; }
+    @source.push(4);
+    is BoundCommaSource.x, [1, 2, 3, 4], 'our @.x := @c still binds the container';
+}
+
+{
+    my @source = 1, 2, 3;
+    class CopiedCommaSource { our @.x = @source; }
+    @source.push(4);
+    is CopiedCommaSource.x, [1, 2, 3], 'our @.x = @c still copies (#8150)';
+}
+
+# --- a trailing comma is a one-slot list, not a missing element ---
+{
+    class TrailingComma { our @.x = 5,; }
+    is TrailingComma.x, [5], 'our @.x = 5, is a one-element list';
+}
+
+# --- a single non-list value still becomes a one-element Array ---
+{
+    class SingleValue { our @.x = 5; }
+    is SingleValue.x, [5], 'our @.x = 5 still becomes a one-element Array';
+}


### PR DESCRIPTION
## Summary

A class-level `@`/`%` attribute initializer written with `=` did not
behave like a list assignment. Two things went wrong, and only the
class-level (`our`/`my`) path had them — the per-instance `has` spelling
was already correct:

```
$ raku  -e 'class C { our @.x = 1, 2, 3; }; say C.x'
[1 2 3]
$ mutsu -e 'class C { our @.x = 1, 2, 3; }; say C.x'
1

$ raku  -e 'class C { our @.x = (1, 2, 3); }; say C.x'
[1 2 3]
$ mutsu -e 'class C { our @.x = (1, 2, 3); }; say C.x'
(1 2 3)
```

Two independent causes, both fixed together (a half-fix here is worse
than none — it leaves the headline `our @.x = 1, 2, 3` spelling wrong
either way):

1. **The comma list was truncated at parse time.** `try_dot_twigil_attr`
   (`src/parser/stmt/decl/my_decl_helpers.rs`) parsed the initializer with
   `expression`, which stops at the first comma. An `@`/`%` sigil
   initializer is a *list* assignment and now parses the whole comma list
   via `parse_comma_or_expr`, mirroring `has_decl`'s `=` branch that the
   per-instance spelling already gets.
2. **The value was never coerced to the attribute's sigil.**
   `class_body_has_decl` (`src/runtime/registration_class_body_attr.rs`)
   stored the evaluated value as-is. Every other attribute-store path goes
   through `coerce_attr_value_by_sigil` — "the ONE list-assignment rule" —
   which is why `(1, 2, 3)` stays a `List` here and becomes an `Array`
   everywhere else. The class-level `=` branch now coerces before
   detaching its own copy; the `:=` bind spelling (which must keep
   aliasing) and the `=` copy semantics from #8150 are both preserved and
   still pinned.

Closes #8175

## Test plan

- Added `t/oo/attribute/class-level-attribute-list-initializer.t`: the
  bare comma-list and parenthesized-list spellings for `our`/`my` on both
  `@` and `%`, the already-correct bracket/`has` spellings as a guard
  against a partial fix, the `:=` bind and `=`-copy (#8150) pins, a
  trailing comma, and a single non-list value.
- Ran the full `t/oo/` sweep (572 files) — all green.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run
  locally. `make roast` comes back with only the three environment-only
  failures documented in `docs/agent-environments.md` for a remote
  container (`roast/6.c/S32-io/file-tests.t`,
  `roast/S16-filehandles/filetest.t` — both `uid 0` chmod-based file
  tests — and `roast/S32-io/IO-Socket-Async.t`, sandboxed network);
  everything else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_