### PR TITLE
feat: ratchet the panic-family and #[allow( surface in src/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,19 @@ jobs:
         # been the profiling finding in five separate perf campaigns (#8087).
         run: make check-magic-keys
 
+      - name: Panic-family / #[allow( surface did not grow
+        # A ratchet, not a ban: PLAN.md's "mutsu must never Rust-panic on any
+        # input" had no enforcement, and the count of
+        # unwrap/expect/panic!/unreachable!/todo!/unimplemented! (and of
+        # #[allow() sites) rose at every architecture review. Both counts may
+        # go down but never up (#8186). scripts/check-panic-surface.py
+        # excludes #[cfg(test)] scaffolding by scanning comments/strings/braces
+        # itself rather than a plain grep, so `make check-panic-surface` runs
+        # its own `--self-test` against synthetic snippets first -- a bug in
+        # the masker could otherwise make the ratchet silently report 0 no
+        # matter what src/ contains.
+        run: make check-panic-surface
+
       - uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e # 1.96.0
         with:
           components: clippy, rustfmt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint roast check-roast-whitelist check-value-wall check-flaky-list check-t-layout check-magic-keys
+.PHONY: test lint roast check-roast-whitelist check-value-wall check-flaky-list check-t-layout check-magic-keys check-panic-surface
 
 CARGO_TARGET_DIR ?= target
 MUTSU_BIN ?= $(CARGO_TARGET_DIR)/release/mutsu
@@ -37,7 +37,7 @@ PROVE_JOBS ?= 4
 # the gc-stress / jit-stress CI jobs keep running the whole t/ suite on debug.
 # See docs/adr/0075-make-test-runs-tap-on-release-binary.md, which supersedes
 # ADR-0014.
-test: check-value-wall check-flaky-list check-t-layout check-magic-keys
+test: check-value-wall check-flaky-list check-t-layout check-magic-keys check-panic-surface
 	@mkdir -p tmp
 	(cargo build --release && cargo test -- --test-threads=1 && cargo test -p mutsu-lsp && MUTSU_BIN='$(CARGO_TARGET_DIR)/release/mutsu' MUTSU_T_TIMEOUT=60 prove -r -e 'scripts/run-t-test.sh' t/) 2>&1 | tee tmp/make-test.log
 
@@ -70,6 +70,14 @@ check-t-layout:
 # sites with: scripts/check-magic-keys.sh --update
 check-magic-keys:
 	scripts/check-magic-keys.sh
+
+# Ratchet on the panic-family (unwrap/expect/panic!/unreachable!/todo!/
+# unimplemented!) and #[allow( surface in src/ (issue #8186). Both counts may
+# go down, never up. Re-cut after a change that shifts either number:
+#   scripts/check-panic-surface.py --update
+check-panic-surface:
+	python3 scripts/check-panic-surface.py --self-test
+	python3 scripts/check-panic-surface.py
 
 roast:
 	@mkdir -p tmp

--- a/PLAN.md
+++ b/PLAN.md
@@ -237,9 +237,10 @@ levers — [#7571](https://github.com/tokuhirom/mutsu/issues/7571), actively wor
       ownership boundary is visible.
 - [ ] **Improve error-message quality and bring edge-case panics to zero** — driven by roast
       pass/fail: `integration/error-reporting.t` and `weird-errors.t` for quality, and the
-      deep-recursion `fatal runtime error: stack overflow` process abort for crashes. Nothing
-      currently stops the panic surface from growing in the meantime
-      ([#8186](https://github.com/tokuhirom/mutsu/issues/8186)).
+      deep-recursion `fatal runtime error: stack overflow` process abort for crashes. The panic
+      surface itself is now ratcheted (`make check-panic-surface`,
+      `scripts/check-panic-surface.py`), so it can only shrink from here — this item is the
+      actual shrinking work.
 - Individual concurrency bugs are individual `todo:ticket` / `todo:deep` issues.
 
 ---
@@ -266,10 +267,11 @@ signal "mutsu differs from raku **and** from the documented expectation" over a 
 - [ ] **Per-type method-coverage matrix** — harness landed (`scripts/method-coverage.raku`); run the
       full-corpus triage and fold the per-type hole list into the backlog.
 - [ ] **Panic-zero sweep** — mutsu must never Rust-panic or process-abort on any input. Extend with
-      parser fuzzing driven through the same harness with a "did it panic?" oracle. The goal has no
-      enforcement mechanism today and the surface grows at every measurement (2,440 `unwrap` /
-      `expect` / `panic!` / `unreachable!` in `src/`): [#8186](https://github.com/tokuhirom/mutsu/issues/8186)
-      is either the ratchet or the decision to reword this goal into something enforceable.
+      parser fuzzing driven through the same harness with a "did it panic?" oracle. The panic-family
+      surface (`unwrap`/`expect`/`panic!`/`unreachable!`/`todo!`/`unimplemented!` in `src/`, test
+      scaffolding excluded) is now ratcheted at 1,906 sites by `make check-panic-surface`
+      ([#8186](https://github.com/tokuhirom/mutsu/issues/8186)) — it can only go down from here, so
+      this item is the remaining work of actually driving it toward zero.
 - [ ] **Error / exception parity** — differential-test that mutsu throws the right `X::` type with a
       matching message and payload, not merely that it fails. Corpus: `Type/X*.rakudoc`.
 

--- a/news/2026-09/panic-surface-ratchet.md
+++ b/news/2026-09/panic-surface-ratchet.md
@@ -1,0 +1,48 @@
+# The panic surface can no longer grow silently
+
+[#8186](https://github.com/tokuhirom/mutsu/issues/8186) observed that `PLAN.md` §8.3 states mutsu
+must never Rust-panic on any input, but nothing enforced it: the count of `unwrap`/`expect`/
+`panic!`/`unreachable!` in `src/` rose at every architecture review taken so far (2,440 as of
+2026-09-12), and `#[allow(` rose alongside it (243). A goal with no enforcement is a wish, and the
+trend was the evidence.
+
+## What shipped
+
+Option 1 from the issue: a ratchet, on the same pattern as `opcode_size_guard`,
+`scripts/check-value-wall.sh` and `scripts/check-magic-keys.sh`.
+
+`scripts/check-panic-surface.py` counts `.unwrap()` / `.unwrap_err()` / `.expect(` / `panic!(` /
+`unreachable!(` / `todo!(` / `unimplemented!(` and `#[allow(` occurrences across `src/`, and compares
+the total against `scripts/panic-surface-baseline.txt`. Either count may go down (or stay flat);
+raising it requires deliberately editing the baseline, so growth becomes something someone chose
+instead of something nobody noticed.
+
+Unlike the other ratchets, this one needed more than a line-grep: `#[cfg(test)]` items nest at
+arbitrary depth in this codebase (not always a trailing `mod tests` block), and per the issue's own
+note, test scaffolding should not consume the production budget. The script does a small
+Rust-comment/string/brace scan — blanking `//`/`/* */` comments, `"..."` and raw `r#"..."#` strings,
+and char literals, then blanking the balanced `{ ... }` body (or bare `...;` statement) of every
+`#[cfg(test)]`-attributed item, stacked attributes included — before counting. That logic gets its
+own `--self-test` against 17 synthetic snippets (comments, strings, nested `#[cfg(test)] mod`
+inside a non-test `mod`, stacked `#[allow(]`+`#[cfg(test)]`, …), run by `make check-panic-surface`
+before it trusts the count on the real tree — a masking bug could otherwise make the ratchet
+silently report 0 no matter what `src/` contains.
+
+Excluding test code drops the enforced baseline to **1,906** panic-family sites and **238**
+`#[allow(` sites (from the raw ~2,475 / 243 a plain `grep -c` would count, test scaffolding
+included).
+
+Wired into `make test` (as `check-panic-surface`, alongside `check-value-wall`/`check-magic-keys`)
+and as its own CI step in `test-check`, next to the other ledger checks — a `.rs`-only change like
+this one still triggers the full test suite (`scripts/ci-docs-only.sh`'s allowlist excludes
+`scripts/*.py`), so the check runs on every relevant PR from here.
+
+`PLAN.md` §6 and §8.3 are updated to point at the ratchet instead of describing it as unenforced;
+the remaining PLAN items (bring edge-case panics to zero, error-message quality) are the actual
+shrinking work the ratchet now protects.
+
+## Left open
+
+The masker is a heuristic (attribute-ordering assumes `#[cfg(test)]` precedes any other stacked
+attribute on the same item, the Rust convention here), not a full parser — acceptable for a ratchet
+whose whole point is a stable, hard-to-game count, not a quality signal.

--- a/scripts/check-panic-surface.py
+++ b/scripts/check-panic-surface.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Ratchet on the panic-family / `#[allow(` surface in src/ (issue #8186).
+
+PLAN.md states the goal that mutsu must never Rust-panic on any input, but
+nothing enforced it: the count of `unwrap`/`expect`/`panic!`/`unreachable!`/
+`todo!`/`unimplemented!` in src/ rose at every architecture review taken so
+far (2,440 as of 2026-09-12), and `#[allow(` rose alongside it (243). This
+script is the "someone chose" ratchet from #8186's option 1: it counts both
+surfaces and fails when either count exceeds the committed baseline in
+scripts/panic-surface-baseline.txt.
+
+The count is a blunt grep-family metric on purpose (stable, hard to game),
+NOT a quality signal by itself -- plenty of the counted sites are provably
+unreachable. What it guarantees is that the total can only go down or stay
+flat; raising it requires deliberately editing the baseline, which makes
+growth visible in review instead of invisible in aggregate.
+
+Test scaffolding is excluded: `#[cfg(test)]` items (a `mod tests { ... }`
+block, or an individual `#[cfg(test)] fn ...`) are blanked out before
+counting, so unit tests do not consume the production budget. This needs a
+real (if approximate) Rust-comment/string/brace scan rather than a line-based
+grep, because `#[cfg(test)]` blocks nest at arbitrary depth and are not
+always the last item in a file.
+
+    scripts/check-panic-surface.py              # check against the baseline
+    scripts/check-panic-surface.py --update     # re-baseline after a change
+
+`make check-panic-surface` runs the check; it is a `make test` prerequisite.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+BASELINE = ROOT / "scripts" / "panic-surface-baseline.txt"
+
+PANIC_RE = re.compile(
+    r"\.unwrap\(\)|\.unwrap_err\(\)|\.expect\(|\bpanic!\(|\bunreachable!\("
+    r"|\btodo!\(|\bunimplemented!\("
+)
+ALLOW_RE = re.compile(r"#\[allow\(")
+
+CFG_TEST_ATTR_RE = re.compile(r"#\[cfg\(test\)\]")
+CHAR_LIT_RE = re.compile(r"'(\\u\{[0-9a-fA-F]+\}|\\.|[^'\\])'")
+
+
+def mask_non_code(src: str) -> str:
+    """Blank comments and string/char literals, preserving length and
+    newlines, so brace and pattern counting only sees real code tokens."""
+    out = list(src)
+    n = len(src)
+    i = 0
+    while i < n:
+        c = src[i]
+        if c == "/" and i + 1 < n and src[i + 1] == "/":
+            j = i
+            while j < n and src[j] != "\n":
+                out[j] = " "
+                j += 1
+            i = j
+        elif c == "/" and i + 1 < n and src[i + 1] == "*":
+            depth = 1
+            out[i] = out[i + 1] = " "
+            j = i + 2
+            while j < n and depth > 0:
+                if src[j : j + 2] == "/*":
+                    out[j] = out[j + 1] = " "
+                    depth += 1
+                    j += 2
+                elif src[j : j + 2] == "*/":
+                    out[j] = out[j + 1] = " "
+                    depth -= 1
+                    j += 2
+                else:
+                    if src[j] != "\n":
+                        out[j] = " "
+                    j += 1
+            i = j
+        elif c == '"':
+            j = i + 1
+            out[i] = " "
+            while j < n and src[j] != '"':
+                if src[j] == "\\" and j + 1 < n:
+                    if src[j] != "\n":
+                        out[j] = " "
+                    j += 1
+                if j < n and src[j] != "\n":
+                    out[j] = " "
+                j += 1
+            if j < n:
+                out[j] = " "
+                j += 1
+            i = j
+        elif c == "r" and i + 1 < n and src[i + 1] in ('"', "#"):
+            j = i + 1
+            hashes = 0
+            while j < n and src[j] == "#":
+                hashes += 1
+                j += 1
+            if j < n and src[j] == '"':
+                start = i
+                j += 1
+                closer = '"' + "#" * hashes
+                idx = src.find(closer, j)
+                end = n if idx == -1 else idx + len(closer)
+                for k in range(start, end):
+                    if src[k] != "\n":
+                        out[k] = " "
+                i = end
+            else:
+                i += 1
+        elif c == "'":
+            m = CHAR_LIT_RE.match(src[i : i + 12])
+            if m:
+                length = m.end()
+                for k in range(length):
+                    if src[i + k] != "\n":
+                        out[i + k] = " "
+                i += length
+            else:
+                i += 1
+        else:
+            i += 1
+    return "".join(out)
+
+
+def _skip_attributes(masked: str, pos: int) -> int:
+    """Advance past whitespace and any further `#[...]` attributes stacked
+    on top of the one already matched, returning the position of the item
+    they annotate."""
+    n = len(masked)
+    while True:
+        while pos < n and masked[pos] in " \t\r\n":
+            pos += 1
+        if pos < n and masked[pos] == "#" and pos + 1 < n and masked[pos + 1] == "[":
+            depth = 0
+            j = pos + 1
+            while j < n:
+                if masked[j] == "[":
+                    depth += 1
+                elif masked[j] == "]":
+                    depth -= 1
+                    if depth == 0:
+                        j += 1
+                        break
+                j += 1
+            pos = j
+            continue
+        return pos
+
+
+def blank_test_regions(masked: str) -> str:
+    """Blank the body of every `#[cfg(test)]`-annotated item: either the
+    balanced `{ ... }` block of a fn/mod/impl, or a single `...;` statement
+    when the item has no block (e.g. a bare `use` behind cfg(test))."""
+    out = list(masked)
+    n = len(masked)
+    for m in CFG_TEST_ATTR_RE.finditer(masked):
+        pos = _skip_attributes(masked, m.end())
+        depth_paren = depth_brack = 0
+        j = pos
+        found_brace = found_semi = None
+        while j < n:
+            ch = masked[j]
+            if ch == "(":
+                depth_paren += 1
+            elif ch == ")":
+                depth_paren -= 1
+            elif ch == "[":
+                depth_brack += 1
+            elif ch == "]":
+                depth_brack -= 1
+            elif ch == "{" and depth_paren == 0 and depth_brack == 0:
+                found_brace = j
+                break
+            elif ch == ";" and depth_paren == 0 and depth_brack == 0:
+                found_semi = j
+                break
+            j += 1
+        if found_brace is not None:
+            depth = 0
+            k = found_brace
+            while k < n:
+                if masked[k] == "{":
+                    depth += 1
+                elif masked[k] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        k += 1
+                        break
+                k += 1
+            end = k
+        elif found_semi is not None:
+            end = found_semi + 1
+        else:
+            end = n
+        # Blank from the `#[cfg(test)]` attribute itself (not just its body),
+        # so a stacked `#[allow(...)]`/`#[test]` on the same test-only item
+        # does not consume the production `#[allow(` budget either.
+        for idx in range(m.start(), end):
+            if out[idx] != "\n":
+                out[idx] = " "
+    return "".join(out)
+
+
+def counts_for_file(path: Path) -> tuple[int, int]:
+    src = path.read_text(encoding="utf-8")
+    masked = blank_test_regions(mask_non_code(src))
+    return len(PANIC_RE.findall(masked)), len(ALLOW_RE.findall(masked))
+
+
+def total_counts() -> tuple[int, int]:
+    panics = allows = 0
+    for path in sorted(SRC.rglob("*.rs")):
+        p, a = counts_for_file(path)
+        panics += p
+        allows += a
+    return panics, allows
+
+
+def read_baseline() -> tuple[int, int]:
+    values: dict[str, int] = {}
+    for line in BASELINE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        values[key.strip()] = int(value.strip())
+    return values["panic_surface"], values["allow_surface"]
+
+
+def write_baseline(panic_surface: int, allow_surface: int) -> None:
+    BASELINE.write_text(
+        "# Ratchet baseline for scripts/check-panic-surface.py (issue #8186).\n"
+        "# These counts may go down (or stay flat), never up. Regenerate with:\n"
+        "#   scripts/check-panic-surface.py --update\n"
+        f"panic_surface={panic_surface}\n"
+        f"allow_surface={allow_surface}\n",
+        encoding="utf-8",
+    )
+
+
+def _count_snippet(src: str) -> tuple[int, int]:
+    masked = blank_test_regions(mask_non_code(src))
+    return len(PANIC_RE.findall(masked)), len(ALLOW_RE.findall(masked))
+
+
+def self_test() -> int:
+    """Exercise the masking logic against synthetic snippets so a change to
+    the tokenizer can't silently make the ratchet fail open (report 0 no
+    matter what src/ actually contains)."""
+    cases: list[tuple[str, str, tuple[int, int]]] = [
+        ("plain unwrap", "fn f() { x.unwrap(); }", (1, 0)),
+        ("plain panic!", 'fn f() { panic!("boom"); }', (1, 0)),
+        ("plain expect", 'fn f() { x.expect("y"); }', (1, 0)),
+        ("plain unreachable!", "fn f() { unreachable!(); }", (1, 0)),
+        ("plain todo!/unimplemented!", "fn f() { todo!(); unimplemented!(); }", (2, 0)),
+        ("plain allow", "#[allow(dead_code)]\nfn f() {}", (0, 1)),
+        ("line comment", "// x.unwrap();\nfn f() {}", (0, 0)),
+        ("block comment", "/* x.unwrap(); */\nfn f() {}", (0, 0)),
+        ("nested block comment", "/* outer /* x.unwrap(); */ still */\nfn f() {}", (0, 0)),
+        ("string literal", 'let s = "panic!(";', (0, 0)),
+        ("string with escaped quote", 'let s = "a\\"panic!(\\"b";', (0, 0)),
+        ("raw string", 'let s = r#"unreachable!("#;', (0, 0)),
+        ("char literal not a string opener", "let c = '\"'; x.unwrap();", (1, 0)),
+        (
+            "cfg(test) mod block excluded",
+            "fn a() { x.unwrap(); }\n"
+            "#[cfg(test)]\n"
+            "mod tests {\n"
+            "    fn t() { y.unwrap(); }\n"
+            "}\n"
+            "fn b() { z.unwrap(); }\n",
+            (2, 0),
+        ),
+        (
+            "cfg(test) fn without block excluded",
+            "#[cfg(test)]\nuse foo::bar;\nfn a() { x.unwrap(); }\n",
+            (1, 0),
+        ),
+        (
+            "stacked attributes before cfg(test) item",
+            "#[cfg(test)]\n#[allow(dead_code)]\nfn t() { x.unwrap(); }\n"
+            "fn b() { y.unwrap(); }\n",
+            (1, 0),
+        ),
+        (
+            "nested cfg(test) mod inside non-test mod",
+            "mod outer {\n"
+            "    fn a() { x.unwrap(); }\n"
+            "    #[cfg(test)]\n"
+            "    mod tests {\n"
+            "        fn t() { y.unwrap(); }\n"
+            "    }\n"
+            "}\n",
+            (1, 0),
+        ),
+    ]
+
+    failures = 0
+    for name, src, expected in cases:
+        got = _count_snippet(src)
+        if got != expected:
+            print(
+                f"check-panic-surface self-test FAILED: {name!r}: "
+                f"expected panic={expected[0]},allow={expected[1]}, "
+                f"got panic={got[0]},allow={got[1]}",
+                file=sys.stderr,
+            )
+            failures += 1
+
+    if failures:
+        print(f"check-panic-surface self-test: {failures} failure(s)", file=sys.stderr)
+        return 1
+    print(f"check-panic-surface self-test: all {len(cases)} cases pass")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        return self_test()
+
+    panic_now, allow_now = total_counts()
+
+    if "--update" in argv:
+        write_baseline(panic_now, allow_now)
+        print(
+            f"check-panic-surface: baseline updated "
+            f"(panic_surface={panic_now}, allow_surface={allow_now})"
+        )
+        return 0
+
+    if not BASELINE.exists():
+        print(
+            f"check-panic-surface: {BASELINE} missing; run "
+            "scripts/check-panic-surface.py --update",
+            file=sys.stderr,
+        )
+        return 1
+
+    panic_base, allow_base = read_baseline()
+    fail = False
+
+    if panic_now > panic_base:
+        print(
+            f"check-panic-surface ratchet FAILED: {panic_now} panic-family sites "
+            f"in src/ (unwrap/expect/panic!/unreachable!/todo!/unimplemented!), "
+            f"baseline {panic_base}.",
+            file=sys.stderr,
+        )
+        print(
+            "New code must handle the error instead of panicking, or return a "
+            "RuntimeError -- see PLAN.md's never-panic goal (#8186).",
+            file=sys.stderr,
+        )
+        fail = True
+    elif panic_now < panic_base:
+        print(
+            f"check-panic-surface: panic_surface={panic_now} (baseline "
+            f"{panic_base}) -- lower the baseline: "
+            "scripts/check-panic-surface.py --update"
+        )
+
+    if allow_now > allow_base:
+        print(
+            f"check-panic-surface ratchet FAILED: {allow_now} `#[allow(` sites "
+            f"in src/, baseline {allow_base}.",
+            file=sys.stderr,
+        )
+        print(
+            "Fix the lint instead of suppressing it, or justify a narrower "
+            "allow -- see #8186.",
+            file=sys.stderr,
+        )
+        fail = True
+    elif allow_now < allow_base:
+        print(
+            f"check-panic-surface: allow_surface={allow_now} (baseline "
+            f"{allow_base}) -- lower the baseline: "
+            "scripts/check-panic-surface.py --update"
+        )
+
+    if fail:
+        return 1
+
+    print(
+        f"check-panic-surface: ok (panic_surface={panic_now}/{panic_base}, "
+        f"allow_surface={allow_now}/{allow_base})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/panic-surface-baseline.txt
+++ b/scripts/panic-surface-baseline.txt
@@ -1,0 +1,5 @@
+# Ratchet baseline for scripts/check-panic-surface.py (issue #8186).
+# These counts may go down (or stay flat), never up. Regenerate with:
+#   scripts/check-panic-surface.py --update
+panic_surface=1906
+allow_surface=238


### PR DESCRIPTION
## Summary

`PLAN.md` §8.3 states mutsu must never Rust-panic on any input, but nothing enforced it: the `unwrap`/`expect`/`panic!`/`unreachable!` count in `src/` rose at every architecture review (2,440 as of 2026-09-12), and `#[allow(` rose alongside it (243). This is option 1 from #8186: a ratchet, on the same pattern as `opcode_size_guard`, `scripts/check-value-wall.sh` and `scripts/check-magic-keys.sh`.

- `scripts/check-panic-surface.py` counts `.unwrap()` / `.unwrap_err()` / `.expect(` / `panic!(` / `unreachable!(` / `todo!(` / `unimplemented!(` and `#[allow(` occurrences across `src/`, and fails when either count exceeds the committed baseline (`scripts/panic-surface-baseline.txt`). Either count may go down (or stay flat); raising it requires deliberately editing the baseline, so growth becomes visible in review instead of invisible in aggregate.
- `#[cfg(test)]` items are excluded from both counts via a small Rust comment/string/brace scan (blanking `//`/`/* */` comments, `"..."`/raw strings and char literals, then the balanced `{ ... }` body — or bare `...;` statement — of every `#[cfg(test)]`-attributed item, stacked attributes included) so test scaffolding does not consume the production budget. `#[cfg(test)]` nests at arbitrary depth in this codebase, not just as a trailing `mod tests` block, so a line-based grep was not enough.
- The masking logic gets its own `--self-test` against 17 synthetic snippets (comments, strings, raw strings, nested `#[cfg(test)] mod` inside a non-test `mod`, stacked `#[allow(]`+`#[cfg(test)]`, …), run by `make check-panic-surface` before it trusts the count on the real tree — a masking bug could otherwise make the ratchet silently report 0 no matter what `src/` contains.
- Excluding test code puts the enforced baseline at **1,906** panic-family sites and **238** `#[allow(` sites.
- Wired into `make test` and into the `test-check` CI job alongside the other ledger checks.
- `PLAN.md` §6 and §8.3 updated to point at the ratchet instead of describing the goal as unenforced.

## Test plan

- [x] `python3 scripts/check-panic-surface.py --self-test` — 17/17 pass
- [x] `make check-panic-surface` — ok (panic_surface=1906/1906, allow_surface=238/238)
- [x] `cargo fmt --all` (no-op, no Rust files changed)
- [x] `make lint` — clean (default clippy, `native`-only clippy, wasm32 clippy, rustdoc)
- [x] `make test` — PASS (Files=4150, Tests=44175)
- [x] `make roast` — failures limited to the three environment-only files documented in `docs/agent-environments.md` (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`: both `uid 0` bypassing `chmod`-based permission checks; `roast/S32-io/IO-Socket-Async.t`: sandboxed network timeout)

Closes #8186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_