### PR TITLE
fix: !!$x (double negation prefix) now parses

### DIFF
--- a/news/2026-09/prefix-double-negation-bang-bang.md
+++ b/news/2026-09/prefix-double-negation-bang-bang.md
@@ -1,0 +1,17 @@
+# `!!$x` (double negation) now parses
+
+`!!$x` and `!!(...)` — raku's idiomatic "boolify" spelling, plain double
+negation — were a parse error, because `parse_prefix_unary_op` excluded
+`!!` wholesale: `!!` is also the ternary's else marker (`$c ?? $a !! $b`),
+and mutsu's bareword-listop parsing already has a history of gobbling it.
+
+The fix recognizes `!!` as a double-negation prefix only when it is glued
+directly onto its term with no whitespace, and its third character is not
+itself `!` (the fatal-stub `!!!` operator, an unrelated atomic 3-bang
+marker parsed separately). This mirrors raku's own rule exactly: `!!$x`
+is `True`, but `!! $x` (a space) is raku's own "Two terms in a row" parse
+error — so a ternary's `!!` marker, which always has a space on both
+sides in valid Raku, can never collide with it.
+
+See [#8206](https://github.com/tokuhirom/mutsu/issues/8206) and the
+regression test `t/lang/operators/prefix-double-negation-bang-bang.t`.

--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -505,6 +505,15 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
     // operator: `+!$x` is `+(!$x)`, `-?$x` is `-(?$x)`. Without this the leading
     // `+`/`-`/`~` falls through to numeric-literal parsing and fails on the `!`.
     let starts_another_prefix = |s: &str| parse_prefix_unary_op(s.trim_start()).is_some();
+    // A word infix operator's own name (`eq`, `and`, `div`, ...) can never be
+    // a term, so `!!eq`/`!!and`/`!!div` are illegal ("doubled prefix:<!>",
+    // `X::Syntax::Confused`) rather than double negation of a bareword call
+    // (roast/S03-metaops/not.t). Only the whole glued word matters, not a
+    // longer identifier merely starting with one (`!!equals` is fine).
+    let glued_word_is_infix_op = |s: &str| {
+        let word_len = s.bytes().take_while(|&b| is_ident_char(Some(b))).count();
+        word_len > 0 && crate::parser::primary::var::is_known_word_infix(&s[..word_len])
+    };
     if input.starts_with('!')
         && !input.starts_with("!~~")
         && !input.starts_with("!%%")
@@ -514,15 +523,18 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
         // own atomic 3-char marker, matched first), so `!!` is a
         // double-negation prefix (`!!$x` == `!(!$x)`, raku's idiomatic
         // "boolify") only when glued directly onto its term with no
-        // whitespace and the third character is not itself `!` -- exactly
-        // the distinction raku makes (`!!$x` is `True`; `!! $x`, with a
-        // space, and `!!!x`, three bangs, are each raku's own "Two terms in
-        // a row" error, never double negation). A ternary's `!!` marker
-        // always has a space on both sides, so this glued-only check can
-        // never mistake it for one (#8206).
+        // whitespace, the third character is not itself `!`, and the glued
+        // word (if any) is not itself a word infix operator's name --
+        // exactly the distinctions raku makes (`!!$x` is `True`; `!! $x`
+        // with a space, `!!!x` with three bangs, and `!!eq` are each raku's
+        // own "Confused"/"Two terms in a row" error, never double
+        // negation). A ternary's `!!` marker always has a space on both
+        // sides, so this glued-only check can never mistake it for one
+        // (#8206).
         && (!input.starts_with("!!")
             || (!input.starts_with("!!!")
-                && matches!(input[2..].chars().next(), Some(c) if unary_term_start(c) || c == '.')))
+                && matches!(input[2..].chars().next(), Some(c) if unary_term_start(c) || c == '.')
+                && !glued_word_is_infix_op(&input[2..])))
     {
         Some((PrefixUnaryOp::Not, 1))
     } else if input.starts_with("?^") {

--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -506,10 +506,23 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
     // `+`/`-`/`~` falls through to numeric-literal parsing and fails on the `!`.
     let starts_another_prefix = |s: &str| parse_prefix_unary_op(s.trim_start()).is_some();
     if input.starts_with('!')
-        && !input.starts_with("!!")
         && !input.starts_with("!~~")
         && !input.starts_with("!%%")
         && !input.starts_with("!===")
+        // `!!` is ALSO the ternary's else marker (`$c ?? $a !! $b`) and the
+        // start of the `!!!` fatal-stub operator (handled elsewhere as its
+        // own atomic 3-char marker, matched first), so `!!` is a
+        // double-negation prefix (`!!$x` == `!(!$x)`, raku's idiomatic
+        // "boolify") only when glued directly onto its term with no
+        // whitespace and the third character is not itself `!` -- exactly
+        // the distinction raku makes (`!!$x` is `True`; `!! $x`, with a
+        // space, and `!!!x`, three bangs, are each raku's own "Two terms in
+        // a row" error, never double negation). A ternary's `!!` marker
+        // always has a space on both sides, so this glued-only check can
+        // never mistake it for one (#8206).
+        && (!input.starts_with("!!")
+            || (!input.starts_with("!!!")
+                && matches!(input[2..].chars().next(), Some(c) if unary_term_start(c) || c == '.')))
     {
         Some((PrefixUnaryOp::Not, 1))
     } else if input.starts_with("?^") {

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -26,6 +26,7 @@ pub(crate) use perl5::detect_perl5_scalar_var;
 pub(crate) use perl5::{brace_deref_text, is_brace_contextualizer};
 pub(in crate::parser) use scalar::mint_anon_state_name;
 pub(in crate::parser) use scalar::parse_symbolic_deref_segments;
+pub(in crate::parser) use sigil_vars::is_known_word_infix;
 
 // ── pub(super): accessible from parser::primary (the parent of `var`)
 //    and all its descendants via `crate::parser::primary::var::` paths ──────

--- a/src/parser/primary/var/sigil_vars.rs
+++ b/src/parser/primary/var/sigil_vars.rs
@@ -892,7 +892,12 @@ fn parse_operator_code_ref_suffix<'a>(
 /// validate the `&[word]` operator-reference form. Symbolic infixes (`&[+]`)
 /// and uppercase meta-ops (`&[Z]`, `&[Xcmp]`) are handled separately and are
 /// never checked against this list.
-fn is_known_word_infix(name: &str) -> bool {
+///
+/// Also reused by `parser::expr::operators::parse_prefix_unary_op`'s `!!`
+/// double-negation check: a word infix's own name can never be a term, so
+/// `!!eq`/`!!and`/`!!div` etc. are illegal (`X::Syntax::Confused`), not
+/// double negation of a bareword call.
+pub(in crate::parser) fn is_known_word_infix(name: &str) -> bool {
     matches!(
         name,
         "div"

--- a/t/lang/operators/prefix-double-negation-bang-bang.t
+++ b/t/lang/operators/prefix-double-negation-bang-bang.t
@@ -9,7 +9,7 @@ use Test;
 # ("Two terms in a row"), and a ternary's `!!` marker always has a space on
 # both sides in valid Raku, so the two can never collide.
 
-plan 11;
+plan 14;
 
 my $x = 1;
 my $zero = 0;
@@ -44,3 +44,14 @@ is (True ?? Int !! Str), Int, 'ternary with a type-object then-branch';
 
 # Plain single negation is unaffected.
 is !$x, False, 'plain single ! negation is unaffected';
+
+# A word infix operator's own name can never be a term, so `!!eq`/`!!and`
+# must stay illegal rather than parse as double negation of a bareword call
+# (roast/S03-metaops/not.t: "Doubled prefix:<!> is illegal").
+throws-like '"a" !!eq "a"', X::Syntax::Confused, '!!eq is illegal, not double negation';
+throws-like 'True !!and False', X::Syntax::Confused, '!!and is illegal too';
+
+# A bareword that is NOT a word infix operator's name is still a legitimate
+# glued term, so double negation of it still works.
+sub truthy { True }
+is !!truthy, True, '!!bareword-call is still double negation when the word is not an infix op';

--- a/t/lang/operators/prefix-double-negation-bang-bang.t
+++ b/t/lang/operators/prefix-double-negation-bang-bang.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+# #8206: `!!$x` (double negation, raku's idiomatic "boolify" spelling) did
+# not parse -- `parse_prefix_unary_op` excluded `!!` wholesale because it is
+# also the ternary's else marker (`$c ?? $a !! $b`). raku itself resolves
+# the ambiguity by requiring `!!` to be glued directly onto its term with no
+# whitespace to mean double negation; with a space it is a compile error
+# ("Two terms in a row"), and a ternary's `!!` marker always has a space on
+# both sides in valid Raku, so the two can never collide.
+
+plan 11;
+
+my $x = 1;
+my $zero = 0;
+
+is !!$x, True, '!!$x is double negation (boolify)';
+is !!$zero, False, '!!$zero is False';
+is !!(1 < 2), True, '!!(...) parses the same way';
+is !!(1 > 2), False, '!!(...) with a false inner expression';
+
+sub f($point) { return !!($point < 1) }
+is f(0.5), True, 'return !!(...) works inside a routine body';
+
+# The ternary's `!!` marker is unaffected -- it always has surrounding
+# whitespace, which the glued-only prefix check can never match.
+is (True ?? 1 !! 2), 1, 'ternary !! marker still works';
+is (False ?? 1 !! 2), 2, 'ternary !! marker still works (else branch)';
+
+# A bareword/type-object then-branch (the ambiguity the ticket calls out --
+# a bareword listop head could otherwise try to gobble the !! as an
+# argument) must still resolve the ternary correctly.
+enum Color <Red Green Blue>;
+is (True ?? Red !! Blue), Red, 'ternary with an enum-value then-branch';
+is (True ?? Int !! Str), Int, 'ternary with a type-object then-branch';
+
+# The `!!!` fatal-stub operator (a distinct, atomic 3-bang marker) must not
+# be mistaken for `!!` applied to a `!`-prefixed term.
+{
+    my $died = False;
+    try { !!!; CATCH { default { $died = True } } }
+    ok $died, '!!! (fatal stub) still throws, unaffected by the !! fix';
+}
+
+# Plain single negation is unaffected.
+is !$x, False, 'plain single ! negation is unaffected';


### PR DESCRIPTION
## Summary

`!!$x` (double negation, raku's idiomatic "boolify" spelling) did not
parse:

```
$ raku  -e 'say !!(1 < 2)'
True
$ mutsu -e 'say !!(1 < 2)'
===SORRY!=== Confused. expected statement: ...
```

`parse_prefix_unary_op` excluded `!!` wholesale, because `!!` is also the
ternary's else marker (`$c ?? $a !! $b`), and mutsu's bareword-listop
parsing already has a history of gobbling it.

raku itself resolves this exact ambiguity by requiring `!!` to be glued
directly onto its term with no whitespace to mean double negation — with
a space, it's a compile error ("Two terms in a row") — and a ternary's
`!!` marker always has a space on both sides in valid Raku, so the two
spellings can never collide. `!!` is now recognized as a double-negation
prefix only when:

- it is glued directly onto its term (no whitespace),
- the third character is not itself `!` (the unrelated, atomic `!!!`
  fatal-stub operator), and
- the glued word (if it starts with a letter) is not itself a **word
  infix operator's name** — `!!eq`, `!!and`, `!!div`, etc. can never be
  double negation of a term, since the operator's bare name isn't a term
  on its own; raku raises `X::Syntax::Confused` there too
  (`roast/S03-metaops/not.t`'s "Doubled prefix:<!> is illegal" — caught by
  running the full roast suite locally before publishing, see below).

The third check reuses the existing `is_known_word_infix` list (already
used to validate the `&[word]` operator-reference form), exposed to the
`!!` check via a `pub(in crate::parser)` re-export.

Closes #8206

## Test plan

- Added `t/lang/operators/prefix-double-negation-bang-bang.t`: `!!$x`/
  `!!(...)` in expression and `return` position, the ternary `!!` marker
  (including bareword/enum/type-object then-branches, the ambiguity the
  issue calls out), the `!!!` fatal-stub operator, plain single `!`, and
  the `!!eq`/`!!and` word-infix-name exclusion (both the illegal case and
  a non-infix bareword call that should still double-negate).
- Ran every `t/` file that mentions `!!` (212 files) — all green.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run
  locally. `make roast` comes back with only the three environment-only
  failures documented in `docs/agent-environments.md` for a remote
  container (`roast/6.c/S32-io/file-tests.t`,
  `roast/S16-filehandles/filetest.t` — both `uid 0` chmod-based file
  tests — and `roast/S32-io/IO-Socket-Async.t`, sandboxed network);
  everything else is green, including `roast/S03-metaops/not.t` (which a
  first version of this fix regressed, then fixed with the word-infix
  exclusion above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_