### PR TITLE
perf(regex): a look-behind stops searching from position zero

### DIFF
--- a/news/2026-09/lookbehind-stops-searching-from-zero.md
+++ b/news/2026-09/lookbehind-stops-searching-from-zero.md
@@ -1,0 +1,101 @@
+# A look-behind stops searching from position zero
+
+Round 22 of the YAML-throughput investigation ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)),
+and the first round of it that removes a **growth rate** rather than a constant.
+
+Rounds 11-21 cut the 60-row benchmark from 8.130 Bn instructions to 1.199 Bn
+(-85%), each by finding work that should not happen and removing it. None of
+them changed how the cost scales with the input, and a measurement taken after
+round 21 showed why that mattered: against rakudo v2026.07 on the same
+container, mutsu was *ahead* on a 10-row document (0.061s vs 0.067s parse) and
+4.01x behind on a 240-row one, because mutsu's instruction count grew as
+`n^1.225` while rakudo's effective per-row cost *fell* over the same range. A
+gap that widens with the input is not a constant-factor problem, so no number of
+further rounds of the same kind would have closed it.
+
+This round removes that exponent. On the 60-row document instructions go
+2,417,734,204 -> 2,065,297,646 (-14.6%); on the 240-row document
+13,207,178,233 -> 7,632,276,629 (**-42.2%**), and the growth from 60 to 240 rows
+goes **5.46x -> 3.70x — `n^1.225` -> `n^0.943`, linear**. The parse-only wall
+clock against rakudo at 240 rows goes 4.01x -> 2.49x, and what remains of the
+ratio's drift with size is rakudo being *sublinear* (MoarVM's JIT warming up),
+not mutsu being superlinear.
+
+## The mechanism
+
+`<?after X>` and `<!after X>` ask whether `X` matches ending exactly at the
+current position. The engine answers by running `X` *forward* from a candidate
+start and checking whether it ends at `pos` — and it tried every start from 0:
+
+```rust
+for start in 0..=pos {
+    if self.regex_match_end_from_caps_in_pkg(pattern, chars, start, pkg)
+        .is_some_and(|(end, _)| end == pos) { … }
+}
+```
+
+So one look-behind costs O(pos). A negative look-behind costs it every time,
+since establishing that nothing matches means exhausting the range.
+
+YAMLish's `token block-ws(Str $indent)` opens with
+`<.space>* [ <!after <.alnum>> <.comment> … ]*` and is evaluated once per block
+entry. O(entries) evaluations x O(document) per evaluation is the `n^1.2`.
+
+A start earlier than `pos` minus the most `X` can consume cannot end at `pos`,
+so those starts are provably unreachable. `regex_lookbehind::lookbehind_start_floor`
+computes that bound and the search begins there.
+
+## Two things the bound has to get right
+
+**It counts grapheme clusters, not `char`s.** One `<.alnum>` can span a base
+character plus any number of combining marks, and `\r\n` is a single cluster
+(`regex_helpers::grapheme_end`). A character bound would therefore be unsound,
+so the floor is found by stepping *back* that many clusters with the same rule
+`grapheme_end` steps forward by. The atoms whose cluster handling does not fit
+that rule — `\n`, `\N`, `\s` — are simply not bounded.
+
+**Every shape it does not model returns `None`**, which means "search from 0" —
+the behaviour before this change. So an unbounded quantifier, a subrule call, an
+interpolated pattern or a future atom kind costs a missed optimization, never a
+wrong answer. `Some` is returned only for a sequence of single-cluster atoms,
+zero-width assertions, transparent groups, alternations (the longest branch) and
+bounded `** a..b` repetitions.
+
+The search order is unchanged for every start that survives, so a positive
+look-behind with captures still resolves to the same match: only starts that
+could not match were dropped.
+
+## How it was found
+
+Rounds 11-21 all measured one document size, which is structurally unable to
+see an asymptotic term — and so this ticket's "item 3" ("candidate enumeration…
+the branching multiplies. Not yet measured directly") survived eleven rounds.
+Three measurements located it:
+
+1. **Two sizes, not one.** 60 vs 240 rows gave the exponent, and the excess over
+   linear scaling (26.8% of the 240-row run) ranked the functions contributing
+   to it — all of them in the core matching loop, growing 8-16x for 4x input.
+2. **Is it memoizable?** A temporary counter over
+   `(package, rule, arguments, remaining)` said no: subrule evaluations are
+   *exactly* linear (87,211 -> 689,491 for 30 -> 240 rows) at a constant 9.24x
+   multiplicity. So the superlinear work was inside a single evaluation, and a
+   packrat-style memo — the obvious guess — would have been a constant-factor
+   change.
+3. **Which rule?** A thread-local rule stack attributing every single-atom match
+   to its innermost enclosing `<subrule>` named `block-ws` outright: 2,168 atom
+   matches per evaluation at 60 rows, 8,648 at 240 (4x the document, 4x the
+   per-evaluation work), and 4,151,040 of the parse's 4,150,080
+   `matches_named_builtin` calls. After the fix it leaves the top of that table
+   entirely.
+
+The lesson worth keeping: **profiling one input size cannot find a growth-rate
+bug, however carefully the attribution is done.** A flat profile at one size and
+a flat profile at two sizes are different claims, and only the second one rules
+out an exponent.
+
+## What is left
+
+`document-prefix` and `empty-document` also scan the whole document per
+evaluation, but they are evaluated a fixed number of times (10 and 4), so they
+are O(n) in total rather than quadratic — about 240k atom matches at 240 rows,
+worth a look but not an exponent. Everything else is as round 21 left it.

--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -8,6 +8,7 @@ mod regex_eval_class;
 mod regex_eval_repeat;
 pub(crate) mod regex_helpers;
 mod regex_interpolate;
+mod regex_lookbehind;
 mod regex_lr_state;
 mod regex_ltm_rank;
 mod regex_match_atom;

--- a/src/runtime/regex/regex_lookbehind.rs
+++ b/src/runtime/regex/regex_lookbehind.rs
@@ -1,0 +1,262 @@
+//! How far back a look-behind has to search.
+//!
+//! `<?after X>` / `<!after X>` ask whether `X` matches ending exactly at the
+//! current position. The engine answers by running `X` forward from a candidate
+//! start and checking whether it ends at `pos`, which means it has to try
+//! starts — and it used to try **every** start from 0, making one look-behind
+//! O(pos) and any pattern that evaluates one per input line O(n^2).
+//!
+//! That was the whole superlinear term in a YAMLish parse
+//! ([#7576](https://github.com/tokuhirom/mutsu/issues/7576)): `token
+//! block-ws($indent)` contains `<!after <.alnum>>` and is evaluated once per
+//! block entry, so its per-evaluation cost grew with the document while its
+//! evaluation count grew with it too. Measured by attributing every single-atom
+//! match to its innermost enclosing rule: `block-ws` went from 2,168 atom
+//! matches per evaluation at 60 rows to 8,648 at 240 (4x the document, 4x the
+//! per-evaluation work, 16x in total), and accounted for 4,151,040 of the
+//! 4,150,080 `matches_named_builtin` calls the whole parse made.
+//!
+//! A start earlier than `pos` minus the most `X` can consume cannot end at
+//! `pos`, so those starts are provably unreachable and skipping them changes no
+//! answer. [`lookbehind_start_floor`] computes that bound and returns the first
+//! start worth trying; when it cannot bound the pattern it returns 0 and the
+//! search is exactly what it was.
+//!
+//! The bound counts **grapheme clusters**, not `char`s, because that is what
+//! the matcher consumes: one `<.alnum>` can span a base character plus any
+//! number of combining marks, and `\r\n` is one cluster
+//! ([`super::regex_helpers::grapheme_end`]). So the floor is found by stepping
+//! back that many clusters with the same rule `grapheme_end` steps forward by,
+//! rather than by subtracting a character count.
+
+use unicode_normalization::char::is_combining_mark;
+
+use crate::runtime::regex_types::{RegexAtom, RegexPattern, RegexQuant};
+
+/// The first start position a look-behind of `pattern` at `pos` can match from.
+///
+/// `0` when the pattern's length cannot be bounded, which is the conservative
+/// answer: the caller then searches every start, as it did before this existed.
+pub(super) fn lookbehind_start_floor(pattern: &RegexPattern, chars: &[char], pos: usize) -> usize {
+    match pattern_max_graphemes(pattern) {
+        Some(max) => step_back_graphemes(chars, pos, max),
+        None => 0,
+    }
+}
+
+/// Walk `count` grapheme clusters back from `pos`, mirroring
+/// [`super::regex_helpers::grapheme_end`]'s notion of a cluster: `\r\n` is one,
+/// and a cluster extends over the combining marks that follow its base.
+fn step_back_graphemes(chars: &[char], pos: usize, count: usize) -> usize {
+    let mut i = pos;
+    for _ in 0..count {
+        if i == 0 {
+            return 0;
+        }
+        if i >= 2 && chars[i - 2] == '\r' && chars[i - 1] == '\n' {
+            i -= 2;
+            continue;
+        }
+        i -= 1;
+        // `chars[i]` may be a combining mark, in which case the cluster starts
+        // at the base character before it.
+        while i > 0 && is_combining_mark(chars[i]) {
+            i -= 1;
+        }
+    }
+    i
+}
+
+/// An upper bound on the grapheme clusters `pattern` can consume, or `None`
+/// when it cannot be bounded.
+///
+/// Deliberately incomplete: every shape this does not model returns `None`, so
+/// a new atom or quantifier kind costs a missed optimization rather than a
+/// wrong answer. The shapes it does model are the ones look-behinds are written
+/// with in practice — a character class, a literal, a short bounded group.
+fn pattern_max_graphemes(pattern: &RegexPattern) -> Option<usize> {
+    let mut total: usize = 0;
+    for token in &pattern.tokens {
+        // A separated quantifier's separator contributes length too; not worth
+        // modelling for a look-behind, so it is simply not bounded.
+        if token.separator.is_some() {
+            return None;
+        }
+        let atom = atom_max_graphemes(&token.atom)?;
+        let reps = quant_max_reps(&token.quant)?;
+        total = total.checked_add(atom.checked_mul(reps)?)?;
+    }
+    Some(total)
+}
+
+/// The most times a quantifier can repeat its atom, or `None` when unbounded.
+fn quant_max_reps(quant: &RegexQuant) -> Option<usize> {
+    match quant {
+        RegexQuant::One => Some(1),
+        RegexQuant::ZeroOrOne => Some(1),
+        RegexQuant::Repeat(_, Some(max)) => Some(*max),
+        // `*`, `+`, `** n..*` and a runtime-computed count are all unbounded.
+        RegexQuant::ZeroOrMore
+        | RegexQuant::OneOrMore
+        | RegexQuant::Repeat(_, None)
+        | RegexQuant::RepeatCode(_) => None,
+    }
+}
+
+/// An upper bound on the grapheme clusters one atom can consume.
+fn atom_max_graphemes(atom: &RegexAtom) -> Option<usize> {
+    match atom {
+        // Exactly one cluster.
+        RegexAtom::Literal(_)
+        | RegexAtom::Any
+        | RegexAtom::CharClass(_)
+        | RegexAtom::CompositeClass { .. }
+        | RegexAtom::UnicodeProp { .. } => Some(1),
+
+        // Zero-width: assertions, markers and declarations consume nothing.
+        RegexAtom::ZeroWidth
+        | RegexAtom::CaptureStartMarker
+        | RegexAtom::CaptureEndMarker
+        | RegexAtom::StartOfLine
+        | RegexAtom::EndOfLine
+        | RegexAtom::AtPosition(_)
+        | RegexAtom::LeftWordBoundary
+        | RegexAtom::RightWordBoundary
+        | RegexAtom::WordBoundary { .. }
+        | RegexAtom::WithinWord { .. }
+        | RegexAtom::UnicodePropAssert { .. }
+        | RegexAtom::Lookaround { .. }
+        | RegexAtom::CodeAssertion { .. }
+        | RegexAtom::VarDecl { .. } => Some(0),
+
+        // Transparent wrappers: the bound is the inner pattern's.
+        RegexAtom::Group(inner)
+        | RegexAtom::CaptureGroup(inner)
+        | RegexAtom::CaptureIsolatedGroup(inner) => pattern_max_graphemes(inner),
+
+        // A branch set consumes at most its longest branch. A conjunction's
+        // branches all match the same span, so the same bound is sound.
+        RegexAtom::Alternation(branches)
+        | RegexAtom::SequentialAlternation(branches)
+        | RegexAtom::Conjunction(branches) => {
+            let mut worst = 0;
+            for branch in branches {
+                worst = worst.max(pattern_max_graphemes(branch)?);
+            }
+            Some(worst)
+        }
+
+        // Everything else — a subrule call above all, but also `\n`/`\N`/`\s`
+        // (whose CRLF handling is not the cluster rule this counts in) and a
+        // pattern interpolated at match time — is not bounded here.
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::regex_types::{CharClass, ClassItem, RegexToken};
+
+    fn pattern(tokens: Vec<RegexToken>) -> RegexPattern {
+        RegexPattern {
+            tokens,
+            anchor_start: false,
+            anchor_end: false,
+            ignore_case: false,
+            ignore_mark: false,
+        }
+    }
+
+    fn token(atom: RegexAtom, quant: RegexQuant) -> RegexToken {
+        RegexToken {
+            atom,
+            quant,
+            named_capture: None,
+            secondary_named_capture: None,
+            hash_capture: None,
+            force_list_capture: false,
+            ratchet: false,
+            frugal: false,
+            separator: None,
+            from_runtime_interpolation: false,
+        }
+    }
+
+    fn one_class() -> RegexAtom {
+        RegexAtom::CharClass(CharClass {
+            negated: false,
+            items: vec![ClassItem::Range('a', 'z')],
+        })
+    }
+
+    #[test]
+    fn a_single_class_is_one_grapheme() {
+        let p = pattern(vec![token(one_class(), RegexQuant::One)]);
+        assert_eq!(pattern_max_graphemes(&p), Some(1));
+    }
+
+    #[test]
+    fn zero_width_atoms_cost_nothing() {
+        let p = pattern(vec![
+            token(RegexAtom::StartOfLine, RegexQuant::One),
+            token(one_class(), RegexQuant::One),
+        ]);
+        assert_eq!(pattern_max_graphemes(&p), Some(1));
+    }
+
+    #[test]
+    fn a_bounded_repeat_multiplies_and_an_unbounded_one_poisons() {
+        let bounded = pattern(vec![token(one_class(), RegexQuant::Repeat(1, Some(3)))]);
+        assert_eq!(pattern_max_graphemes(&bounded), Some(3));
+        let unbounded = pattern(vec![token(one_class(), RegexQuant::OneOrMore)]);
+        assert_eq!(pattern_max_graphemes(&unbounded), None);
+    }
+
+    #[test]
+    fn an_alternation_takes_its_longest_branch() {
+        let short = pattern(vec![token(one_class(), RegexQuant::One)]);
+        let long = pattern(vec![
+            token(one_class(), RegexQuant::One),
+            token(RegexAtom::Literal('x'), RegexQuant::One),
+        ]);
+        let p = pattern(vec![token(
+            RegexAtom::Alternation(vec![short, long]),
+            RegexQuant::One,
+        )]);
+        assert_eq!(pattern_max_graphemes(&p), Some(2));
+    }
+
+    #[test]
+    fn a_subrule_call_is_not_bounded() {
+        let p = pattern(vec![token(
+            RegexAtom::Named(Default::default()),
+            RegexQuant::One,
+        )]);
+        assert_eq!(pattern_max_graphemes(&p), None);
+    }
+
+    #[test]
+    fn the_floor_walks_back_whole_clusters() {
+        // A base character followed by two combining marks is one cluster, so
+        // stepping back one cluster from its end lands on the base.
+        let chars: Vec<char> = "ae\u{301}\u{302}".chars().collect();
+        assert_eq!(chars.len(), 4);
+        assert_eq!(step_back_graphemes(&chars, 4, 1), 1);
+        assert_eq!(step_back_graphemes(&chars, 4, 2), 0);
+        // CRLF is one cluster, matching `grapheme_end`.
+        let crlf: Vec<char> = "a\r\n".chars().collect();
+        assert_eq!(step_back_graphemes(&crlf, 3, 1), 1);
+        // Walking past the start clamps rather than wrapping.
+        assert_eq!(step_back_graphemes(&crlf, 3, 99), 0);
+    }
+
+    #[test]
+    fn an_unbounded_pattern_searches_from_zero() {
+        let chars: Vec<char> = "abcdef".chars().collect();
+        let unbounded = pattern(vec![token(one_class(), RegexQuant::ZeroOrMore)]);
+        assert_eq!(lookbehind_start_floor(&unbounded, &chars, 6), 0);
+        let bounded = pattern(vec![token(one_class(), RegexQuant::One)]);
+        assert_eq!(lookbehind_start_floor(&bounded, &chars, 6), 5);
+    }
+}

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -458,7 +458,13 @@ impl Interpreter {
             } => {
                 let matched = if *is_behind {
                     let mut found = false;
-                    for start in 0..=pos {
+                    // A start earlier than `pos` minus the most the pattern can
+                    // consume cannot end at `pos`, so the search begins there
+                    // rather than at 0 — what made one look-behind O(pos) and a
+                    // per-line look-behind O(n^2) (#7576).
+                    let floor =
+                        super::regex_lookbehind::lookbehind_start_floor(pattern, chars, pos);
+                    for start in floor..=pos {
                         if self
                             .regex_match_end_from_caps_in_pkg(pattern, chars, start, pkg)
                             .is_some_and(|(end, _)| end == pos)

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -382,7 +382,13 @@ impl Interpreter {
                 let mut inner_vars = crate::runtime::RegexVarMap::default();
                 let matched = if *is_behind {
                     let mut found = false;
-                    for start in 0..=pos {
+                    // A start earlier than `pos` minus the most the pattern can
+                    // consume cannot end at `pos`, so the search begins there
+                    // rather than at 0 — what made one look-behind O(pos) and a
+                    // per-line look-behind O(n^2) (#7576).
+                    let floor =
+                        super::regex_lookbehind::lookbehind_start_floor(pattern, chars, pos);
+                    for start in floor..=pos {
                         if let Some((end, mut inner)) =
                             self.regex_match_end_from_caps_in_pkg(pattern, chars, start, pkg)
                             && end == pos

--- a/t/regex/syntax/regex-lookbehind-bounded-search.t
+++ b/t/regex/syntax/regex-lookbehind-bounded-search.t
@@ -1,0 +1,66 @@
+use v6;
+use Test;
+
+# A look-behind is answered by running its pattern forward from candidate start
+# positions and asking whether one ends at the current position. The engine used
+# to try every start from 0, which made one `<?after …>` cost O(pos) and any
+# pattern that evaluates one per input line quadratic (#7576). It now starts no
+# earlier than `pos` minus the most the look-behind pattern can consume.
+#
+# That bound is only sound if it is an upper bound, so these rows exercise the
+# shapes where getting it wrong changes an answer: a pattern the engine must NOT
+# bound (an unbounded quantifier), one whose grapheme cluster is longer than one
+# `char` (a base plus combining marks), the alternation/group cases where the
+# bound is the longest branch, and position 0 where the floor has to clamp.
+# Every expectation below was verified against rakudo v2026.07.
+#
+# The CRLF cluster is deliberately not exercised from Raku: a `\r\n` written in
+# a *pattern* cannot consume the single cluster as two atoms in either engine, so
+# the rows one can write here say nothing about the look-behind. The floor's CRLF
+# handling is pinned by `regex_lookbehind`'s own unit tests instead, and the
+# bound declines to model `\n` at all, so such a look-behind keeps searching from
+# 0 exactly as before.
+
+plan 19;
+
+# --- the bounded single-atom case: what the fix actually speeds up -----------
+ok 'abc' ~~ / 'ab' <?after b> c /, 'positive look-behind of one class matches';
+nok 'abc' ~~ / 'ab' <!after b> c /, 'negative look-behind of one class rejects';
+ok 'abc' ~~ / 'ab' <!after z> c /, 'negative look-behind passes when it cannot match';
+ok 'a1c' ~~ / 'a1' <?after \d> c /, 'one-class look-behind over a digit';
+
+# --- a multi-atom bound is the sum, and must look back far enough ------------
+ok 'xabc' ~~ / 'xab' <?after 'ab'> c /, 'two-literal look-behind looks back two';
+nok 'xabc' ~~ / 'xab' <?after 'xa'> c /, 'two-literal look-behind does not match further back';
+ok 'xabc' ~~ / 'xab' <?after x? 'ab'> c /, 'an optional atom widens the bound';
+
+# --- a bound the engine must not apply: an unbounded quantifier --------------
+ok 'aaaab' ~~ / 'aaaa' <?after a+> b /, 'unbounded look-behind still searches back';
+ok 'aaaab' ~~ / 'aaaa' <?after ^ a+> b /, 'anchored unbounded look-behind still matches';
+nok 'aaaab' ~~ / 'aaaa' <!after a+> b /, 'negated unbounded look-behind still rejects';
+
+# --- alternation / group: the bound is the longest branch --------------------
+ok 'xyabc' ~~ / 'xyab' <?after [ 'ab' | 'zzzz' ]> c /, 'alternation look-behind takes a branch';
+ok 'xyabc' ~~ / 'xyab' <?after [ 'yab' ]> c /, 'group look-behind looks back three';
+nok 'xyabc' ~~ / 'xyab' <?after [ 'qq' | 'zz' ]> c /, 'alternation look-behind that cannot match';
+
+# --- clusters are not chars: a base plus combining marks is one grapheme -----
+# "e" + COMBINING ACUTE + COMBINING CIRCUMFLEX is a single cluster, so a
+# one-cluster look-behind has to step back over all three chars.
+my $combining = "a\c[LATIN SMALL LETTER E]\c[COMBINING ACUTE ACCENT]\c[COMBINING CIRCUMFLEX ACCENT]z";
+ok $combining ~~ / ^ . <-[z]>+ <?after \w> z $ /,
+    'one-cluster look-behind steps back over combining marks';
+ok $combining ~~ / ^ . <-[z]>+ <!after \d> z $ /,
+    'negated one-cluster look-behind over combining marks';
+
+# --- the floor has to clamp at the start of the string ----------------------
+ok 'ab' ~~ / ^ <!after \w> 'ab' $ /, 'negated look-behind at position 0 passes';
+nok 'ab' ~~ / ^ <?after \w> 'ab' $ /, 'positive look-behind at position 0 fails';
+
+# --- a look-behind inside a quantified group, the YAMLish shape -------------
+# `token block-ws($indent) { <.space>* [ <!after <.alnum>> <.comment> … ]* }` is
+# what made this quadratic; the essential shape is a per-iteration look-behind.
+ok "a   # c\nb" ~~ / ^ a \s* [ <!after \w> '#' \N* ]? \n b $ /,
+    'look-behind inside an optional group, the block-ws shape';
+ok "ax  # c\nb" ~~ / ^ 'ax' \s* [ <!after \d> '#' \N* ]? \n b $ /,
+    'the same shape with the look-behind passing on a letter';


### PR DESCRIPTION
Round 22 of #7576, and the first round of it that removes a **growth rate** rather than a constant.

Rounds 11-21 cut the 60-row benchmark 8.130 Bn -> 1.199 Bn instructions (-85%), each by finding work that should not happen. None of them changed how the cost *scales*, and a measurement taken after round 21 showed why that mattered: against rakudo v2026.07 on the same container mutsu was **ahead** on a 10-row document (0.061s vs 0.067s) and **4.01x behind** on a 240-row one, because mutsu grew as `n^1.225` while rakudo's effective per-row cost *fell* over the same range. A gap that widens with the input is not a constant-factor problem, so no number of further rounds of the same kind would have closed it.

| | 60 rows | 240 rows | growth | exponent |
| --- | ---: | ---: | ---: | ---: |
| before | 2,417,734,204 | 13,207,178,233 | 5.46x | 1.225 |
| after | 2,065,297,646 | 7,632,276,629 | **3.70x** | **0.943** |
| | **-14.6%** | **-42.2%** | | |

Parse-only wall clock against rakudo, idle box, median of 3:

| rows | mutsu | rakudo | ratio (was) |
| --- | ---: | ---: | ---: |
| 10 | 0.061s | 0.090s | **0.68x** (0.91x) |
| 60 | 0.298s | 0.181s | 1.65x (1.91x) |
| 120 | 0.595s | 0.288s | 2.07x (2.75x) |
| 240 | 1.152s | 0.425s | **2.71x** (4.01x) |
| 480 | 2.333s | 0.792s | 2.95x (n/a) |

mutsu is linear over that range now (120 -> 480 rows: 3.92x for 4x input); what is left of the ratio's drift is rakudo being *sublinear* (2.75x for the same 4x), not mutsu being superlinear.

## The mechanism

`<?after X>` / `<!after X>` ask whether `X` matches ending exactly at the current position. The engine answers by running `X` **forward** from a candidate start and checking whether it ends at `pos` — and it tried every start from 0:

```rust
for start in 0..=pos {
    if self.regex_match_end_from_caps_in_pkg(pattern, chars, start, pkg)
        .is_some_and(|(end, _)| end == pos) { … }
}
```

One look-behind therefore cost O(pos), and a **negative** one paid it in full every time, since establishing that nothing matches means exhausting the range.

YAMLish's `token block-ws(Str $indent)` opens with `<.space>* [ <!after <.alnum>> <.comment> … ]*` and is evaluated once per block entry. O(entries) evaluations x O(document) each is the entire superlinear term.

A start earlier than `pos` minus the most `X` can consume cannot end at `pos`, so those starts are provably unreachable. `regex_lookbehind::lookbehind_start_floor` computes that bound and the search begins there.

## Two things the bound has to get right

**It counts grapheme clusters, not `char`s.** One `<.alnum>` can span a base character plus any number of combining marks, and `\r\n` is a single cluster (`regex_helpers::grapheme_end`), so a character bound would be unsound. The floor is found by stepping *back* that many clusters with the same rule `grapheme_end` steps forward by. The atoms whose cluster handling does not fit that rule — `\n`, `\N`, `\s` — are deliberately not bounded.

**Every shape it does not model returns `None`, which means "search from 0"** — exactly the previous behaviour. An unbounded quantifier, a subrule call, an interpolated pattern or a future atom kind costs a missed optimization, never a wrong answer. `Some` comes back only for a sequence of single-cluster atoms, zero-width assertions, transparent groups, alternations (longest branch) and bounded `** a..b` repetitions. The surviving starts are tried in the same order as before, so a positive look-behind with captures resolves to the same match.

## How it was found, since rounds 11-21 all walked past it

Those rounds measured **one** document size, which is structurally unable to see an asymptotic term — which is why this ticket's own "item 3" ("candidate enumeration… the branching multiplies. Not yet measured directly") survived eleven rounds. Three measurements located it:

1. **Two sizes, not one.** 60 vs 240 rows gave the exponent, and the excess over linear scaling (26.8% of the 240-row run) ranked the contributors — all in the core matching loop, growing 8-16x for 4x input.
2. **Is it memoizable?** A temporary `(package, rule, arguments, remaining)` counter said no: subrule evaluations are *exactly* linear (87,211 -> 689,491 for 30 -> 240 rows) at a constant **9.24x** multiplicity. So the superlinear work was inside a single evaluation, and a packrat-style memo — the obvious guess, and the one I proposed first — would have been another constant.
3. **Which rule?** A thread-local rule stack attributing every single-atom match to its innermost enclosing `<subrule>` named `block-ws` outright: **2,168** atom matches per evaluation at 60 rows, **8,648** at 240 (4x the document, 4x the per-evaluation work, 16x in total), accounting for 4,151,040 of the parse's 4,150,080 `matches_named_builtin` calls. After the fix it leaves the top of that table entirely.

The lesson worth keeping: **profiling one input size cannot find a growth-rate bug, however careful the attribution.** A flat profile at one size and a flat profile at two sizes are different claims, and only the second rules out an exponent.

## Tests

- `t/regex/syntax/regex-lookbehind-bounded-search.t` (new, 19 rows, all verified against rakudo v2026.07) pins the shapes where a wrong bound changes an answer: an unbounded quantifier the engine must **not** bound, a cluster longer than one `char` (base + two combining marks), alternation/group bounds, multi-atom bounds, and position 0 where the floor clamps. The existing `t/regex/syntax/lookbehind.t` keeps covering the basic semantics.
- `regex_lookbehind`'s unit tests pin the bound function itself, including the CRLF cluster — which cannot be exercised from Raku, because a `\r\n` written in a *pattern* cannot consume the single cluster as two atoms in either engine.
- `cargo fmt --all`, `make lint`, `make test` (4157 files, 44307 tests) and `make roast` (1437 files, 219635 tests) all run locally before publishing. roast's only failures are the three documented container-only ones — `roast/6.c/S32-io/file-tests.t` (`Failed: 4`) and `roast/S16-filehandles/filetest.t` (`Failed: 25`) because the container runs as `uid 0`, and `roast/S32-io/IO-Socket-Async.t` (exit 124) on the sandboxed network — matching `docs/agent-environments.md` exactly, counts included.

## What is left

`document-prefix` and `empty-document` also scan the whole document per evaluation, but are evaluated a fixed number of times (10 and 4), so they are O(n) in total rather than quadratic — ~240k atom matches at 240 rows, worth a look but not an exponent. Everything else is as round 21 left it.

Correction to the record while I am here: my earlier measurement comment on #7576 named #8095 as "still the largest single identified item". It is **closed** (by #8135); round 18 had already posted that correction and I missed it.

The ticket stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_