### PR TITLE
perf(regex): the subrule call that needs no activation

### DIFF
--- a/news/2026-09/the-subrule-call-that-needs-no-activation.md
+++ b/news/2026-09/the-subrule-call-that-needs-no-activation.md
@@ -1,0 +1,108 @@
+# The `<subrule>` call that needs no activation
+
+Round 21 of [#7576](https://github.com/tokuhirom/mutsu/issues/7576). Instructions
+on the 60-row YAMLish document go **1,238,570,142 -> 1,199,253,834 (-3.17%)**.
+Attribution is callgrind `Ir` throughout, cache warmed first (`tmp/prof60.sh`,
+the round-15 harness).
+
+Round 20 left left-recursion bookkeeping as the largest single cluster at ~3.6%:
+three thread-local hash-map operations per `<subrule>` call — begin the
+activation, ask whether its seed was consulted, tear it down — on a grammar with
+no left recursion at all. Every previous round made those operations *cheaper*
+(one map instead of three, an interned key instead of three `String` clones, one
+probe instead of two). This round asks the prior question instead: does the call
+need an activation?
+
+## What the activation is for, and when nothing can use it
+
+An activation exists so that a re-entry of the same `(rule name, arguments,
+position)` key reads a growing seed instead of recursing forever. So it is dead
+weight exactly when nothing can re-enter the key while it lives — and a key is
+re-entered only by a call to a rule of the *same name*.
+
+The rule call graph already decides that. `regex_call_graph::reenter_decline`
+walks from `(package, rule name)` and reports whether a call to that name is
+reachable; the streamed `<subrule>` path (ADR-0073 Slice 2) has consulted it
+since #7548. Round 20's note named the two things that stopped it being a slice,
+and both turn out to be answerable:
+
+**The key carries no package while the analysis is per package.** It does — but
+the walk's comparison is on the callee's NAME alone (`callee.1 == name_sym`),
+which is precisely the question a package-blind key asks. What the walk cannot
+see is an *enclosing* activation of the same name in another package, since that
+call is not in this call's cone. So the gate also requires that no activation of
+the name is live anywhere on the stack, which is now an array index rather than a
+lookup: `LrState` keeps a per-`Symbol::id` count of live activations next to the
+key map, bumped and dropped by `lr_begin_activation` / `lr_end_activation`.
+
+**A wrong verdict fails as unbounded recursion, not as a wrong answer.** True,
+and it is why the second precondition is new. The walk deliberately treats an
+embedded `{ ... }` / `<?{ ... }>` block as harmless — it names no edge, and both
+callers keep a runtime escape for the case where user code re-enters the rule by
+hand (the eager arm's `first_only` retry, the streamed path's `seed_consulted`
+fallback). Skipping the activation skips the very escape that covers it. So the
+walk now reports a second fact alongside the edges — does any rule in the cone
+run user code at all (`{ ... }`, `<?{ ... }>`, `:my $x = ...`, a `** { ... }`
+quantifier bound, a `<:prop(...)>` predicate) — and the gate requires `false`.
+
+With all three conditions met the skip is not an approximation: in every state
+where it applies, the three map operations it replaces would have created an
+entry, read `false` out of it, and removed it again.
+
+## What it is worth
+
+`std::thread::LocalKey::with` goes **83,245,564 (6.72%) -> 63,769,904 (5.32%)**
+inclusive, and the two callers round 20 named are the whole of the difference:
+
+| caller | before | after |
+| --- | ---: | ---: |
+| `for_each_atom_candidate` (the streamed subrule path) | 22,169,959 Ir / 134,850 calls | *nothing left to show* |
+| `regex_match_atom_all_with_capture_in_pkg_inner` (the eager arm) | 21,984,162 Ir / 130,045 calls | 4,396,376 Ir / 24,946 calls |
+| the gate itself (`subrule_needs_no_lr_bookkeeping`) | — | 6,910,900 Ir / 86,473 calls |
+
+The gate is memoized per `(package, rule name)` per token generation — 41 cone
+walks for 86,473 asks — and its cache miss is `#[inline(never)]` so the probe
+that answers every other call stays a few instructions. It does not take a
+registry read lock to rule out a custom-HOW grammar, either: both call sites
+already know that answer (the streamed path declines on it outright, the eager
+arm binds it for its own dispatch attempt), and asking again cost an `RwLock`
+acquisition per `<subrule>` call for a fact that is not even memoizable.
+
+## Pinning it
+
+`t/regex/regex-lr-bookkeeping-gate.t` is twelve rows of the constructs that have
+to keep the gate shut — a directly left-recursive rule, a mutually recursive
+pair, a `{ ... }` block that re-enters its own rule name at the same position, a
+`<?{ ... }>` assertion, a `** { ... }` quantifier bound, a side-effecting block
+whose firing order is observable — plus the plain grammar whose results must not
+change and the rule name shared by two grammars. A widened gate would not give a
+wrong answer on any of them; it would recurse until the stack ran out, so every
+row is also a does-it-terminate row. The ten rows rakudo can run (it has no
+growing-seed loop and hangs on a left-recursive rule) were verified against
+rakudo 2026.07.
+
+Two Rust unit tests in `regex_lr_state` cover what Raku cannot reach
+deterministically: a live activation of the name closes the gate and reopens it
+on teardown, a new token generation retires every verdict, and the re-entry
+branch of `lr_begin_or_reenter` does not count as a second activation — counting
+it would leak a live activation and wedge the gate shut for the rest of the run.
+
+## What the next round starts from
+
+Re-measured after this round rather than carried forward:
+
+- **Allocator traffic is now the largest cluster by a distance**: `malloc`
+  5.02%, `_int_free` 6.41%, `_int_malloc` 3.18%, `free` 2.95%, plus `memcpy`
+  2.46%. With `CapStore::merge_delta` at 1.89% self and `RawTable::clone` at
+  1.44%, this is the capture store's design pass that rounds 15-20 have each
+  deferred — it is not a slice, and it is the only thing left that is worth
+  several percent.
+- `Symbol::intern` is now the single biggest `LocalKey::with` client at
+  **28,995,150 Ir (2.42%) over 209,978 interns**, diffuse callers.
+- The gate's own residual, 0.78%: 2,507,881 Ir of self plus the 6,910,900 Ir
+  probe. Half of it (the memoized verdict) could live on the `NamedAtom` node
+  the way round 20 put the lookup spec there, but the other half — is an
+  activation of this name live — is dynamic and has to read the thread-local.
+
+Cumulative over rounds 11-21 on the 60-row document: **8.130 Bn -> 1.199 Bn
+`Ir` (-85.2%)**.

--- a/src/runtime/regex/regex_call_graph.rs
+++ b/src/runtime/regex/regex_call_graph.rs
@@ -32,6 +32,14 @@
 //! keep a runtime escape for that (`regex_match_atom.rs`'s `first_only`
 //! retry, and the streamed subrule's seed-consulted fallback in
 //! `regex_match_lazy_subrule.rs`), exactly as the first half of Slice 2 does.
+//!
+//! The walk therefore also reports whether the cone runs user code *at all*
+//! ([`DirectCalls::runs_user_code`]). That second bit is what the
+//! left-recursion gate needs and the streamed path does not: a cone with no
+//! reachable call to its own name AND no user code in it cannot re-enter its
+//! key by any route, so the activation the key exists for can be skipped
+//! outright rather than merely escaped from afterwards
+//! ([`Interpreter::subrule_needs_no_lr_bookkeeping`]).
 
 use std::cell::RefCell;
 // `STREAMABLE` is probed before every `<subrule>` call is even resolved, so
@@ -53,6 +61,19 @@ type RuleNode = (Symbol, Symbol);
 /// call cone is answered "not proven" rather than walked further — the
 /// analysis exists to save work, not to spend it.
 const MAX_REACHABLE_RULES: usize = 512;
+
+/// What one rule's candidates dispatch to, as far as the walk can name it.
+pub(super) struct DirectCalls {
+    /// The rules every candidate calls directly.
+    callees: Vec<RuleNode>,
+    /// Some atom in one of the candidates runs user code — a `{ ... }` /
+    /// `<?{ ... }>` block, a `:my $x = ...` declaration, a `** { ... }`
+    /// quantifier bound, a `<:prop(...)>` property predicate. That code can
+    /// call any rule by hand, so it is an edge the walk cannot name. The
+    /// streamed path tolerates it (it has a runtime escape); the
+    /// left-recursion gate does not.
+    runs_user_code: bool,
+}
 
 /// Why a `<subrule>` call could not take the streamed path.
 ///
@@ -141,7 +162,7 @@ thread_local! {
     #[allow(clippy::type_complexity)]
     static DIRECT_CALLS: RefCell<(
         u64,
-        HashMap<RuleNode, Result<std::sync::Arc<Vec<RuleNode>>, StreamDecline>>,
+        HashMap<RuleNode, Result<std::sync::Arc<DirectCalls>, StreamDecline>>,
     )> = RefCell::new((0, HashMap::default()));
 
     /// `pkg -> subrule atom text -> may this call be streamed?`. This is the
@@ -170,30 +191,41 @@ impl Interpreter {
     /// and an unresolvable edge both mean "may re-enter" but cost entirely
     /// different work to clear.
     fn reenter_decline(&mut self, name: &str, pkg: Symbol) -> Option<StreamDecline> {
+        self.cone_walk(name, pkg).0
+    }
+
+    /// The walk itself, reporting both facts it can establish about the cone:
+    /// why the key may be re-entered (`None` = proven unreachable), and whether
+    /// no rule in the cone runs user code. The second is only meaningful
+    /// alongside a `None` first — an aborted walk answers `false` rather than
+    /// guessing at the part it never reached.
+    fn cone_walk(&mut self, name: &str, pkg: Symbol) -> (Option<StreamDecline>, bool) {
         let name_sym = Symbol::intern(name);
         let start: RuleNode = (pkg, name_sym);
         let mut seen: HashSet<RuleNode> = HashSet::from_iter([start]);
         let mut queue: VecDeque<RuleNode> = VecDeque::from([start]);
+        let mut code_free = true;
         while let Some((cur_pkg, cur_name)) = queue.pop_front() {
             let calls = match self.direct_rule_calls(cur_name.as_str(), cur_pkg) {
                 Ok(calls) => calls,
-                Err(reason) => return Some(reason),
+                Err(reason) => return (Some(reason), false),
             };
-            for callee in calls.iter() {
+            code_free &= !calls.runs_user_code;
+            for callee in calls.callees.iter() {
                 // Reaching the starting NAME again closes the loop the
                 // growing-seed algorithm exists for.
                 if callee.1 == name_sym {
-                    return Some(StreamDecline::ReentersOwnName);
+                    return (Some(StreamDecline::ReentersOwnName), false);
                 }
                 if seen.len() >= MAX_REACHABLE_RULES {
-                    return Some(StreamDecline::ReachableSetTooLarge);
+                    return (Some(StreamDecline::ReachableSetTooLarge), false);
                 }
                 if seen.insert(*callee) {
                     queue.push_back(*callee);
                 }
             }
         }
-        None
+        (None, code_free)
     }
 
     /// The rules every candidate of `<name>` in `pkg` calls directly, or `None`
@@ -207,7 +239,7 @@ impl Interpreter {
         &mut self,
         name: &str,
         pkg: Symbol,
-    ) -> Result<std::sync::Arc<Vec<RuleNode>>, StreamDecline> {
+    ) -> Result<std::sync::Arc<DirectCalls>, StreamDecline> {
         let generation = token_defs_gen();
         let key: RuleNode = (pkg, Symbol::intern(name));
         if let Some(hit) = DIRECT_CALLS.with(|c| {
@@ -256,18 +288,24 @@ impl Interpreter {
         pkg: Symbol,
         candidates: &[super::regex_token_resolve::ParsedTokenCandidate],
         raw_empty: bool,
-    ) -> Result<std::sync::Arc<Vec<RuleNode>>, StreamDecline> {
+    ) -> Result<std::sync::Arc<DirectCalls>, StreamDecline> {
         if raw_empty || candidates.is_empty() {
             // No token/regex/rule answers to this name here. It is either a
             // builtin assertion or character class (`<alpha>`, `<ws>` with no
             // grammar override, `<sym>`), which cannot dispatch to a user rule,
             // or a plain grammar METHOD — arbitrary user code, so unknowable.
             return match self.registry().user_method_overloads(pkg.as_str(), name) {
-                None => Ok(std::sync::Arc::new(Vec::new())),
+                None => Ok(std::sync::Arc::new(DirectCalls {
+                    callees: Vec::new(),
+                    runs_user_code: false,
+                })),
                 Some(_) => Err(StreamDecline::CalleeIsMethod),
             };
         }
-        let mut out: Vec<RuleNode> = Vec::new();
+        let mut out = DirectCalls {
+            callees: Vec::new(),
+            runs_user_code: false,
+        };
         for (parsed, sub_pkg, _) in candidates.iter() {
             // A candidate's own body resolves its unqualified subrule
             // references against the package that DEFINED it, not against the
@@ -279,8 +317,8 @@ impl Interpreter {
         // Sorted by interned id, not lexicographically: the order is only a
         // means to `dedup`, and comparing two `u32`s beats resolving four
         // strings.
-        out.sort_by_key(|(pkg, name)| (pkg.id(), name.id()));
-        out.dedup();
+        out.callees.sort_by_key(|(pkg, name)| (pkg.id(), name.id()));
+        out.callees.dedup();
         Ok(std::sync::Arc::new(out))
     }
 }
@@ -318,6 +356,60 @@ impl Interpreter {
                 .or_default()
                 .insert(atom_text.to_string(), verdict);
         });
+        verdict
+    }
+
+    /// May a `<name>` call in `pkg` skip its left-recursion activation
+    /// entirely?
+    ///
+    /// The activation exists so that a re-entry of the same `(name, args,
+    /// position)` key reads a growing seed instead of recursing forever. Two
+    /// things have to hold for it to be dead weight, and both are properties of
+    /// the call cone rather than of this call:
+    ///
+    /// * nothing reachable from `(pkg, name)` calls a rule of the same *name* —
+    ///   the key carries no package, so the walk's name-only comparison is
+    ///   exactly the right question;
+    /// * no rule in the cone runs user code, which could name one by hand and
+    ///   is the case the callers' runtime escapes exist for.
+    ///
+    /// A live activation of the same name elsewhere on the stack answers `false`
+    /// without consulting any of it — see
+    /// [`super::regex_lr_state::lr_skip_verdict`]. The result is that the skip
+    /// is not an approximation: in every state where it applies, the three map
+    /// operations it replaces would have created an entry, read `false` from
+    /// it, and removed it again.
+    ///
+    /// CALLERS MUST HAVE RULED OUT A CUSTOM-HOW GRAMMAR — one routes dispatch
+    /// through a user `find_method`, so the call graph is not what runs. Both
+    /// call sites already know the answer (the streamed path declines on it
+    /// outright, the eager arm binds it for its own dispatch attempt), and
+    /// asking again here would take a registry read lock per `<subrule>` call
+    /// for a fact that is not even memoizable: a custom-HOW grammar can be
+    /// declared after a verdict is cached, and `TOKEN_DEFS_GEN` is not what
+    /// tracks it.
+    #[inline]
+    pub(super) fn subrule_needs_no_lr_bookkeeping(&mut self, name: Symbol, pkg: Symbol) -> bool {
+        let generation = token_defs_gen();
+        match super::regex_lr_state::lr_skip_verdict(name, pkg, generation) {
+            Some(hit) => hit,
+            None => self.compute_lr_bookkeeping_verdict(name, pkg, generation),
+        }
+    }
+
+    /// [`Interpreter::subrule_needs_no_lr_bookkeeping`]'s cache miss: once per
+    /// `(package, rule name)` per token generation, out of line so the probe
+    /// that answers every other call stays a few instructions.
+    #[inline(never)]
+    fn compute_lr_bookkeeping_verdict(
+        &mut self,
+        name: Symbol,
+        pkg: Symbol,
+        generation: u64,
+    ) -> bool {
+        let (decline, code_free) = self.cone_walk(name.as_str(), pkg);
+        let verdict = decline.is_none() && code_free;
+        super::regex_lr_state::lr_record_skip_verdict(name, pkg, generation, verdict);
         verdict
     }
 
@@ -419,8 +511,15 @@ fn pattern_text_is_static_outside_code_blocks(pattern: &str) -> bool {
 /// Append every rule `pattern` (matched in `pkg`) can dispatch to. Returns
 /// `false` when it contains a construct whose target is not statically known,
 /// in which case `out` is meaningless.
-fn collect_pattern_calls(pattern: &RegexPattern, pkg: Symbol, out: &mut Vec<RuleNode>) -> bool {
+fn collect_pattern_calls(pattern: &RegexPattern, pkg: Symbol, out: &mut DirectCalls) -> bool {
     pattern.tokens.iter().all(|token| {
+        // `** { ... }` decides its repeat count by running the block.
+        if matches!(
+            token.quant,
+            crate::runtime::regex_types::RegexQuant::RepeatCode(_)
+        ) {
+            out.runs_user_code = true;
+        }
         collect_atom_calls(&token.atom, pkg, out)
             && token
                 .separator
@@ -429,7 +528,7 @@ fn collect_pattern_calls(pattern: &RegexPattern, pkg: Symbol, out: &mut Vec<Rule
     })
 }
 
-fn collect_atom_calls(atom: &RegexAtom, pkg: Symbol, out: &mut Vec<RuleNode>) -> bool {
+fn collect_atom_calls(atom: &RegexAtom, pkg: Symbol, out: &mut DirectCalls) -> bool {
     match atom {
         // Matches text or asserts on its own; reaches no dispatcher.
         RegexAtom::Literal(_)
@@ -438,14 +537,9 @@ fn collect_atom_calls(atom: &RegexAtom, pkg: Symbol, out: &mut Vec<RuleNode>) ->
         | RegexAtom::Newline
         | RegexAtom::NotNewline
         | RegexAtom::ZeroWidth
-        // User code. See the module header: treated as harmless here, with a
-        // runtime escape at both call sites.
-        | RegexAtom::CodeAssertion { .. }
-        | RegexAtom::UnicodeProp { .. }
         | RegexAtom::UnicodePropAssert { .. }
         | RegexAtom::CaptureStartMarker
         | RegexAtom::CaptureEndMarker
-        | RegexAtom::VarDecl { .. }
         | RegexAtom::CompositeClass { .. }
         | RegexAtom::LeftWordBoundary
         | RegexAtom::RightWordBoundary
@@ -461,6 +555,20 @@ fn collect_atom_calls(atom: &RegexAtom, pkg: Symbol, out: &mut Vec<RuleNode>) ->
         | RegexAtom::SameAssertion { .. }
         | RegexAtom::AtPosition(_)
         | RegexAtom::TildeMarker => true,
+        // User code. See the module header: it names no edge the walk can
+        // record, so it stays "harmless" for the streamed path's purposes
+        // (which has a runtime escape) — but it is recorded, because the
+        // left-recursion gate skips the very escape that covers it.
+        RegexAtom::CodeAssertion { .. } | RegexAtom::VarDecl { .. } => {
+            out.runs_user_code = true;
+            true
+        }
+        // `<:Numeric_Value(...)>` takes a predicate expression; the bare
+        // property form does not.
+        RegexAtom::UnicodeProp { args, .. } => {
+            out.runs_user_code |= args.is_some();
+            true
+        }
         RegexAtom::Group(p) | RegexAtom::CaptureGroup(p) | RegexAtom::CaptureIsolatedGroup(p) => {
             collect_pattern_calls(p, pkg, out)
         }
@@ -475,7 +583,7 @@ fn collect_atom_calls(atom: &RegexAtom, pkg: Symbol, out: &mut Vec<RuleNode>) ->
         }
         RegexAtom::WsRule => {
             // `<.ws>` dispatches to whatever `ws` the grammar resolves to.
-            out.push((pkg, Symbol::intern("ws")));
+            out.callees.push((pkg, Symbol::intern("ws")));
             true
         }
         RegexAtom::Named(name) => {
@@ -499,7 +607,7 @@ fn collect_atom_calls(atom: &RegexAtom, pkg: Symbol, out: &mut Vec<RuleNode>) ->
             {
                 return false;
             }
-            out.push((pkg, spec.lookup_sym));
+            out.callees.push((pkg, spec.lookup_sym));
             true
         }
         // `<{ ... }>` matches whatever regex the code returns; `<~~>` re-enters

--- a/src/runtime/regex/regex_lr_state.rs
+++ b/src/runtime/regex/regex_lr_state.rs
@@ -14,6 +14,16 @@
 //! left-recursive ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)).
 //! One map of one entry struct, keyed by the *interned* rule name, does the
 //! same work in one hash lookup per operation and no allocation at all.
+//!
+//! Round 21 asks the prior question instead: does this call need an activation
+//! at all? A `<subrule>` call can only ever re-enter its own key through a call
+//! to a rule of the same name, and the rule call graph
+//! ([`super::regex_call_graph`]) already decides whether one is reachable. When
+//! it proves none is, AND no rule in the call cone runs user code that could
+//! name one by hand, AND no activation of that name is live further up the
+//! stack, the three map operations are provably a no-op and are skipped
+//! outright. The gate itself is the memoized verdict plus one `Vec` index, in
+//! the same thread-local the state lives in.
 
 use rustc_hash::FxHashMap as HashMap;
 use std::cell::RefCell;
@@ -57,6 +67,59 @@ impl LrKey {
     }
 }
 
+/// Everything the left-recursion machinery keeps per thread.
+///
+/// One thread-local rather than three: `lr_begin_or_reenter` and
+/// `lr_end_activation` touch the key map and the per-name activation count
+/// together, and the gate reads the count and the memoized verdict together, so
+/// splitting them would only buy extra [`std::thread::LocalKey`]
+/// accesses on the hottest path in the matcher.
+struct LrState {
+    /// Per-key state for the calls currently in flight.
+    keys: HashMap<LrKey, LrEntry>,
+    /// How many activations of each rule NAME are live, indexed by
+    /// [`Symbol::id`]. A name with no live activation cannot be re-entered by
+    /// anything, which is what lets a proven-safe call skip `keys` entirely —
+    /// and answering it by array index keeps the gate cheaper than the one hash
+    /// lookup it replaces.
+    active: Vec<u32>,
+    /// The token generation [`LrState::skip`] was computed under. Rule bodies
+    /// can be redefined (`TOKEN_DEFS_GEN`), which invalidates every verdict.
+    generation: u64,
+    /// `(package, rule name) -> this call provably needs no bookkeeping`, as
+    /// decided by [`super::regex_call_graph`]'s cone walk.
+    skip: HashMap<(Symbol, Symbol), bool>,
+}
+
+impl LrState {
+    /// Const-constructible so the thread-local needs no lazy-initialization
+    /// check on every access — this is the matcher's hottest thread-local.
+    const fn new() -> Self {
+        LrState {
+            keys: HashMap::with_hasher(rustc_hash::FxBuildHasher),
+            active: Vec::new(),
+            generation: 0,
+            skip: HashMap::with_hasher(rustc_hash::FxBuildHasher),
+        }
+    }
+
+    #[inline]
+    fn bump(&mut self, name: Symbol) {
+        let idx = name.id() as usize;
+        if idx >= self.active.len() {
+            self.active.resize(idx + 1, 0);
+        }
+        self.active[idx] += 1;
+    }
+
+    #[inline]
+    fn unbump(&mut self, name: Symbol) {
+        if let Some(slot) = self.active.get_mut(name.id() as usize) {
+            *slot = slot.saturating_sub(1);
+        }
+    }
+}
+
 /// One key's left-recursion state.
 #[derive(Default)]
 struct LrEntry {
@@ -83,18 +146,20 @@ impl LrEntry {
 }
 
 thread_local! {
-    /// Per-key left-recursion state for the calls currently in flight.
+    /// Per-key left-recursion state for the calls currently in flight, the
+    /// per-name activation counts, and the memoized "needs no bookkeeping"
+    /// verdicts.
     ///
-    /// Fx-hashed rather than SipHash-hashed: this map is probed several times
-    /// per `<subrule>` call at every position, and a grammar rule name is not
-    /// adversarial input.
-    static LR_STATE: RefCell<HashMap<LrKey, LrEntry>> = RefCell::new(HashMap::default());
+    /// Fx-hashed rather than SipHash-hashed: these maps are probed several
+    /// times per `<subrule>` call at every position, and a grammar rule name is
+    /// not adversarial input.
+    static LR_STATE: RefCell<LrState> = const { RefCell::new(LrState::new()) };
 }
 
 /// `true` when this key is already being evaluated further up the stack, i.e.
 /// entering it again would be a left-recursive re-entry.
 pub(super) fn lr_key_is_active(key: &LrKey) -> bool {
-    LR_STATE.with(|s| s.borrow().get(key).is_some_and(|e| e.seed.is_some()))
+    LR_STATE.with(|s| s.borrow().keys.get(key).is_some_and(|e| e.seed.is_some()))
 }
 
 /// Mark `key` as under evaluation with an empty seed, returning the enclosing
@@ -102,10 +167,48 @@ pub(super) fn lr_key_is_active(key: &LrKey) -> bool {
 pub(super) fn lr_begin_activation(key: &LrKey) -> bool {
     LR_STATE.with(|s| {
         let mut s = s.borrow_mut();
-        let entry = s.entry(key.clone()).or_default();
+        s.bump(key.name);
+        let entry = s.keys.entry(key.clone()).or_default();
         entry.seed = Some(Vec::new());
         std::mem::take(&mut entry.seed_read)
     })
+}
+
+/// The gate [`super::regex_call_graph`] decides and this module caches: may a
+/// `<name>` call in `pkg` skip its activation entirely?
+///
+/// `None` means "not decided for this token generation" and asks the caller to
+/// run the cone walk and report back through [`lr_record_skip_verdict`]. A live
+/// activation of the same NAME answers `Some(false)` outright, whatever the
+/// walk says: the verdict is about what this call's own cone can reach, and an
+/// *enclosing* call of the same name is not in it (two grammars that define the
+/// same rule name share a key, while the walk is per package). That case keeps
+/// the full bookkeeping, so the skip is observationally identical to taking it.
+#[inline]
+pub(super) fn lr_skip_verdict(name: Symbol, pkg: Symbol, generation: u64) -> Option<bool> {
+    LR_STATE.with(|s| {
+        let s = s.borrow();
+        if s.active.get(name.id() as usize).is_some_and(|&n| n > 0) {
+            return Some(false);
+        }
+        if s.generation != generation {
+            return None;
+        }
+        s.skip.get(&(pkg, name)).copied()
+    })
+}
+
+/// Record what the cone walk decided, discarding every verdict from an earlier
+/// token generation.
+pub(super) fn lr_record_skip_verdict(name: Symbol, pkg: Symbol, generation: u64, verdict: bool) {
+    LR_STATE.with(|s| {
+        let mut s = s.borrow_mut();
+        if s.generation != generation {
+            s.generation = generation;
+            s.skip.clear();
+        }
+        s.skip.insert((pkg, name), verdict);
+    });
 }
 
 /// What a `<subrule>` call found when it asked to start an activation.
@@ -133,13 +236,15 @@ pub(super) enum LrBegin {
 pub(super) fn lr_begin_or_reenter(key: &LrKey) -> LrBegin {
     LR_STATE.with(|s| {
         let mut s = s.borrow_mut();
-        let entry = s.entry(key.clone()).or_default();
+        let entry = s.keys.entry(key.clone()).or_default();
         if let Some(seed) = entry.seed.as_ref() {
             entry.seed_read = true;
             return LrBegin::Reentry(seed.clone());
         }
         entry.seed = Some(Vec::new());
-        LrBegin::Began(std::mem::take(&mut entry.seed_read))
+        let outer_seed_read = std::mem::take(&mut entry.seed_read);
+        s.bump(key.name);
+        LrBegin::Began(outer_seed_read)
     })
 }
 
@@ -148,7 +253,8 @@ pub(super) fn lr_begin_or_reenter(key: &LrKey) -> LrBegin {
 pub(super) fn lr_end_activation(key: &LrKey, outer_seed_read: bool) -> bool {
     LR_STATE.with(|s| {
         let mut s = s.borrow_mut();
-        match s.entry(key.clone()) {
+        s.unbump(key.name);
+        match s.keys.entry(key.clone()) {
             Entry::Occupied(mut occupied) => {
                 let entry = occupied.get_mut();
                 entry.seed = None;
@@ -174,14 +280,14 @@ pub(super) fn lr_end_activation(key: &LrKey, outer_seed_read: bool) -> bool {
 
 /// Has anything read `key`'s seed?
 pub(super) fn lr_seed_was_consulted(key: &LrKey) -> bool {
-    LR_STATE.with(|s| s.borrow().get(key).is_some_and(|e| e.seed_read))
+    LR_STATE.with(|s| s.borrow().keys.get(key).is_some_and(|e| e.seed_read))
 }
 
 /// Replace the seed of the activation that owns `key` (one iteration of the
 /// growing-seed loop).
 pub(super) fn lr_store_seed(key: &LrKey, seed: Vec<(usize, RegexCaptures)>) {
     LR_STATE.with(|s| {
-        s.borrow_mut().entry(key.clone()).or_default().seed = Some(seed);
+        s.borrow_mut().keys.entry(key.clone()).or_default().seed = Some(seed);
     });
 }
 
@@ -202,7 +308,7 @@ mod tests {
         assert!(lr_key_is_active(&k));
         assert!(!lr_end_activation(&k, outer));
         assert!(!lr_key_is_active(&k));
-        LR_STATE.with(|s| assert!(!s.borrow().contains_key(&k)));
+        LR_STATE.with(|s| assert!(!s.borrow().keys.contains_key(&k)));
     }
 
     #[test]
@@ -223,7 +329,7 @@ mod tests {
         assert!(!lr_end_activation(&k, inner));
         assert!(lr_seed_was_consulted(&k));
         assert!(lr_end_activation(&k, outer));
-        LR_STATE.with(|s| assert!(!s.borrow().contains_key(&k)));
+        LR_STATE.with(|s| assert!(!s.borrow().keys.contains_key(&k)));
     }
 
     #[test]
@@ -242,7 +348,48 @@ mod tests {
         assert!(matches!(lr_begin_or_reenter(&k), LrBegin::Began(_)));
         assert!(matches!(lr_begin_or_reenter(&k), LrBegin::Reentry(seed) if seed.is_empty()));
         lr_end_activation(&k, false);
-        LR_STATE.with(|s| assert!(!s.borrow().contains_key(&k)));
+        LR_STATE.with(|s| assert!(!s.borrow().keys.contains_key(&k)));
+    }
+
+    #[test]
+    fn a_live_activation_of_the_name_closes_the_skip_gate() {
+        let name = Symbol::intern("lr_gate_name");
+        let pkg = Symbol::intern("lr_gate_pkg");
+        // Undecided until someone runs the cone walk.
+        assert_eq!(lr_skip_verdict(name, pkg, 1), None);
+        lr_record_skip_verdict(name, pkg, 1, true);
+        assert_eq!(lr_skip_verdict(name, pkg, 1), Some(true));
+
+        // An activation of the same NAME — at any position, in any package —
+        // makes the key re-enterable from outside this call's own cone, which
+        // is the one thing the walk cannot see. The gate closes while it lives.
+        let k = key("lr_gate_name", 11);
+        let outer = lr_begin_activation(&k);
+        assert_eq!(lr_skip_verdict(name, pkg, 1), Some(false));
+        lr_end_activation(&k, outer);
+        assert_eq!(lr_skip_verdict(name, pkg, 1), Some(true));
+
+        // A new token generation retires every verdict.
+        assert_eq!(lr_skip_verdict(name, pkg, 2), None);
+        lr_record_skip_verdict(name, pkg, 2, false);
+        assert_eq!(lr_skip_verdict(name, pkg, 2), Some(false));
+    }
+
+    #[test]
+    fn a_reentry_does_not_count_as_a_second_activation() {
+        // `lr_begin_or_reenter` bumps the name count only on the branch that
+        // actually begins an activation: the re-entry branch returns the seed
+        // and its caller never calls `lr_end_activation`, so counting it would
+        // leak a live activation and wedge the gate shut for the rest of the
+        // run.
+        let name = Symbol::intern("lr_gate_reentry");
+        let pkg = Symbol::intern("lr_gate_pkg2");
+        let k = LrKey::new(name, None, 4);
+        lr_record_skip_verdict(name, pkg, 1, true);
+        let outer = lr_begin_activation(&k);
+        assert!(matches!(lr_begin_or_reenter(&k), LrBegin::Reentry(_)));
+        lr_end_activation(&k, outer);
+        assert_eq!(lr_skip_verdict(name, pkg, 1), Some(true));
     }
 
     #[test]

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -532,8 +532,9 @@ impl Interpreter {
             // `find_method` routes subrule dispatch through it (the
             // Metamodel::GrammarHOW protocol); `None` falls through to the
             // normal engine path.
-            if !candidates.is_empty()
-                && !self.registry().grammar_custom_how.is_empty()
+            let custom_how =
+                !candidates.is_empty() && !self.registry().grammar_custom_how.is_empty();
+            if custom_how
                 && let Some(result) =
                     self.try_custom_how_subrule_dispatch(&spec, chars, pos, pkg, &arg_values)
             {
@@ -564,7 +565,18 @@ impl Interpreter {
                     }
                     n.into_boxed_str()
                 });
-                let lr_key = LrKey::new(spec.lookup_sym, lr_args, chars.len() - pos);
+                // ... unless nothing can re-enter the key at all. The rule call
+                // graph decides that (`subrule_needs_no_lr_bookkeeping`), and
+                // when it does the whole activation — create the entry, read
+                // `false` out of it, remove it again — is provably a no-op, so
+                // the key is never built and the three map operations never
+                // happen. An argument-bearing call keeps the bookkeeping: its
+                // arguments are part of the key, and they are runtime data the
+                // walk does not model.
+                let lr_key = (!arg_values.is_empty()
+                    || custom_how
+                    || !self.subrule_needs_no_lr_bookkeeping(spec.lookup_sym, pkg))
+                .then(|| LrKey::new(spec.lookup_sym, lr_args, chars.len() - pos));
 
                 // Is this call already active (left recursion), and if not,
                 // start its activation — one map operation for both, since
@@ -579,20 +591,23 @@ impl Interpreter {
                 // (= no match yet). This key starts out un-consulted for THIS
                 // activation; a stale entry from an earlier activation at the
                 // same key must not be read as "left-recursive" here.
-                let outer_seed_read = match super::regex_lr_state::lr_begin_or_reenter(&lr_key) {
-                    super::regex_lr_state::LrBegin::Reentry(seed) => {
-                        // Wrap seed into outer captures.
-                        // build_named_candidates_from_inner returns items in the
-                        // same order as input (HIGHEST FIRST). Caller expects
-                        // LOWEST FIRST, so reverse.
-                        let mut result = Self::build_named_candidates_from_inner(
-                            seed, pos, &spec, None, // no sym_key for seed
-                        );
-                        result.reverse();
-                        return result;
+                let mut outer_seed_read = false;
+                if let Some(lr_key) = &lr_key {
+                    match super::regex_lr_state::lr_begin_or_reenter(lr_key) {
+                        super::regex_lr_state::LrBegin::Reentry(seed) => {
+                            // Wrap seed into outer captures.
+                            // build_named_candidates_from_inner returns items in
+                            // the same order as input (HIGHEST FIRST). Caller
+                            // expects LOWEST FIRST, so reverse.
+                            let mut result = Self::build_named_candidates_from_inner(
+                                seed, pos, &spec, None, // no sym_key for seed
+                            );
+                            result.reverse();
+                            return result;
+                        }
+                        super::regex_lr_state::LrBegin::Began(outer) => outer_seed_read = outer,
                     }
-                    super::regex_lr_state::LrBegin::Began(outer_seed_read) => outer_seed_read,
-                };
+                }
 
                 // best_inner_max: max inner_end seen so far (None = nothing matched yet).
                 let mut best_inner_max: Option<usize> = None;
@@ -740,7 +755,7 @@ impl Interpreter {
                     // identical set — and since every nested subrule did the same,
                     // that redundant second pass compounded to 2^depth over a
                     // precedence-climbing grammar (99problems-41-to-50.t P47).
-                    let seed_was_consulted = lr_seed_was_consulted(&lr_key);
+                    let seed_was_consulted = lr_key.as_ref().is_some_and(lr_seed_was_consulted);
                     if !seed_was_consulted {
                         best_raw = deduped_raw;
                         break;
@@ -772,7 +787,9 @@ impl Interpreter {
                         // Seed grew: store the raw matches (HIGHEST FIRST) as the seed.
                         best_inner_max = new_max;
                         best_raw = deduped_raw.clone();
-                        lr_store_seed(&lr_key, deduped_raw);
+                        if let Some(lr_key) = &lr_key {
+                            lr_store_seed(lr_key, deduped_raw);
+                        }
                     } else {
                         // No growth: done.
                         break;
@@ -782,7 +799,9 @@ impl Interpreter {
                 // Clean up this activation, restoring the enclosing one's
                 // consulted flag: an inner activation of the same key must not
                 // mask the outer one's.
-                lr_end_activation(&lr_key, outer_seed_read);
+                if let Some(lr_key) = &lr_key {
+                    lr_end_activation(lr_key, outer_seed_read);
+                }
 
                 // Wrap best_raw into outer captures and return.
                 // best_raw is HIGHEST FIRST; build_named_candidates_from_inner returns in

--- a/src/runtime/regex/regex_match_lazy_subrule.rs
+++ b/src/runtime/regex/regex_match_lazy_subrule.rs
@@ -79,8 +79,17 @@ impl Interpreter {
             return decline(reason);
         }
         let spec = name.spec();
-        let lr_key = super::regex_lr_state::LrKey::new(spec.lookup_sym, None, chars.len() - pos);
-        if super::regex_lr_state::lr_key_is_active(&lr_key) {
+        // The same gate the eager arm uses: when the call graph proves nothing
+        // in the cone can re-enter this key — not by a rule call and not by
+        // hand from user code — the activation below is dead weight and is
+        // skipped outright, `lr_key` and all. `seed_consulted` is then `false`
+        // by construction, which is exactly what the skip asserts.
+        let lr_key = (!self.subrule_needs_no_lr_bookkeeping(spec.lookup_sym, pkg))
+            .then(|| super::regex_lr_state::LrKey::new(spec.lookup_sym, None, chars.len() - pos));
+        if lr_key
+            .as_ref()
+            .is_some_and(super::regex_lr_state::lr_key_is_active)
+        {
             return decline(StreamDecline::LrKeyActive);
         }
         // Same resolution the eager arm performs (memoized for a static body,
@@ -99,7 +108,9 @@ impl Interpreter {
         let parsed = std::sync::Arc::clone(parsed);
         let sub_pkg = *sub_pkg;
 
-        let outer_seed_read = super::regex_lr_state::lr_begin_activation(&lr_key);
+        let outer_seed_read = lr_key
+            .as_ref()
+            .is_some_and(super::regex_lr_state::lr_begin_activation);
         // Ends are deduplicated the way the eager arm does it: the first (=
         // highest-priority) path to reach an end wins, later ones are dropped.
         let mut seen_ends: Vec<usize> = Vec::new();
@@ -135,10 +146,14 @@ impl Interpreter {
                 // across the continuation and restore it for the rest of the
                 // body walk; the code-block re-entry the activation exists to
                 // catch happens inside the body, which is still covered.
-                *seed_consulted_in_cont |=
-                    super::regex_lr_state::lr_end_activation(&lr_key, outer_seed_read);
+                if let Some(lr_key) = &lr_key {
+                    *seed_consulted_in_cont |=
+                        super::regex_lr_state::lr_end_activation(lr_key, outer_seed_read);
+                }
                 let stop = on(interp, store, end, delta);
-                super::regex_lr_state::lr_begin_activation(&lr_key);
+                if let Some(lr_key) = &lr_key {
+                    super::regex_lr_state::lr_begin_activation(lr_key);
+                }
                 if stop {
                     *unwind = true;
                     return true;
@@ -158,8 +173,9 @@ impl Interpreter {
                 &mut MatchSink::Cont(&mut cont),
             );
         }
-        let seed_consulted = super::regex_lr_state::lr_end_activation(&lr_key, outer_seed_read)
-            || seed_consulted_in_cont;
+        let seed_consulted = lr_key.as_ref().is_some_and(|lr_key| {
+            super::regex_lr_state::lr_end_activation(lr_key, outer_seed_read)
+        }) || seed_consulted_in_cont;
         if seed_consulted && !unwind {
             // A `{ ... }` block re-entered this key after all, so the single
             // pass above is not the growing-seed loop's answer. Nothing has

--- a/t/regex/regex-lr-bookkeeping-gate.t
+++ b/t/regex/regex-lr-bookkeeping-gate.t
@@ -1,0 +1,105 @@
+use v6;
+use Test;
+
+# Round 21 of #7576: a `<subrule>` call skips its left-recursion activation
+# entirely when the rule call graph proves nothing can re-enter the key — three
+# thread-local map operations per call on a grammar with no left recursion.
+#
+# The gate has exactly two preconditions, and this file pins the constructs that
+# have to keep failing them:
+#
+#   * nothing reachable from the call names a rule of the same name (the
+#     growing-seed loop is the answer when one does), and
+#   * nothing in the call cone runs USER CODE. A `{ ... }` block, a `<?{ ... }>`
+#     assertion, a `:my $x = ...` declaration and a `** { ... }` quantifier bound
+#     are all arbitrary code that could call the rule by hand at the same
+#     position, which the activation — and only the activation — makes
+#     terminate.
+#
+# A widened gate that admitted any of these would not give a wrong answer; it
+# would recurse until the stack ran out. So every row here is also a
+# does-it-terminate row.
+#
+# Every row except the two explicitly-left-recursive ones was verified against
+# rakudo 2026.07. Rakudo has no growing-seed loop and hangs on a left-recursive
+# rule, the same caveat `t/regex/regex-left-recursion-key-identity.t` records.
+
+plan 12;
+
+# --- the gate must stay shut: a rule that reaches its own name ---------------
+
+grammar LeftRec {
+    token TOP  { <expr> }
+    token expr { <expr> '+' <term> | <term> }
+    token term { \d+ }
+}
+is ~(LeftRec.parse('1+2+3') // ''), '1+2+3', 'a directly left-recursive rule still grows its seed';
+
+grammar MutualRec {
+    token TOP  { <a> }
+    token a    { <b> '!' | <lit> }
+    token b    { <a> }
+    token lit  { 'x' }
+}
+is ~(MutualRec.parse('x!') // ''), 'x!', 'a MUTUALLY recursive pair still grows its seed';
+
+# --- the gate must stay shut: user code anywhere in the cone ----------------
+
+# A `{ ... }` block re-entering the same rule name at the same position. The
+# outer call is at `remaining == 1` and so is the nested parse, so both land on
+# the same left-recursion key; the depth guard is what makes the construct
+# finite at the Raku level, and the activation is what makes the ENGINE finite.
+my $depth = 0;
+my $inner = 'not-run';
+grammar BlockReenter {
+    token TOP   { <thing> }
+    token thing {
+        'a'
+        { if $depth == 0 { $depth = 1; $inner = BlockReenter.parse('a', :rule<thing>).defined.Str } }
+    }
+}
+ok BlockReenter.parse('a').defined, 'a rule whose block re-enters its own name still parses';
+is $inner, 'True', '... and the re-entering nested parse succeeds';
+
+grammar CodeAssert {
+    token TOP  { <word> }
+    token word { \w+ <?{ $/.chars == 3 }> }
+}
+ok CodeAssert.parse('abc').defined, 'a `<?{ ... }>` assertion in the cone accepts its match';
+nok CodeAssert.parse('abcd').defined, '... and rejects the one it should';
+
+grammar QuantCode {
+    token TOP { <pad> 'x' }
+    token pad { ' ' ** { 1..3 } }
+}
+ok QuantCode.parse('  x').defined, 'a `** { ... }` quantifier bound in the cone still matches';
+
+my @fired;
+grammar BlockSideEffect {
+    token TOP   { <thing>+ }
+    token thing { $<c>=[\w] { @fired.push(~$<c>) } }
+}
+ok BlockSideEffect.parse('abc').defined, 'a rule with a side-effecting block parses';
+is @fired.join(','), 'a,b,c', '... and its block fires once per matched item, in order';
+
+# --- the gate must OPEN: plain rules, whose results must not change ----------
+
+grammar Plain {
+    token TOP     { <entry>+ % ',' }
+    token entry   { <key> '=' <value> }
+    token key     { <[a..z]>+ }
+    token value   { <digits> | <word> }
+    token digits  { \d+ }
+    token word    { \w+ }
+}
+my $m = Plain.parse('a=1,bb=xy,c=3');
+ok $m.defined, 'a code-free, recursion-free grammar parses';
+is $m<entry>.map({ ~.<key> }).join('|'), 'a|bb|c', '... with every capture where it belongs';
+
+# The left-recursion key carries no package, while the gate's analysis is per
+# package: a rule name shared by two grammars must still resolve to its own
+# rule, and neither call may read the other's seed.
+grammar ShareA { token TOP { <part> }; token part { 'x' } }
+grammar ShareB { token TOP { <part> }; token part { 'y' } }
+ok ShareA.parse('x').defined && ShareB.parse('y').defined && !ShareA.parse('y').defined,
+    'a rule name shared by two grammars resolves per grammar';


### PR DESCRIPTION
Round 21 of #7576. Instructions on the 60-row YAMLish document go
**1,238,570,142 -> 1,199,253,834 (-3.17%)**. Attribution is callgrind `Ir`
throughout, cache warmed first (`tmp/prof60.sh`, the round-15 harness).

Round 20 left left-recursion bookkeeping as the largest single cluster at ~3.6%:
three thread-local hash-map operations per `<subrule>` call — begin the
activation, ask whether its seed was consulted, tear it down — on a grammar with
no left recursion at all. Every previous round made those operations *cheaper*
(one map instead of three, an interned key instead of three `String` clones, one
probe instead of two). This round asks the prior question: does the call need an
activation?

## The two things round 20 said stopped it being a slice

An activation exists so that a re-entry of the same `(rule name, arguments,
position)` key reads a growing seed instead of recursing forever — and a key is
re-entered only by a call to a rule of the *same name*. `regex_call_graph::reenter_decline`
already decides that; the streamed path has consulted it since #7548. Round 20's
two objections are both answerable:

**"`LrKey` carries no package while the analysis is per package."** It does — but
the walk's comparison is on the callee's NAME alone (`callee.1 == name_sym`),
which is precisely the question a package-blind key asks. What the walk cannot
see is an *enclosing* activation of the same name in another package, since that
call is not in this call's cone. So the gate also requires that no activation of
the name is live anywhere on the stack, which is now an array index rather than a
lookup: `LrState` keeps a per-`Symbol::id` count of live activations next to the
key map, bumped and dropped by `lr_begin_activation` / `lr_end_activation`.

**"A wrong `None` fails as unbounded recursion rather than a wrong answer."**
True, and it is why the second precondition is new. The walk deliberately treats
an embedded `{ ... }` / `<?{ ... }>` block as harmless — it names no edge, and
both callers keep a runtime escape for the case where user code re-enters the
rule by hand (the eager arm's `first_only` retry, the streamed path's
`seed_consulted` fallback). Skipping the activation skips the very escape that
covers it. So the walk now reports a second fact alongside the edges — does any
rule in the cone run user code at all (`{ ... }`, `<?{ ... }>`, `:my $x = ...`, a
`** { ... }` quantifier bound, a `<:prop(...)>` predicate) — and the gate requires
`false`.

With all three conditions met the skip is not an approximation: in every state
where it applies, the three map operations it replaces would have created an
entry, read `false` out of it, and removed it again.

## What it is worth

`std::thread::LocalKey::with` goes **83,245,564 (6.72%) -> 63,769,904 (5.32%)**
inclusive, and the two callers round 20 named are the whole of the difference:

| caller | before | after |
| --- | ---: | ---: |
| `for_each_atom_candidate` (the streamed subrule path) | 22,169,959 Ir / 134,850 calls | *nothing left to show* |
| `regex_match_atom_all_with_capture_in_pkg_inner` (the eager arm) | 21,984,162 Ir / 130,045 calls | 4,396,376 Ir / 24,946 calls |
| the gate itself (`subrule_needs_no_lr_bookkeeping`) | — | 6,910,900 Ir / 86,473 calls |

The gate is memoized per `(package, rule name)` per token generation — 41 cone
walks for 86,473 asks — with an `#[inline(never)]` cache miss. It does not take a
registry read lock to rule out a custom-HOW grammar, either: both call sites
already know that answer (the streamed path declines on it outright, the eager
arm binds it for its own dispatch attempt), and asking again cost an `RwLock`
acquisition per `<subrule>` call for a fact that is not even memoizable.

## Pinning it

`t/regex/regex-lr-bookkeeping-gate.t` is twelve rows of the constructs that have
to keep the gate shut — a directly left-recursive rule, a mutually recursive
pair, a `{ ... }` block that re-enters its own rule name at the same position, a
`<?{ ... }>` assertion, a `** { ... }` quantifier bound, a side-effecting block
whose firing order is observable — plus the plain grammar whose results must not
change and the rule name shared by two grammars. A widened gate would not give a
wrong answer on any of them; it would recurse until the stack ran out, so every
row is also a does-it-terminate row. The ten rows rakudo can run (it has no
growing-seed loop and hangs on a left-recursive rule) were verified against
rakudo 2026.07.

Two Rust unit tests in `regex_lr_state` cover what Raku cannot reach
deterministically: a live activation of the name closes the gate and reopens it
on teardown, a new token generation retires every verdict, and the re-entry
branch of `lr_begin_or_reenter` does not count as a second activation — counting
it would leak a live activation and wedge the gate shut for the rest of the run.

## Verification

- `make test` — **PASS**, 4151 files / 44187 tests.
- `make lint` — green (default clippy, `jit` off, wasm32 lib, rustdoc).
- `make roast` — 1437 files / 219635 tests, failing only the three
  container-only files `docs/agent-environments.md` documents:
  `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t`
  (`chmod` tests meaningless as uid 0) and `roast/S32-io/IO-Socket-Async.t`
  (sandboxed network), each with exactly the failure shape recorded there.

## What the next round starts from

Re-measured after this round rather than carried forward:

- **Allocator traffic is now the largest cluster by a distance** — `malloc`
  5.02%, `_int_free` 6.41%, `_int_malloc` 3.18%, `free` 2.95%, plus `memcpy`
  2.46%. With `CapStore::merge_delta` at 1.89% self and `RawTable::clone` at
  1.44%, this is the capture store's design pass that rounds 15-20 have each
  deferred.
- `Symbol::intern` is now the single biggest `LocalKey::with` client at
  28,995,150 Ir (2.42%) over 209,978 interns, diffuse callers.
- The gate's own residual, 0.78%. Half of it could live on the `NamedAtom` node
  the way round 20 put the lookup spec there; the other half — is an activation
  of this name live — is dynamic and has to read the thread-local.

Written up in `news/2026-09/the-subrule-call-that-needs-no-activation.md`.
Cumulative over rounds 11-21 on the 60-row document: **8.130 Bn -> 1.199 Bn `Ir`
(-85.2%)**.

The ticket stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_