### PR TITLE
fix: deny scripts/check-panic-surface.py on the ci-docs-only allowlist, and record the ledger's second ticket batch

### DIFF
--- a/docs/ecosystem-parity.md
+++ b/docs/ecosystem-parity.md
@@ -34,7 +34,7 @@ sides, and publish the difference.
 > **41.1%** dist parity — 53.4% file, 63.1% assertion — and `history.tsv` plus the
 > chart carry it over time. A sweep runs nightly, on dispatch, or locally (§8).
 > P5's first batch filed fifteen root-caused issues covering ~330 distribution
-> slots (§9).
+> slots, and a second batch twelve more covering ~110 (§9).
 >
 > **What to do with this now: pick work, not phases.** Either take a root cause
 > from the clustered issues (§9), or take a distribution with the
@@ -721,6 +721,60 @@ splits a cluster, which is progress even though it moves no KPI.
 What is left after this batch is a long tail: 985 clusters in total, of which
 these fifteen are the ones affecting ten or more distributions. The tail is a
 **sampling** job (`--min-dists 1`), not an exhaustive-triage one.
+
+### The second batch (2026-09-13)
+
+Twelve issues from the corpus measured at `1557d41` (the 2026-09-11 `scope=all`
+sweep), covering ~110 further distribution slots. This batch went *below* the
+ten-distribution line the first one stopped at, and the interesting result is
+that the message-shaped clusters down there **split**: three of the twelve came
+out of one cluster.
+
+| issue | dists | root cause |
+|---|---|---|
+| [#8209](https://github.com/tokuhirom/mutsu/issues/8209) | 19 | a `{`/`}` inside a string literal ends a regex code assertion early (one line of `DSL::Shared`) |
+| [#8210](https://github.com/tokuhirom/mutsu/issues/8210) | 18 | `use Foo:if($cond)` — `Raku.legacy` unimplemented, so the `if` pragma dies in `EXPORT` (`todo:deep`) |
+| [#8211](https://github.com/tokuhirom/mutsu/issues/8211) | 12 | `.grep`/`.first`/`.classify` on a non-`%`-sigil Hash hand the block the Hash, not its Pairs |
+| [#8214](https://github.com/tokuhirom/mutsu/issues/8214) | 9 | a local `sub` cannot shadow a routine imported by `sub EXPORT` (false redeclaration) |
+| [#8213](https://github.com/tokuhirom/mutsu/issues/8213) | 8 | `OUTER::MY::` does not resolve, `MY::` sees outer lexicals, `<<$name>>` subscript throws |
+| [#8212](https://github.com/tokuhirom/mutsu/issues/8212) | 7 | `role R[::T] does R` — a parameterised role cannot compose its own base |
+| [#8215](https://github.com/tokuhirom/mutsu/issues/8215) | 13 | missing nqp ops `push`, `hash`, `p6bindattrinvres` (three clusters, one fix site) |
+| [#8216](https://github.com/tokuhirom/mutsu/issues/8216) | 5 | an anonymous role literal as a `does` argument reads as a role named `role` |
+| [#8217](https://github.com/tokuhirom/mutsu/issues/8217) | 5 | `use NativeCall::Types` is not resolvable on its own |
+| [#8218](https://github.com/tokuhirom/mutsu/issues/8218) | 5 | a `my class` inside a `module` is installed into that package (false self-inheritance) |
+| [#8219](https://github.com/tokuhirom/mutsu/issues/8219) | 1 | a `when` whose matcher is a comma list does not parse — and a literal list matcher silently sinks |
+| [#8220](https://github.com/tokuhirom/mutsu/issues/8220) | 1 | `CORE::<&infix:<+>>` mis-parses by context, and `CORE::` holds no operator routines |
+
+**One message was three bugs.** `eco-cluster: 5ed688f7` (26 distributions, all
+reporting `X::Syntax::Missing: Missing block`) is not one fix: bisecting its
+members' files gave the brace-in-a-string-literal assertion bug (#8209, 19
+dists), the comma-list `when` (#8219), and the `CORE::<&op>` pair (#8220) — plus
+one member, `App::Moneymoor`, already in #7954's table. A *named* exception is no
+more of a root cause than an expectation dump; only the located line is. So the
+"verify a cluster before filing it" rule applies to the named `X::Syntax::*`
+buckets exactly as it does to `expected statement …`.
+
+**The reverse also happened.** The three `nqp-op` clusters are separate
+signatures with one fix site, so they were filed as one ticket (#8215), the way
+#8024 was. Cluster count is a starting point in both directions.
+
+Two clusters were examined and deliberately **not** filed:
+
+- `eco-cluster: 7e654040` (`Type Array does not support associative indexing.`,
+  8 dists) is heterogeneous — `OrderedHash` reaches it through `my %h does
+  OrderedHash[…]` (a `does` mixin on a `%` variable), while `Ujumla` and
+  `Docker::File` reach it from test files with no such declaration. Filing it as
+  one ticket would produce a mega-ticket no single fix closes; it needs per-dist
+  triage first.
+- `eco-cluster: 4aad304a` (`Function 'X' needs parens to avoid gobbling block`,
+  6 dists) did not reproduce from the construct its line names (a qualified
+  typename in a `when`, which works today), so its reported lines are containers
+  rather than causes. It needs the same bisect treatment #8209 got.
+
+`eco-cluster: f15ddd40` (`check-phaser`, 21 dists) is still opaque and is
+**waiting on a re-measure**, not on triage: #8000 (the `CHECK` message swallowing
+its inner exception) landed after this sweep, so these records carry the old
+uninformative text. Re-measure that status before reading anything into them.
 
 ## 10. Known limits and follow-ups
 

--- a/news/2026-09/ecosystem-parity-second-ticket-batch.md
+++ b/news/2026-09/ecosystem-parity-second-ticket-batch.md
@@ -1,0 +1,73 @@
+# The ecosystem ledger's second ticket batch: one message was three bugs
+
+The first P5 batch (2026-09-11) filed fifteen root-caused issues off the parity
+ledger and stopped at the ten-distribution line, leaving "a long tail: 985
+clusters, a sampling job". This is the second pass, going below that line:
+twelve issues covering about 110 further distribution slots, all verified
+against the `raku` oracle and minimised before filing.
+
+| issue | dists | root cause |
+|---|---|---|
+| [#8209](https://github.com/tokuhirom/mutsu/issues/8209) | 19 | a `{`/`}` inside a string literal ends a regex code assertion early |
+| [#8210](https://github.com/tokuhirom/mutsu/issues/8210) | 18 | `use Foo:if($cond)` — `Raku.legacy` unimplemented, so the `if` pragma dies in `EXPORT` |
+| [#8215](https://github.com/tokuhirom/mutsu/issues/8215) | 13 | missing nqp ops `push`, `hash`, `p6bindattrinvres` |
+| [#8211](https://github.com/tokuhirom/mutsu/issues/8211) | 12 | `.grep`/`.first`/`.classify` on a non-`%`-sigil Hash hand the block the Hash, not its Pairs |
+| [#8214](https://github.com/tokuhirom/mutsu/issues/8214) | 9 | a local `sub` cannot shadow a routine imported by `sub EXPORT` |
+| [#8213](https://github.com/tokuhirom/mutsu/issues/8213) | 8 | `OUTER::MY::` does not resolve, `MY::` sees outer lexicals, `<<$name>>` throws |
+| [#8212](https://github.com/tokuhirom/mutsu/issues/8212) | 7 | `role R[::T] does R` — a parameterised role cannot compose its own base |
+| [#8216](https://github.com/tokuhirom/mutsu/issues/8216) | 5 | an anonymous role literal as a `does` argument reads as a role named `role` |
+| [#8217](https://github.com/tokuhirom/mutsu/issues/8217) | 5 | `use NativeCall::Types` is not resolvable on its own |
+| [#8218](https://github.com/tokuhirom/mutsu/issues/8218) | 5 | a `my class` inside a `module` is installed into that package |
+| [#8219](https://github.com/tokuhirom/mutsu/issues/8219) | 1 | a `when` whose matcher is a comma list does not parse |
+| [#8220](https://github.com/tokuhirom/mutsu/issues/8220) | 1 | `CORE::<&infix:<+>>` mis-parses by context, and `CORE::` holds no operator routines |
+
+## The finding that changes how the tail should be read
+
+`scripts/ecosystem-tickets.py` clusters by normalised error message, and below
+the ten-distribution line that stops being a proxy for a root cause. The clearest
+case is `eco-cluster: 5ed688f7`: 26 distributions, every one reporting
+`X::Syntax::Missing: Missing block`, which reads like one parser bug. Bisecting
+its members' files gave **three unrelated bugs** — the brace-in-a-string-literal
+assertion extent (#8209), a comma-list `when` (#8219), and the `CORE::<&op>` pair
+(#8220) — plus one member already recorded in #7954's table.
+
+The lesson is that a *named* exception is no more of a root cause than the
+expectation dump #7988 is about. `X::Syntax::Missing` names the parser's
+recovery point, not the construct; only the located line does. The existing
+"verify a cluster before filing it" rule therefore applies to the named
+`X::Syntax::*` buckets exactly as it does to `expected statement …`, and the way
+to work one is to bisect the file rather than to read the message.
+
+Cluster count misleads in the other direction too. The three `nqp-op` clusters
+(`push`, `hash`, `p6bindattrinvres`) are distinct signatures with a single fix
+site, so they were filed as one ticket the way #8024 was.
+
+## Leverage still concentrates in dependencies
+
+#8209's 19 distributions are the whole `DSL::*` family, and every one of them
+fails on **the same line of the same dependency** —
+`DSL::Shared::Roles::CommonStructures.rakumod:127`, a `regex` whose code
+assertion contains `'${'`. #8210's list contains `Cro::HTTP` and
+`Cro::WebSocket`, so its real reach is wider than the 18 records that name it.
+This is the same shape as the first batch's #7999 (one parse gap in
+`Terminal::Widgets` blocking 16 distributions): a ticket's value is set by what
+depends on the distribution it was found in, not by its own record count.
+
+## Two clusters examined and deliberately not filed
+
+- `eco-cluster: 7e654040` (`Type Array does not support associative indexing.`,
+  8 dists) is heterogeneous: `OrderedHash` reaches it through `my %h does
+  OrderedHash[…]`, while `Ujumla` and `Docker::File` reach it from test files
+  with no such declaration. One ticket over those would be a mega-ticket no
+  single fix closes.
+- `eco-cluster: 4aad304a` (`Function 'X' needs parens to avoid gobbling block`,
+  6 dists) did not reproduce from the construct its reported line names — a
+  qualified typename in a `when` works today — so those lines are containers,
+  not causes.
+
+`eco-cluster: f15ddd40` (`check-phaser`, 21 dists) is waiting on a re-measure
+rather than on triage: #8000 made the `CHECK` message carry its inner exception,
+and it landed after the sweep these records came from.
+
+Filing nothing for a cluster you could not reduce is the right outcome; the cost
+of a vague ticket is paid by whoever picks it up.

--- a/news/2026-09/panic-ratchet-was-on-the-docs-allowlist.md
+++ b/news/2026-09/panic-ratchet-was-on-the-docs-allowlist.md
@@ -1,0 +1,55 @@
+# The panic ratchet could have edited itself without running CI
+
+`scripts/check-panic-surface.py` — the #8186 ratchet that keeps the
+panic-family and `#[allow(` surface in `src/` from growing — was wired into
+`make test` and into `ci.yml` when it landed, but was never taken off
+`ci-docs-only.sh`'s documentation allowlist. The allowlist covers `scripts/*.py`
+with one hand-maintained exception (`migrate-t-layout.py`), and the new script
+was not added to it.
+
+Two consequences, one loud and one quiet.
+
+The loud one: `scripts/ci-docs-only.sh --self-test` and `--check-inputs` are both
+steps of the `changes` job, so the guard failed on **every** pull request, not
+only documentation ones:
+
+```
+not ok - scripts/check-panic-surface.py is read by the build but is on the documentation allowlist
+ci-docs-only --check-inputs: 1 build input(s) classified as documentation
+```
+
+The quiet one is the reason that guard exists. Until this was fixed, a pull
+request whose only change was `scripts/check-panic-surface.py` classified as
+documentation, so `build`, `test-suites`, `lint-configs` and the rest reported
+`skipped` — which counts as success for branch protection. The ratchet's
+baseline could have been raised, or its `--self-test` weakened, by a change that
+never once ran the suite that enforces it.
+
+## The fix
+
+One `return 1` line in `is_doc_path`, beside the `migrate-t-layout.py` exception
+it mirrors, plus a self-test case (`check false 'the panic ratchet'`) so the deny
+is pinned rather than re-derivable. That is the cost the guard's own comment
+predicts for a genuinely-new build input: "one `return 1` line here rather than a
+silently-untested merge".
+
+## Why `--check-inputs` caught it and nothing else did
+
+`--check-inputs` does not trust the allowlist; it derives the claim. It scans the
+Makefile and `ci.yml` for every repository path they name — comments stripped,
+non-existent paths dropped — and fails if any of those paths is on the allowlist.
+That is exactly the rot it was built for, and it worked: the ratchet commit's
+only mistake was not acting on the red it produced.
+
+Its documented limit is that it scans **one hop** — a path reached *through* a
+script CI runs is not covered. Both ratchet baselines are safe from that gap for
+a different reason: `scripts/panic-surface-baseline.txt` and
+`scripts/magic-keys-baseline.tsv` are nested paths, and `is_doc_path`'s `*/*`
+case denies every nested path that no earlier case allowed, so only `*.py` under
+`scripts/` was ever at risk. A sweep of the Makefile and `ci.yml` confirms
+`check-panic-surface.py` and `migrate-t-layout.py` are the only two Python files
+the build names, and that the other four `make test` prerequisites
+(`check-value-wall`, `check-flaky-list`, `check-t-layout`, `check-magic-keys`)
+reach no further Python.
+
+Closes #8222.

--- a/scripts/ci-docs-only.sh
+++ b/scripts/ci-docs-only.sh
@@ -100,6 +100,10 @@ is_doc_path() {
     .github/*) return 0 ;;
     # `make check-t-layout` (a `make test` prerequisite and a CI step) runs it.
     scripts/migrate-t-layout.py) return 1 ;;
+    # `make check-panic-surface` (likewise a `make test` prerequisite and a CI
+    # step, #8186) runs it -- and it carries the ratchet's own baseline, so a
+    # change to it must never skip the suite that enforces it.
+    scripts/check-panic-surface.py) return 1 ;;
     scripts/*.py) return 0 ;;
     LICENSE) return 0 ;;
     */*) return 1 ;;          # any other nested path: not documentation
@@ -345,6 +349,7 @@ self_test() {
   check true  'reporting python'        scripts/plot_roast_history.py
   check true  'ecosystem tooling'       scripts/ecosystem-sweep.py scripts/ecosystem_common.py
   check false 'a python make test runs' scripts/migrate-t-layout.py
+  check false 'the panic ratchet'       scripts/check-panic-surface.py
   check false 'shell script'            scripts/run-t-test.sh
   check false 'node script'             scripts/check-site-snippets.mjs
   check false 'nested tsv'              t/fixtures/data.tsv


### PR DESCRIPTION
Two commits from one ecosystem-triage session: the triage batch's own record, and a CI-gate bug the triage happened to surface.

## `93cd331a` — fix: deny `scripts/check-panic-surface.py` on the docs allowlist

Closes #8222.

The #8186 panic ratchet wired `scripts/check-panic-surface.py` into `make test` (as a prerequisite) and into `ci.yml`, but left it on `ci-docs-only.sh`'s documentation allowlist, which covers `scripts/*.py` with one hand-maintained exception (`migrate-t-layout.py`).

Two consequences, one loud and one quiet:

- **Loud:** `--self-test` and `--check-inputs` are both steps of the `changes` job, so the guard failed on *every* pull request, not only documentation ones.
- **Quiet, and the reason the guard exists:** a pull request whose only change was the ratchet script classified as documentation, so `build`, `test-suites`, `lint-configs` and the rest reported `skipped` — which counts as success for branch protection. The ratchet's baseline could have been raised, or its own `--self-test` weakened, by a change that never ran the suite that enforces it.

The fix is the one `return 1` line the guard's own comment predicts for a genuinely-new build input, beside the `migrate-t-layout.py` exception it mirrors, plus a self-test case (`check false 'the panic ratchet'`) so the deny is pinned rather than re-derivable.

`--check-inputs` had been reporting this correctly all along — it derives the claim from the Makefile and `ci.yml` rather than trusting the allowlist. The ratchet commit simply did not act on the red it produced.

### No sibling gap

`--check-inputs` documents that it scans **one hop**, so I checked the rest by hand rather than assuming:

- Sweeping the Makefile and `ci.yml` for `scripts/*.py`: `check-panic-surface.py` and `migrate-t-layout.py` are the only two the build names.
- The other four `make test` prerequisites (`check-value-wall`, `check-flaky-list`, `check-t-layout`, `check-magic-keys`) reach no further Python.
- Both ratchet baselines — `scripts/panic-surface-baseline.txt` and `scripts/magic-keys-baseline.tsv` — are nested paths, which `is_doc_path`'s `*/*` case already denies. Only `*.py` under `scripts/` was ever at risk, so the one-hop limit leaves nothing exposed here and the scan did not need widening.

Verified against all four invocations CI makes of this script:

| invocation | result |
|---|---|
| `--self-test` | all cases pass, including the new `the panic ratchet` case |
| `--check-inputs` | `no build input is on the documentation allowlist` |
| classify `scripts/check-panic-surface.py` | `false` — the build runs |
| `--gc-value` | `true` — this script is itself in `is_gc_value_path`, as intended |

## `05614ec0` — docs: record the ecosystem ledger's second ticket batch

Documentation only. Triaged `scripts/ecosystem-tickets.py` output for the corpus measured at `1557d41`, below the ten-distribution line the first P5 batch stopped at, and filed twelve root-caused issues covering ~110 further distribution slots: #8209 #8210 #8211 #8212 #8213 #8214 #8215 #8216 #8217 #8218 #8219 #8220.

Every cluster was verified against the `raku` oracle and minimised before filing, which produced the finding worth recording: **below that line, a message-shaped cluster is not a root cause.** `eco-cluster: 5ed688f7` — 26 distributions all reporting `X::Syntax::Missing: Missing block` — bisected into three unrelated bugs (a brace inside a string literal ending a regex code assertion early, a comma-list `when` matcher, and the `CORE::<&op>` pair). A named exception names the parser's recovery point, not the construct, so the "verify a cluster before filing it" rule applies to the named `X::Syntax::*` buckets exactly as it does to `expected statement …`.

Conversely the three `nqp-op` clusters are one fix site and were filed as one ticket, the way #8024 was. Two clusters (`7e654040`, `4aad304a`) were examined and deliberately **not** filed, with the reason recorded so the next pass does not re-derive it; `f15ddd40` is waiting on a re-measure, since #8000 landed after this sweep.

## Testing

| gate | result |
|---|---|
| `cargo fmt --all` | no changes |
| `make lint` | clean (all four configurations) |
| `make test` | **PASS** — Files=4151, Tests=44230 |
| `make roast` | red **only** on the three container-only files |

The roast failures are exactly the ones [docs/agent-environments.md](https://github.com/tokuhirom/mutsu/blob/main/docs/agent-environments.md) enumerates as artifacts of this environment, matching file *and* test numbers:

- `roast/6.c/S32-io/file-tests.t` — `Failed: 4`, tests 6-8, 10 (runs as `uid 0`)
- `roast/S16-filehandles/filetest.t` — `Failed: 25`, tests 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125 (runs as `uid 0`)
- `roast/S32-io/IO-Socket-Async.t` — exit 124, ran 17 (sandboxed network)

Nothing in this diff is reachable from either suite, which is the expected result rather than a lucky one: the change is to a classifier script only the `changes` job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY3oyX6EL7mp5QXou1vVd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY3oyX6EL7mp5QXou1vVd3)_