### PR TITLE
fix: a WhateverCode dimension in a multi-dim subscript returns a List (6.d)

### DIFF
--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -113,22 +113,22 @@ impl Interpreter {
             self.stack.push(slot);
             return Ok(());
         }
-        // A subscript containing a slice dimension (`*` or an index list) over
-        // ALREADY-EXISTING leaves selects several leaves that cannot collapse to
-        // one cell. Promote each selected leaf to a shared `ContainerRef` cell
-        // and hand back a plain list of those cells — the array analogue of the
+        // A subscript containing a slice dimension (`*`, an index list, or a
+        // WhateverCode/block `Sub`) over ALREADY-EXISTING leaves selects one or
+        // more leaves that read back as a List rather than a bare scalar (a
+        // `Sub` dimension always classifies this way even when it resolves to
+        // a single index — `dim_is_multi` is the same rule the plain-read path
+        // and multi-dim assignment use, so a call argument like `f(@m[*-1;
+        // 0])` agrees with the `say @m[*-1; 0]` statement form, #8188).
+        // Promote each selected leaf to a shared `ContainerRef` cell and hand
+        // back a plain list of those cells — the array analogue of the
         // `@slice := @array[1,2]` bound-slice (see `array_slot_ref` /
         // `slice_bind_indices`). A `\raw` / `is rw` parameter bound to this list
         // then distributes a `target = values` assignment element-wise through
         // the cells (see the sigilless bound-slice write-through in the assign
         // ops), while a read decontainerizes each cell transparently. Missing
         // leaves and hash roots fall back to the plain (non-aliasing) read.
-        let is_slice = dims.iter().any(|d| {
-            matches!(
-                Self::normalize_multidim_dim(d).view(),
-                ValueView::Whatever | ValueView::Array(..)
-            )
-        });
+        let is_slice = dims.iter().any(Self::dim_is_multi);
         if is_slice {
             let deref_target = match target.view() {
                 ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
@@ -372,15 +372,12 @@ impl Interpreter {
         if dims.is_empty() {
             return Ok(None);
         }
-        // A slice dimension (`*`, a list, or a range) selects multiple leaves and
-        // cannot collapse to a single cell.
-        for d in dims {
-            if matches!(
-                Self::normalize_multidim_dim(d).view(),
-                ValueView::Whatever | ValueView::Array(..)
-            ) {
-                return Ok(None);
-            }
+        // A slice dimension (`*`, a list, a range, or a WhateverCode/block
+        // `Sub` — `dim_is_multi`, #8188) reads back as a List even when it
+        // selects only one leaf, so it cannot collapse to a single bare cell
+        // here; the caller's `is_slice` branch handles it instead.
+        if dims.iter().any(Self::dim_is_multi) {
+            return Ok(None);
         }
 
         // Read through a `ContainerRef` / `Scalar` wrapper while keeping the
@@ -700,7 +697,26 @@ impl Interpreter {
                 Ok(Value::array(out))
             }
             _ => {
-                // Scalar index — resolve WhateverCode / block first
+                // Scalar index — resolve WhateverCode / block first. A
+                // WhateverCode/block dimension (`Sub`) is a slice dimension
+                // even when it resolves to a single index: rakudo hands back
+                // a one-element List for it (`@m[*-1; 0]` is `(4)`, not `4`),
+                // the same classification `dim_is_multi` already uses for
+                // multi-dim ASSIGNMENT. A plain scalar dimension (Int, a
+                // numeric-coercible Str/Rat/Num) stays single-element.
+                let wraps_as_slice = matches!(dim.view(), ValueView::Sub(..));
+                // Whether a REMAINING dimension also wraps its own result --
+                // if so, the recursive read below already comes back as an
+                // Array, and wrapping it again here would double-nest instead
+                // of producing one flat slice (mirrors the `has_more_multi`
+                // flatten the Whatever/Array-dimension branches above use).
+                let has_more_multi = wraps_as_slice
+                    && rest.iter().any(|v| {
+                        matches!(
+                            Self::normalize_multidim_dim(v).view(),
+                            ValueView::Whatever | ValueView::Array(..) | ValueView::Sub(..)
+                        )
+                    });
                 let resolved = self.resolve_whatever_code_index(dim, target);
                 // A block subscript may return a Range or a list of indices
                 // (e.g. `{0,1}` returns the List `(0,1)`). Re-dispatch such a
@@ -715,20 +731,20 @@ impl Interpreter {
                     }
                 }
                 let idx = resolved.as_ref().unwrap_or(dim);
-                if let Some(i) = Self::index_to_usize(idx) {
+                let scalar = if let Some(i) = Self::index_to_usize(idx) {
                     let (items, is_real) = match target.view() {
                         ValueView::Array(items, kind) => (items, kind.is_real_array()),
                         _ => return Ok(Value::NIL),
                     };
                     if i < items.len() {
-                        self.multi_dim_index_read(&items[i], rest)
+                        self.multi_dim_index_read(&items[i], rest)?
                     } else if is_real {
                         // Out of bounds on a real Array: the element default
                         // (Any), like a single-dim OOB read; a List stays Nil.
-                        Ok(Value::package(crate::symbol::wk::any()))
+                        Value::package(crate::symbol::wk::any())
                     } else {
                         // Out of bounds — return Nil for scalar index
-                        Ok(Value::NIL)
+                        Value::NIL
                     }
                 } else {
                     // Non-numeric index (e.g., string "0")
@@ -739,16 +755,25 @@ impl Interpreter {
                             _ => return Ok(Value::NIL),
                         };
                         if i < items.len() {
-                            self.multi_dim_index_read(&items[i], rest)
+                            self.multi_dim_index_read(&items[i], rest)?
                         } else if is_real {
-                            Ok(Value::package(crate::symbol::wk::any()))
+                            Value::package(crate::symbol::wk::any())
                         } else {
-                            Ok(Value::NIL)
+                            Value::NIL
                         }
                     } else {
-                        Ok(Value::NIL)
+                        Value::NIL
                     }
-                }
+                };
+                Ok(if wraps_as_slice {
+                    if has_more_multi && let ValueView::Array(inner, ..) = scalar.view() {
+                        Value::array(inner.to_vec())
+                    } else {
+                        Value::array(vec![scalar])
+                    }
+                } else {
+                    scalar
+                })
             }
         }
     }

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -113,22 +113,22 @@ impl Interpreter {
             self.stack.push(slot);
             return Ok(());
         }
-        // A subscript containing a slice dimension (`*`, an index list, or a
-        // WhateverCode/block `Sub`) over ALREADY-EXISTING leaves selects one or
-        // more leaves that read back as a List rather than a bare scalar (a
-        // `Sub` dimension always classifies this way even when it resolves to
-        // a single index — `dim_is_multi` is the same rule the plain-read path
-        // and multi-dim assignment use, so a call argument like `f(@m[*-1;
-        // 0])` agrees with the `say @m[*-1; 0]` statement form, #8188).
-        // Promote each selected leaf to a shared `ContainerRef` cell and hand
-        // back a plain list of those cells — the array analogue of the
-        // `@slice := @array[1,2]` bound-slice (see `array_slot_ref` /
-        // `slice_bind_indices`). A `\raw` / `is rw` parameter bound to this list
-        // then distributes a `target = values` assignment element-wise through
-        // the cells (see the sigilless bound-slice write-through in the assign
-        // ops), while a read decontainerizes each cell transparently. Missing
-        // leaves and hash roots fall back to the plain (non-aliasing) read.
-        let is_slice = dims.iter().any(Self::dim_is_multi);
+        // A subscript containing a slice dimension (`*`, an index list, or --
+        // under 6.d and earlier -- a WhateverCode/block `Sub`) over ALREADY-
+        // EXISTING leaves selects one or more leaves that read back as a List
+        // rather than a bare scalar, even when it resolves to a single index
+        // (`dim_is_read_slice` is the same rule the plain-read path uses, so a
+        // call argument like `f(@m[*-1; 0])` agrees with the `say @m[*-1; 0]`
+        // statement form, #8188). Promote each selected leaf to a shared
+        // `ContainerRef` cell and hand back a plain list of those cells — the
+        // array analogue of the `@slice := @array[1,2]` bound-slice (see
+        // `array_slot_ref` / `slice_bind_indices`). A `\raw` / `is rw`
+        // parameter bound to this list then distributes a `target = values`
+        // assignment element-wise through the cells (see the sigilless
+        // bound-slice write-through in the assign ops), while a read
+        // decontainerizes each cell transparently. Missing leaves and hash
+        // roots fall back to the plain (non-aliasing) read.
+        let is_slice = dims.iter().any(Self::dim_is_read_slice);
         if is_slice {
             let deref_target = match target.view() {
                 ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
@@ -372,11 +372,12 @@ impl Interpreter {
         if dims.is_empty() {
             return Ok(None);
         }
-        // A slice dimension (`*`, a list, a range, or a WhateverCode/block
-        // `Sub` — `dim_is_multi`, #8188) reads back as a List even when it
-        // selects only one leaf, so it cannot collapse to a single bare cell
-        // here; the caller's `is_slice` branch handles it instead.
-        if dims.iter().any(Self::dim_is_multi) {
+        // A slice dimension (`*`, a list, a range, or -- under 6.d and
+        // earlier -- a WhateverCode/block `Sub`; `dim_is_read_slice`, #8188)
+        // reads back as a List even when it selects only one leaf, so it
+        // cannot collapse to a single bare cell here; the caller's
+        // `is_slice` branch handles it instead.
+        if dims.iter().any(Self::dim_is_read_slice) {
             return Ok(None);
         }
 
@@ -697,26 +698,23 @@ impl Interpreter {
                 Ok(Value::array(out))
             }
             _ => {
-                // Scalar index — resolve WhateverCode / block first. A
-                // WhateverCode/block dimension (`Sub`) is a slice dimension
-                // even when it resolves to a single index: rakudo hands back
-                // a one-element List for it (`@m[*-1; 0]` is `(4)`, not `4`),
-                // the same classification `dim_is_multi` already uses for
-                // multi-dim ASSIGNMENT. A plain scalar dimension (Int, a
-                // numeric-coercible Str/Rat/Num) stays single-element.
-                let wraps_as_slice = matches!(dim.view(), ValueView::Sub(..));
+                // Scalar index — resolve WhateverCode / block first. Under
+                // 6.d and earlier, a WhateverCode/block dimension (`Sub`) is
+                // a slice dimension even when it resolves to a single index:
+                // rakudo hands back a one-element List for it (`@m[*-1; 0]`
+                // is `(4)`, not `4`). 6.e reclassifies it as a plain scalar
+                // index instead (`roast/S32-array/multislice-6e.t`), the
+                // same exception `assoc_multislice` already carves out for
+                // an associative subscript. A plain scalar dimension (Int, a
+                // numeric-coercible Str/Rat/Num) stays single-element in
+                // every version.
+                let wraps_as_slice = Self::dim_is_read_slice(dim);
                 // Whether a REMAINING dimension also wraps its own result --
                 // if so, the recursive read below already comes back as an
                 // Array, and wrapping it again here would double-nest instead
                 // of producing one flat slice (mirrors the `has_more_multi`
                 // flatten the Whatever/Array-dimension branches above use).
-                let has_more_multi = wraps_as_slice
-                    && rest.iter().any(|v| {
-                        matches!(
-                            Self::normalize_multidim_dim(v).view(),
-                            ValueView::Whatever | ValueView::Array(..) | ValueView::Sub(..)
-                        )
-                    });
+                let has_more_multi = wraps_as_slice && rest.iter().any(Self::dim_is_read_slice);
                 let resolved = self.resolve_whatever_code_index(dim, target);
                 // A block subscript may return a Range or a list of indices
                 // (e.g. `{0,1}` returns the List `(0,1)`). Re-dispatch such a
@@ -1341,6 +1339,22 @@ impl Interpreter {
             Self::normalize_multidim_dim(dim).view(),
             ValueView::Whatever | ValueView::Array(..) | ValueView::Sub(..)
         )
+    }
+
+    /// Whether a multi-dim subscript dimension makes a READ into a slice (a
+    /// one-or-more-element List) rather than a bare scalar. Agrees with
+    /// `dim_is_multi` for `Whatever`/an explicit index list, but a
+    /// `WhateverCode`/block `Sub` dimension slices only under 6.d and
+    /// earlier: `roast/S32-array/multislice-6e.t` measures `@array[*-1;0;0]`
+    /// as the bare `42` under `use v6.e.PREVIEW`, where 6.d (rakudo's
+    /// current default) gives `(42,)` -- the same 6.e exception
+    /// `assoc_multislice` already carves out for an associative subscript.
+    fn dim_is_read_slice(dim: &Value) -> bool {
+        match Self::normalize_multidim_dim(dim).view() {
+            ValueView::Whatever | ValueView::Array(..) => true,
+            ValueView::Sub(..) => !crate::parser::current_language_version().starts_with("6.e"),
+            _ => false,
+        }
     }
 
     /// Resolve one assignment dimension against the current `target` container

--- a/t/routines/dispatch/multidim-whatevercode-dimension-list.t
+++ b/t/routines/dispatch/multidim-whatevercode-dimension-list.t
@@ -13,7 +13,11 @@ use Test;
 # 0]` is `(4)`), and so does an ordinary block dimension (`@m[{0}; 0]` is
 # `(1)`) -- both go through the same runtime representation as `*-1`.
 #
-# Every expectation below was measured against rakudo (#8188).
+# Every expectation below was measured against rakudo (#8188), under the
+# default `v6.d` this file implicitly runs as. 6.e reclassifies a
+# WhateverCode/block dimension back to a plain scalar index (the same
+# exception the associative subscript already has) -- that side is pinned
+# separately by `roast/S32-array/multislice-6e.t` under `use v6.e.PREVIEW`.
 
 plan 18;
 

--- a/t/routines/dispatch/multidim-whatevercode-dimension-list.t
+++ b/t/routines/dispatch/multidim-whatevercode-dimension-list.t
@@ -1,0 +1,85 @@
+use v6;
+use Test;
+
+# A `WhateverCode` dimension (`*-1`) in a multi-dimensional subscript makes
+# rakudo classify the dimension as a slice of one, returning a one-element
+# List -- the same as a Range dimension that happens to select one element
+# (`@m[0..0; 0]` is `(1)`), NOT the bare element a plain Int dimension gives
+# (`@m[1; 0]` is `4`). mutsu resolved the WhateverCode to a plain Int index
+# and then took the scalar path, losing the List wrapper.
+#
+# It is the VALUE's shape that decides this, not the subscript's literal
+# syntax: a variable holding a WhateverCode still slices (`my $i = *-1; @m[$i;
+# 0]` is `(4)`), and so does an ordinary block dimension (`@m[{0}; 0]` is
+# `(1)`) -- both go through the same runtime representation as `*-1`.
+#
+# Every expectation below was measured against rakudo (#8188).
+
+plan 18;
+
+my @m = [[1, 2, 3], [4, 5, 6]];
+
+# The four dimension kinds, bracket spelling.
+is-deeply @m[*-1; 0], (4,), 'a WhateverCode dimension wraps the leaf in a List';
+is @m[*-1; 0].^name, 'List', 'and its type is List, not Int';
+is-deeply @m[1; *-1], (6,), 'a WhateverCode in the second dimension also wraps';
+is-deeply @m[1; 0], 4, 'a plain Int dimension stays a bare scalar';
+is-deeply @m[0+0; 0], 1, 'a numeric-expression Int dimension stays scalar too';
+is-deeply @m[0..0; 0], (1,), 'a Range dimension (already a slice) is unaffected';
+
+# The dotted spelling goes through the same lowering (#8155) and must agree.
+is-deeply @m.[*-1; 0], (4,), 'the dotted spelling wraps a WhateverCode dimension too';
+
+# Classification follows the VALUE, not literal `*` syntax.
+{
+    my $i = *-1;
+    is-deeply @m[$i; 0], (4,), 'a WhateverCode held in a variable still wraps';
+}
+{
+    my $j = 0 + 0;
+    is-deeply @m[$j; 0], 1, 'a plain Int held in a variable stays scalar';
+}
+
+# An ordinary block dimension shares the WhateverCode runtime representation
+# and slices the same way, even for a single-index block.
+is-deeply @m[{0}; 0], (1,), 'a block dimension also wraps its single result';
+
+# Two WhateverCode dimensions at once: the result is one flat List, not a
+# nested List of Lists.
+is-deeply @m[*-1; *-1], (6,), 'two WhateverCode dimensions flatten to one List';
+
+# A WhateverCode dimension alongside a Range dimension: still one flat List.
+{
+    my @n = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
+    is-deeply @n[*-1; 1..2], (8, 9), 'WhateverCode + Range flattens to one List';
+}
+
+# Three dimensions, WhateverCode in the middle.
+{
+    my @d = [[[7, 8], [9, 10]], [[11, 12], [13, 14]]];
+    is-deeply @d[0; *-1; 0], (9,), 'a WhateverCode in a middle dimension wraps';
+}
+
+# Out-of-range WhateverCode resolution still wraps the resulting `Any`.
+{
+    my @e = [[1, 2], [3, 4]];
+    is-deeply @e[*+5; 0], (Any,), 'an out-of-range WhateverCode dimension still wraps';
+}
+
+# It is an rvalue subscript classification only -- assignment through it keeps
+# working as a slice-distributing target (already correct before this fix).
+{
+    my @w = [[1, 2, 3], [4, 5, 6]];
+    @w[*-1; 0] = 99;
+    is-deeply @w, [[1, 2, 3], [99, 5, 6]], 'assignment through a WhateverCode dimension is unaffected';
+}
+
+# Single-dimension WhateverCode subscript (not multi-dim) is untouched by this
+# fix -- it stays a plain scalar, matching rakudo.
+is @m[*-1].gist, '[4 5 6]', 'a single-dimension WhateverCode subscript stays a plain element';
+
+# `.^name` on every wrapped case is `List`, never `Array`.
+is @m[*-1; *-1].^name, 'List', 'flattened multi-WhateverCode result is a List';
+is @m[{0}; 0].^name, 'List', 'block-dimension result is a List';
+
+done-testing;


### PR DESCRIPTION
## Summary

A `*-1`-style dimension in a multi-dimensional subscript (`@m[*-1; 0]`)
resolved to a plain scalar index and then took the single-element read
path, returning the bare leaf. rakudo classifies a WhateverCode/block
dimension as a slice of one regardless of what it resolves to, so it
hands back a one-element List instead (the same classification a Range
dimension that happens to select one element already gets). The
divergence affected the bracket and dotted spellings equally, and
predates #8155.

```
$ raku  -e 'my @m = [[1,2,3],[4,5,6]]; say @m[*-1; 0]; say @m[*-1;0].^name'
(4)
List
$ mutsu -e 'my @m = [[1,2,3],[4,5,6]]; say @m[*-1; 0]; say @m[*-1;0].^name'
4
Int
```

Two call sites needed the fix, since a multi-dim subscript compiles to
different bytecode depending on where it's used:

- `multi_dim_index_read`'s scalar-index branch now wraps the result in a
  one-element List when the dimension is a `Sub` (WhateverCode or an
  ordinary block), flattening instead of double-wrapping when a
  remaining dimension is itself multi (`@m[*-1; *-1]`, `@n[*-1; 1..2]`).
- A multi-dim subscript passed as an ordinary call argument (`f(@m[*-1;
  0])`) compiles to `MultiDimIndexBindRef` instead, whose own
  slice/scalar classification (`multi_dim_slot_ref`'s guard and
  `exec_multi_dim_index_bind_ref_op`'s `is_slice` check) didn't
  recognize a `Sub` dimension either, so the call-argument spelling
  disagreed with the statement spelling of the same expression — this
  is what `is-deeply @m[*-1; 0], (4,)` in the test exercises.

**6.e caveat found via roast, not the issue's own repro:** rakudo's
`v6.e.PREVIEW` reclassifies a WhateverCode/block dimension back to a
plain scalar index (the same exception the associative subscript
already has via `assoc_multislice`) — `roast/S32-array/
multislice-6e.t` measures `@array[*-1;0;0]` as the bare `42` under
6.e, where 6.d (rakudo's current default) gives `(42,)`. A first pass
at this fix regressed 8 subtests in that file before this was found.
Both call sites now go through a new `dim_is_read_slice` (a
version-aware sibling of the pre-existing `dim_is_multi`, which is
multi-dim ASSIGNMENT's distribution classification and is left
untouched) instead of duplicating the Whatever/Array/Sub match a third
and fourth time.

Closes #8188

## Test plan

- Added `t/routines/dispatch/multidim-whatevercode-dimension-list.t`
  (6.d, the default): both spellings, all four dimension kinds (Int,
  Range, WhateverCode, WhateverCode via a variable, and a plain
  block), nested/adjacent multi dimensions, three dimensions, an
  out-of-range WhateverCode, assignment through it (unaffected), and
  the call-argument shape. Every expectation measured against rakudo
  first.
- `roast/S32-array/multislice-6e.t` (6.e): 812/812 (was 804/812 before
  the version-gating fix).
- Ran the full `t/collections/`, `t/routines/dispatch/`, and `t/oo/`
  sweeps (1256 files, 14326 tests) — all green.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run
  locally. `make roast` comes back with only the three
  environment-only failures documented in `docs/agent-environments.md`
  for a remote container (`roast/6.c/S32-io/file-tests.t`,
  `roast/S16-filehandles/filetest.t` — both `uid 0` chmod-based file
  tests — and `roast/S32-io/IO-Socket-Async.t`, sandboxed network);
  everything else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_