### PR TITLE
fix(parser): distinguish parameterized role candidates

### DIFF
--- a/news/2026-09/parameterized-role-composes-base-candidate.md
+++ b/news/2026-09/parameterized-role-composes-base-candidate.md
@@ -1,0 +1,9 @@
+# Parameterized roles can compose their base candidate
+
+Parameterized roles may now compose the unparameterized candidate from their
+same-named role group. Genuine self-composition of an unparameterized role is
+still rejected.
+
+Pinned by `t/oo/role/parameterized-role-composes-base-candidate.t`.
+
+Closes #8212.

--- a/src/parser/stmt/class/role_decl.rs
+++ b/src/parser/stmt/class/role_decl.rs
@@ -313,14 +313,18 @@ pub(crate) fn role_decl_with_keyword<'a>(input: &'a str, kw: &str) -> PResult<'a
         if let Some(r) = keyword("does", rest) {
             let (r, _) = ws1(r)?;
             let (r, role_name) = qualified_ident(r)?;
-            if role_name == name {
+            let (r, _) = ws(r)?;
+            let (r, bracket_suffix) = parse_optional_bracket_suffix(r)?;
+            // A parameterised role may compose the unparameterised candidate
+            // of its own role group (`role R[Int $n] does R`).  Only reject
+            // the same candidate: an unparameterised declaration composing
+            // its unparameterised self (`role R does R`) remains invalid.
+            if role_name == name && type_params.is_empty() && bracket_suffix.is_empty() {
                 return Err(PError::fatal(format!(
                     "X::InvalidType: role '{}' cannot compose itself",
                     name
                 )));
             }
-            let (r, _) = ws(r)?;
-            let (r, bracket_suffix) = parse_optional_bracket_suffix(r)?;
             let (r, _) = ws(r)?;
             let args = super::class_decl::parse_bracket_arg_exprs(bracket_suffix);
             parent_roles.push((format!("{}{}", role_name, bracket_suffix), args, false));

--- a/t/oo/role/parameterized-role-composes-base-candidate.t
+++ b/t/oo/role/parameterized-role-composes-base-candidate.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+plan 3;
+
+role R {
+    method who { 'base' }
+}
+
+role R[Int $n] does R {
+    method n { $n }
+}
+
+class C does R[3] { }
+my $instance = C.new;
+is $instance.who, 'base',
+    'a parameterized role can compose its same-named base candidate';
+is $instance.n, 3,
+    'the parameterized role still receives its bound argument';
+
+throws-like 'role S does S { }', X::InvalidType,
+    'an unparameterized role cannot compose its own candidate';
+
+done-testing;


### PR DESCRIPTION
## Summary
- allow a parameterized role to compose the unparameterized candidate from its same-named role group
- keep genuine unparameterized self-composition rejected
- add focused regression coverage and a news entry

## Tests
- scripts/run-t-test.sh t/oo/role/parameterized-role-composes-base-candidate.t
- make check-t-layout
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast

Closes #8212