### PR TITLE
fix: allow local subs to shadow imported routines

### DIFF
--- a/news/2026-09/imported-routine-can-be-shadowed.md
+++ b/news/2026-09/imported-routine-can-be-shadowed.md
@@ -1,0 +1,3 @@
+An imported routine can now be shadowed by a same-named local `sub` declaration,
+including routines installed by a module's `sub EXPORT`. A second local
+declaration in the same scope still raises `X::Redeclaration`. (#8214)

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -140,6 +140,7 @@ impl Interpreter {
             registry.proto_tokens.clone(),
             registry.our_scoped_functions.keys().copied().collect(),
             self.user_declared_infix_ops.clone(),
+            self.imported_routine_aliases.clone(),
         )
     }
 
@@ -160,6 +161,7 @@ impl Interpreter {
             proto_tokens,
             our_scoped_keys,
             user_infix_ops,
+            imported_routine_aliases,
         ) = snapshot;
         // Restore the user-declared infix operator set.  In Raku, operators are
         // lexically scoped per compilation unit; not restoring this caused a
@@ -167,6 +169,7 @@ impl Interpreter {
         // arithmetic (e.g. Test.rakumod's `$num_of_tests_run + 1`) after the
         // block exited, resetting the test counter to Nil.
         self.user_declared_infix_ops = user_infix_ops;
+        self.imported_routine_aliases = imported_routine_aliases;
         self.reinstate_module_functions(&mut functions, is_eval);
         // Collect our-scoped functions that were newly added during this block
         // (not present in the snapshot) that need to persist after scope restoration.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2842,6 +2842,12 @@ pub struct Interpreter {
     /// Each entry saves (function_keys, class_names, newline_mode, strict_mode, fatal_mode)
     /// before a block with `use`.
     import_scope_stack: Vec<ImportScopeSnapshot>,
+    /// Routine aliases installed by an import, keyed by their target package
+    /// and name. A local `sub` may shadow such an alias, but two declarations
+    /// in the same scope must still be rejected. The set is restored together
+    /// with routine-registry snapshots so a nested lexical declaration cannot
+    /// consume an import belonging to its caller.
+    pub(crate) imported_routine_aliases: HashSet<Symbol>,
     pub(crate) strict_mode: bool,
     pub(crate) fatal_mode: bool,
     /// True only on the throwaway nested `Interpreter` `eval-lives-ok`/
@@ -4338,6 +4344,7 @@ pub(crate) type RoutineRegistrySnapshot = (
     rustc_hash::FxHashSet<String>,
     rustc_hash::FxHashSet<Symbol>,
     std::sync::Arc<std::collections::HashMap<String, HashSet<Symbol>>>, // user_declared_infix_ops snapshot
+    HashSet<Symbol>, // imported routine aliases snapshot
 );
 
 /// What a lexical import scope (`{ use Foo; ... }`) restores when it pops: the
@@ -4373,6 +4380,10 @@ pub(crate) struct ImportScopeSnapshot {
     /// written for the first time inside a `use`-containing block — see
     /// `pop_import_scope`'s doc comment for the regression that caused.
     pub(crate) imported_env_keys: HashSet<Symbol>,
+    /// Imported routine aliases visible before this scope was pushed. The
+    /// registry snapshot alone cannot distinguish an imported alias from a
+    /// declaration made in this scope when the names collide.
+    pub(crate) imported_routine_aliases: HashSet<Symbol>,
     pub(crate) newline_mode: NewlineMode,
     pub(crate) strict_mode: bool,
     pub(crate) fatal_mode: bool,

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -812,6 +812,12 @@ impl Interpreter {
         let allow_redeclare = supersede || is_method_value_decl;
         let is_our_scoped = custom_traits.iter().any(|(t, _)| t == "__our_scoped");
         let is_lexical_hoist = custom_traits.iter().any(|(t, _)| t == "__lexical_hoist");
+        let package = self.current_package();
+        // Imports are aliases in the importing scope, not declarations in
+        // that scope. A later local `sub` replaces the alias; once replaced,
+        // the alias marker is consumed so another local declaration still
+        // raises X::Redeclaration.
+        let imported_routine_alias = !is_our_scoped && self.imported_routine_alias(&package, name);
         // Idempotent re-registration fast path. A `RegisterSub` re-executes every
         // time its enclosing frame runs (e.g. a `my sub` inside a hot routine),
         // but the declaration it installs is constant. When a structurally
@@ -1134,6 +1140,7 @@ impl Interpreter {
             if !matches!(existing.view(), ValueView::Mixin(..))
                 && !shadows_outer_eval_name
                 && !allow_lexical_shadow
+                && !imported_routine_alias
                 && !is_method_value_decl
             {
                 return Err(RuntimeError::redeclaration_routine(name));
@@ -1163,6 +1170,11 @@ impl Interpreter {
                     .clone_from(&new_def.compiled);
             }
             if same && !has_user_custom_traits {
+                if imported_routine_alias {
+                    self.remove_imported_routine_alias(&package, name);
+                    self.env.remove(&format!("&{name}"));
+                    self.env.remove(&format!("&{package}::{name}"));
+                }
                 // A structurally identical stub at a DIFFERENT site (line) is
                 // recognized as `same` (registration_identity strips SetLine),
                 // so its own site fingerprint must still be remembered here —
@@ -1237,12 +1249,17 @@ impl Interpreter {
                 && !has_proto
                 && !allow_redeclare
                 && !allow_lexical_shadow
+                && !imported_routine_alias
                 && !shadows_outer_eval_single
                 && !has_user_custom_traits
             {
                 return Err(RuntimeError::redeclaration_routine(name));
             }
-        } else if !allow_redeclare && !allow_lexical_shadow && !has_user_custom_traits {
+        } else if !allow_redeclare
+            && !allow_lexical_shadow
+            && !imported_routine_alias
+            && !has_user_custom_traits
+        {
             if has_multi && !has_proto && !shadows_outer_eval_multi {
                 return Err(RuntimeError::redeclaration_routine(name));
             }
@@ -1282,7 +1299,7 @@ impl Interpreter {
             .iter()
             .any(|(t, _)| t == "hidden-from-USAGE")
             .then(|| def.body_fingerprint());
-        if !multi && allow_lexical_shadow && !is_our_scoped {
+        if !multi && (allow_lexical_shadow || imported_routine_alias) && !is_our_scoped {
             let lexical_single = format!("{}::{}", self.current_package(), name);
             let lexical_multi_prefix = format!("{}::{}/", self.current_package(), name);
             self.registry_mut().functions_mut().retain(|key, _| {
@@ -1299,7 +1316,12 @@ impl Interpreter {
         // block whose own `multi f` had just been declared. Sibling candidates
         // of this multi's own group are keyed with a `/` suffix and are left
         // alone.
-        if multi && allow_lexical_shadow && !is_our_scoped && has_single && !has_proto {
+        if multi
+            && (allow_lexical_shadow || imported_routine_alias)
+            && !is_our_scoped
+            && has_single
+            && !has_proto
+        {
             let lexical_single = Symbol::intern(&format!("{}::{}", self.current_package(), name));
             self.registry_mut().functions_mut().remove(&lexical_single);
             self.fn_resolve_gen += 1;
@@ -1676,6 +1698,14 @@ impl Interpreter {
                     Err(e) => return Err(e),
                 }
             }
+        }
+        if imported_routine_alias {
+            self.remove_imported_routine_alias(&package, name);
+            // A custom `sub EXPORT` may have installed a callable value in
+            // env in addition to the registry alias. Remove both spellings
+            // so an explicit `&name` follows the local declaration too.
+            self.env.remove(&format!("&{name}"));
+            self.env.remove(&format!("&{package}::{name}"));
         }
         Ok(SubRegisterOutcome::Installed)
     }

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -938,6 +938,7 @@ impl Interpreter {
                 .filter_map(|key| self.env.get_sym(*key).map(|value| (*key, value.clone())))
                 .collect();
             let saved_imports = std::mem::take(&mut self.module_imported_names);
+            let saved_imported_routine_aliases = std::mem::take(&mut self.imported_routine_aliases);
             let saved_pending_rw_writeback_len = self.pending_rw_writeback_sources.len();
             // Pragmas set by a module are lexical to that module. The module
             // mainline runs in this interpreter, so restore the caller's mode
@@ -968,6 +969,7 @@ impl Interpreter {
                 .truncate(saved_pending_rw_writeback_len);
             self.strict_mode = saved_strict_mode;
             let imported = std::mem::replace(&mut self.module_imported_names, saved_imports);
+            self.imported_routine_aliases = saved_imported_routine_aliases;
             module_scope_names = self.collect_module_scope_names(&before_env_keys);
             // `module_imported_names` records the ENV KEY the import landed under,
             // because the restore loop below has to undo that exact key. For the

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3195,6 +3195,7 @@ impl Interpreter {
             hash_autovivify: false,
             newline_mode: NewlineMode::Lf,
             import_scope_stack: Vec::new(),
+            imported_routine_aliases: HashSet::new(),
             strict_mode: false,
             fatal_mode: false,
             suppress_cross_eval_class_redeclaration_check: false,

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -49,6 +49,7 @@ impl Interpreter {
                 shadowed_proto_functions: HashMap::new(),
                 shadowed_proto_names: HashSet::new(),
                 imported_env_keys: HashSet::new(),
+                imported_routine_aliases: self.imported_routine_aliases.clone(),
                 newline_mode: self.newline_mode,
                 strict_mode: self.strict_mode,
                 fatal_mode: self.fatal_mode,
@@ -70,6 +71,24 @@ impl Interpreter {
         }
     }
 
+    /// Record a routine name imported into `package`. A later local
+    /// declaration may replace this alias, while another declaration after
+    /// that replacement remains a genuine redeclaration.
+    pub(crate) fn record_imported_routine_alias(&mut self, package: &str, name: &str) {
+        self.imported_routine_aliases
+            .insert(Symbol::intern(&format!("{package}::{name}")));
+    }
+
+    pub(crate) fn imported_routine_alias(&self, package: &str, name: &str) -> bool {
+        self.imported_routine_aliases
+            .contains(&Symbol::intern(&format!("{package}::{name}")))
+    }
+
+    pub(crate) fn remove_imported_routine_alias(&mut self, package: &str, name: &str) {
+        self.imported_routine_aliases
+            .remove(&Symbol::intern(&format!("{package}::{name}")));
+    }
+
     /// Restore function/class/proto registries to the last saved snapshot,
     /// removing any entries added since the push.
     pub(crate) fn pop_import_scope(&mut self) {
@@ -83,6 +102,7 @@ impl Interpreter {
                 shadowed_proto_functions,
                 shadowed_proto_names: _,
                 imported_env_keys,
+                imported_routine_aliases,
                 newline_mode,
                 strict_mode,
                 fatal_mode,
@@ -203,6 +223,7 @@ impl Interpreter {
             self.strict_mode = strict_mode;
             self.fatal_mode = fatal_mode;
             self.monkey_typing = monkey_typing;
+            self.imported_routine_aliases = imported_routine_aliases;
             // Removing imported functions when a lexical import scope pops must
             // invalidate the name-keyed function-resolution caches: a sub that
             // was OTF-compiled and cached under its bare name while in scope

--- a/src/runtime/runtime_module_export_sub.rs
+++ b/src/runtime/runtime_module_export_sub.rs
@@ -340,6 +340,10 @@ impl Interpreter {
             Some('$') => key[1..].to_string(),
             _ => key,
         };
+        if sigil == Some('&') {
+            let package = self.current_package();
+            self.record_imported_routine_alias(&package, &env_key[1..]);
+        }
         self.env.insert(env_key, value);
         self.fn_resolve_gen += 1;
     }

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -429,6 +429,7 @@ impl Interpreter {
             if !import_all && !is_mandatory && symbol_tags.is_disjoint(&requested) {
                 continue;
             }
+            self.record_imported_routine_alias(&target_pkg, &name);
             // An imported operator sub (e.g. `method infix:<as> is export`'s
             // sub form) must be visible to the EVAL parser so code parsed at
             // runtime recognizes the new operator symbol.

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -733,6 +733,7 @@ impl Interpreter {
             hash_autovivify: false,
             newline_mode: self.newline_mode,
             import_scope_stack: Vec::new(),
+            imported_routine_aliases: self.imported_routine_aliases.clone(),
             strict_mode: self.strict_mode,
             fatal_mode: self.fatal_mode,
             suppress_cross_eval_class_redeclaration_check: false,

--- a/t/lib/Issue8214ImportShadow.rakumod
+++ b/t/lib/Issue8214ImportShadow.rakumod
@@ -1,0 +1,6 @@
+module Issue8214ImportShadow { }
+sub EXPORT(*@subs) {
+    my %export;
+    %export{ '&' ~ $_ } := sub { "imported" } for @subs;
+    %export
+}

--- a/t/lib/Issue8214StaticExport.rakumod
+++ b/t/lib/Issue8214StaticExport.rakumod
@@ -1,0 +1,2 @@
+module Issue8214StaticExport { }
+sub static-shadow is export { "imported" }

--- a/t/modules/import-export/imported-sub-can-be-shadowed.t
+++ b/t/modules/import-export/imported-sub-can-be-shadowed.t
@@ -1,0 +1,17 @@
+use Test;
+use lib 't/lib';
+
+plan 4;
+
+use Issue8214ImportShadow <shadowed>;
+sub shadowed() { "local" }
+is shadowed(), "local", 'a local sub shadows a sub EXPORT import';
+is &shadowed(), "local", 'the local declaration also owns the code symbol';
+
+use Issue8214StaticExport;
+sub static-shadow() { "local" }
+is static-shadow(), "local", 'a local sub shadows a regular export';
+
+throws-like {
+    EVAL 'sub issue8214-duplicate() { 1 }; sub issue8214-duplicate() { 2 }'
+}, X::Redeclaration, 'two local declarations still raise redeclaration';


### PR DESCRIPTION
Closes #8214

Imported routine aliases are tracked separately from same-scope declarations, so a local `sub` can replace an imported routine without triggering a false redeclaration. The marker is scoped with imports and routine snapshots, and custom `sub EXPORT` environment aliases are removed when shadowed. Same-scope duplicate declarations still raise `X::Redeclaration`.

Validation:
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test`
- `make roast`