### PR TITLE
fix(scope): keep lexical pseudo-stashes frame-local

### DIFF
--- a/news/2026-09/outer-my-pseudo-package.md
+++ b/news/2026-09/outer-my-pseudo-package.md
@@ -1,0 +1,9 @@
+# Lexical pseudo-stashes respect their selected scope
+
+`MY::` now lists only the current lexical scope, while `OUTER::MY::` resolves
+symbols from the immediate outer scope. Interpolating `<<...>>` subscripts also
+work on the composed pseudo-stash form.
+
+Pinned by `t/modules/outer-my-pseudo-package.t`.
+
+Closes #8213.

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -303,8 +303,10 @@ impl Compiler {
                 }
             }
             Expr::PseudoStash(name) => {
-                let name_idx = self.code.add_constant(Value::str(name.clone()));
-                self.code.emit(OpCode::GetPseudoStash(name_idx));
+                if !self.emit_lexical_stash(name) {
+                    let name_idx = self.code.add_constant(Value::str(name.clone()));
+                    self.code.emit(OpCode::GetPseudoStash(name_idx));
+                }
             }
             Expr::Unary { op, expr } => {
                 self.compile_expr_unary(op, expr);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2134,6 +2134,58 @@ impl Compiler {
         self.code.add_lex_scope_chain(chain)
     }
 
+    /// Emit a pseudo-stash for exactly one lexical frame when `name` is a
+    /// literal `MY::`/`LEXICAL::` spelling, optionally preceded by one or more
+    /// `OUTER::` prefixes. The ordinary runtime pseudo-stash path is backed by
+    /// the flattened environment, which is intentionally broader than one
+    /// lexical frame and therefore makes `MY::` leak enclosing variables.
+    pub(crate) fn emit_lexical_stash(&mut self, name: &str) -> bool {
+        let Some(stash_name) = name.strip_suffix("::") else {
+            return false;
+        };
+        let mut remaining = stash_name;
+        let mut depth = 0usize;
+        while let Some(rest) = remaining.strip_prefix("OUTER::") {
+            depth += 1;
+            remaining = rest;
+        }
+        if !matches!(remaining, "MY" | "LEXICAL") {
+            return false;
+        }
+
+        let scopes = self.full_scope_chain();
+        let Some(target_index) = scopes.len().checked_sub(depth + 1) else {
+            return false;
+        };
+        let target = &scopes[target_index];
+        let entries = target
+            .keys()
+            .map(|var_name| {
+                let slot = match lex_scope::resolve_outer(&scopes, &self.local_map, var_name, depth)
+                {
+                    lex_scope::OuterResolution::Read { slot, .. } => slot,
+                    lex_scope::OuterResolution::NotDeclared => None,
+                };
+                let display_name = if var_name.starts_with(['$', '@', '%', '&'])
+                    || var_name.chars().next().is_some_and(|c| c.is_uppercase())
+                {
+                    var_name.clone()
+                } else {
+                    format!("${var_name}")
+                };
+                Value::array(vec![
+                    Value::str(display_name),
+                    Value::str(var_name.clone()),
+                    Value::int(depth as i64),
+                    Value::int(slot.map_or(-1, |slot| slot as i64)),
+                ])
+            })
+            .collect();
+        let spec_idx = self.code.add_constant(Value::array(entries));
+        self.code.emit(OpCode::GetLexicalStash(spec_idx));
+        true
+    }
+
     /// Record the compiler-authoritative positional-parameter → local-slot map
     /// into `code.param_local_slots`, so the VM's `precompute_param_local_slots`
     /// need not re-resolve parameter names by searching `locals` (§1.5).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -876,6 +876,10 @@ pub(crate) enum OpCode {
     GetHashVar(u32),
     GetBareWord(u32),
     GetPseudoStash(u32),
+    /// Build a lexical pseudo-stash from a compiler-baked scope description.
+    /// Unlike `GetPseudoStash`, this names exactly one lexical frame, so an
+    /// inner `MY::` cannot accidentally expose captured outer variables.
+    GetLexicalStash(u32),
     /// Replace the role *group* type object on the stack with the INDIVIDUAL
     /// parametric role that was just declared (the group's current candidate).
     /// Emitted right after a `role` declaration used in expression position, so
@@ -6510,6 +6514,7 @@ impl CompiledCode {
                 | OpCode::GetOuterVar { .. }
                 | OpCode::GetCallerOuterVar { .. }
                 | OpCode::GetPseudoStash(_)
+                | OpCode::GetLexicalStash(_)
                 | OpCode::SymbolicDeref { .. }
                 | OpCode::SymbolicDerefStore(_)
                 | OpCode::IndirectCodeLookup(_) => true,

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1365,6 +1365,7 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             }
             // Handle ::<SYMBOL> subscript syntax (e.g., CORE::<&run>)
             if let Some(after_bracket) = after.strip_prefix('<')
+                && !after.starts_with("<<")
                 && let Some(end) = after_bracket.find('>')
             {
                 let symbol = &after_bracket[..end];
@@ -1393,6 +1394,7 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 || after.starts_with(';')
                 || after.starts_with(')')
                 || after.starts_with(',')
+                || after.starts_with("<<")
                 || after.starts_with(' ')
                 || after.starts_with('\n')
                 || after.starts_with('\r')

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -820,6 +820,10 @@ impl Interpreter {
                 self.exec_get_pseudo_stash_op(code, *name_idx);
                 *ip += 1;
             }
+            OpCode::GetLexicalStash(spec_idx) => {
+                self.exec_get_lexical_stash_op(code, *spec_idx);
+                *ip += 1;
+            }
             OpCode::RoleGroupToCandidate => {
                 self.exec_role_group_to_candidate_op();
                 *ip += 1;

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -554,6 +554,76 @@ impl Interpreter {
         self.stack.push(stash);
     }
 
+    /// Build a pseudo-stash for the exact lexical frame selected by the
+    /// compiler. Each entry is `[display-key, bare-name, depth, slot]`; a
+    /// non-negative slot is live in this frame, while an outer-frame entry is
+    /// resolved through the same captured lexical path as `GetOuterVar`.
+    pub(super) fn exec_get_lexical_stash_op(&mut self, code: &CompiledCode, spec_idx: u32) {
+        let mut entries: HashMap<String, Value> = HashMap::new();
+        let Some(ValueView::Array(spec, _)) =
+            code.constants.get(spec_idx as usize).map(Value::view)
+        else {
+            let stash = self.pseudo_stash_hash(entries);
+            self.stack.push(stash);
+            return;
+        };
+        for item in spec.items() {
+            let ValueView::Array(parts, _) = item.view() else {
+                continue;
+            };
+            if parts.items().len() != 4 {
+                continue;
+            }
+            let (
+                ValueView::Str(display),
+                ValueView::Str(name),
+                ValueView::Int(depth),
+                ValueView::Int(slot),
+            ) = (
+                parts.items()[0].view(),
+                parts.items()[1].view(),
+                parts.items()[2].view(),
+                parts.items()[3].view(),
+            )
+            else {
+                continue;
+            };
+            let depth = depth.max(0) as usize;
+            let value = if depth == 0 {
+                if slot >= 0 {
+                    self.locals
+                        .get(slot as usize)
+                        .cloned()
+                        .unwrap_or(Value::NIL)
+                } else {
+                    self.get_env_with_main_alias(&name).unwrap_or(Value::NIL)
+                }
+            } else {
+                let slot = (slot >= 0).then_some(slot as u32);
+                self.get_outer_var(code, &name, depth, slot)
+            };
+            entries.insert(display.to_string(), value);
+        }
+        // Imported type/package aliases are lexical names too, but they are
+        // maintained in the runtime environment rather than in a compiler
+        // scope frame. Preserve those visible package bindings while keeping
+        // ordinary scalar entries frame-local; the latter are precisely what
+        // makes MY:: stop leaking enclosing lexicals.
+        for (key, value) in self.env().iter() {
+            let key = key.resolve();
+            if self.should_hide_from_my_global_stash(&key)
+                || !matches!(value.view(), ValueView::Package(_))
+            {
+                continue;
+            }
+            let display = Self::add_sigil_prefix(&key);
+            entries.entry(display).or_insert_with(|| value.clone());
+        }
+        self.add_visible_routines_to_pseudo_stash(&mut entries);
+        let stash = self.pseudo_stash_hash(entries);
+        self.stack.push(stash);
+    }
+
     /// Wrap a lexical-pad snapshot as a `PseudoStash`.
     ///
     /// Raku reports every pseudo-package view of a pad (`MY::`, `OUTER::`,

--- a/t/modules/outer-my-pseudo-package.t
+++ b/t/modules/outer-my-pseudo-package.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+plan 5;
+
+my $x = 42;
+{
+    my $name = '$x';
+
+    is OUTER::MY::{'$x'}, 42,
+        'OUTER::MY:: resolves a symbol from the immediate outer scope';
+    is OUTER::MY::{$name}, 42,
+        'OUTER::MY:: supports a dynamically selected symbol';
+    is OUTER::MY::<<$name>>, 42,
+        'OUTER::MY:: supports an interpolating angle subscript';
+    ok OUTER::MY::<<$name>>:exists,
+        'OUTER::MY:: reports the dynamically selected symbol as existing';
+    nok MY::<$x>:exists,
+        'MY:: does not see a lexical declared by an enclosing scope';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary
- keep MY:: and LEXICAL:: pseudo-stashes limited to their selected lexical frame
- support OUTER::MY:: lookups and interpolating <<...>> subscripts
- preserve visible imported package/type aliases
- add focused regression coverage and a news entry

## Tests
- scripts/run-t-test.sh t/modules/outer-my-pseudo-package.t
- make check-t-layout
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast

Closes #8213