### PR TITLE
fix(make): `make test` and `make roast` can fail again

### DIFF
--- a/.agents/skills/mutsu-ticket-flow/SKILL.md
+++ b/.agents/skills/mutsu-ticket-flow/SKILL.md
@@ -243,7 +243,8 @@ Before publishing an implementation PR, run `cargo fmt --all`, `make lint`, `mak
 `make roast` once each (`make lint` rather than a bare `cargo clippy` — it adds the three
 configurations CI's `lint-configs` job gates on and the default clippy is blind to). Inspect
 `tmp/make-test.log` and `tmp/make-roast.log` with the Grep tool rather than rerunning a suite for
-its output. Do not publish an implementation PR until both full suites succeed.
+its output. Do not publish an implementation PR until both full suites succeed — each target exits
+non-zero when its suite fails, so check the status and do not rely on skimming the log.
 
 In a remote container `make roast` has a fixed set of three environment-only failures it cannot
 avoid (`uid 0` breaks two `chmod`-based file-test files; the network sandbox times out one socket

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,9 +250,19 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # The four ledger checks run FIRST, before any toolchain: they read
+      # These ledger checks run FIRST, before any toolchain: they read
       # files and finish in about a second each, so an unsorted whitelist or an
       # expired quarantine entry should not have to wait out a clippy pass.
+      - name: Suite exit status is not masked by `tee`
+        # `make test` / `make roast` pipe into `tee`, so their exit status is
+        # only meaningful while the recipe shell has `pipefail` set. It did not,
+        # for a long time, and a red suite exited 0 -- breaking the local
+        # pre-publication gate CLAUDE.md relies on (#8221). This job is the only
+        # place CI looks at it: the suites themselves run as individual steps
+        # here, never through those targets, which is exactly why the defect
+        # could persist unnoticed.
+        run: make check-pipefail
+
       - name: Roast whitelist is sorted
         run: make check-roast-whitelist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ Raku documentation.
 - `make test`: Rust tests, build, and local TAP tests; its log is
   `tmp/make-test.log`.
 - `make roast`: whitelisted roast tests; its log is `tmp/make-roast.log`.
+  Both targets exit non-zero when their suite fails, so the exit status is the
+  verdict; the log is where you find which file failed.
 - `cargo fmt --all`: format Rust.
 - `cargo clippy -- -D warnings`: lint with warnings denied.
 
@@ -88,7 +90,8 @@ Add a focused regression test for each behavior change, normally under `t/` — 
 the category `docs/t-directory-layout.md` names for it, never at `t/` top level.
 Run a targeted test while iterating. Before publishing a code PR, run
 `cargo fmt --all`, `cargo clippy -- -D warnings`, `make test`, and `make roast`
-once each. After either full command runs, inspect its saved log. A failing
+once each, and do not publish unless each exits zero. After either full command
+runs, inspect its saved log for the detail rather than re-running it. A failing
 full test belongs to the branch: diagnose it and use targeted checks as needed
 for further evidence. Keep `roast-whitelist.txt` sorted when changing it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,7 +404,7 @@ CI costs a wake, a fix-up commit and a reviewer's attention; discovering it loca
 suites are a pre-publication gate, not an inner loop:
 
 - Run individual roast tests with `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' roast/<path>.t` (the `MUTSU_FUDGE=1` is required — see the build/run section above), or the exact files you touched / suspect regressed.
-- Read the saved logs (`tmp/make-test.log`, `tmp/make-roast.log`) with the Grep tool instead of re-running a suite to see its output.
+- Both suites report failure in their **exit status** (`bash -o pipefail`, guarded by the `check-pipefail` target; see "Checking `make test` / `make roast` results" below). Read the saved logs (`tmp/make-test.log`, `tmp/make-roast.log`) with the Grep tool to find out *which* file failed — never to find out *whether* something failed, and never by re-running a suite to see its output.
 - **Some `make roast` failures are the container, not your change** — running as `uid 0` makes the
   `chmod`-based file tests meaningless, and the sandboxed network breaks one socket test. The exact
   files, the discriminator for each, and how to tell them from a real failure are in
@@ -450,17 +450,24 @@ Numbers recorded in PERFORMANCE.md / PLAN.md / news must come from the **bench C
 
 ## Checking `make test` / `make roast` results
 
-`make test` and `make roast` automatically save their full output to log files via `tee`:
+**The exit status is the verdict; the log is the detail.** Both recipes end in `| tee tmp/make-*.log`
+but run under `bash -o pipefail` (`SHELL` / `.SHELLFLAGS` at the top of the Makefile), so a failing
+`cargo build`, `cargo test` or `prove` makes `make` exit non-zero. That was **not** true before
+[#8221](https://github.com/tokuhirom/mutsu/issues/8221): plain `sh` reported `tee`'s status, always
+0, so every red suite looked green and the only thing catching it was reading the log by eye. That is
+why the older rule here amounted to "grep the log to find out whether it passed" — **do not go back
+to judging green that way.** A zero exit now means the suite passed; a non-zero one is a real failure
+and not something to interpret away (the only licensed exception is a `make roast` red whose failing
+files are a subset **by name** of the container-only list in
+[docs/agent-environments.md](docs/agent-environments.md)). The `check-pipefail` target — a
+prerequisite of both suites, costing milliseconds — fails loudly if that masking ever returns.
+
+Both targets also save their complete output, so you never need to re-run one to see it:
 - `make test` → `tmp/make-test.log`
 - `make roast` → `tmp/make-roast.log`
 
-**After running `make test` or `make roast`, always use the Grep tool on the log file instead of re-running the command.** Do NOT re-run `make test` or `make roast` just to grep the output — use the saved log file.
-
-```
-# Use the Grep tool on these files:
-# tmp/make-test.log
-# tmp/make-roast.log
-```
+**When a suite exits non-zero, read its log with the Grep tool to find which file failed.** Do NOT
+re-run `make test` or `make roast` just to get the output again — it is already on disk.
 
 ## Running mutsu safely
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
-.PHONY: test lint roast check-roast-whitelist check-value-wall check-flaky-list check-t-layout check-magic-keys check-panic-surface
+.PHONY: test lint roast check-roast-whitelist check-value-wall check-flaky-list check-t-layout check-magic-keys check-panic-surface check-pipefail
+
+# Recipes run under bash with `pipefail`, because the two suite recipes pipe
+# into `tee` and POSIX sh reports only the *last* command's status -- `tee`'s,
+# which is always 0. Without this, a failing `cargo build`, `cargo test` or
+# `prove` made `make test` / `make roast` exit 0, i.e. the pre-publication gate
+# CLAUDE.md relies on reported success on a red suite (#8221). `check-pipefail`
+# below is the guard that this stays true; it is a prerequisite of both targets.
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -c
 
 CARGO_TARGET_DIR ?= target
 MUTSU_BIN ?= $(CARGO_TARGET_DIR)/release/mutsu
@@ -37,7 +46,7 @@ PROVE_JOBS ?= 4
 # the gc-stress / jit-stress CI jobs keep running the whole t/ suite on debug.
 # See docs/adr/0075-make-test-runs-tap-on-release-binary.md, which supersedes
 # ADR-0014.
-test: check-value-wall check-flaky-list check-t-layout check-magic-keys check-panic-surface
+test: check-pipefail check-value-wall check-flaky-list check-t-layout check-magic-keys check-panic-surface
 	@mkdir -p tmp
 	(cargo build --release && cargo test -- --test-threads=1 && cargo test -p mutsu-lsp && MUTSU_BIN='$(CARGO_TARGET_DIR)/release/mutsu' MUTSU_T_TIMEOUT=60 prove -r -e 'scripts/run-t-test.sh' t/) 2>&1 | tee tmp/make-test.log
 
@@ -80,10 +89,24 @@ check-panic-surface:
 	python3 scripts/check-panic-surface.py --self-test
 	python3 scripts/check-panic-surface.py
 
-roast:
+roast: check-pipefail
 	@mkdir -p tmp
 	@rm -f temp-file-RT-126006-test
 	(cargo build --release && MUTSU_BIN=$(MUTSU_BIN) prove -j$(PROVE_JOBS) -e 'scripts/run-roast-test.sh' $(shell cat roast-whitelist.txt)) 2>&1 | tee tmp/make-roast.log
+
+# Guard for #8221. Both suite recipes end in `| tee tmp/make-*.log`, so their
+# exit status is only meaningful while the recipe shell has `pipefail` set. This
+# target fails if a false-in-the-pipeline is ever masked again -- e.g. because
+# SHELL/.SHELLFLAGS above were reverted, or a shell without `pipefail` is in
+# use. It runs no build and costs milliseconds, so both suites depend on it.
+check-pipefail:
+	@if (exit 1) 2>&1 | tee /dev/null; then \
+		echo 'check-pipefail: FAILED -- a failing command in a `| tee` pipeline exits 0.' >&2; \
+		echo '  The recipe shell is not running with pipefail, so `make test` and' >&2; \
+		echo '  `make roast` would report success on a red suite (issue #8221).' >&2; \
+		echo '  Restore `SHELL := /bin/bash` and `.SHELLFLAGS := -o pipefail -c`.' >&2; \
+		exit 1; \
+	fi
 
 check-roast-whitelist:
 	LC_ALL=C sort -c roast-whitelist.txt

--- a/docs/agent-environments.md
+++ b/docs/agent-environments.md
@@ -142,6 +142,12 @@ an ordinary user.
 network sandbox is the difference. The mechanism has not been pinned down further, so treat a *new*
 failure shape there (a concrete `not ok`, rather than the timeout) as real.
 
+Since [#8221](https://github.com/tokuhirom/mutsu/issues/8221) `make roast` propagates a failing
+suite into its **exit status** (it used to report `tee`'s, always 0). So in a remote container the
+target exits non-zero on these three alone: here, and only here, the status is not by itself the
+verdict — read the `Test Summary Report` and check the failing set against the table above. On the
+local box, and for `make test` everywhere, a non-zero exit is a real failure.
+
 Two things this list is not:
 
 - **It is not a licence to skim the summary.** Read the `Test Summary Report` and confirm the failing

--- a/news/2026-09/make-test-and-make-roast-can-fail-again.md
+++ b/news/2026-09/make-test-and-make-roast-can-fail-again.md
@@ -1,0 +1,68 @@
+# `make test` and `make roast` can fail again
+
+Both suite targets ended their recipe in `| tee tmp/make-*.log`, and make runs recipes
+under `/bin/sh` with no `pipefail`, so the status make saw was **`tee`'s** — which is
+always 0. A failing `prove`, a failing `cargo test`, and even a failing
+`cargo build --release` all left `make test` exiting 0:
+
+```console
+$ sh -c '(false) 2>&1 | tee /dev/null; echo "pipeline status=$?"'
+pipeline status=0
+```
+
+That made the two commands CLAUDE.md names as the pre-publication gate —
+
+> Before opening a PR, run `cargo fmt --all`, `make lint`, `make test` and `make roast`
+> once each, and do not publish until both suites are green.
+
+— unable to report anything but success. It was caught for real while working #8087
+stage 3: one `#[test]` in `src/runtime/meta_ns.rs` failed, the log ended in
+`test result: FAILED. 1134 passed; 1 failed`, and `make test` still exited 0. Only a
+by-hand grep of the log noticed. The prerequisites (`check-t-layout` and friends) failed
+correctly all along, being separate targets rather than part of the piped line, so
+`make test` failed on a layout violation and passed on a failing test suite — precisely
+the wrong way round. CI was never affected: `ci.yml` runs the steps individually and
+never invokes these targets, which is exactly why the defect could sit there unnoticed.
+
+The recipes now run under a shell that propagates it:
+
+```make
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -c
+```
+
+Two lines fix both targets and any future piped recipe, and `tee` keeps writing the logs
+as before.
+
+## The guard
+
+A fix to a silent-failure bug that is itself silent when reverted is worth little, so
+`check-pipefail` is a new target — a prerequisite of both `test` and `roast`, and a CI
+step next to the ledger checks — that fails if a false-in-the-pipeline is ever masked
+again:
+
+```make
+check-pipefail:
+	@if (exit 1) 2>&1 | tee /dev/null; then \
+		echo 'check-pipefail: FAILED -- ...' >&2; exit 1; \
+	fi
+```
+
+It builds nothing and costs milliseconds. Verified both directions: `make check-pipefail`
+exits 0 as configured, and `make check-pipefail SHELL=/bin/sh .SHELLFLAGS=-c` — the
+simulated revert — fails with the diagnostic. A suite-shaped recipe
+(`(echo building && false) 2>&1 | tee log`) now exits non-zero while still writing its
+log. CI gets the step even though CI does not use these targets, because nothing else
+there ever looks at the property.
+
+## The documentation this had bent
+
+The masking had quietly reshaped the instructions around it. CLAUDE.md's
+"Checking `make test` / `make roast` results" told agents to grep `tmp/make-test.log`
+*instead of* trusting the command, which was the only workable advice while the exit
+status was a constant — and it taught judging green by eye, which is both expensive and
+easy to get wrong. That section, the matching bullet in "Run both full suites yourself",
+the `AGENTS.md` summary, and the `mutsu-ticket-flow` skill now all draw the line the same
+way: **the exit status is the verdict, the log is the detail.** Read the log to find
+*which* file failed, never to find out *whether* something failed, and never by re-running
+a suite to see output that is already on disk.


### PR DESCRIPTION
## The bug

Both suite recipes end in `| tee tmp/make-*.log`, and make runs recipes under `/bin/sh` with no `pipefail`, so the status make saw was **`tee`'s** — always 0. A failing `prove`, a failing `cargo test`, and even a failing `cargo build --release` all left `make test` exiting 0:

```console
$ sh -c '(false) 2>&1 | tee /dev/null; echo "status=$?"'
status=0
```

That made the two commands CLAUDE.md names as the pre-publication gate unable to report anything but success. The `check-*` prerequisites failed correctly all along, being separate targets rather than part of the piped line — so `make test` failed on a `t/` layout violation and passed on a failing test suite, precisely the wrong way round. CI was never affected: `ci.yml` runs the steps individually and never invokes these targets, which is exactly why the defect could sit unnoticed.

## The fix

```make
SHELL := /bin/bash
.SHELLFLAGS := -o pipefail -c
```

Two lines fix both targets and any future piped recipe; `tee` keeps writing the logs as before.

## The guard

A fix to a silent-failure bug that is itself silent when reverted is worth little, so `check-pipefail` is a new target — a prerequisite of both `test` and `roast`, and a CI step beside the ledger checks, since nothing else in CI ever looks at this property. It builds nothing and costs milliseconds. Verified both directions:

```console
$ make check-pipefail                                 # exit 0
$ make check-pipefail SHELL=/bin/sh .SHELLFLAGS=-c    # simulated revert
check-pipefail: FAILED -- a failing command in a `| tee` pipeline exits 0.
make: *** [Makefile:103: check-pipefail] Error 1
```

and a suite-shaped recipe, `(echo building && false) 2>&1 | tee log`, now exits non-zero while still writing its log.

## The documentation this had bent

The masking had quietly reshaped the instructions around it. CLAUDE.md's "Checking `make test` / `make roast` results" told agents to grep `tmp/make-test.log` *instead of* trusting the command — the only workable advice while the exit status was a constant, but it taught judging green by eye. That section, the matching bullet in "Run both full suites yourself", the `AGENTS.md` summary and the `mutsu-ticket-flow` skill now draw the line the same way: **the exit status is the verdict, the log is the detail.** Read the log to find *which* file failed, never to find out *whether* something failed, and never by re-running a suite for output already on disk.

`docs/agent-environments.md` gets the one nuance the change creates: in a remote container `make roast` now exits non-zero on the documented environment-only set alone, so there — and only there — the Test Summary Report is the verdict and must still be a subset of those three files by name.

## Validation

- `make test` — **green**, exit 0 (Files=4166, Tests=44406, `Result: PASS`).
- `make roast` — exit 2, `Result: FAIL`, failing exactly the three container-only files (`roast/6.c/S32-io/file-tests.t` Failed: 4, `roast/S16-filehandles/filetest.t` Failed: 25, `roast/S32-io/IO-Socket-Async.t` exit 124 / planned 40 ran 17), i.e. the licensed set in `docs/agent-environments.md` — and the first run in which that red is visible in the exit status at all.
- `cargo fmt --all` clean; no Rust source is touched by this PR.
- `scripts/ci-docs-only.sh --check-inputs` / `--self-test` pass.

Closes #8221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoRrJgwXv3pryDCnR3aYKS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoRrJgwXv3pryDCnR3aYKS)_