### PR TITLE
fix(modules): keep a module load's writes to the caller's dynamics

### DIFF
--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -275,6 +275,7 @@ YAMLish	basic.rakutest
 YAMLish	p5-tests.rakutest
 YAMLish	roundtrip.rakutest
 YAMLish	test-harness.rakutest
+if	if.rakutest
 zef	00-load.rakutest
 zef	build.rakutest
 zef	distribution-depends-parsing.rakutest

--- a/docs/batteries/if-pragma.md
+++ b/docs/batteries/if-pragma.md
@@ -74,13 +74,13 @@ difference is the deliberately mutsu-specific `Raku.legacy` assertion).
 
 ## Status / limitations
 
-- The `if` upstream suite is **0/1 files** in the release gate (nothing
-  whitelisted). All five of `t/if.rakutest`'s assertions run and the three
-  `:if` ones behave correctly, but the file counts loads by having the loaded
-  module's `sub EXPORT` increment a caller **dynamic variable**, and mutsu
-  discards a module load's writes to the caller's dynamics
-  ([#8229](https://github.com/tokuhirom/mutsu/issues/8229)). That gap is
-  unrelated to the pragma — a module *mainline* write is lost the same way.
+- The `if` upstream suite is **1/1 files** in the release gate: `t/if.rakutest`
+  passes 5/5 and is whitelisted. It reached that only once a module load stopped
+  discarding its writes to the *caller's* dynamic variables
+  ([#8229](https://github.com/tokuhirom/mutsu/issues/8229)) — the file counts
+  loads by having the loaded module's `sub EXPORT` increment
+  `$*PACKAGE_LOADED`. That gap was unrelated to the pragma: a module *mainline*
+  write was lost the same way.
 - **The `:if` value is evaluated at run time, not at BEGIN.** Rakudo replaces a
   false `use` with `RakuAST::Statement::Empty` at compile time; mutsu still
   scans the named module at parse time (registering its exports) and only skips

--- a/news/2026-09/module-load-keeps-caller-dynamic-writes.md
+++ b/news/2026-09/module-load-keeps-caller-dynamic-writes.md
@@ -1,0 +1,79 @@
+# A module load no longer throws away its writes to the caller's dynamics
+
+A module that wrote a **dynamic variable belonging to the importing scope** had
+that write discarded. Both halves of a load were affected — the mainline and
+`sub EXPORT`:
+
+```raku
+# lib/Mainline.rakumod
+$*PACKAGE_LOADED++;
+
+# lib/Bar.rakumod
+sub EXPORT (|) { $*PACKAGE_LOADED++; BEGIN Map.new }
+```
+
+```
+$ raku  -I lib -e 'my $*PACKAGE_LOADED = 0; EVAL q[use Mainline]; say $*PACKAGE_LOADED'
+1
+$ mutsu -I lib -e 'my $*PACKAGE_LOADED = 0; EVAL q[use Mainline]; say $*PACKAGE_LOADED'
+0        # and the same 1-vs-0 for the `sub EXPORT` shape
+```
+
+An ordinary sub call propagates such a write correctly
+(`pop_caller_env_with_writeback`), and so does a plain `EVAL`, so the loss was
+specific to the module-load boundary.
+
+## Root cause
+
+Both halves restore the caller's env **wholesale** after running module code,
+and that restore is what reverted the dynamic:
+
+- `Interpreter::apply_module_export` snapshots `self.env` before the `EXPORT`
+  call and assigns it straight back afterwards. Dropping EXPORT's own
+  params/locals is deliberate — the call's scalar return-merge writes them into
+  whatever env is current at return time, where a stale entry would shadow a
+  capture the returned sub closes over — but the same assignment reverted every
+  `$*` write, which is the *caller's* state, not EXPORT's.
+- The module-load path in `run_modules.rs` restores every plain caller binding
+  (`saved_plain_env`) for the same kind of reason: an `our $x` in a module can
+  replace a same-named caller lexical's env entry before the module's exports
+  are installed. A mainline `$*x` write went the same way.
+
+## The fix
+
+Both restores are now narrowed by one predicate,
+`crate::env::is_dynamic_var_env_key` (memoized on `Symbol`):
+
+- `run_modules.rs` skips dynamic keys when replaying `saved_plain_env`. A
+  dynamic the module declared for itself never entered that snapshot — it is a
+  compunit lexical, already extracted into `unit_lexicals` — so it still dies
+  with the load.
+- `apply_module_export` restores through a new
+  `restore_caller_env_keeping_dynamics`, which carries a post-call value back
+  only for a dynamic key the caller **already had**. EXPORT's own lexicals are
+  dropped exactly as before.
+
+`rerun_module_export` needed one more thing. Raku runs `sub EXPORT` on every
+import, not once per process, and mutsu re-runs it against the module scope
+remembered from the *first* load — so a second `use` read that load's stale
+`$*PACKAGE_LOADED`, incremented it back to the value the caller already had,
+and the carry-back correctly saw no change. Dynamics are dynamic-scope, so the
+importer's live bindings are now overlaid onto the remembered module env before
+the re-run (`overlay_caller_dynamics`). `my $*X = 0; EVAL q[use Bar]; EVAL q[use
+Bar]` now says 2, as rakudo does.
+
+## Consequence for the `if` battery
+
+`modules/if/`'s upstream `t/if.rakutest` counts loads exactly this way
+(`my $*PACKAGE_LOADED = 0; EVAL $code; is $*PACKAGE_LOADED, 1`), so three of its
+five assertions failed on this alone and the battery shipped with an empty
+whitelist. The file now passes 5/5 and is whitelisted in
+`batteries-whitelist.txt`, taking the `if` suite from 0/1 to 1/1 files in the
+release gate.
+
+Pinned by `t/modules/module-load-writes-caller-dynamic.t` (6 assertions, green
+under rakudo too), which also pins the two directions the narrowing must not
+break: an outer dynamic binding of the same name stays untouched, and a `sub
+EXPORT` lexical still does not leak into the importer.
+
+Fixes [#8229](https://github.com/tokuhirom/mutsu/issues/8229).

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -1156,6 +1156,17 @@ impl Interpreter {
             // values have been extracted above. Qualified package globals and
             // newly-created module names are intentionally left alone.
             for (key, value) in &saved_plain_env {
+                // A `$*x` the importer already owned belongs to ITS dynamic
+                // scope, not to the module that assigned it: a mainline
+                // `$*PACKAGE_LOADED++` is how a module reports a load-time
+                // fact, and reverting it here threw that write away along with
+                // the module's own lexicals (#8229). A dynamic the module
+                // declared for itself never entered `saved_plain_env` (it is a
+                // compunit lexical, extracted into `unit_lexicals` above), so
+                // it still dies with the load.
+                if key.is_dynamic_var_env_key() {
+                    continue;
+                }
                 self.env.insert_sym(*key, value.clone());
             }
             match saved_qfile {

--- a/src/runtime/runtime_module_export_sub.rs
+++ b/src/runtime/runtime_module_export_sub.rs
@@ -45,6 +45,51 @@ impl Interpreter {
         }
     }
 
+    /// Put `caller_env` back as the current env after module code ran in
+    /// `self.env`, but keep that code's writes to dynamic variables the
+    /// caller already owned.
+    ///
+    /// A `$*x` belongs to the dynamic scope that *declared* it, not to the
+    /// module that assigns it, so a `sub EXPORT { $*PACKAGE_LOADED++ }` has to
+    /// leave the importer's counter incremented — that is how a module reports
+    /// a load-time fact, and how `modules/if/`'s own suite counts loads
+    /// (#8229). The wholesale restore this replaces dropped those writes along
+    /// with EXPORT's params and locals, which is the only thing it is actually
+    /// there to drop (see `apply_module_export`).
+    ///
+    /// Only keys the caller already had are carried over, so a dynamic the
+    /// module declared for itself still dies with the load.
+    fn restore_caller_env_keeping_dynamics(&mut self, mut caller_env: crate::env::Env) {
+        for (key, value) in &self.env {
+            if key.is_dynamic_var_env_key()
+                && caller_env.contains_key_sym(*key)
+                && caller_env.get_sym(*key) != Some(value)
+            {
+                caller_env.insert_sym(*key, value.clone());
+            }
+        }
+        self.env = caller_env;
+    }
+
+    /// Overlay the importer's live dynamic variables onto a remembered
+    /// module-scope env, before `sub EXPORT` is re-run in it.
+    ///
+    /// [`ModuleExportDef::Sub`] carries the module's own scope as it stood at
+    /// its FIRST load, so a re-`use` would otherwise run EXPORT against that
+    /// load's `$*x` values. A `$*PACKAGE_LOADED` already incremented to 1 then
+    /// reads as 0, increments back to 1, and
+    /// [`Interpreter::restore_caller_env_keeping_dynamics`] sees no change to
+    /// carry back — the second load goes uncounted (#8229). Dynamics are
+    /// dynamic-scope: the live binding belongs to whoever is importing now,
+    /// not to the scope that happened to load the module first.
+    fn overlay_caller_dynamics(env: &mut crate::env::Env, caller_env: &crate::env::Env) {
+        for (key, value) in caller_env {
+            if key.is_dynamic_var_env_key() {
+                env.insert_sym(*key, value.clone());
+            }
+        }
+    }
+
     /// If the just-loaded module defined `sub EXPORT`, call it with the `use`
     /// arguments and install the symbols from its returned `Map`(s) into the
     /// caller's scope. `EXPORT` itself is special (never an export), so it is
@@ -90,7 +135,7 @@ impl Interpreter {
                 self.env = module_env;
                 self.bind_compile_time_lang();
                 let result = self.call_sub_value(export_sub.clone(), export_args, false)?;
-                self.env = caller_env;
+                self.restore_caller_env_keeping_dynamics(caller_env);
                 self.install_export_map(&result, importer.as_deref());
                 if let Some(m) = self.module_load_stack.last().cloned() {
                     self.module_export_defs
@@ -128,7 +173,7 @@ impl Interpreter {
         let result = self.compile_and_call_function_def(&def, export_args, &empty_fns);
         self.current_unit = saved_unit;
         let result = result?;
-        self.env = caller_env;
+        self.restore_caller_env_keeping_dynamics(caller_env);
         // `EXPORT` must not itself become a callable in (or leak from) the
         // module; drop every registered `EXPORT` routine now that it has run.
         self.remove_export_routine();
@@ -154,8 +199,9 @@ impl Interpreter {
         let export_args = self.pending_use_export_args.take().unwrap_or_default();
         let saved_env = self.env.clone();
         let result = match def {
-            ModuleExportDef::Sub(d, module_env) => {
+            ModuleExportDef::Sub(d, mut module_env) => {
                 let empty_fns = crate::opcode::CompiledFns::default();
+                Self::overlay_caller_dynamics(&mut module_env, &saved_env);
                 self.env = module_env;
                 self.bind_compile_time_lang();
                 // Same compunit anchoring as the first-load path above.
@@ -170,7 +216,11 @@ impl Interpreter {
                 self.call_sub_value(v, export_args, false)?
             }
         };
-        self.env = saved_env;
+        // Same discipline as the first-load path: EXPORT's own lexicals go,
+        // the importer's dynamics keep whatever EXPORT wrote (#8229). Raku
+        // runs `sub EXPORT` on every import, so a re-`use` must report its
+        // load the same way the first one did.
+        self.restore_caller_env_keeping_dynamics(saved_env);
         let importer = self.module_load_stack.last().cloned();
         self.install_export_map(&result, importer.as_deref());
         Ok(())

--- a/t/lib/Issue8229/DynCountExport.rakumod
+++ b/t/lib/Issue8229/DynCountExport.rakumod
@@ -1,0 +1,4 @@
+sub EXPORT (|) {
+    $*PACKAGE_LOADED++;
+    BEGIN Map.new
+}

--- a/t/lib/Issue8229/DynCountExportLocal.rakumod
+++ b/t/lib/Issue8229/DynCountExportLocal.rakumod
@@ -1,0 +1,5 @@
+sub EXPORT (|) {
+    $*PACKAGE_LOADED++;
+    my $export-local = 'from-export';
+    BEGIN Map.new
+}

--- a/t/lib/Issue8229/DynCountMainline.rakumod
+++ b/t/lib/Issue8229/DynCountMainline.rakumod
@@ -1,0 +1,1 @@
+$*PACKAGE_LOADED++;

--- a/t/lib/Issue8229/DynCountNested.rakumod
+++ b/t/lib/Issue8229/DynCountNested.rakumod
@@ -1,0 +1,1 @@
+$*PACKAGE_LOADED++;

--- a/t/modules/module-load-writes-caller-dynamic.t
+++ b/t/modules/module-load-writes-caller-dynamic.t
@@ -1,0 +1,66 @@
+use v6;
+use Test;
+
+# A module load must not discard its writes to a dynamic variable that belongs
+# to the IMPORTING scope. Both halves of a load were affected: the mainline and
+# `sub EXPORT` each ran in the caller's env and had that env restored wholesale
+# afterwards, which reverted `$*x` along with the module's own lexicals.
+#
+# `$*` state set by an importer is a normal way for a module to report a
+# load-time fact -- `modules/if/`'s upstream `t/if.rakutest` counts loads
+# exactly this way, and three of its five assertions failed on this alone.
+# https://github.com/tokuhirom/mutsu/issues/8229
+#
+# The loads go through EVAL so the `use` really happens inside the dynamic
+# scope; a plain top-level `use` runs at BEGIN, before the `my $*...`
+# assignment.
+
+plan 6;
+
+use lib 't/lib/Issue8229';
+
+{
+    my $*PACKAGE_LOADED = 0;
+    EVAL q[use DynCountMainline];
+    is $*PACKAGE_LOADED, 1, "a module mainline's write to a caller dynamic survives the load";
+}
+
+{
+    my $*PACKAGE_LOADED = 0;
+    EVAL q[use DynCountExport];
+    is $*PACKAGE_LOADED, 1, "a `sub EXPORT`'s write to a caller dynamic survives the load";
+}
+
+# Raku runs `sub EXPORT` on every import, not once per process, so a re-`use`
+# of an already-loaded module counts again. That re-run reads the module's
+# remembered scope, which must not shadow the importer's *live* dynamic.
+{
+    my $*PACKAGE_LOADED = 0;
+    EVAL q[use DynCountExport];
+    EVAL q[use DynCountExport];
+    is $*PACKAGE_LOADED, 2, 'a re-`use` re-runs EXPORT and counts against the live dynamic';
+}
+
+# The carry-back is keyed on the dynamic, not on the loading frame: a nested
+# dynamic scope sees only its own binding change. A module mainline runs once
+# per process, so this needs a module no earlier assertion has loaded.
+{
+    my $*PACKAGE_LOADED = 10;
+    {
+        my $*PACKAGE_LOADED = 0;
+        EVAL q[use DynCountNested];
+        is $*PACKAGE_LOADED, 1, 'the innermost dynamic binding is the one that is written';
+    }
+    is $*PACKAGE_LOADED, 10, 'an outer dynamic binding of the same name is untouched';
+}
+
+# Only dynamics are carried back. `sub EXPORT`'s own lexicals must still die
+# with the call -- dropping them is what the wholesale env restore was there
+# for, and narrowing it must not turn EXPORT's scratch variables into writes
+# the importer sees.
+{
+    my $*PACKAGE_LOADED = 0;
+    my $export-local = 'caller';
+    EVAL q[use DynCountExportLocal];
+    is $export-local, 'caller', "a `sub EXPORT` lexical does not leak into the importer";
+}


### PR DESCRIPTION
A module that wrote a dynamic variable belonging to the **importing** scope had that write discarded. Both halves of a load were affected — the mainline and `sub EXPORT`:

```
# Mainline.rakumod:  $*PACKAGE_LOADED++;
# Bar.rakumod:       sub EXPORT (|) { $*PACKAGE_LOADED++; BEGIN Map.new }

$ raku  -I lib -e 'my $*PACKAGE_LOADED = 0; EVAL q[use Mainline]; say $*PACKAGE_LOADED'
1
$ mutsu -I lib -e 'my $*PACKAGE_LOADED = 0; EVAL q[use Mainline]; say $*PACKAGE_LOADED'
0        # and the same 1-vs-0 for the `sub EXPORT` shape
```

An ordinary sub call propagates such a write correctly (`pop_caller_env_with_writeback`), and so does a plain `EVAL`, so the loss was specific to the module-load boundary.

## Root cause

Both halves restore the caller's env **wholesale** after running module code, and each restore has a real job that this reverted as a side effect:

- `apply_module_export` snapshots `self.env` before the `EXPORT` call and assigns it back afterwards, to drop EXPORT's own params/locals — the call's scalar return-merge writes their post-return values into whatever env is current at return time, where a stale entry would shadow a capture the returned sub closes over. The same assignment reverted every `$*` write, which is the *caller's* state, not EXPORT's.
- `run_modules.rs` replays `saved_plain_env` for a comparable reason: an `our $x` in a module can replace a same-named caller lexical's env entry before the module's exports are installed. A mainline `$*x` write went the same way.

## The fix

Both restores are narrowed by one predicate, `crate::env::is_dynamic_var_env_key` (memoized on `Symbol`):

- `run_modules.rs` skips dynamic keys when replaying `saved_plain_env`. A dynamic the module declared for itself never entered that snapshot — it is a compunit lexical, already extracted into `unit_lexicals` — so it still dies with the load.
- `apply_module_export` restores through a new `restore_caller_env_keeping_dynamics`, which carries a post-call value back only for a dynamic key the caller **already had**. EXPORT's own lexicals are dropped exactly as before.

`rerun_module_export` needed one more thing. Raku runs `sub EXPORT` on every import, not once per process, and mutsu re-runs it against the module scope remembered from the *first* load — so a second `use` read that load's stale `$*PACKAGE_LOADED`, incremented it back to the value the caller already had, and the carry-back correctly saw no change. Dynamics are dynamic-scope, so the importer's live bindings are now overlaid onto the remembered module env before the re-run (`overlay_caller_dynamics`). `my $*X = 0; EVAL q[use Bar]; EVAL q[use Bar]` now says `2`, as rakudo does.

## The `if` battery goes 0/1 -> 1/1

`modules/if/`'s upstream `t/if.rakutest` counts loads exactly this way (`my $*PACKAGE_LOADED = 0; EVAL $code; is $*PACKAGE_LOADED, 1`), so three of its five assertions failed on this alone and the battery shipped with an empty whitelist. Verified against the pinned upstream commit:

```
$ prove -e './target/debug/mutsu -I modules/if/lib' <clone>/t/if.rakutest
All tests successful.  Files=1, Tests=5
```

`if	if.rakutest` is added to `batteries-whitelist.txt` (still `LC_ALL=C` sorted), and `docs/batteries/if-pragma.md`'s status section is updated.

## Tests

`t/modules/module-load-writes-caller-dynamic.t` — 6 assertions, **green under rakudo too**. Besides the two shapes from the issue and the re-`use` count, it pins the two directions the narrowing must not break: an outer dynamic binding of the same name stays untouched, and a `sub EXPORT` lexical still does not leak into the importer.

## Out of scope, filed separately

The mirror-image gap — a module's own file-scope `my $*x` leaking into the importer, where rakudo reports it undeclared — is **pre-existing** (it reproduces with this change reverted) and is filed as [#8241](https://github.com/tokuhirom/mutsu/issues/8241), together with the related "mutsu never fails on a write to an undeclared dynamic".

## Verification

- `cargo fmt --all`, `make lint` (all four configurations) — clean
- `make test` — `Files=4172, Tests=44438, Result: PASS`
- `make roast` — the three documented remote-container environment failures only, by name and subtest range: `6.c/S32-io/file-tests.t` (4: tests 6-8, 10) and `S16-filehandles/filetest.t` (25: 57-64, 69-72, 77-80, 101/103/105/107/109/111/117/121/125), both because the container runs as `uid 0`; `S32-io/IO-Socket-Async.t` (exit 124, planned 40 ran 17) from the network sandbox. See `docs/agent-environments.md`.

Closes #8229

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_