### PR TITLE
fix(parser): avoid heredoc statement span panic

### DIFF
--- a/news/2026-09/heredoc-statement-modifier-no-panic.md
+++ b/news/2026-09/heredoc-statement-modifier-no-panic.md
@@ -1,0 +1,3 @@
+# Heredoc statement modifiers no longer panic on multibyte text
+
+The parser now avoids slicing a non-contiguous heredoc remainder by byte-length subtraction when deciding whether a `try` or `gather` statement ends with a block. Such heredocs now produce normal parse results instead of panicking inside a multibyte character.

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -1635,10 +1635,10 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
     // `Selkie` and `App::Moneymoor` both fail to load on ([#7993]).
     //
     // [#7993]: https://github.com/tokuhirom/mutsu/issues/7993
-    let consumed = &input[..input.len() - rest_before_ws.len()];
     if separated_by_newline
         && matches!(expr, Expr::Try { .. } | Expr::Gather(_))
-        && consumed.trim_end().ends_with('}')
+        && crate::parser::expr::consumed_span(input, rest_before_ws)
+            .is_some_and(|consumed| consumed.trim_end().ends_with('}'))
     {
         return parse_statement_modifier(rest_before_ws, stmt);
     }

--- a/t/lang/quoting/heredoc-unicode-statement-panic.t
+++ b/t/lang/quoting/heredoc-unicode-statement-panic.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# Regression for #8193: after a heredoc, the parser may resume from a freshly
+# built remainder rather than a suffix of the original input. Computing a
+# consumed span by subtracting string lengths can then slice through a
+# multi-byte character and panic. Two heredocs are needed to reach the bad
+# offset in the original Collection::RefreshPlugins reduction.
+
+class MapFail is Exception {
+    has $.note;
+    method message { $.note }
+}
+
+sub parse-heredoc-body() {
+    my %plugins; my %released; my $mode; my $plug; my $format;
+    my $n-plug = %plugins{$mode}{$plug}<name> // $plug;
+    my $n-auth = %plugins{$mode}{$plug}<auth> // 'collection';
+    MapFail.new(:note(qq:to/WARN/)).throw unless %released{$format}{$n-plug}{$n-auth};
+        Auth error? No released plugin ｢$n-plug｣_v?_auth_｢$n-auth｣ for ｢$plug｣ in ｢$mode｣
+            If a 'name' key is set in 'plugins.rakuon', has the 'auth' key been set too?
+        WARN
+
+    my $n-v = %plugins{$mode}{$n-plug}<major>
+        // %released{$format}{$n-plug}{$n-auth}<latest>;
+    MapFail.new(:note(qq:to/WARN/)).throw unless ($n-v ~~ any(%released{$format}{$n-plug}{$n-auth}<vers>.list));
+        Major part error? No released plugin ｢{ $n-plug }_v{ $n-v }_auth_{ $n-auth }｣ corresponding to ｢$plug｣ in ｢$mode｣
+        WARN
+}
+
+ok True, 'a multi-byte heredoc after a statement modifier parses without panicking';
+done-testing;


### PR DESCRIPTION
Closes #8193

The statement-modifier parser used `input.len() - rest_before_ws.len()` to decide whether a `try`/`gather` expression ended with `}`. Heredoc parsing can return a remainder from a freshly built buffer, so that subtraction can land inside a multibyte character and panic. Use the existing pointer-provenance `consumed_span` helper and conservatively skip the block-ending check when no contiguous span exists.

Adds a regression test with the two-heredoc Collection reduction and multibyte `｢｣` text.

Validation:
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make check-t-layout`
- `make test` (4151 files, 44176 tests)
- `make roast` (1437 files, 219658 tests)