### PR TITLE
fix(parser): decide where a statement ends from the source, not from a copy of the rule

### DIFF
--- a/news/2026-09/statement-modifier-boundaries-and-two-more-shadowings.md
+++ b/news/2026-09/statement-modifier-boundaries-and-two-more-shadowings.md
@@ -1,0 +1,122 @@
+# Where a statement ends: seven parse gaps from the ecosystem's biggest cluster
+
+Continuing [#7988](https://github.com/tokuhirom/mutsu/issues/7988) after
+[#8194](https://github.com/tokuhirom/mutsu/pull/8194). Same method: re-probe the cluster's
+distributions with a real `use`, group the failures by the source line the parser stopped on (which
+the location fix from #8065 made possible), minimise each, fix.
+
+Five of the seven gaps fixed here are about the same question — **where does a statement end?** — and
+every one of the seven was a rule mutsu already knew, applied by a site that kept its own weaker copy
+of it.
+
+## `}` ends a statement only when it ends the line
+
+Raku needs no `;` after a statement whose `}` ends its line. mutsu had that rule twice, both times
+slightly wrong:
+
+- **The `do BLOCK while` check.** `do { ... } while ...` on one line is the Perl 5 idiom rakudo
+  rejects with X::Obsolete, and the same goes for `until`/`for`/`given`. mutsu skipped *all*
+  whitespace before looking for the keyword, so it also rejected
+
+      my $x = do { 1 }
+      for @list { ... }
+
+  which is two statements. `MetamodelX::Red::Model` (Red), `PDF::Font::Loader::FontObj::CID` and
+  `App::MoarVM::HeapAnalyzer::Model` each failed to load on exactly that shape. The check now fires
+  only when no newline separates the `}` from the keyword.
+
+- **The "a statement ending in a block takes no modifier across a newline" rule.** That one was
+  decided from the AST — "does this statement's last expression *contain* a trailing block" — which
+  is equally true of `@a = @a.grep({ ... })`, where the line ends in `)`, the statement is
+  unfinished, and the next line's `if` really is its modifier:
+
+      @envelopes = @envelopes.grep({ ($_.id // -1) != $exclude-id })
+          if $exclude-id.defined;
+
+  App::Moneymoor writes ten of its modules that way. The rule now reads the source text to see
+  whether the `}` actually ends the line, which is what its own doc comment already claimed.
+
+## An extra modifier belongs to the enclosing statement, not to this one
+
+A statement takes at most one conditional modifier and then at most one loop modifier. mutsu raised
+X::Syntax::Confused ("Missing semicolon") the moment it saw a third, which reads the rule as "nobody
+may take this keyword" when it means "*this* statement may not". `do STMT` is the construct that can
+take it:
+
+    do return False unless %h<auth> ~~ $!auth if $!auth;
+
+(Pakku::Spec — ten more Pakku compunits behind it) is a `do`-wrapped `return … unless …` whose `if …`
+modifies the `do` statement. The chain now simply ends at the extra keyword and records the error for
+whoever finds the keyword unconsumed — the statement list, which is where rakudo raises it too. The
+diagnostic is unchanged for every illegal chain, and now carries a source location it did not have
+before (`Missing semicolon at -e:1`, matching rakudo).
+
+The record is deliberately not consumed when read: a block body is parsed more than once
+(speculatively as a hash composer first, then as a block, the second time as a pure memo hit that
+re-runs no modifier loop), and a record taken by the discarded attempt was missing from the one that
+survived.
+
+## A comment is whitespace, and a trailing comma is an empty list slot
+
+A trailing comma may be followed by a statement modifier (`die "x", if @c`, pinned since
+`t/control/trailing-comma-before-statement-modifier.t`). That rule was stated three times with
+different terminator sets: the paren-less listop path knew about modifiers, the two colon-argument
+paths (`obj.m: a, b` and `$x .= m: a`) only knew `;` `}` `)` `]`. And the modifier lookahead trimmed
+*spaces* rather than whitespace, so a comment in the gap hid the keyword from every path:
+
+    self.set-from-file: $!browser, #`[ $.debug ] unless $driver;
+
+(WebDriver2's driver provider.) The lookahead now uses `ws`, and both colon-argument paths accept a
+modifier after a trailing comma.
+
+## An anonymous destructure in a later pointy parameter
+
+    has &.set-content = -> $_, $content, (:$label, :$screen, |) { ... }
+
+A *first* parameter spelled as a bare sub-signature is unpacked by the pointy header itself; a later
+one goes through the per-parameter parser, which had a branch for `:(…)`, one for `Type (…)`, one for
+`$var (…)` — and none for a bare `(…)`. The whole block failed with "Malformed initializer". It now
+delegates to the parameter parser that already builds this shape for `sub ($c, (:$label))`, the third
+such delegation in that file.
+
+## An enum value shadows a core routine of the same name
+
+    my enum LogLevel <nothing error warn info now debug all>;
+    ...
+    ) if  all   ≤ $!verbose;
+
+`all` here is an enum value, so it is a complete nullary term. mutsu treated a core listop head as
+one unconditionally and demanded `≤ $!verbose` as its argument, which is why Pakku::Log — and the nine
+compunits that load it — failed to parse. Two sites now consult the declared-enum-value registry that
+`given`/`when` and the ternary parser already used: the listop-argument gate, and the zero-arg-callable
+gate that made `sort.value` read as `sort().value`.
+
+## `.<>` — the zen slice on the topic
+
+    prepare-param($_, %pars).() for .<>     # Test::Describe::It
+    self!run-test: |.<> for $test.subs      # Test::Describe::Expect
+
+The topic parser keeps its own copy of each subscript (`.<key>`, `.[i]`, `.{k}`), and the angle one
+demanded at least one key, so the zero-width spelling reached no branch at all. It now yields the bare
+topic with the subscript unconsumed and lets the undotted postfix branches parse it — the same rewind
+that gave `$x.[0; 1]` and `$x.<>` their full set of spellings in #8194 — which brings the
+`:k`/`:v`/`:kv`/`:p` adverbs along for free.
+
+## Measured
+
+Load probes over the cluster's cached checkouts, all provided compunits per distribution:
+
+| distribution | before | after |
+| --- | --- | --- |
+| App::Moneymoor | 44/54 | **54/54** |
+| Grammar::Editor | 2/9 | **9/9** |
+| Selkie::UI | 43/45 | **45/45** |
+| Pakku | 1/26 | **20/26** |
+| Test::Describe | 4/9 | 6/9 |
+| WebDriver2 | 48/194 | 51/194 |
+
+Test::Describe's two `.<>` modules parse; its `Root` stops on an unrelated "Two terms in a row".
+Pakku's remaining six stop at unrelated clusters (`CompUnit::Repository::Staging` is not
+implemented); Red's `do…for` site is fixed but the distribution stops later, on a `class Red:ver<…>`
+that only fails once `Red::Operators` has been imported — recorded on the issue rather than guessed
+at here.

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1368,10 +1368,19 @@ fn postfix_expr_loop_from(
                         let r4 = &r4[1..];
                         let (r4, _) = ws(r4)?;
                         // Handle a trailing comma before a statement terminator
-                        // (`;` / `}`) or the close of an enclosing group (`)` / `]`)
-                        // — Raku allows `(obj.m: 1, 2,)` and `[obj.m: 1, 2,]`; the
-                        // closer belongs to the surrounding group, not the arg list.
-                        if r4.starts_with([';', '}', ')', ']']) || r4.is_empty() {
+                        // (`;` / `}`), the close of an enclosing group (`)` / `]`),
+                        // or a statement modifier — Raku allows `(obj.m: 1, 2,)`,
+                        // `[obj.m: 1, 2,]` and `obj.m: 1, unless $x` alike: the
+                        // comma is an empty list slot and what follows belongs to
+                        // the enclosing group or statement, not to the arg list.
+                        // (`self.set-from-file: $!browser, #`[ $.debug ] unless
+                        // $driver;` — WebDriver2.)
+                        if r4.starts_with([';', '}', ')', ']'])
+                            || r4.is_empty()
+                            || crate::parser::stmt::modifier::is_stmt_modifier_after_trailing_comma(
+                                r4,
+                            )
+                        {
                             r_inner = r4;
                             break;
                         }
@@ -1577,10 +1586,19 @@ fn postfix_expr_loop_from(
                         let r4 = &r4[1..];
                         let (r4, _) = ws(r4)?;
                         // Handle a trailing comma before a statement terminator
-                        // (`;` / `}`) or the close of an enclosing group (`)` / `]`)
-                        // — Raku allows `(obj.m: 1, 2,)` and `[obj.m: 1, 2,]`; the
-                        // closer belongs to the surrounding group, not the arg list.
-                        if r4.starts_with([';', '}', ')', ']']) || r4.is_empty() {
+                        // (`;` / `}`), the close of an enclosing group (`)` / `]`),
+                        // or a statement modifier — Raku allows `(obj.m: 1, 2,)`,
+                        // `[obj.m: 1, 2,]` and `obj.m: 1, unless $x` alike: the
+                        // comma is an empty list slot and what follows belongs to
+                        // the enclosing group or statement, not to the arg list.
+                        // (`self.set-from-file: $!browser, #`[ $.debug ] unless
+                        // $driver;` — WebDriver2.)
+                        if r4.starts_with([';', '}', ')', ']'])
+                            || r4.is_empty()
+                            || crate::parser::stmt::modifier::is_stmt_modifier_after_trailing_comma(
+                                r4,
+                            )
+                        {
                             r_inner = r4;
                             break;
                         }

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -607,13 +607,19 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             if r.starts_with('{') {
                 let (r, body) = parse_block_body(r)?;
                 let (r_ws, _) = ws(r)?;
-                for kw in &["while", "until", "for", "given"] {
-                    if keyword(kw, r_ws).is_some() {
-                        return Err(PError::obsolete_at(
-                            &format!("do...{kw}"),
-                            "repeat...while or repeat...until",
-                            r_ws,
-                        ));
+                // A `}` that ends its line ends the statement, so a loop
+                // keyword on a later line opens a new one; only the same-line
+                // spelling is the Perl 5 `do BLOCK while ...` idiom.
+                let skipped = &r[..r.len() - r_ws.len()];
+                if !skipped.contains('\n') {
+                    for kw in &["while", "until", "for", "given"] {
+                        if keyword(kw, r_ws).is_some() {
+                            return Err(PError::obsolete_at(
+                                &format!("do...{kw}"),
+                                "repeat...while or repeat...until",
+                                r_ws,
+                            ));
+                        }
                     }
                 }
                 // The one site that parses the `do` keyword's own braces, and
@@ -1748,6 +1754,11 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     // Skip when directly followed by '.' — `func.method` is `(func()).method`,
     // but `func .method` is a listop call with topic-method-call argument.
     if is_listop(&name)
+        // A lexical enum value shadows the core routine of the same name, and a
+        // value is a complete nullary term: Pakku's `my enum LogLevel <... all>`
+        // makes `all ≤ $!verbose` a comparison, not a call to the junction
+        // builtin with `≤ $!verbose` demanded as its argument.
+        && !crate::parser::stmt::simple::is_user_declared_enum_value(&name)
         && !r.is_empty()
         && !r.starts_with(';')
         && !r.starts_with('}')
@@ -2134,7 +2145,13 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     // genuinely need an argument are absent from the table and keep falling
     // through to the bareword/X::Obsolete path below. See
     // [`is_zero_arg_callable_builtin`] for how the table was measured.
-    if is_terminator_or_dot && is_zero_arg_callable_builtin(&name) {
+    // …unless a lexical enum value shadows the routine, in which case the name is
+    // that value: with `my enum Dir <asc sort desc>` in scope, `sort.value` is the
+    // enum value's `.value`, not `sort().value` on an empty sort.
+    if is_terminator_or_dot
+        && is_zero_arg_callable_builtin(&name)
+        && !crate::parser::stmt::simple::is_user_declared_enum_value(&name)
+    {
         return Ok((rest, make_call_expr(name, input, vec![])));
     }
 

--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -593,7 +593,13 @@ pub(crate) fn is_infix_word_op(name: &str) -> bool {
 
 /// Check if input starts with a statement modifier keyword.
 pub(crate) fn is_stmt_modifier_ahead(input: &str) -> bool {
-    let input = input.trim_start();
+    // `ws`, not `trim_start`: a comment is whitespace too, and an *embedded*
+    // one can sit between a statement's last argument and its modifier —
+    // `self.set-from-file: $!browser, #`[ $.debug ] unless $driver;`
+    // (WebDriver2). Trimming only spaces left the comment in front of the
+    // keyword, so the argument parser tried to read `unless $driver` as one
+    // more argument.
+    let input = crate::parser::helpers::ws(input).map_or(input, |(r, ())| r);
     for kw in &["if", "unless", "for", "while", "until", "given", "when"] {
         if input.starts_with(kw)
             && !input

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -1285,6 +1285,15 @@ pub(in crate::parser::primary) fn topic_method_call(input: &str) -> PResult<'_, 
             },
         ));
     }
+    // `.<>` / `.«»` — the zen slice on the topic. There are no keys to parse, so
+    // rather than restate the zero-width case (and, after it, the `:k`/`:v`/`:kv`
+    // adverbs it may carry), hand the subscript back to the undotted postfix
+    // branches by yielding the bare topic with the opener unconsumed: `.<>` is
+    // exactly `$_<>`. Test::Describe's `prepare-param($_, %pars).() for .<>` is
+    // the shape that found this.
+    if r.starts_with("<>") || r.starts_with("\u{ab}\u{bb}") {
+        return Ok((r, Expr::Var("_".to_string())));
+    }
     // .<key> topical hash/associative lookup: equivalent to $_<key>
     if r.starts_with('<') && !r.starts_with("<=") && !r.starts_with("<<") && !r.starts_with("<=>") {
         let r2 = &r[1..];

--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -118,8 +118,16 @@ pub(crate) fn parse_colon_args(input: &str) -> PResult<'_, Vec<Expr>> {
         }
         let r2 = &r2[1..];
         let (r2, _) = ws(r2)?;
-        // Trailing comma before `;` or `}`.
-        if r2.starts_with(';') || r2.starts_with('}') || r2.is_empty() {
+        // Trailing comma before `;`, `}`, or a statement modifier — the comma is
+        // an empty list slot, exactly as in the listop argument path (see
+        // `is_stmt_modifier_after_trailing_comma`). Without the modifier case,
+        // `self.set-from-file: $!browser, #`[ $.debug ] unless $driver;`
+        // (WebDriver2) demanded one more argument and read `unless …` as it.
+        if r2.starts_with(';')
+            || r2.starts_with('}')
+            || r2.is_empty()
+            || crate::parser::stmt::modifier::is_stmt_modifier_after_trailing_comma(r2)
+        {
             r_inner = r2;
             break;
         }

--- a/src/parser/stmt/control/pointy_param.rs
+++ b/src/parser/stmt/control/pointy_param.rs
@@ -35,6 +35,20 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         return Ok((r, p));
     }
 
+    // Anonymous destructure with no type constraint at all: `-> $c, ($a, $b)`
+    // and `-> $_, $content, (:$label, :$screen, |)` (Selkie::UI's
+    // `&.set-content`, and Grammar::Editor through it). A *first* parameter
+    // spelled that way is unpacked by the pointy header itself, so only a later
+    // one reaches here — where the type-constraint branches above do not match
+    // (there is no type) and the sigil branches below cannot start at a `(`.
+    // Same delegation as the two branches below: `sub ($c, (:$label))` already
+    // builds exactly this parameter.
+    if input.starts_with('(') {
+        let (r, mut p) = crate::parser::stmt::sub_param::parse_single_param(input)?;
+        p.block_param = true;
+        return Ok((r, p));
+    }
+
     // Anonymous parameter carrying BOTH a type constraint and an unpacking
     // sub-signature: `-> Pair (:key($k), :value($v)) { ... }`, and its bracket
     // spelling `-> List [$a, $b]`. Only the *named* form (`-> Pair $p (:$key)`)

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -10,6 +10,52 @@ use crate::value::Value;
 use super::super::helpers::is_raku_identifier_start;
 use super::{keyword, parse_comma_or_expr};
 
+thread_local! {
+    /// The "Missing semicolon" error for a modifier chain this thread stopped
+    /// short of, keyed by the address of the offending keyword.
+    ///
+    /// A statement takes at most one conditional modifier and then at most one
+    /// loop modifier; a further one is not this statement's business, it is the
+    /// *enclosing* statement's. `do STMT` is the construct that has one:
+    /// `do return False unless %h<auth> ~~ $!auth if $!auth;` (Pakku::Spec) is a
+    /// `do`-wrapped statement carrying `unless …`, and the `if …` modifies the
+    /// `do` statement itself. Raising the error where the chain is detected
+    /// therefore rejects legal code, so the chain merely *ends* there and the
+    /// error is handed to whoever discovers the keyword is unconsumable — the
+    /// statement list, see `pending_extra_modifier_error`.
+    static PENDING_EXTRA_MODIFIER: std::cell::RefCell<Option<(crate::parser::memo::MemoKey, PError)>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// The deferred "Missing semicolon" error iff it belongs to `at`, i.e. the
+/// statement really did end leaving a modifier keyword nobody could consume.
+///
+/// Reading it does NOT consume the record: a block body is parsed more than once
+/// (speculatively as a hash composer first, then as a block, the second time as a
+/// pure memo hit that re-runs no modifier loop), so a record taken by the
+/// discarded attempt would be missing from the one that survives. Only an
+/// enclosing statement actually consuming the keyword clears it, in
+/// `clear_pending_extra_modifier`.
+pub(crate) fn pending_extra_modifier_error(at: &str) -> Option<PError> {
+    let key = crate::parser::memo::memo_key(at);
+    PENDING_EXTRA_MODIFIER.with(|p| match p.borrow().as_ref() {
+        Some((k, e)) if *k == key => Some(e.clone()),
+        _ => None,
+    })
+}
+
+/// Drop the deferred error once an enclosing statement has consumed the keyword
+/// it was recorded for.
+fn clear_pending_extra_modifier(at: &str) {
+    let key = crate::parser::memo::memo_key(at);
+    PENDING_EXTRA_MODIFIER.with(|p| {
+        let mut slot = p.borrow_mut();
+        if slot.as_ref().is_some_and(|(k, _)| *k == key) {
+            *slot = None;
+        }
+    });
+}
+
 /// After parsing a postfix modifier condition, check if the remaining input
 /// starts on a new line with a bare word that is not a statement modifier.
 /// This detects "two terms in a row across lines" errors like:
@@ -311,7 +357,17 @@ pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, S
     // statement modifier.
     if stmt_ends_with_block(&stmt) {
         let consumed_len = input.len().saturating_sub(rest.len());
-        if input[..consumed_len].contains('\n') {
+        // …and only when the `}` really does end the line. The AST test answers
+        // "does this statement's last expression *contain* a trailing block",
+        // which is also true of `@a = @a.grep({ ... })` — there the line ends in
+        // `)`, so the statement is unfinished and the next line's `if` IS its
+        // modifier (App::Moneymoor writes ten modules that way). Read the source
+        // text before the statement's end to tell the two apart; with no source
+        // recorded (a nested/EVAL buffer), keep the conservative old answer.
+        if input[..consumed_len].contains('\n')
+            && crate::parser::primary::source_span_at(input)
+                .is_none_or(|(pre, _)| pre.trim_end().ends_with('}'))
+        {
             return Ok((input, stmt));
         }
     }
@@ -343,10 +399,14 @@ pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, S
             return Ok((rest, current_stmt));
         }
 
+        // An enclosing statement that can take this keyword has consumed it, so
+        // the deferred error recorded for it is moot.
+        clear_pending_extra_modifier(rest);
+
         // A second modifier is only legal as `conditional THEN loop`
         // (`EXPR if COND for LIST`). Any other chain — two conditionals, two
-        // loops, a loop then a conditional, or a third modifier — needs a `;`
-        // and so is X::Syntax::Confused ("Missing semicolon").
+        // loops, a loop then a conditional, or a third modifier — ends this
+        // statement, and needs a `;` unless an enclosing statement takes it.
         if let Some(next_kw) = leading_modifier_keyword(rest)
             && let Some(&first) = parsed_kinds.first()
             && (parsed_kinds.len() >= 2 || !second_modifier_allowed(first, next_kw))
@@ -370,10 +430,14 @@ pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, S
                 crate::symbol::Symbol::intern("X::Syntax::Confused"),
                 attrs,
             );
-            return Err(PError::fatal_with_exception(
-                "Missing semicolon".to_string(),
-                Box::new(ex),
-            ));
+            let mut err =
+                PError::fatal_with_exception("Missing semicolon".to_string(), Box::new(ex));
+            err.remaining_len = Some(rest.len());
+            let key = crate::parser::memo::memo_key(rest);
+            PENDING_EXTRA_MODIFIER.with(|p| {
+                *p.borrow_mut() = Some((key, err));
+            });
+            return Ok((rest, current_stmt));
         }
 
         let kw = leading_modifier_keyword(rest);

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -454,6 +454,14 @@ pub(crate) fn stmt_list_with_mode(
                 // a semicolon, newline, closing brace, or end-of-input is required
                 // before the next statement.  `sub f { 3 } sub g { 3 }` on a
                 // single line is a syntax error.
+                // A modifier chain that ended early left the offending keyword
+                // for an enclosing statement to take (`do STMT unless A if B`).
+                // Reaching it here means nothing did, so the statement really
+                // was missing its `;` — see `pending_extra_modifier_error`.
+                let (r_ws, _) = ws(r)?;
+                if let Some(err) = super::modifier::pending_extra_modifier_error(r_ws) {
+                    return Err(err);
+                }
                 if is_block_ending_stmt(&stmt) && !has_statement_separator(r) {
                     return Err(PError::fatal(
                         "X::Syntax::Confused: Strange text after block (missing semicolon or comma?)"

--- a/t/collections/subscript/topic-zen-slice.t
+++ b/t/collections/subscript/topic-zen-slice.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# `.<>` is the zen slice on the topic — `$_<>`, the whole container. The topic
+# parser has its own copy of each subscript (`.<key>`, `.[i]`, `.{k}`), and the
+# angle one required at least one key, so the zero-width spelling reached no
+# branch and the term failed to parse:
+#
+#     self!run-test: |.<> for $test.subs      # Test::Describe::Expect
+#     prepare-param($_, %pars).() for .<>     # Test::Describe::It
+#
+# It now yields the bare topic with the subscript unconsumed, so the undotted
+# postfix branches parse it — the same rewind that gave `$x.[0; 1]` and `$x.<>`
+# their full set of spellings — which also brings the `:k`/`:v`/`:kv`/`:p`
+# adverbs along for free.
+
+plan 9;
+
+{
+    my @a = 1, 2, 3;
+    with @a { is .<>.elems, 3, '.<> on an array topic is the whole array' }
+    given @a { is .<>.join(','), '1,2,3', 'and it keeps the elements' }
+}
+{
+    my %h = a => 1, b => 2;
+    with %h { is .<>.elems, 2, '.<> on a hash topic is the whole hash' }
+    with %h { is-deeply .<>:k.sort.list, ('a', 'b'), 'a `:k` adverb on the topic zen slice' }
+    with %h { is-deeply .<>:v.sort.list, (1, 2), 'and `:v`' }
+}
+{
+    my $x = (1, 2);
+    given $x { is-deeply .<>, (1, 2), '.<> on a scalar topic decontainerizes it' }
+}
+
+# In the shape the distributions use: as a `for` list, and flattened into a call.
+{
+    my @seen;
+    my @items = 'a', 'b';
+    with @items {
+        @seen.push: $_ for .<>;
+    }
+    is @seen.join(','), 'a,b', '.<> as a `for` statement-modifier list';
+}
+{
+    sub take-two($x, $y) { "$x/$y" }
+    my @pair = 'l', 'r';
+    with @pair { is take-two(|.<>), 'l/r', '|.<> flattens the topic into a call' }
+}
+
+# The keyed spellings are unchanged.
+{
+    my %h = k => 'v';
+    with %h { is .<k>, 'v', '.<key> still looks up a key' }
+}

--- a/t/control/do-block-newline-then-loop-keyword.t
+++ b/t/control/do-block-newline-then-loop-keyword.t
@@ -1,0 +1,66 @@
+use v6;
+use Test;
+
+# `do BLOCK while ...` is the Perl 5 idiom Raku rejects (X::Obsolete, "please use
+# repeat...while"), and the same rejection covers `until`, `for` and `given` on
+# the SAME line. It does not reach the next line: a `}` that ends its line ends
+# the statement, so
+#
+#     my $x = do { 1 }
+#     for @list { ... }
+#
+# is two statements. mutsu skipped all whitespace before looking for the keyword,
+# so it rejected that too — which is how `MetamodelX::Red::Model` (Red),
+# `PDF::Font::Loader::FontObj::CID` and `App::MoarVM::HeapAnalyzer::Model` all
+# failed to load, each on a `do { ... }` whose block is followed by an ordinary
+# loop statement.
+
+plan 12;
+
+# The next line opens a new statement, and the `do` block still yields its value.
+{
+    my @seen;
+    my $x = do { 1 }
+    for 1, 2 { @seen.push: $_ }
+    is $x, 1, 'do block value survives a following `for` statement';
+    is @seen.join(','), '1,2', 'and the `for` ran as its own statement';
+}
+
+{
+    my $i = 0;
+    my $x = do { 7 }
+    while $i < 2 { $i++ }
+    is $x, 7, 'do block value survives a following `while` statement';
+    is $i, 2, 'and the `while` ran as its own statement';
+}
+
+{
+    my $i = 0;
+    my $x = do { 8 }
+    until $i >= 3 { $i++ }
+    is $x, 8, 'do block value survives a following `until` statement';
+    is $i, 3, 'and the `until` ran as its own statement';
+}
+
+{
+    my $seen = '';
+    my $x = do { 9 }
+    given 'topic' { $seen = $_ }
+    is $x, 9, 'do block value survives a following `given` statement';
+    is $seen, 'topic', 'and the `given` ran as its own statement';
+}
+
+# A comment between the `}` and the newline does not change that.
+{
+    my @seen;
+    my $x = do { 4 }   # trailing comment
+    for 1, 2 { @seen.push: $_ }
+    is $x, 4, 'a trailing comment still leaves two statements';
+    is @seen.elems, 2, 'and the loop still ran';
+}
+
+# The same-line spellings are still the obsolete-syntax error.
+throws-like 'my $i = 0; do { $i++ } while $i < 3', X::Obsolete,
+    'do BLOCK while on one line is still rejected';
+throws-like 'do { say $_ } for 1, 2', X::Obsolete,
+    'do BLOCK for on one line is still rejected';

--- a/t/control/do-stmt-modifier-belongs-to-outer.t
+++ b/t/control/do-stmt-modifier-belongs-to-outer.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+# A statement takes at most one conditional modifier and then at most one loop
+# modifier. A further modifier is not that statement's business — it belongs to
+# whatever encloses it, and `do STMT` is the construct that can be that
+# enclosure:
+#
+#     do return False unless %h<auth> ~~ $!auth if $!auth;
+#
+# (Pakku::Spec, ten more Pakku compunits behind it) is a `do`-wrapped `return …
+# unless …`, and the `if …` modifies the `do` statement itself. mutsu raised
+# "Missing semicolon" the moment it saw the second keyword, so it rejected this.
+# The diagnosis now waits until the statement list finds the keyword unconsumed,
+# which is where rakudo raises it too.
+
+plan 9;
+
+{
+    sub f($x) {
+        do return 'early' unless $x ~~ 1 if $x;
+        'late'
+    }
+    is f(2), 'early', 'outer `if` true and inner `unless` true: the `do return` fires';
+    is f(1), 'late',  'outer `if` true, inner `unless` false: falls through';
+    is f(0), 'late',  'outer `if` false: the whole `do` statement is skipped';
+}
+
+# The `do`-wrapped statement may carry a loop modifier of its own too.
+{
+    my @seen;
+    my $on = 1;
+    do @seen.push: $_ for 1, 2 if $on;
+    is @seen.join(','), '1,2', 'do STMT for LIST if COND runs the loop';
+    @seen = ();
+    $on = 0;
+    do @seen.push: $_ for 1, 2 if $on;
+    is @seen.elems, 0, 'and the outer `if` still gates it';
+}
+
+# Without the `do` there is no enclosing statement to take the second keyword,
+# so the chain is still X::Syntax::Confused ("Missing semicolon") — and now it
+# carries a source location, as rakudo's does.
+throws-like 'say 1 if 2 if 3', X::Syntax::Confused,
+    'two conditionals are still rejected';
+throws-like 'say 1 for 1..2 for 3..4', X::Syntax::Confused,
+    'two loops are still rejected';
+throws-like 'say 1 for 3..4 if 2', X::Syntax::Confused,
+    'a loop then a conditional is still rejected';
+throws-like 'sub f($x) { do return 1 unless $x if $x if $x }', X::Syntax::Confused,
+    'a `do` absorbs one extra modifier, not two';

--- a/t/control/statement-modifier-after-block-argument-call.t
+++ b/t/control/statement-modifier-after-block-argument-call.t
@@ -1,0 +1,80 @@
+use v6;
+use Test;
+
+# A statement whose last expression ends in a `{ ... }` block is self-terminating
+# when that brace ends the line: `my @a = gather { ... }` followed by a line
+# starting with `if` is two statements, not a modifier.
+#
+# mutsu decided that from the AST alone — "does the trailing expression contain a
+# block" — which is also true of `@a = @a.grep({ ... })`, where the line ends in
+# `)` and the statement is therefore NOT finished. The next line's `if` really is
+# its modifier, as rakudo reads it:
+#
+#     @envelopes = @envelopes.grep({ ($_.id // -1) != $exclude-id })
+#         if $exclude-id.defined;
+#
+# (App::Moneymoor, which writes ten of its modules that way.) The rule now reads
+# the source text to see whether the `}` actually ends the line.
+
+plan 10;
+
+# The modifier attaches when the line ends in something other than `}`.
+{
+    my @a = 1, 2, 3;
+    my $on = True;
+    @a = @a.grep({ $_ != 2 })
+        if $on;
+    is-deeply @a, [1, 3], 'a modifier on the next line applies to a `.grep({...})` assignment';
+}
+{
+    my @a = 1, 2, 3;
+    my $on = False;
+    @a = @a.grep({ $_ != 2 })
+        if $on;
+    is-deeply @a, [1, 2, 3], 'and a false condition leaves the assignment undone';
+}
+{
+    my @seen;
+    my $n = 0;
+    @seen.push(
+        do { $n++ }
+    ) for 1, 2;
+    is $n, 2, 'a `for` modifier after a multi-line argument list still loops';
+}
+{
+    my @a = 1, 2, 3;
+    my @kept = @a.map({ $_ * 2 })
+        unless False;
+    is-deeply @kept, [2, 4, 6], 'an `unless` modifier attaches the same way';
+}
+
+# A `}` that really does end the line still terminates the statement.
+{
+    my @a = gather { take 7 }
+    if @a { pass 'a following `if` is its own statement after a `gather {...}` line' }
+    is-deeply @a, [7], 'and the gather assignment kept its value unconditionally';
+}
+{
+    my $x = do { 5 }
+    unless $x { flunk 'unreachable' }
+    is $x, 5, 'a `do {...}` line is self-terminating too';
+}
+{
+    my $ran = False;
+    sub f(@mask) {
+        return 'early' if @mask.first: { !.defined }
+        $ran = True;
+        'late'
+    }
+    is f([1, 2]), 'late', 'a block-terminated modifier condition still ends the statement';
+    ok $ran, 'so the following statement ran';
+}
+
+# A bare block statement is unaffected: a modifier never attaches across a newline.
+{
+    my $count = 0;
+    {
+        $count++;
+    }
+    if $count { pass 'a bare block keeps its `}`-ends-the-line reading' }
+}

--- a/t/control/statement-modifier-after-trailing-comma-comment.t
+++ b/t/control/statement-modifier-after-trailing-comma-comment.t
@@ -1,0 +1,73 @@
+use v6;
+use Test;
+
+# A trailing comma in an argument list is an empty list slot, so a statement
+# modifier may follow it (`die "x", if @c` — see
+# t/control/trailing-comma-before-statement-modifier.t). That rule was stated
+# three times with different terminator sets: the paren-less listop path knew
+# about modifiers, the two colon-argument paths (`obj.m: a, b` and `$x .= m: a`)
+# only knew `;` `}` `)` `]`. And the modifier lookahead trimmed *spaces* rather
+# than whitespace, so an embedded comment between the comma and the keyword hid
+# it from every path:
+#
+#     self.set-from-file: $!browser, #`[ $.debug ] unless $driver;
+#
+# (WebDriver2's driver provider.)
+
+plan 11;
+
+class C {
+    has @.seen;
+    method f(*@a) { @!seen.append: @a; @a.elems }
+    method g($guard) {
+        self.f: 1, #`[ dropped ] unless $guard;
+        self.f: 2, if $guard;
+        'done'
+    }
+}
+
+# The method colon-argument form, with and without a comment in the gap.
+{
+    my $c = C.new;
+    is ($c.f: 1, unless 0), 1, 'a trailing comma before `unless` in a colon-arg list';
+    is $c.seen.join(','), '1', 'and the one argument arrived';
+}
+{
+    my $c = C.new;
+    is ($c.f: 1, #`[ x ] unless 0), 1, 'an embedded comment between the comma and `unless`';
+    is $c.seen.join(','), '1', 'the comment is not an argument';
+}
+{
+    my $c = C.new;
+    is $c.g(True), 'done', 'both forms parse inside a method body';
+    is $c.seen.join(','), '2', 'the guarded calls ran as their conditions say';
+}
+{
+    my $c = C.new;
+    $c.f: 1, 2, #`( trailing ) if 1;
+    is $c.seen.join(','), '1,2', 'a multi-argument colon list keeps all of its arguments';
+}
+
+# `.=` colon-arg calls take the same rule.
+{
+    my $s = 'aa';
+    $s .= subst: 'a', 'b', unless 0;
+    is $s, 'ba', 'a trailing comma before `unless` in a `.=` colon-arg list';
+}
+
+# A paren-less listop head with a comment before the modifier.
+{
+    my @out;
+    @out.push: 3;
+    lives-ok { EVAL 'my @c; say join ",", 1, #`[ c ] if @c' },
+        'a builtin listop head with a comment before `if`';
+}
+
+# Things that must NOT change: a trailing comma still closes an argument list
+# before a group closer, and a same-named pair key is still a pair.
+{
+    my $c = C.new;
+    is ($c.f: 1, 2,), 2, 'a trailing comma before `)` still ends the list';
+    my @a = 1, if => 2;
+    is-deeply @a, [1, (if => 2)], 'an `if =>` pair key is still a pair';
+}

--- a/t/routines/signature/pointy-anon-destructure-later-param.t
+++ b/t/routines/signature/pointy-anon-destructure-later-param.t
@@ -1,0 +1,64 @@
+use v6;
+use Test;
+
+# A pointy block's parameter may be an anonymous destructure — a bare
+# sub-signature with no variable of its own:
+#
+#     has &.set-content = -> $_, $content, (:$label, :$screen, |) { ... }
+#
+# (Selkie::UI's tab-bar builder, and Grammar::Editor through it.)
+#
+# A *first* parameter spelled that way was unpacked by the pointy header itself,
+# but a later one went through the per-parameter parser, which had a branch for
+# `:(…)`, one for `Type (…)`, and one for `$var (…)` — and none for a bare `(…)`.
+# The whole block then failed to parse ("Malformed initializer"). It now delegates
+# to the same parameter parser `sub ($c, (:$label))` already uses.
+
+plan 9;
+
+# Positional destructure in second position.
+{
+    my &f = -> $c, ($a, $b) { "$c:$a:$b" };
+    is f(1, (2, 3)), '1:2:3', 'a positional destructure as the second parameter';
+}
+
+# Named (hash) destructure in second position, with and without a slurpy.
+{
+    my &f = -> $c, (:$label) { "$c:$label" };
+    is f(1, {:label<x>}), '1:x', 'a named destructure as the second parameter';
+}
+{
+    my &f = -> $_, $content, (:$label, :$screen, |) { "$content:$label:$screen" };
+    is f(0, 'c', {:label<a>, :screen<b>, :extra(9)}), 'c:a:b',
+        'a named destructure with a slurpy ignores the extra keys';
+}
+
+# Third position, and a nested destructure.
+{
+    my &f = -> $a, $b, ($c, $d) { "$a$b$c$d" };
+    is f(1, 2, (3, 4)), '1234', 'a destructure as the third parameter';
+}
+{
+    my &f = -> $a, ($b, ($c, $d)) { "$a$b$c$d" };
+    is f(1, (2, (3, 4))), '1234', 'a destructure nested inside a destructure';
+}
+
+# The same spelling in a `for` header and in a `sub` signature.
+{
+    my @out;
+    for 1, (2, 3), 4, (5, 6) -> $head, ($a, $b) {
+        @out.push: "$head-$a-$b";
+    }
+    is @out.join(' '), '1-2-3 4-5-6', 'a `for` header takes it too';
+    is @out.elems, 2, 'the `for` iterated twice, two items per iteration';
+}
+{
+    my $s = sub ($c, (:$label, |)) { "$c/$label" };
+    is $s(1, {:label<y>, :z(2)}), '1/y', 'the `sub` spelling is unchanged';
+}
+
+# A first-position destructure still works (it takes the new branch now).
+{
+    my &f = -> ($a, $b) { $a + $b };
+    is f((3, 4)), 7, 'a first-position destructure still unpacks';
+}

--- a/t/types/enum-subset/enum-value-shadows-core-listop.t
+++ b/t/types/enum-subset/enum-value-shadows-core-listop.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# An enum value is a lexical symbol like any other, so it shadows a core routine
+# of the same name:
+#
+#     my enum LogLevel <nothing error warn info now debug all>;
+#     ...
+#     ) if  all   ≤ $!verbose;
+#
+# (Pakku::Log, with nine more Pakku compunits behind it.) mutsu's parser treated a
+# core listop head as one unconditionally, so `all ≤ $!verbose` became a call to
+# the junction builtin with `≤ $!verbose` demanded as its argument, and every
+# compunit that loaded Pakku::Log failed to parse. A declared enum value is a
+# complete nullary term instead.
+
+plan 12;
+
+# The junction builtins, shadowed.
+{
+    my enum L <nothing debug all>;
+    is (all ≤ debug), False, 'a shadowing `all` is a term, not the junction builtin';
+    is all.value, 2, 'and it is the enum value';
+    is all.key, 'all', 'with the enum key';
+}
+{
+    my enum J <any one none>;
+    is any.value, 0, 'a shadowing `any`';
+    is one.value, 1, 'a shadowing `one`';
+    is none.value, 2, 'a shadowing `none`';
+    is (any < none), True, 'they compare as enum values';
+}
+
+# A listop that is not a junction: `sort`.
+{
+    my enum Dir <asc sort desc>;
+    is sort.value, 1, 'a shadowing `sort` is the enum value';
+    is (sort > asc), True, 'and it compares as one';
+}
+
+# The unshadowed builtins still take paren-less arguments.
+{
+    my @a = 1, 2, 3;
+    is (so all(@a) > 0), True, 'the `all` junction still works with parens';
+    is (so all @a > 0), True, 'and paren-less';
+    is-deeply (sort 3, 1, 2), (1, 2, 3), 'paren-less `sort` still sorts';
+}


### PR DESCRIPTION
Continues [#7988](https://github.com/tokuhirom/mutsu/issues/7988) after #8194. Method unchanged: re-probe the cluster's distributions with a real `use`, group the failures by the **source line the parser stopped on** (possible since the location fix in #8065), minimise each, fix.

Seven gaps. Five are the same question asked at five different sites — *where does a statement end?* — and all seven are a rule mutsu already had, applied by a site that kept its own weaker copy of it.

## `}` ends a statement only when it ends the line

| construct | distributions |
|---|---|
| `do { 1 }` then a `for`/`while`/`until`/`given` statement on the next line | MetamodelX::Red::Model, PDF::Font::Loader::FontObj::CID, App::MoarVM::HeapAnalyzer::Model |
| `@a = @a.grep({ ... })` then `if COND;` on the next line | App::Moneymoor (ten modules) |

The first is the `do BLOCK while` check (X::Obsolete, the Perl 5 idiom). It skipped *all* whitespace before looking for the keyword, so it also rejected the two-statement reading rakudo gives when the `}` ends the line. It now fires only when no newline separates them; the same-line spellings are still rejected, for all four keywords.

The second is the "a statement ending in a block takes no modifier across a newline" rule, which was decided from the AST — "does the trailing expression *contain* a block" — and so also fired for a line ending in `)`. There the statement is unfinished and the next line's `if` really is its modifier. It now reads the source text, which is what its own doc comment already claimed ("when its trailing `}` sits at the end of a line").

## An extra modifier belongs to the enclosing statement

```raku
do return False unless %h<auth> ~~ $!auth if $!auth;   # Pakku::Spec
```

A statement takes one conditional modifier then one loop modifier. mutsu raised X::Syntax::Confused ("Missing semicolon") the moment it saw a third — reading the rule as "nobody may take this keyword" when it means "*this* statement may not". `do STMT` is the construct that can be the enclosure. The chain now ends at the extra keyword and hands the error to whoever finds the keyword unconsumed: the statement list, which is where rakudo raises it. Every illegal chain is still X::Syntax::Confused with the same `pre`/`post` spans, and now carries a source location it lacked before (`Missing semicolon at -e:1`, matching rakudo).

The deferred record is read without being consumed, deliberately: a block body is parsed more than once (speculatively as a hash composer, then as a block — the second time a pure memo hit that re-runs no modifier loop), and a record taken by the discarded attempt was missing from the surviving one. It is keyed by the memo key of the offending keyword, so it cannot outlive its buffer.

## A comment is whitespace, and a trailing comma is an empty list slot

```raku
self.set-from-file: $!browser, #`[ $.debug ] unless $driver;   # WebDriver2
```

The trailing-comma-then-modifier rule (`die "x", if @c`) was stated three times with different terminator sets: the paren-less listop path knew about modifiers, the two colon-argument paths (`obj.m: a, b` and `$x .= m: a`) only knew `;` `}` `)` `]`. And the modifier lookahead trimmed *spaces* rather than whitespace, so a comment in the gap hid the keyword from every path. The lookahead uses `ws` now, and both colon-argument paths take the modifier case.

## An anonymous destructure in a later pointy parameter

```raku
has &.set-content = -> $_, $content, (:$label, :$screen, |) { ... }   # Selkie::UI
```

A *first* parameter spelled as a bare sub-signature is unpacked by the pointy header; a later one goes through the per-parameter parser, which had a branch for `:(…)`, one for `Type (…)`, one for `$var (…)` — and none for a bare `(…)`, so the whole block failed with "Malformed initializer". It delegates to the parameter parser that already builds this shape for `sub ($c, (:$label))` — the third such delegation in that file.

## `.<>` — the zen slice on the topic

```raku
prepare-param($_, %pars).() for .<>     # Test::Describe::It
```

The topic parser keeps its own copy of each subscript, and the angle one demanded at least one key. It now yields the bare topic with the subscript unconsumed and lets the undotted postfix branches parse it — the rewind that gave `$x.[0; 1]` and `$x.<>` their full set of spellings in #8194 — so the `:k`/`:v`/`:kv`/`:p` adverbs come along for free.

## An enum value shadows a core routine of the same name

```raku
my enum LogLevel <nothing error warn info now debug all>;
...
) if  all   ≤ $!verbose;                # Pakku::Log
```

`all` is an enum value here, so it is a complete nullary term; mutsu treated a core listop head as one unconditionally and demanded `≤ $!verbose` as its argument. Two gates now consult the declared-enum-value registry that `given`/`when` and the ternary parser already used: the listop-argument gate, and the zero-arg-callable gate that read `sort.value` as `sort().value`.

## Measured

Load probes over the cached checkouts, all provided compunits per distribution:

| distribution | before | after |
|---|---|---|
| App::Moneymoor | 44/54 | **54/54** |
| Grammar::Editor | 2/9 | **9/9** |
| Selkie::UI | 43/45 | **45/45** |
| Pakku | 1/26 | **20/26** |
| Test::Describe | 4/9 | 6/9 |
| WebDriver2 | 48/194 | 51/194 |

## Filed, not fixed

- #8205 — the zen slice answers an **empty list** in its guillemet and double-angle spellings (`%h«»`, `@a<<>>`). A silent wrong answer, pre-existing, and no cluster member needs it; the right fix is one helper shared by all three subscript arms rather than a third copy.
- #8206 — `!!$x` does not parse at all, because `!!` is excluded from the prefix table for the ternary's sake. `Pray` loads on nothing else, but making `!!` a prefix lets a bareword listop in a ternary's then-branch gobble the `!!` marker, so it needs its own test.

## Tests

`t/control/do-block-newline-then-loop-keyword.t`, `t/control/do-stmt-modifier-belongs-to-outer.t`, `t/control/statement-modifier-after-block-argument-call.t`, `t/control/statement-modifier-after-trailing-comma-comment.t`, `t/routines/signature/pointy-anon-destructure-later-param.t`, `t/collections/subscript/topic-zen-slice.t`, `t/types/enum-subset/enum-value-shadows-core-listop.t` — every one of them run under rakudo as well as mutsu, and green in both.

`make test` green (4157 files, 44247 tests). `make roast` green apart from the three container-only exceptions `docs/agent-environments.md` licenses (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` as `uid 0`, `S32-io/IO-Socket-Async.t` on the sandboxed network). `make lint` green in all four configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1adnMgRUumMEzzQ57Z4D8)_