### PR TITLE
fix(rakuast): retain scalar regex interpolation

### DIFF
--- a/docs/adr/0088-rakuast-regex-boundary-tree.md
+++ b/docs/adr/0088-rakuast-regex-boundary-tree.md
@@ -1,9 +1,9 @@
 # ADR-0088: RakuAST and execution share a source-level regex tree
 
 - Status: Accepted (static source-tree, RakuAST, execution-lowering,
-  static-value-provenance, declaration-provenance, and positional-capture
-  slices implemented 2026-09-12; dynamic contents and the complete
-  execution-tree migration remain)
+  static-value-provenance, declaration-provenance, positional-capture, and
+  scalar-interpolation slices implemented 2026-09-12/13; other dynamic
+  contents and the complete execution-tree migration remain)
 - Date: 2026-09-12
 - Related: [ADR-0011](0011-rakuast-model-layer-and-phasing.md) (the RakuAST
   model layer and its bidirectional conversion),
@@ -360,10 +360,10 @@ tree provenance alongside it. Declaration-normalized values and the remaining
 string-only entry points must still migrate without rediscovering source trees
 from normalized declaration text.
 
-The following remain intentionally open: dynamic assertions and interpolation,
-captures and subrules, adverbs with runtime arguments, declaration-normalized
-values, and replacing string-only regex inputs with parser-produced tree
-provenance throughout the remaining matcher entry points.
+The following remain intentionally open: dynamic assertions and non-scalar
+interpolation, captures and subrules, adverbs with runtime arguments,
+declaration-normalized values, and replacing string-only regex inputs with
+parser-produced tree provenance throughout the remaining matcher entry points.
 
 ## 8. Static execution-lowering slice (2026-09-12)
 
@@ -444,9 +444,31 @@ slots therefore keep the matcher's established sub-Match and positional
 numbering semantics without executing user code during conversion.
 
 This slice intentionally covers only the ordinary `( ... )` form. Named
-capture aliases, subrule assertions, variable interpolation, code
-assertions, and other runtime-valued regex nodes remain explicit follow-up
-boundaries. The focused regressions are in
+capture aliases, subrule assertions, scalar interpolation, code assertions,
+and other runtime-valued regex nodes remain explicit follow-up boundaries. The
+focused regressions are in
 `t/rakuast/rakuast-regex.t` and `t/regex/regex-tree-captures.t`; they pin the
 model shape, constructor/EVAL lowering, capture spans, and quantified capture
 iteration values.
+
+## 12. Scalar interpolation source and execution slice (2026-09-13)
+
+Ordinary lexical scalar interpolation (`$name` and `${name}`) now has a shared
+`RegexNode::Interpolation` representation. The read direction emits
+`RakuAST::Regex::Interpolation` with `sequential => False` and a
+`RakuAST::Var::Lexical`; the write direction accepts only that scalar form and
+keeps array/hash and code-bearing interpolation as explicit boundaries.
+
+The execution lowerer maps the node to the existing match-time
+`RegexAtom::VarInterp` path. That preserves the current closure-scope and
+match-time lookup behavior while avoiding a source-tree-to-string reparse for
+parser-created values. Token declarations retain their source tree while the
+normalized execution body continues to apply declaration policy exactly once.
+Type-sensitive values and modifier-bearing patterns deliberately retain the
+legacy parser path until their value-aware Unicode and runtime semantics are
+part of a later slice.
+
+The focused regressions are in `t/rakuast/rakuast-regex.t` and
+`t/regex/regex-tree-interpolation.t`. They pin Rakudo's interpolation node
+shape, constructed-tree lowering, stored-value lookup after lexical mutation,
+type-sensitive fallback, and the declaration boundary.

--- a/news/2026-09/rakuast-regex-variable-interpolation.md
+++ b/news/2026-09/rakuast-regex-variable-interpolation.md
@@ -1,0 +1,12 @@
+# Regex scalar interpolation retains its RakuAST boundary
+
+The shared `RegexTree` now retains ordinary `$name` interpolation in regex
+contents. `.AST` exposes it as `RakuAST::Regex::Interpolation` with the
+corresponding `RakuAST::Var::Lexical`, and parser-created, constructed, and
+token-declaration regexes lower plain scalar values to the existing match-time
+matcher path. Regex-valued, collection-valued, and modifier-sensitive forms
+retain the established parser path until their value-aware execution slices
+are migrated.
+
+Array/hash interpolation, code interpolation, named aliases, and subrules
+remain explicit follow-up boundaries under ADR-0088.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2313,6 +2313,13 @@ fn regex_node(node: &RegexNode) -> Result<RakuAstNode, RuntimeError> {
             RakuAstClass::RegexCapturingGroup,
             vec![node_field(None, regex_node(child)?)],
         ),
+        RegexNode::Interpolation { name, sequential } => (
+            RakuAstClass::RegexInterpolation,
+            vec![
+                leaf_field(Some("sequential"), Value::truth(*sequential)),
+                node_field(Some("var"), var_lexical("$", name)),
+            ],
+        ),
         RegexNode::Quantified { atom, quantifier } => {
             let quantifier = match quantifier {
                 RegexQuantifier::ZeroOrMore => RakuAstClass::RegexQuantifierZeroOrMore,

--- a/src/rakuast/fields.rs
+++ b/src/rakuast/fields.rs
@@ -152,6 +152,7 @@ pub(super) fn model_fields(class: RakuAstClass) -> &'static [(&'static str, Abse
         RegexLiteral => &[("text", Absent::Required)],
         RegexQuote => &[("quoted", Absent::Required)],
         RegexGroup | RegexCapturingGroup | RegexWithWhitespace => &[("regex", Absent::Required)],
+        RegexInterpolation => &[("sequential", Absent::False), ("var", Absent::Required)],
         RegexQuantifiedAtom => &[
             ("atom", Absent::Required),
             ("quantifier", Absent::Required),

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1595,6 +1595,30 @@ fn lower_regex_node(node: &RakuAstNode) -> Result<RegexNode, RuntimeError> {
         RakuAstClass::RegexCapturingGroup => Ok(RegexNode::CapturingGroup(Box::new(
             lower_regex_node(named_child_or_positional(node)?)?,
         ))),
+        RakuAstClass::RegexInterpolation => {
+            let sequential = bool_field(node, "sequential")?;
+            if sequential {
+                return Err(unsupported(node));
+            }
+            let var = named_child(node, "var")?;
+            if var.class != RakuAstClass::VarLexical {
+                return Err(unsupported(node));
+            }
+            let name_value = positional_leaf(var)?;
+            let ValueView::Str(name) = name_value.view() else {
+                return Err(unsupported(node));
+            };
+            let Some(name) = name.strip_prefix('$') else {
+                return Err(unsupported(node));
+            };
+            if name.is_empty() || name.starts_with(['*', '?', '^', '.', '!']) {
+                return Err(unsupported(node));
+            }
+            Ok(RegexNode::Interpolation {
+                name: name.to_string(),
+                sequential,
+            })
+        }
         RakuAstClass::RegexWithWhitespace => Ok(RegexNode::WithWhitespace(Box::new(
             lower_regex_node(named_child_or_positional(node)?)?,
         ))),

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -64,6 +64,7 @@ pub enum RakuAstClass {
     RegexWithWhitespace,
     RegexGroup,
     RegexCapturingGroup,
+    RegexInterpolation,
     RegexAlternation,
     RegexQuantifiedAtom,
     RegexQuantifierZeroOrMore,
@@ -267,6 +268,7 @@ impl RakuAstClass {
             RegexWithWhitespace => "RakuAST::Regex::WithWhitespace",
             RegexGroup => "RakuAST::Regex::Group",
             RegexCapturingGroup => "RakuAST::Regex::CapturingGroup",
+            RegexInterpolation => "RakuAST::Regex::Interpolation",
             RegexAlternation => "RakuAST::Regex::Alternation",
             RegexQuantifiedAtom => "RakuAST::Regex::QuantifiedAtom",
             RegexQuantifierZeroOrMore => "RakuAST::Regex::Quantifier::ZeroOrMore",
@@ -476,7 +478,12 @@ impl RakuAstClass {
             // through this list.
             | TermSelf => TERM,
             ApplyInfix | ApplyPrefix | ApplyPostfix | ApplyListInfix | Ternary => EXPR,
-            RegexLiteral | RegexQuote | RegexGroup | RegexCapturingGroup | RegexWithWhitespace => &[
+            RegexLiteral
+            | RegexQuote
+            | RegexGroup
+            | RegexCapturingGroup
+            | RegexInterpolation
+            | RegexWithWhitespace => &[
                 "RakuAST::Regex::Atom",
                 "RakuAST::Regex::Term",
                 "RakuAST::Regex",
@@ -607,6 +614,7 @@ fn semantic_type_object_ancestors(class_name: &str) -> &'static [&'static str] {
         | "RakuAST::Regex::Quote"
         | "RakuAST::Regex::Group"
         | "RakuAST::Regex::CapturingGroup"
+        | "RakuAST::Regex::Interpolation"
         | "RakuAST::Regex::WithWhitespace" => &[
             "RakuAST::Regex::Atom",
             "RakuAST::Regex::Term",
@@ -691,6 +699,7 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::RegexWithWhitespace,
     RakuAstClass::RegexGroup,
     RakuAstClass::RegexCapturingGroup,
+    RakuAstClass::RegexInterpolation,
     RakuAstClass::RegexAlternation,
     RakuAstClass::RegexQuantifiedAtom,
     RakuAstClass::RegexQuantifierZeroOrMore,
@@ -1314,6 +1323,34 @@ pub fn construct(
             fields,
         }))));
     }
+    if class_name == "RakuAST::Regex::Interpolation" && method == "new" {
+        let var = named_arg(args, "var")
+            .ok_or_else(|| RuntimeError::new("RakuAST::Regex::Interpolation.new requires `var`"))?;
+        require_rakuast_class(
+            &var,
+            RakuAstClass::VarLexical,
+            "RakuAST::Regex::Interpolation.new",
+        )?;
+        let sequential = named_arg(args, "sequential").unwrap_or_else(|| Value::truth(false));
+        if !matches!(sequential.view(), ValueView::Bool(_)) {
+            return Err(RuntimeError::new(
+                "RakuAST::Regex::Interpolation.new expects `sequential` to be Bool",
+            ));
+        }
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::RegexInterpolation,
+            fields: vec![
+                RakuAstField {
+                    name: Some("sequential"),
+                    value: RakuAstFieldValue::Node(sequential),
+                },
+                RakuAstField {
+                    name: Some("var"),
+                    value: RakuAstFieldValue::Node(var),
+                },
+            ],
+        }))));
+    }
     if class_name == "RakuAST::QuotedRegex" && method == "new" {
         let body = named_arg(args, "body")
             .ok_or_else(|| RuntimeError::new("RakuAST::QuotedRegex.new requires `body`"))?;
@@ -1529,6 +1566,7 @@ fn require_regex_node(value: &Value, constructor: &str) -> Result<(), RuntimeErr
                     | RakuAstClass::RegexWithWhitespace
                     | RakuAstClass::RegexGroup
                     | RakuAstClass::RegexCapturingGroup
+                    | RakuAstClass::RegexInterpolation
                     | RakuAstClass::RegexAlternation
                     | RakuAstClass::RegexQuantifiedAtom
                     | RakuAstClass::RegexCharClassDigit
@@ -1835,6 +1873,7 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::RegexWithWhitespace
             | RakuAstClass::RegexGroup
             | RakuAstClass::RegexCapturingGroup
+            | RakuAstClass::RegexInterpolation
             | RakuAstClass::RegexQuantifiedAtom
             | RakuAstClass::RegexQuantifierZeroOrMore
             | RakuAstClass::RegexQuantifierOneOrMore

--- a/src/regex_tree.rs
+++ b/src/regex_tree.rs
@@ -45,6 +45,10 @@ pub(crate) enum RegexNode {
     Alternation(Vec<RegexNode>),
     Group(Box<RegexNode>),
     CapturingGroup(Box<RegexNode>),
+    Interpolation {
+        name: String,
+        sequential: bool,
+    },
     Quantified {
         atom: Box<RegexNode>,
         quantifier: RegexQuantifier,
@@ -61,10 +65,10 @@ pub(crate) enum RegexQuantifier {
 }
 
 impl RegexTree {
-    /// Parse the static subset whose source shape is currently needed by the
-    /// RakuAST boundary. Returning `None` is intentional: execution still
-    /// receives the original pattern, while the converter reports an honest
-    /// unsupported boundary for a construct without a source tree.
+    /// Parse the supported source subset whose shape is currently needed by
+    /// the RakuAST boundary. Returning `None` is intentional: execution
+    /// still receives the original pattern, while the converter reports an
+    /// honest unsupported boundary for a construct without a source tree.
     pub(crate) fn parse_static(source: &str, declaration: bool) -> Option<Self> {
         let mut parser = Parser {
             chars: source.chars().collect(),
@@ -85,12 +89,22 @@ impl RegexTree {
         self.body.to_source()
     }
 
-    /// Lower the static source tree into the execution matcher plan.
+    /// Return the scalar variables whose values are read by interpolation
+    /// nodes. The execution boundary uses this to preserve Regex-valued
+    /// interpolation, whose value is itself a regex rather than literal text.
+    pub(crate) fn interpolation_names(&self) -> Vec<String> {
+        let mut names = Vec::new();
+        self.body.collect_interpolation_names(&mut names);
+        names
+    }
+
+    /// Lower the supported source tree into the execution matcher plan.
     ///
     /// The runtime parser still owns every construct that needs package state,
-    /// interpolation, or code evaluation.  This deliberately small bridge is
-    /// for the source forms that `parse_static` can prove are structural only;
-    /// returning `None` keeps those forms on the established parser path.
+    /// type-sensitive interpolation, or code evaluation. This deliberately
+    /// small bridge is for the source forms that `parse_static` can prove are
+    /// structurally representable; returning `None` keeps other forms on the
+    /// established parser path.
     pub(crate) fn lower_execution(
         &self,
         ratchet: bool,
@@ -272,6 +286,16 @@ impl RegexTree {
                         ratchet,
                     )])
                 }
+                RegexNode::Interpolation { name, sequential } => {
+                    if *sequential {
+                        return None;
+                    }
+                    Some(vec![token(
+                        crate::runtime::RegexAtom::VarInterp(name.clone()),
+                        crate::runtime::RegexQuant::One,
+                        ratchet,
+                    )])
+                }
                 RegexNode::Quantified { atom, quantifier } => {
                     let quant = match quantifier {
                         RegexQuantifier::ZeroOrMore => crate::runtime::RegexQuant::ZeroOrMore,
@@ -314,6 +338,22 @@ impl RegexTree {
 }
 
 impl RegexNode {
+    fn collect_interpolation_names(&self, names: &mut Vec<String>) {
+        match self {
+            Self::Interpolation { name, .. } => names.push(name.clone()),
+            Self::Sequence(nodes) | Self::Alternation(nodes) => {
+                for node in nodes {
+                    node.collect_interpolation_names(names);
+                }
+            }
+            Self::Group(child)
+            | Self::CapturingGroup(child)
+            | Self::Quantified { atom: child, .. }
+            | Self::WithWhitespace(child) => child.collect_interpolation_names(names),
+            Self::Literal(_) | Self::Quote(_) | Self::CharClassDigit => {}
+        }
+    }
+
     fn to_source(&self) -> String {
         match self {
             Self::Literal(text) => text
@@ -359,6 +399,7 @@ impl RegexNode {
             }
             Self::Group(child) => format!("[{}]", child.to_source()),
             Self::CapturingGroup(child) => format!("({})", child.to_source()),
+            Self::Interpolation { name, .. } => format!("${name}"),
             Self::Quantified { atom, quantifier } => {
                 let suffix = match quantifier {
                     RegexQuantifier::ZeroOrMore => '*',
@@ -510,8 +551,10 @@ impl Parser {
                     sequence_for_multichar_literal(inner),
                 )))
             }
+            '$' => self.parse_interpolation(),
+            '@' | '%' => None,
             ')' | ']' if stops.contains(&ch) => None,
-            '|' | '+' | '*' | '?' | '.' | '^' | '$' | '<' | '>' => None,
+            '|' | '+' | '*' | '?' | '.' | '^' | '<' | '>' => None,
             _ => self.parse_literal(),
         }
     }
@@ -523,6 +566,11 @@ impl Parser {
             self.pos += 1;
             match ch {
                 c if c == quote => return Some(RegexNode::Quote(text)),
+                // A double-quoted regex term has its own qq interpolation
+                // segments. Keep that form on the explicit follow-up path
+                // until the shared tree can retain those segments instead of
+                // pretending that `$name` was part of one quoted literal.
+                '$' | '@' | '%' if quote == '"' => return None,
                 // Quoted escapes can decode codepoints (`\\x20`) or alter
                 // quoting (`\\"`).  The current Quote node stores only the
                 // decoded-looking text, so it cannot preserve that source
@@ -548,14 +596,76 @@ impl Parser {
     }
 
     fn parse_literal(&mut self) -> Option<RegexNode> {
+        // Regex declarators contain Main-slang code rather than regex source
+        // terms.  Keeping a partial tree for one would route a declaration
+        // through the value-aware matcher and change its writeback semantics
+        // (notably for :temp and :constant).  The legacy parser remains the
+        // execution and RakuAST boundary for these forms.
+        if self.declaration && self.starts_embedded_declaration() {
+            return None;
+        }
         let start = self.pos;
         while let Some(ch) = self.chars.get(self.pos).copied() {
-            if ch.is_whitespace() || matches!(ch, '|' | '+' | '*' | '?' | '(' | ')' | '[' | ']') {
+            if ch.is_whitespace()
+                || matches!(
+                    ch,
+                    '|' | '+' | '*' | '?' | '(' | ')' | '[' | ']' | '$' | '@' | '%'
+                )
+            {
                 break;
             }
             self.pos += 1;
         }
         (self.pos > start).then(|| RegexNode::Literal(self.chars[start..self.pos].iter().collect()))
+    }
+
+    fn starts_embedded_declaration(&self) -> bool {
+        if self.chars.get(self.pos) != Some(&':') {
+            return false;
+        }
+        let rest: String = self.chars[self.pos + 1..].iter().collect();
+        ["my ", "our ", "state ", "constant ", "temp ", "let "]
+            .iter()
+            .any(|keyword| rest.starts_with(keyword))
+    }
+
+    fn parse_interpolation(&mut self) -> Option<RegexNode> {
+        self.pos += 1; // '$'
+        let name = if self.consume_if('{') {
+            let name = self.parse_variable_name()?;
+            if !self.consume_if('}') {
+                return None;
+            }
+            name
+        } else {
+            self.parse_variable_name()?
+        };
+        Some(RegexNode::Interpolation {
+            name,
+            sequential: false,
+        })
+    }
+
+    fn parse_variable_name(&mut self) -> Option<String> {
+        let start = self.pos;
+        let first = self.chars.get(self.pos).copied()?;
+        if !first.is_alphabetic() && first != '_' {
+            return None;
+        }
+        self.pos += 1;
+        while let Some(ch) = self.chars.get(self.pos).copied() {
+            let hyphen = ch == '-'
+                && self
+                    .chars
+                    .get(self.pos + 1)
+                    .is_some_and(|next| next.is_alphabetic() || *next == '_');
+            if ch.is_alphanumeric() || ch == '_' || hyphen {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        Some(self.chars[start..self.pos].iter().collect())
     }
 
     fn parse_quantifier(&mut self) -> Option<RegexQuantifier> {

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -1528,8 +1528,9 @@ impl Interpreter {
     }
 
     /// Parse a regex value while retaining parser-produced source provenance.
-    /// Static values use the shared `RegexTree` directly; values synthesized by
-    /// runtime code, and trees outside the current execution subset, retain the
+    /// Values with a supported source tree use it directly, including the
+    /// match-time scalar interpolation node. Values synthesized by runtime
+    /// code, and trees outside the current execution subset, retain the
     /// established string parser path.
     pub(super) fn parse_regex_value(&self, value: &Value) -> Option<std::sync::Arc<RegexPattern>> {
         let pattern = match value.view() {
@@ -1540,10 +1541,43 @@ impl Interpreter {
         let Some(tree) = value.regex_source_tree() else {
             return self.parse_regex(&pattern);
         };
-        if !regex_pattern_is_static(&pattern) {
+        let interpolation_names = tree.interpolation_names();
+        // The direct tree plan's VarInterp atom intentionally handles the
+        // plain scalar case. Regex values, collections, and other objects
+        // retain the established parser path because their interpolation has
+        // type-specific semantics (a Regex is recompiled, a Hash is
+        // rejected, and a Junction becomes alternatives). Do this before the
+        // tree-plan cache lookup because the lexical may change type between
+        // matches.
+        // Case-folding and ignore-mark also stay on the parser path: their
+        // value-aware Unicode expansion needs the interpolated text to join
+        // the pattern's fold/remapping pass.
+        if (!interpolation_names.is_empty()
+            && static_execution_policy(&pattern)
+                .is_some_and(|(_, ignore_case, ignore_mark, _)| ignore_case || ignore_mark))
+            || interpolation_names.iter().any(|name| {
+                self.env
+                    .get(name)
+                    .or_else(|| self.env.get(&format!("${name}")))
+                    .is_some_and(|value| {
+                        !matches!(
+                            value.deref_container().view(),
+                            ValueView::Int(_)
+                                | ValueView::BigInt(_)
+                                | ValueView::Num(_)
+                                | ValueView::Str(_)
+                                | ValueView::Bool(_)
+                                | ValueView::Rat(_, _)
+                                | ValueView::FatRat(_, _)
+                                | ValueView::BigRat(_, _)
+                                | ValueView::Complex(_, _)
+                                | ValueView::Nil
+                        )
+                    })
+            })
+        {
             return self.parse_regex(&pattern);
         }
-
         // Include the tree fingerprint in the existing plan-cache key. This
         // keeps the cache honest if a future parser creates two source trees
         // with the same compatibility spelling.

--- a/t/rakuast/rakuast-regex.t
+++ b/t/rakuast/rakuast-regex.t
@@ -5,10 +5,10 @@ use Test;
 
 # RakuAST regex tree support (ADR-0088, issue #8033). The parser keeps a
 # source-level static regex tree and the converter maps it to the same node
-# shapes Rakudo exposes. These examples are intentionally static: dynamic
-# assertions and interpolations remain explicit follow-up boundaries.
+# shapes Rakudo exposes. Dynamic assertions and non-scalar interpolations
+# remain explicit follow-up boundaries.
 
-plan 17;
+plan 21;
 
 is Q[/a/].AST.gist, q:to/END/.chomp, 'a regex literal has a Literal body';
     RakuAST::StatementList.new(
@@ -83,6 +83,27 @@ is Q[/(a)/].AST.gist, q:to/END/.chomp, 'a capture group remains a CapturingGroup
         expression => RakuAST::QuotedRegex.new(
           body => RakuAST::Regex::CapturingGroup.new(
             RakuAST::Regex::Literal.new("a")
+          )
+        )
+      )
+    )
+    END
+
+is Q[/a $x b/].AST.gist, q:to/END/.chomp, 'a scalar interpolation remains an Interpolation node';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedRegex.new(
+          body => RakuAST::Regex::Sequence.new(
+            RakuAST::Regex::WithWhitespace.new(
+              RakuAST::Regex::Literal.new("a")
+            ),
+            RakuAST::Regex::WithWhitespace.new(
+              RakuAST::Regex::Interpolation.new(
+                sequential => False,
+                var        => RakuAST::Var::Lexical.new("\$x")
+              )
+            ),
+            RakuAST::Regex::Literal.new("b")
           )
         )
       )
@@ -200,6 +221,13 @@ my $literal = RakuAST::Regex::Literal.new("a");
 is $literal.text, 'a', 'regex literal text is available through its accessor';
 ok $literal ~~ RakuAST::Regex::Atom, 'regex atoms retain their semantic type';
 ok $literal ~~ RakuAST::Regex, 'regex nodes retain their Regex type';
+my $interpolation = RakuAST::Regex::Interpolation.new(
+    sequential => False,
+    var => RakuAST::Var::Lexical.new(q[$x]),
+);
+is $interpolation.var.name, '$x', 'interpolation exposes its lexical variable';
+ok $interpolation ~~ RakuAST::Regex::Atom, 'interpolation retains its regex atom type';
+is $interpolation.sequential, False, 'scalar interpolation is non-sequential';
 my $constructed = RakuAST::QuotedRegex.new(
     match-immediately => True,
     body              => RakuAST::Regex::Literal.new("test"),

--- a/t/regex/regex-tree-interpolation.t
+++ b/t/regex/regex-tree-interpolation.t
@@ -1,0 +1,56 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# ADR-0088 issue #8033: ordinary scalar interpolation is retained in the
+# shared RegexTree, exposed through RakuAST, and lowered to the existing
+# match-time VarInterp atom. Array/hash interpolation, code interpolation,
+# named aliases, and subrules remain separate boundaries.
+
+plan 12;
+
+my $x = 'X';
+my $rx = /a $x b/;
+ok 'aXb' ~~ $rx, 'a parser-created regex reads its scalar interpolation';
+$x = 'Y';
+ok 'aYb' ~~ $rx, 'the stored regex reads the current lexical value';
+nok 'aXb' ~~ $rx, 'the stored regex no longer matches the old value';
+
+my $interpolated = EVAL(RakuAST::QuotedRegex.new(
+    body => RakuAST::Regex::Sequence.new(
+        RakuAST::Regex::Literal.new('a'),
+        RakuAST::Regex::Interpolation.new(
+            sequential => False,
+            var => RakuAST::Var::Lexical.new(q[$x]),
+        ),
+        RakuAST::Regex::Literal.new('b'),
+    ),
+));
+ok 'aYb' ~~ $interpolated, 'a constructed interpolation lowers through EVAL';
+$x = 'Z';
+ok 'aZb' ~~ $interpolated, 'a constructed interpolation stays match-time dynamic';
+
+my $case = 'rex';
+ok 'Rex' ~~ m:i/$case/, 'scalar interpolation honors regex ignorecase';
+
+my $hash = { a => 1 };
+throws-like { 'a' ~~ /$hash/ }, X::Syntax::Reserved,
+    'hash interpolation keeps its reserved syntax error';
+
+grammar GRegexInterpolated {
+    token x { a $x b }
+}
+ok 'aZb' ~~ &GRegexInterpolated::x,
+    'a token declaration retains scalar interpolation provenance';
+$x = 'Q';
+ok 'aQb' ~~ &GRegexInterpolated::x,
+    'a token declaration reads the current lexical value';
+
+my $ast = Q[/a $x b/].AST;
+ok $ast.gist.contains('RakuAST::Regex::Interpolation'),
+    'the parser AST names the interpolation node';
+is RakuAST::Regex::Interpolation.new(:var(RakuAST::Var::Lexical.new(q[$x]))).var.name,
+    '$x', 'the constructor accepts a lexical interpolation variable';
+nok 'aZb' ~~ /a @($x) b/,
+    'the bounded slice does not conflate array interpolation with scalar interpolation';


### PR DESCRIPTION
Part of #8033.

This slice retains ordinary scalar regex interpolation in the shared RegexTree/RakuAST path.

- Supports `$name` and `${name}` as `RakuAST::Regex::Interpolation` with `sequential => False`, resolving the current lexical value at match time.
- Keeps non-scalar and type-sensitive interpolation, declaration forms, quote interpolation, and modifier-sensitive forms on the legacy path to preserve their existing behavior.
- Adds focused parser/compiler/runtime tests, RakuAST coverage, an ADR update, and a news entry.

Validation:

- `cargo fmt --all`
- `make lint`
- `make test`: PASS (44,335 tests)
- `make roast`: PASS (219,658 tests)
- Focused regression tests for scalar interpolation, dynamic lexical lookup, declaration provenance, non-scalar fallback, and modifiers.