### PR TITLE
fix(parser): preserve guillemet zen slices

### DIFF
--- a/news/2026-09/zen-slice-angle-spellings.md
+++ b/news/2026-09/zen-slice-angle-spellings.md
@@ -1,0 +1,15 @@
+# Guillemet and double-angle zen slices keep the whole container
+
+Empty angle subscripts are zen slices in all three spellings: `<>`, `«»`, and
+`<<>>`. mutsu already handled the plain angle spelling, but parsed the two
+interpolating spellings as empty key lists, so `%hash«»` and `%hash<<>>`
+returned no values instead of the whole hash. Their dotted spellings had the
+same gap.
+
+The parser now shares the zen-slice expression and `:k` / `:v` / `:kv` / `:p`
+adverb mapping across all three postcircumfix arms. Non-empty interpolating
+subscripts continue to use their existing quote-word semantics.
+
+Pinned by `t/collections/subscript/zen-slice-angle-spellings.t`.
+
+Closes #8205.

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -759,6 +759,47 @@ fn brace_is_postcircumfix(expr: &Expr, term_ends_with_ws: bool) -> bool {
         && !matches!(expr, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. }))
 }
 
+/// Build the expression for an empty angle subscript (`<>`, `«»`, or `<<>>`).
+///
+/// All three spellings are zen slices when their contents contain no words.
+/// The adverbs are postfixes on the resulting collection, so consume them here
+/// together with the synthetic `__mutsu_zen_angle` call.
+fn parse_zen_angle(expr: Expr, rest: &str) -> (Expr, &str) {
+    let indexed_expr = match &expr {
+        Expr::HashVar(_) => expr,
+        _ => Expr::MethodCall {
+            target: Box::new(expr),
+            name: Symbol::intern("__mutsu_zen_angle"),
+            args: Vec::new(),
+            modifier: None,
+            quoted: false,
+        },
+    };
+    let zen_adverb = [
+        (":kv", "kv"),
+        (":k", "keys"),
+        (":v", "values"),
+        (":p", "pairs"),
+    ]
+    .into_iter()
+    .find(|(adv, _)| {
+        rest.starts_with(adv) && !is_ident_char(rest.as_bytes().get(adv.len()).copied())
+    });
+    if let Some((adv, method)) = zen_adverb {
+        return (
+            Expr::MethodCall {
+                target: Box::new(indexed_expr),
+                name: Symbol::intern(method),
+                args: Vec::new(),
+                modifier: None,
+                quoted: false,
+            },
+            &rest[adv.len()..],
+        );
+    }
+    (indexed_expr, rest)
+}
+
 fn postfix_expr_loop(rest: &str, expr: Expr, allow_ws_dot: bool) -> PResult<'_, Expr> {
     postfix_expr_loop_from(rest, expr, allow_ws_dot, (false, false), false)
 }
@@ -1916,53 +1957,18 @@ fn postfix_expr_loop_from(
                         .collect(),
                 )
             };
-            let indexed_expr = if is_zen_angle {
-                match &expr {
-                    Expr::HashVar(_) => expr.clone(),
-                    _ => Expr::MethodCall {
-                        target: Box::new(expr.clone()),
-                        name: Symbol::intern("__mutsu_zen_angle"),
-                        args: Vec::new(),
-                        modifier: None,
-                        quoted: false,
-                    },
-                }
+            let (indexed_expr, r) = if is_zen_angle {
+                parse_zen_angle(expr, r)
             } else {
-                Expr::Index {
-                    target: Box::new(expr),
-                    index: Box::new(index_expr),
-                    is_positional: false,
-                }
+                (
+                    Expr::Index {
+                        target: Box::new(expr),
+                        index: Box::new(index_expr),
+                        is_positional: false,
+                    },
+                    r,
+                )
             };
-            // Zen-slice `:k`/`:v`/`:kv`/`:p` adverbs map to the keys/values/kv/pairs
-            // method (`%h<>:k` is `%h.keys`, `%h<>:v` is `%h.values`). Probe the
-            // two-letter `:kv` before the one-letter `:k`/`:v` so `:kv` is not read
-            // as `:k` + a stray `v`.
-            let zen_adverb = is_zen_angle
-                .then(|| {
-                    [
-                        (":kv", "kv"),
-                        (":k", "keys"),
-                        (":v", "values"),
-                        (":p", "pairs"),
-                    ]
-                    .into_iter()
-                    .find(|(adv, _)| {
-                        r.starts_with(adv) && !is_ident_char(r.as_bytes().get(adv.len()).copied())
-                    })
-                })
-                .flatten();
-            if let Some((adv, method)) = zen_adverb {
-                expr = Expr::MethodCall {
-                    target: Box::new(indexed_expr),
-                    name: Symbol::intern(method),
-                    args: Vec::new(),
-                    modifier: None,
-                    quoted: false,
-                };
-                rest = &r[adv.len()..];
-                continue;
-            }
             // Check for :exists / :!exists / :delete adverbs
             if let Some((r_after, exists_expr)) = try_parse_exists_adverb(r, indexed_expr.clone()) {
                 expr = exists_expr;
@@ -1981,13 +1987,28 @@ fn postfix_expr_loop_from(
             if let Some(end) = r.find('\u{00BB}') {
                 let content = &r[..end];
                 let r = &r[end + '\u{00BB}'.len_utf8()..];
-                expr = Expr::Index {
-                    target: Box::new(expr),
-                    index: Box::new(crate::parser::primary::angle_words_subscript_index_expr(
-                        content,
-                    )),
-                    is_positional: false,
+                let (indexed_expr, r) = if split_angle_words(content).is_empty() {
+                    parse_zen_angle(expr, r)
+                } else {
+                    (
+                        Expr::Index {
+                            target: Box::new(expr),
+                            index: Box::new(
+                                crate::parser::primary::angle_words_subscript_index_expr(content),
+                            ),
+                            is_positional: false,
+                        },
+                        r,
+                    )
                 };
+                if let Some((r_after, exists_expr)) =
+                    try_parse_exists_adverb(r, indexed_expr.clone())
+                {
+                    expr = exists_expr;
+                    rest = r_after;
+                    continue;
+                }
+                expr = indexed_expr;
                 rest = r;
                 continue;
             }
@@ -2002,13 +2023,28 @@ fn postfix_expr_loop_from(
             if let Some(end) = r.find(">>") {
                 let content = &r[..end];
                 let r = &r[end + 2..];
-                expr = Expr::Index {
-                    target: Box::new(expr),
-                    index: Box::new(crate::parser::primary::angle_words_subscript_index_expr(
-                        content,
-                    )),
-                    is_positional: false,
+                let (indexed_expr, r) = if split_angle_words(content).is_empty() {
+                    parse_zen_angle(expr, r)
+                } else {
+                    (
+                        Expr::Index {
+                            target: Box::new(expr),
+                            index: Box::new(
+                                crate::parser::primary::angle_words_subscript_index_expr(content),
+                            ),
+                            is_positional: false,
+                        },
+                        r,
+                    )
                 };
+                if let Some((r_after, exists_expr)) =
+                    try_parse_exists_adverb(r, indexed_expr.clone())
+                {
+                    expr = exists_expr;
+                    rest = r_after;
+                    continue;
+                }
+                expr = indexed_expr;
                 rest = r;
                 continue;
             }

--- a/t/collections/subscript/zen-slice-angle-spellings.t
+++ b/t/collections/subscript/zen-slice-angle-spellings.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+# Empty angle subscripts are zen slices in all three spellings. The
+# interpolating guillemet and ASCII double-angle forms must not turn an empty
+# key list into an empty result.
+
+plan 16;
+
+my @a = 10, 20;
+is @a<>.elems, 2, 'plain angle zen slice keeps the array';
+is @a«».elems, 2, 'guillemet zen slice keeps the array';
+is @a<<>>.elems, 2, 'double-angle zen slice keeps the array';
+is @a.<>.elems, 2, 'dotted plain angle zen slice keeps the array';
+is @a.«».elems, 2, 'dotted guillemet zen slice keeps the array';
+is @a.<<>>.elems, 2, 'dotted double-angle zen slice keeps the array';
+
+my %h = a => 1, b => 2;
+is-deeply %h<>:k.sort.List, ('a', 'b'), 'plain angle zen slice maps :k';
+is-deeply %h«»:k.sort.List, ('a', 'b'), 'guillemet zen slice maps :k';
+is-deeply %h<<>>:k.sort.List, ('a', 'b'), 'double-angle zen slice maps :k';
+is-deeply %h.<>:v.sort.List, (1, 2), 'dotted plain angle zen slice maps :v';
+is-deeply %h.«»:v.sort.List, (1, 2), 'dotted guillemet zen slice maps :v';
+is-deeply %h.<<>>:v.sort.List, (1, 2), 'dotted double-angle zen slice maps :v';
+
+is %h«»:kv.elems, 4, 'guillemet zen slice maps :kv';
+is %h<<>>:p.elems, 2, 'double-angle zen slice maps :p';
+is %h.«»:kv.elems, 4, 'dotted guillemet zen slice maps :kv';
+is %h.<<>>:p.elems, 2, 'dotted double-angle zen slice maps :p';
+
+done-testing;


### PR DESCRIPTION
Closes #8205.

Empty `<>`, `«»`, and `<<>>` subscripts are zen slices. The parser already lowered the plain angle spelling to the whole-container expression, but the interpolating guillemet and ASCII double-angle spellings produced an empty key list instead. This also affected dotted spellings.

The three postcircumfix arms now share zen-slice construction and `:k` / `:v` / `:kv` / `:p` adverb mapping while preserving non-empty interpolating subscript behavior.

Validation:
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make check-t-layout`
- `make test` (4,157 files, 44,304 tests)
- `make roast` (1,437 files, 219,658 tests)
