### PR TITLE
fix(parser): handle quoted braces in regex assertions

### DIFF
--- a/news/2026-09/regex-code-assertion-quoted-braces.md
+++ b/news/2026-09/regex-code-assertion-quoted-braces.md
@@ -1,0 +1,3 @@
+Regex code assertions now ignore braces inside quoted strings when finding the
+end of the assertion body. This fixes regexes and grammars that use `'{` or
+`'}'` in assertion code. Closes #8209.

--- a/src/parser/primary/regex/scan.rs
+++ b/src/parser/primary/regex/scan.rs
@@ -490,23 +490,11 @@ fn scan_to_delim_inner(
                     chars.next(); // skip ? or !
                 }
                 chars.next(); // skip {
-                let mut brace_depth = 1u32;
-                loop {
-                    match chars.next() {
-                        Some((_, '{')) => brace_depth += 1,
-                        Some((_, '}')) => {
-                            brace_depth -= 1;
-                            if brace_depth == 0 {
-                                break;
-                            }
-                        }
-                        Some((_, '\\')) => {
-                            chars.next();
-                        }
-                        Some(_) => {}
-                        None => return None,
-                    }
-                }
+                // The assertion body is Raku code, so a brace in a quoted
+                // string is not its closing brace (`<?{ $x eq '}' }>`).
+                // Reuse the quote-aware scanner used by ordinary embedded
+                // code blocks rather than counting braces in raw source.
+                skip_interp_block(&mut chars)?;
                 // Consume the closing >
                 if let Some((_, '>')) = chars.next() {
                     // done

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -148,6 +148,59 @@ fn scan_angle_assertion_body(rest: &[char], honor_quotes: bool) -> AngleBodyScan
     }
 }
 
+/// Scan the body of a `{ ... }` code assertion, having already consumed the
+/// opening brace. Braces inside quoted strings are code, not block delimiters.
+fn scan_code_assertion_body(rest: &[char]) -> Option<(String, usize)> {
+    let mut code = String::new();
+    let mut brace_depth = 1usize;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    for (idx, &ch) in rest.iter().enumerate() {
+        if let Some(closer) = quote {
+            code.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == closer {
+                quote = None;
+            }
+            continue;
+        }
+        if escaped {
+            escaped = false;
+            code.push(ch);
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            code.push(ch);
+            continue;
+        }
+        if let Some(closer) = super::regex_parse::regex_quote_closer(ch) {
+            quote = Some(closer);
+            code.push(ch);
+            continue;
+        }
+        match ch {
+            '{' => {
+                brace_depth += 1;
+                code.push(ch);
+            }
+            '}' => {
+                brace_depth -= 1;
+                if brace_depth == 0 {
+                    return Some((code, idx + 1));
+                }
+                code.push(ch);
+            }
+            _ => code.push(ch),
+        }
+    }
+    None
+}
+
 /// True when `s` (the text after the `?`/`!` prefix of a `<?…>` / `<!…>`
 /// assertion) names a subrule that a general zero-width lookahead can wrap: an
 /// identifier-led rule name, optionally prefixed with `.` for a non-capturing
@@ -2582,21 +2635,10 @@ impl Interpreter {
                             }
                             // Skip '{'
                             chars.next();
-                            let mut code = String::new();
-                            let mut brace_depth = 1usize;
-                            for ch in chars.by_ref() {
-                                if ch == '{' {
-                                    brace_depth += 1;
-                                    code.push(ch);
-                                } else if ch == '}' {
-                                    brace_depth -= 1;
-                                    if brace_depth == 0 {
-                                        break;
-                                    }
-                                    code.push(ch);
-                                } else {
-                                    code.push(ch);
-                                }
+                            let rest: Vec<char> = chars.clone().collect();
+                            let (code, consumed) = scan_code_assertion_body(&rest)?;
+                            for _ in 0..consumed {
+                                chars.next();
                             }
                             // Consume the closing '>'
                             if chars.peek() == Some(&'>') {

--- a/t/regex/regex-code-assertion-quoted-braces.t
+++ b/t/regex/regex-code-assertion-quoted-braces.t
@@ -1,0 +1,16 @@
+use Test;
+
+plan 3;
+
+# Braces in quoted strings inside a regex code assertion are code, not
+# delimiters for the assertion body.
+grammar G {
+    regex TOP { (.+) <?{ '}' eq '}' }> }
+}
+
+ok G.parse('x{').defined,
+    'a quoted closing brace does not terminate a grammar code assertion';
+ok ('ab' ~~ / . <?{ '}' eq '}' }> /).defined,
+    'a quoted closing brace does not terminate a standalone code assertion';
+ok ('ab' ~~ / . <?{ '{' eq '{' }> /).defined,
+    'a quoted opening brace does not affect code assertion balancing';


### PR DESCRIPTION
## Summary

- make regex delimiter scanning ignore braces inside quoted code assertion strings
- make runtime regex parsing use the same quote-aware brace balancing
- add regression coverage and a news entry

Closes #8209

## Validation

- cargo fmt --all
- cargo clippy -- -D warnings
- make check-t-layout
- make test
- make roast