### PR TITLE
fix(supply): route a detached worker's failure, panic included, to QUIT

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -233,7 +233,6 @@ levers — [#7571](https://github.com/tokuhirom/mutsu/issues/7571), actively wor
       deferred. **No roast pressure remains** (all 99 S17 files are whitelisted); the motive is
       thread consumption under heavy concurrency, so start this only on a measured trigger and an
       updated ADR.
-- [ ] Propagate Supply detached-worker panics to QUIT (currently swallowed) — [#8185](https://github.com/tokuhirom/mutsu/issues/8185).
 - [ ] Split out the roast fudge logic. File size (376 over 500 lines, 138 over 1000, still growing —
       `ANALYSIS.md` §6) is **not** a standalone campaign: split when a campaign opens the file and the
       ownership boundary is visible.

--- a/news/2026-09/supply-worker-failures-reach-quit.md
+++ b/news/2026-09/supply-worker-failures-reach-quit.md
@@ -1,0 +1,72 @@
+# A Supply worker's failure — Rust panic included — now reaches QUIT
+
+A failure raised by a Supply's *producer* code had two ways of going missing,
+and issue [#8185](https://github.com/tokuhirom/mutsu/issues/8185) (`PLAN.md` §5)
+tracked the worse of them.
+
+**The silent one.** `run_supply_act_loop` is the detached driver every
+channel-backed Supply tap runs on, and since ADR-0020 it runs on a pooled
+worker. `worker_pool`'s `worker_loop` catches an escaping panic and discards it
+by design — a panicking task must not take the worker's `live` accounting with
+it. So a Rust panic raised outside the VM's own `run_inner_guarded` frames
+(native method plumbing, dispatch helpers) unwound straight past the tap into
+that `let _ = catch_unwind`: no diagnostic, no exception, no exit code, just a
+Supply that stopped producing while the consumer waited forever. A silently dead
+Supply is the worst shape a concurrency bug can take, and it also undercuts
+`QUIT` as a mechanism — a handler that cannot observe the most severe failure
+mode teaches users not to rely on it.
+
+**The loud-but-misrouted one.** Even a plain `die` in a `supply { }` body
+consumed by `react`/`whenever` never reached the subscription's `QUIT` phasers;
+it became an `X::React::Died` that killed the whole react. `raku` hands it to
+`QUIT` and only dies the react when nothing handles it.
+
+## What changed
+
+The panic boundary is per-worker, not pool-wide. A `catch_unwind` in
+`worker_pool::submit` would have changed the failure semantics of every pooled
+task — hyper/race batches, throttle workers, `start {}` bodies — to fix one of
+them. Instead `run_supply_act_loop` wraps its own user-code dispatch in
+`vm::guard_worker_panic`, the same boundary `start {}`/`Promise` workers already
+install, so a panic becomes the catchable `X::AdHoc` the VM boundary would have
+produced (`Internal error: <payload>`). No new exception type: the mapping
+already existed, and the `Internal error:` prefix is what keeps a mutsu bug
+distinguishable from a user-level failure once it is sitting in a `QUIT` block.
+
+From there it is an ordinary failure, and three routes were opened for one:
+
+- `run_supply_act_loop` learned a `producer_supplier_id`. It is `Some` at
+  exactly one of its four call sites — the branch driving a `supply { }` block's
+  own `whenever` body over a live channel-backed source, which is producer code
+  rather than a downstream tap handler. A failure there is delivered to the
+  enclosing supply's registered `quit =>` handlers through the serialize-group
+  link, for the same reason `invoke_supply_done_callback_for_supplier` reaches
+  them that way (ADR-0031 Decision A), and the emitter is marked quit so the
+  supply's other sinks and pending promises see the terminal state.
+- `run_react_consumer` now attributes a body failure on an
+  `emitter_supplier_id`-owning subscription to that on-demand supply's quit.
+  The field and the attribution already existed for a LAST-phaser die; this is
+  its body-side twin.
+- The two on-demand branches that ran a `supply { }` body inline
+  (`vm_react_loop.rs`'s `build_react_subscriptions` and
+  `vm_react_supply_helpers.rs`'s nested-stage registration) now give the
+  subscribing `whenever`'s `QUIT` phasers first refusal before wrapping the
+  failure in `X::React::Died`.
+
+Consumer-side callbacks are deliberately untouched: `raku` does not route an
+exception thrown by a tap body to that same tap's quit handler, so the other
+three act-loop call sites pass `None` and keep today's loud
+"Unhandled exception in code scheduled on thread" report. An unhandled supply
+failure with no `QUIT` anywhere still dies the react, so nothing became quieter —
+a failure that used to vanish is now either handled or reported.
+
+## Pin
+
+`t/concurrency/supply/supply-worker-panic-reaches-quit.t` — twelve assertions
+covering the panic and the `die` for both the inline `supply { }` body and the
+detached act-loop worker, that a healthy supply still completes without running
+`QUIT`, that an unhandled body die still dies the react, and that a panic in an
+ordinary non-Supply pooled task (`start {}`) still breaks its own Promise
+unchanged. The panic trigger is the `@a[2**64 - 1] = 1` index-OOB that
+`t/vm/start-panic-boundary.t` already uses; a merely-large index is guarded by a
+fallible reservation and would not reach the boundary at all.

--- a/src/runtime/native_methods/encoding.rs
+++ b/src/runtime/native_methods/encoding.rs
@@ -488,6 +488,7 @@ impl Interpreter {
         is_lines: bool,
         line_chomp: bool,
         mut head_limit: Option<usize>,
+        producer_supplier_id: Option<u64>,
     ) {
         use super::state::take_complete_lines_from_buffer;
         use std::io::Write;
@@ -608,7 +609,16 @@ impl Interpreter {
                 // `runtime::react_done_handler_depth`.
                 let _react_done_handler =
                     crate::runtime::react_done_handler_depth::ReactDoneHandlerGuard::new();
-                let result = match end_cb {
+                // `guard_worker_panic` (issue #8185): this loop runs detached on a
+                // pooled worker, whose `worker_loop` catches and *discards* an
+                // escaping panic — a Rust panic raised outside the VM's own
+                // `run_inner_guarded` frames (native method plumbing, dispatch
+                // helpers) therefore killed the tap silently, with no
+                // diagnostic and no quit. Converting it here to the same
+                // catchable `X::AdHoc` ("Internal error: ...") the VM boundary
+                // produces puts it on the ordinary failure path below, so it
+                // reaches a `quit =>` handler or the loud unhandled report.
+                let result = crate::vm::guard_worker_panic(|| match end_cb {
                     Some((end, _)) if is_done_marker => {
                         interp.invoke_done_callback(end).map(|_| ())
                     }
@@ -616,7 +626,7 @@ impl Interpreter {
                     None => interp
                         .call_sub_value(cb.clone(), vec![value], true)
                         .map(|_| ()),
-                };
+                });
                 drop(_react_done_handler);
                 // Flush stdout (check both the per-interpreter buffer and the
                 // shared thread output buffer used by thread clones).
@@ -666,6 +676,25 @@ impl Interpreter {
                 if let Err(err) = result {
                     if err.is_react_done() || err.is_last() || err.is_supply_body_done() {
                         break 'outer;
+                    }
+                    // When `cb` is *producer* code — a `supply { }` block's
+                    // `whenever` body, driven here because its source is a live
+                    // channel — its failure is the enclosing supply's quit, not
+                    // an unhandled crash of the process: deliver it to the
+                    // emitter's registered `quit =>` handlers and tear the loop
+                    // down (issue #8185). Reached via the serialize-group link
+                    // for the same reason `invoke_supply_done_callback_for_supplier`
+                    // is (ADR-0031 Decision A): the downstream handler lives on
+                    // the enclosing supply block's emitter, not on this source.
+                    let mut err = err;
+                    if let Some(sid) = producer_supplier_id {
+                        match Self::deliver_act_loop_producer_quit(interp, sid, &err) {
+                            Ok(true) => break 'outer,
+                            Ok(false) => {}
+                            // The quit handler itself failed: report *that*,
+                            // loudly, rather than losing both errors.
+                            Err(handler_err) => err = handler_err,
+                        }
                     }
                     eprintln!(
                         "Unhandled exception in code scheduled on thread\n{}",

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -734,6 +734,9 @@ impl Interpreter {
                                     false,
                                     true,
                                     None,
+                                    // Consumer-side tap callback: raku does not
+                                    // route its failure to its own quit handler.
+                                    None,
                                 );
                             },
                         ));

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -238,6 +238,66 @@ impl Interpreter {
         }
     }
 
+    /// Deliver a failure raised by *producer* code running on a detached
+    /// `run_supply_act_loop` worker to the enclosing supply's `quit =>`
+    /// handlers (issue #8185).
+    ///
+    /// `err` is a `die` from a `supply { }` block's `whenever` body, or a Rust
+    /// panic the act loop's `guard_worker_panic` boundary has already converted
+    /// into a catchable `X::AdHoc` ("Internal error: ..."). Either way raku
+    /// treats it as that supply quitting, so it belongs on the downstream tap's
+    /// quit handler rather than on the process-killing unhandled-exception
+    /// path the act loop otherwise takes.
+    ///
+    /// `supplier_id` is the enclosing supply block's emitter; the handlers are
+    /// reached through the serialize-group link for the same reason
+    /// `invoke_supply_done_callback_for_supplier` does it
+    /// (ADR-0031 Decision A) — a whenever-subscribed source's downstream
+    /// handler lives on that emitter, not on the source's own supplier.
+    ///
+    /// Returns `Ok(false)` when no handler is registered, leaving the caller to
+    /// report the failure loudly exactly as before, and `Err` when a handler
+    /// itself failed — that error takes the same loud path, so a broken quit
+    /// handler cannot make a supply failure disappear either. A control signal
+    /// from a handler (`done`/`last`, which a quit handler commonly ends with)
+    /// counts as delivered. On success the emitter is also marked quit so the
+    /// supply's other sinks and pending promises see the terminal state instead
+    /// of waiting on a producer that is gone.
+    pub(in crate::runtime) fn deliver_act_loop_producer_quit(
+        interp: &mut Interpreter,
+        supplier_id: u64,
+        err: &RuntimeError,
+    ) -> Result<bool, RuntimeError> {
+        let quit_cbs = take_supplier_quit_callbacks_via_group(supplier_id);
+        if quit_cbs.is_empty() {
+            return Ok(false);
+        }
+        let reason = err
+            .exception
+            .as_deref()
+            .cloned()
+            .unwrap_or_else(|| Value::str(err.message.to_string()));
+        let mut handler_err = None;
+        for qcb in quit_cbs {
+            match interp.call_supply_quit_handler(qcb, reason.clone()) {
+                Ok(()) => {}
+                Err(e)
+                    if e.is_react_done()
+                        || e.is_last()
+                        || e.is_supply_body_done()
+                        || e.is_next() => {}
+                Err(e) => {
+                    handler_err.get_or_insert(e);
+                }
+            }
+        }
+        crate::runtime::native_methods::supplier_quit(supplier_id, reason);
+        match handler_err {
+            Some(e) => Err(e),
+            None => Ok(true),
+        }
+    }
+
     /// Marker registered on the emitter's done so that a supply terminating via
     /// `done` fires every whenever source's on-close callbacks plus the
     /// downstream done handler.

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -341,6 +341,9 @@ impl Interpreter {
                             is_lines,
                             line_chomp,
                             head_limit,
+                            // Consumer-side tap callback: raku does not route
+                            // its failure to its own quit handler.
+                            None,
                         );
                     });
                     let mut tap_handle_attrs = HashMap::new();
@@ -793,6 +796,11 @@ impl Interpreter {
                                         is_lines,
                                         line_chomp,
                                         None,
+                                        // `body_cb` is the enclosing `supply { }`
+                                        // block's own `whenever` body: producer
+                                        // code, so a failure in it quits this
+                                        // supply through its emitter (#8185).
+                                        Some(emitter_supplier_id),
                                     );
                                 });
                             } else if let ValueView::Instance {
@@ -1533,6 +1541,8 @@ impl Interpreter {
                             None,
                             false,
                             true,
+                            None,
+                            // Consumer-side tap callback (scheduler drain shim).
                             None,
                         );
                     });

--- a/src/runtime/react_died.rs
+++ b/src/runtime/react_died.rs
@@ -45,6 +45,41 @@ impl Interpreter {
         Self::wrap_react_died(err)
     }
 
+    /// Deliver an on-demand `supply { ... }` body failure to the subscribing
+    /// `whenever`'s `QUIT` phasers before it is allowed to become an
+    /// `X::React::Died` (issue #8185).
+    ///
+    /// raku hands an exception thrown inside a supply block to that supply's
+    /// consumer as a *quit*; only an unhandled one dies the enclosing `react`.
+    /// `err` is the body's failure — a `die`, or a Rust panic the VM boundary
+    /// has already converted into a catchable `X::AdHoc` ("Internal error:
+    /// ..."), so a mutsu bug in a supply worker reaches `QUIT` instead of
+    /// vanishing with the worker.
+    ///
+    /// Returns `Ok(true)` when a `QUIT` phaser consumed the failure (the caller
+    /// retires the subscription and keeps the react alive) and `Ok(false)` when
+    /// the `whenever` registered none (the caller dies the react as before). An
+    /// error raised by the `QUIT` phaser itself — including the `done` signal a
+    /// phaser body commonly ends with — propagates to the caller.
+    pub(crate) fn deliver_supply_body_quit(
+        &mut self,
+        quit_callbacks: &[Value],
+        err: &RuntimeError,
+    ) -> Result<bool, RuntimeError> {
+        if quit_callbacks.is_empty() {
+            return Ok(false);
+        }
+        let reason = err
+            .exception
+            .as_deref()
+            .cloned()
+            .unwrap_or_else(|| Value::str(err.message.to_string()));
+        for quit_cb in quit_callbacks {
+            self.call_supply_quit_handler(quit_cb.clone(), reason.clone())?;
+        }
+        Ok(true)
+    }
+
     /// Check if a value is a subscription registration from `whenever` inside `supply`.
     pub(crate) fn is_supply_subscription_registration(value: &Value) -> bool {
         if let ValueView::Array(items, ..) = value.view()

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -147,7 +147,27 @@ impl Interpreter {
                 sub.done = true;
                 Ok(false)
             }
-            Err(e) => Err(e),
+            // A die (or a Rust panic already converted to `X::AdHoc` at the VM
+            // boundary) in a subscription that was flattened out of an
+            // on-demand `supply { ... }` body is that supply's *quit*, not a
+            // raw crash of this drive loop: `supplier_quit` its emitter so the
+            // owning subscription's `QUIT` phasers get a chance to handle it,
+            // matching `raku`. This is the body-side twin of the LAST-phaser
+            // attribution in `vm_react_subscriptions.rs`'s `SinkEvent::Done`
+            // arm (issue #8185); both hang off `emitter_supplier_id`.
+            Err(e) => {
+                let Some(sid) = sub.emitter_supplier_id else {
+                    return Err(e);
+                };
+                let cause = e
+                    .exception
+                    .as_deref()
+                    .cloned()
+                    .unwrap_or_else(|| Value::str(e.message.to_string()));
+                crate::runtime::native_methods::supplier_quit(sid, cause);
+                sub.done = true;
+                Ok(false)
+            }
         }
     }
 
@@ -393,6 +413,23 @@ impl Interpreter {
                             if let Err(od_err) = od_res
                                 && !od_err.is_react_done()
                             {
+                                // The body died (or a Rust panic in it was
+                                // converted at the VM boundary): that is this
+                                // supply's quit, so give this `whenever`'s QUIT
+                                // phasers first refusal before the react dies
+                                // (issue #8185). Only this stage's own stream
+                                // consumer is retired when a phaser handles it —
+                                // the react lives on, so an earlier `whenever`'s
+                                // consumer must stay registered. Dying still
+                                // unwinds every consumer this react pushed.
+                                self.supply_stream_consumers.truncate(stream_idx);
+                                let quit_cbs = items
+                                    .get(3)
+                                    .and_then(crate::runtime::Interpreter::value_array_items)
+                                    .unwrap_or_default();
+                                if self.deliver_supply_body_quit(&quit_cbs, &od_err)? {
+                                    continue;
+                                }
                                 self.supply_stream_consumers
                                     .truncate(stream_base.unwrap_or(stream_idx));
                                 return Err(crate::runtime::Interpreter::wrap_react_died(od_err));

--- a/src/vm/vm_react_supply_helpers.rs
+++ b/src/vm/vm_react_supply_helpers.rs
@@ -131,6 +131,17 @@ impl Interpreter {
             && !e.is_react_done()
         {
             self.supply_stream_consumers.truncate(stream_idx);
+            // This nested stage's body failed: hand it to the subscribing
+            // `whenever`'s QUIT phasers before dying the react (issue #8185),
+            // the same way the top-level on-demand branch in `vm_react_loop.rs`
+            // does.
+            let quit_cbs = items
+                .get(3)
+                .and_then(crate::runtime::Interpreter::value_array_items)
+                .unwrap_or_default();
+            if self.deliver_supply_body_quit(&quit_cbs, &e)? {
+                return Ok(Some(true));
+            }
             return Err(crate::runtime::Interpreter::wrap_react_died(e));
         }
         if streamed_done {

--- a/t/concurrency/supply/supply-worker-panic-reaches-quit.t
+++ b/t/concurrency/supply/supply-worker-panic-reaches-quit.t
@@ -1,0 +1,140 @@
+use Test;
+
+# Issue #8185: a failure raised by a Supply's *producer* code must reach the
+# consumer's quit handler, and that has to hold for a Rust-level panic
+# (overflow / index-OOB / capacity-overflow) just as much as for a `die`.
+#
+# Two gaps made it not hold. A panic raised on a detached `run_supply_act_loop`
+# worker outside the VM's own `catch_unwind` frames unwound into the worker
+# pool, whose `worker_loop` catches and discards it (ADR-0020) -- the tap simply
+# went silent, with no diagnostic, no exception and no exit code. And even a
+# plain `die` in a `supply { }` body consumed by `react`/`whenever` bypassed the
+# subscription's QUIT phasers and killed the whole react as `X::React::Died`.
+#
+# The panic trigger below is the same one `t/vm/start-panic-boundary.t` uses:
+# `@a[2**64 - 1] = 1` wraps `index + 1` to zero, so no slot is allocated and the
+# store panics. A merely-large index is guarded by a fallible reservation and
+# surfaces as a clean error instead, so it would not exercise this boundary.
+
+plan 12;
+
+# 1: a panic in a `supply { }` body reaches the consuming whenever's QUIT.
+{
+    my $quit-message;
+    my @received;
+    react {
+        whenever supply { emit 1; my @a; @a[2**64 - 1] = 1; emit 2; } -> $v {
+            @received.push($v);
+            QUIT { $quit-message = .message; done }
+        }
+        whenever Promise.in(5) { done }
+    }
+    is @received, [1], 'values emitted before the panic are still delivered';
+    ok $quit-message.defined, 'a supply-body panic reaches the QUIT phaser';
+    ok $quit-message.contains('Internal error'),
+        'the QUIT reason carries the internal-error prefix';
+}
+
+# 2: the same shape with a plain `die` (the panic path must not be a special
+# case bolted beside a working die path -- before this fix neither worked).
+{
+    my $quit-message;
+    react {
+        whenever supply { emit 1; die "boom"; } -> $v {
+            QUIT { $quit-message = .message; done }
+        }
+        whenever Promise.in(5) { done }
+    }
+    is $quit-message, 'boom', 'a supply-body die reaches the QUIT phaser';
+}
+
+# 3: a panic in a `whenever` body inside a `supply { }` block, driven by a
+# detached act-loop worker over a live channel-backed source, reaches the
+# downstream tap's `quit =>` handler.
+{
+    my $done-promise = Promise.new;
+    my $quit-reason;
+    my @received;
+    my $src = supply {
+        whenever Supply.interval(0.05) -> $i {
+            emit $i;
+            my @a; @a[2**64 - 1] = 1;
+        }
+    }
+    my $tap = $src.tap(
+        -> $v { @received.push($v) },
+        quit => -> $e { $quit-reason = $e; $done-promise.keep(True) },
+        done => -> { $done-promise.keep(False) },
+    );
+    await Promise.anyof($done-promise, Promise.in(5));
+    ok $quit-reason.defined, 'a detached worker panic reaches the tap quit handler';
+    ok $quit-reason.Str.contains('Internal error'),
+        'the tap quit reason carries the internal-error prefix';
+    is @received, [0], 'the value emitted before the panic still reached the tap';
+    $tap.close;
+}
+
+# 4: same detached shape with a `die`.
+{
+    my $done-promise = Promise.new;
+    my $quit-reason;
+    my $src = supply {
+        whenever Supply.interval(0.05) -> $i {
+            emit $i;
+            die "worker boom";
+        }
+    }
+    my $tap = $src.tap(
+        -> $v { },
+        quit => -> $e { $quit-reason = $e; $done-promise.keep(True) },
+        done => -> { $done-promise.keep(False) },
+    );
+    await Promise.anyof($done-promise, Promise.in(5));
+    is $quit-reason.Str, 'worker boom',
+        'a detached worker die reaches the tap quit handler';
+    $tap.close;
+}
+
+# 5: a healthy supply is unaffected -- the new failure route must not turn an
+# ordinary completion into a quit.
+{
+    my @received;
+    my $quit-ran = False;
+    react {
+        whenever supply { emit 1; emit 2; done; } -> $v {
+            @received.push($v);
+            QUIT { $quit-ran = True }
+        }
+        whenever Promise.in(5) { done }
+    }
+    is @received, [1, 2], 'a healthy supply still delivers every value';
+    nok $quit-ran, 'a healthy supply does not run the QUIT phaser';
+}
+
+# 6: a panic in an ordinary (non-Supply) pooled task still behaves as before --
+# it breaks its Promise and `await` rethrows it, rather than being rerouted.
+{
+    my $caught;
+    try {
+        my $p = start { my @a; @a[2**64 - 1] = 1; };
+        await $p;
+        CATCH { default { $caught = .message } }
+    }
+    ok $caught.defined && $caught.contains('Internal error'),
+        'a panic in a plain start{} still breaks its Promise';
+}
+
+# 7: an unhandled supply-body die (no QUIT phaser anywhere) still dies the
+# react, exactly as before -- a supply failure must not become silent just
+# because it now has a delivery route.
+{
+    my $died;
+    try {
+        react {
+            whenever supply { die "unhandled boom" } -> $v { }
+        }
+        CATCH { default { $died = .message } }
+    }
+    ok $died.defined && $died.contains('unhandled boom'),
+        'an unhandled supply-body die still dies the react';
+}


### PR DESCRIPTION
A failure raised by a Supply's *producer* code had two ways of going missing.

**The silent one.** `run_supply_act_loop` is the detached driver every channel-backed Supply tap runs on, and since ADR-0020 it runs on a pooled worker. `worker_pool`'s `worker_loop` catches an escaping panic and discards it by design — a panicking task must not take the worker's `live` accounting with it. So a Rust panic raised outside the VM's own `run_inner_guarded` frames (native method plumbing, dispatch helpers) unwound straight past the tap into that `let _ = catch_unwind`: no diagnostic, no exception, no exit code, just a Supply that stopped producing while the consumer waited forever.

**The loud-but-misrouted one.** Even a plain `die` in a `supply { }` body consumed by `react`/`whenever` never reached the subscription's `QUIT` phasers; it became an `X::React::Died` that killed the whole react. `raku` hands it to `QUIT` and only dies the react when nothing handles it.

```raku
my $s = supply { emit 1; die "boom"; }
react { whenever $s -> $v { say "got $v"; QUIT { say "QUIT: $_"; done } } }
say "after";
```

| | before | raku / after |
|---|---|---|
| output | `got 1` then `A react block: Died because of the exception: boom`, exit 1 | `got 1` / `QUIT: boom` / `after`, exit 0 |

## What changed

The panic boundary is **per-worker, not pool-wide**. A `catch_unwind` in `worker_pool::submit` would have changed the failure semantics of every pooled task — hyper/race batches, throttle workers, `start {}` bodies — to fix one of them. Instead `run_supply_act_loop` wraps its own user-code dispatch in `vm::guard_worker_panic`, the same boundary `start {}`/`Promise` workers already install, so a panic becomes the catchable `X::AdHoc` the VM boundary would have produced (`Internal error: <payload>`). No new exception type: the mapping already existed, and the `Internal error:` prefix keeps a mutsu bug distinguishable from a user-level failure once it is sitting in a `QUIT` block.

From there it is an ordinary failure, and three routes were opened for one:

- **`run_supply_act_loop` learned a `producer_supplier_id`.** It is `Some` at exactly one of its four call sites — the branch driving a `supply { }` block's own `whenever` body over a live channel-backed source, which is producer code rather than a downstream tap handler. A failure there is delivered to the enclosing supply's registered `quit =>` handlers through the serialize-group link, for the same reason `invoke_supply_done_callback_for_supplier` reaches them that way (ADR-0031 Decision A), and the emitter is marked quit so the supply's other sinks and pending promises see the terminal state.
- **`run_react_consumer`** now attributes a body failure on an `emitter_supplier_id`-owning subscription to that on-demand supply's quit. The field and the attribution already existed for a LAST-phaser die; this is its body-side twin.
- **The two on-demand branches that run a `supply { }` body inline** (`vm_react_loop.rs`'s `build_react_subscriptions` and `vm_react_supply_helpers.rs`'s nested-stage registration) now give the subscribing `whenever`'s `QUIT` phasers first refusal before wrapping the failure in `X::React::Died`.

Consumer-side callbacks are deliberately untouched: `raku` does not route an exception thrown by a tap body to that same tap's quit handler, so the other three act-loop call sites pass `None` and keep today's loud "Unhandled exception in code scheduled on thread" report. An unhandled supply failure with no `QUIT` anywhere still dies the react, and a quit handler that itself fails takes the loud path too — nothing became quieter, a failure that used to vanish is now either handled or reported.

## Testing

- `t/concurrency/supply/supply-worker-panic-reaches-quit.t` (new, 12 assertions): the panic and the `die` for both the inline `supply { }` body and the detached act-loop worker; a healthy supply still completes without running `QUIT`; an unhandled body die still dies the react; and a panic in an ordinary non-Supply pooled task (`start {}`) still breaks its own Promise unchanged. The 9 behavioural assertions all pass under the `raku` oracle; the 3 that don't are the `Internal error` prefix pins, which are mutsu's own panic mapping by construction (same convention as `t/vm/start-panic-boundary.t`).
- Existing panic-boundary pins still green: `t/vm/start-panic-boundary.t`, `t/vm/codegen/vm-panic-boundary.t`, `t/lang/operators/hyper-race-panic-boundary.t`.
- `make test`: **PASS** — 4151 files, 44187 tests, 0 failures.
- `make roast`: 1437 files, 219635 tests; the only failures are the two documented `uid 0` container-only files with their exact documented test numbers (`roast/6.c/S32-io/file-tests.t` 6-8/10 and `roast/S16-filehandles/filetest.t` 57-64/69-72/77-80/101…125 — see `docs/agent-environments.md`).
- `make lint`: **PASS** — all four configurations (default clippy, `jit` off, wasm32 lib, rustdoc).

Closes #8185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY5aYEwfnfbQouXEYKWq6y

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY5aYEwfnfbQouXEYKWq6y)_