### PR TITLE
fix(collections): iterate scalar-held hashes as pairs

### DIFF
--- a/news/2026-09/hash-predicate-methods-iterate-pairs.md
+++ b/news/2026-09/hash-predicate-methods-iterate-pairs.md
@@ -1,0 +1,10 @@
+# Hash predicate methods iterate pairs through scalar holders
+
+`Hash.grep`, `Hash.first`, and `Hash.classify` now iterate a Hash's key-value
+pairs even when the Hash is held in a scalar or reached through a Hash element.
+Predicate blocks therefore receive the same `Pair` values as they do for a
+direct `%`-sigiled Hash.
+
+Pinned by `t/collections/hash/hash-predicate-iteration.t`.
+
+Closes #8211.

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -215,12 +215,15 @@ impl Interpreter {
                 ValueView::Seq(values) => items.extend(values.iter().cloned()),
                 ValueView::Slip(values) => items.extend(values.iter().cloned()),
                 ValueView::LazyList(ll) => items.extend(self.force_lazy_list_bridge(&ll)?),
-                // Hash/Set/Bag/Mix classify their pairs (elem => True for Set,
-                // elem => count/weight for Bag/Mix), same as for-iteration.
-                ValueView::Hash(_)
-                | ValueView::Set(..)
-                | ValueView::Bag(..)
-                | ValueView::Mix(..) => items.extend(crate::runtime::utils::value_to_list(arg)),
+                // A Hash receiver iterates its own pairs even when the hash is
+                // held in a scalar and therefore carries itemization metadata.
+                // Set/Bag/Mix classify their elements as usual.
+                ValueView::Hash(_) => {
+                    items.extend(crate::runtime::utils::value_to_list_for_receiver(arg))
+                }
+                ValueView::Set(..) | ValueView::Bag(..) | ValueView::Mix(..) => {
+                    items.extend(crate::runtime::utils::value_to_list(arg))
+                }
                 _ if arg.is_range() => items.extend(crate::runtime::utils::value_to_list(arg)),
                 _ => items.push(arg.clone()),
             }

--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -122,7 +122,7 @@ impl Interpreter {
         // `Seq`, a native or multi-dimensional array) keeps the bare-item scan.
         let items = Self::buf_as_byte_items(&target)
             .or_else(|| Self::array_element_cells(&target))
-            .unwrap_or_else(|| crate::runtime::utils::value_to_list(&target));
+            .unwrap_or_else(|| crate::runtime::utils::value_to_list_for_receiver(&target));
         if let Some((idx, value)) = self.find_first_match_over_items(func, &items, has_end)? {
             return Ok(super::super::builtins_collection::format_first_result(
                 idx,

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -442,8 +442,14 @@ impl Interpreter {
             ValueView::Slip(items) => {
                 self.eval_grep_with_adverb(args.first().cloned(), items.to_vec(), &grep_adverb)
             }
-            ValueView::Set(..) | ValueView::Bag(..) | ValueView::Mix(..) | ValueView::Hash(..) => {
+            ValueView::Set(..) | ValueView::Bag(..) | ValueView::Mix(..) => {
                 let items = crate::runtime::utils::value_to_list(&target);
+                self.eval_grep_with_adverb(args.first().cloned(), items, &grep_adverb)
+            }
+            ValueView::Hash(..) => {
+                // A Hash held in a scalar is itemized as an element, but a
+                // Hash receiver still iterates its own key-value pairs.
+                let items = crate::runtime::utils::value_to_list_for_receiver(&target);
                 self.eval_grep_with_adverb(args.first().cloned(), items, &grep_adverb)
             }
             _ => {

--- a/src/vm/vm_native_first.rs
+++ b/src/vm/vm_native_first.rs
@@ -94,7 +94,7 @@ impl Interpreter {
         // `Seq` of bare items, a native or multi-dimensional array, a `Hash`)
         // keeps the bare-item scan.
         let items = Self::array_element_cells(target)
-            .unwrap_or_else(|| crate::runtime::utils::value_to_list(target));
+            .unwrap_or_else(|| crate::runtime::utils::value_to_list_for_receiver(target));
         // `.first` answers the element's VALUE; a container above is the
         // matcher's binding, not the result.
         let answer = |v: Value| Some(Ok(v.deref_container()));

--- a/t/collections/hash/hash-predicate-iteration.t
+++ b/t/collections/hash/hash-predicate-iteration.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+plan 9;
+
+my %source = a => 1, b => 0;
+my $held = %source;
+my %nested = inner => %source;
+
+is %source.grep({ .value }).map({ .key }).sort.join(','), 'a',
+    'grep sees Hash pairs from a % variable';
+is $held.grep({ .value }).map({ .key }).sort.join(','), 'a',
+    'grep sees Hash pairs from a scalar-held Hash';
+is %nested<inner>.grep({ .value }).map({ .key }).sort.join(','), 'a',
+    'grep sees Hash pairs from a Hash element';
+
+is %source.first({ .value }).key, 'a',
+    'first sees Hash pairs from a % variable';
+is $held.first({ .value }).key, 'a',
+    'first sees Hash pairs from a scalar-held Hash';
+is %nested<inner>.first({ .value }).key, 'a',
+    'first sees Hash pairs from a Hash element';
+
+is %source.classify({ .value }).keys.sort.join(','), '0,1',
+    'classify sees Hash pairs from a % variable';
+is $held.classify({ .value }).keys.sort.join(','), '0,1',
+    'classify sees Hash pairs from a scalar-held Hash';
+is %nested<inner>.classify({ .value }).keys.sort.join(','), '0,1',
+    'classify sees Hash pairs from a Hash element';
+
+done-testing;


### PR DESCRIPTION
## Summary
- iterate Hash receivers through their own pairs even when itemized by a scalar holder
- keep grep, first, and classify predicate blocks consistent across direct, scalar-held, and nested Hashes
- add focused regression coverage and a news entry

## Tests
- scripts/run-t-test.sh t/collections/hash/hash-predicate-iteration.t
- make check-t-layout
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast

Closes #8211