### PR TITLE
fix(compiler): keep the native reference when `++$p` is a call argument

### DIFF
--- a/news/2026-09/prefix-incdec-argument-keeps-a-native-rw-reference.md
+++ b/news/2026-09/prefix-incdec-argument-keeps-a-native-rw-reference.md
@@ -1,0 +1,68 @@
+# `f(++$p)` keeps the native `is rw` reference
+
+`sub outer(int $p is rw) { inner(++$p) }` used to die with
+
+```
+Parameter '$p' expects a writable container (variable) as an argument,
+but got '6' (Int) as a value without a container.
+```
+
+where rakudo binds the reference straight through, so `inner`'s `--$p` reaches
+`outer`'s caller and the two operations cancel. Fixed: the argument now
+compiles as the two things it means.
+
+## Why rakudo accepts it
+
+A *native*-typed `is rw` parameter is not bound to a `Scalar`; it is bound to a
+native reference to the caller's storage. Rakudo's native `prefix:<++>` writes
+through that reference and hands the reference back, so the result is still a
+writable location and the next callee's own `is rw` parameter binds it.
+
+The shape is narrow, and deliberately so. Rakudo rejects every neighbouring
+spelling:
+
+| argument | rakudo |
+| --- | --- |
+| `++$p`, `$p` a native `is rw` parameter | accepted |
+| `++$x`, `$x` a plain `my int` lexical | `Expected a modifiable native int argument for '$p'` |
+| `++$p`, `$p` a non-native `$p is rw` | `expects a writable container ... as a value without a container` |
+| `$p++` (postfix), any operand | `Expected a modifiable native int argument for '$p'` |
+
+Postfix yields the old value and a `Scalar`'s `prefix:<++>` yields a value, so
+neither can be a location; a plain native lexical is not a reference to begin
+with.
+
+## The fix
+
+`Compiler::compile_call_arg_with_escape` is the single place every positional
+argument passes. It now recognises `++$p` / `--$p` whose operand is one of the
+*enclosing routine's* native `is rw` parameters — compile-time information the
+compiler already has in the signature it is compiling — and splits it: emit the
+increment for its effect, discard its value, then compile the bare variable as
+the argument. The bare-variable path already hands a parameter the caller's
+container correctly, so nothing new is needed on the binding side, and no
+runtime gate is involved (unlike the ADR-0067 accessor markers, the operand's
+own declaration settles this at compile time).
+
+Every operand shape rakudo refuses falls through to the pre-existing value
+path, so it keeps failing exactly as it did. The new
+`native_rw_params` set on `Compiler` is seeded per routine body and inherited
+by nested blocks, since the parameter stays lexically visible there.
+
+Pinned by `t/routines/signature/rw-param-incdec-arg-container.t`, whose eleven
+assertions cover the four rakudo behaviours in the table above, the relay
+across three frames, and the fact that the increment still happens when the
+callee does not want a container at all.
+
+## What it unblocks
+
+`JSON::Fast`'s whitespace scanner hands a pre-incremented position straight to
+its comment scanner (`nom-comment($text, ++$pos)`), which un-eats the character
+with `--$pos` when JSONC comments are not allowed. Without the reference
+reaching back, `from-json` concluded it had consumed the whole string and
+accepted trailing garbage — `from-json(q<{"a":"b"}/>)` returned `{:a("b")}`
+instead of complaining. One of the two blockers ([#8233]) on running the real
+upstream distribution ([#8226], ADR-0096 §D4/E2).
+
+[#8226]: https://github.com/tokuhirom/mutsu/issues/8226
+[#8233]: https://github.com/tokuhirom/mutsu/issues/8233

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -433,6 +433,26 @@ impl Compiler {
     /// Promise and run later on another thread), so the locals it captures and
     /// mutates must be promoted to shared `ContainerRef` cells (escape analysis).
     pub(super) fn compile_call_arg_with_escape(&mut self, arg: &Expr, escaping: bool) {
+        // `f(++$p)` where `$p` is one of THIS routine's native `is rw`
+        // parameters: `$p` is a native reference to the caller's location, and
+        // rakudo's native `prefix:<++>` writes through it and hands the
+        // reference back, so the callee's own `is rw` parameter binds the
+        // caller's storage (`sub inner(int $p is rw) { --$p }` cancels the
+        // increment two frames up). Compiling the increment as an ordinary
+        // expression loses that: it leaves the incremented *value* on the
+        // stack, and the callee rejects it as "a value without a container".
+        //
+        // Split it into the two things it means — perform the increment, then
+        // pass the variable — so the argument takes the plain `Expr::Var`
+        // path, which already binds a parameter through correctly. The gate in
+        // `native_rw_param_incdec_operand` keeps every operand shape rakudo
+        // rejects on the old value path, so those still error.
+        if let Some(name) = self.native_rw_param_incdec_operand(arg) {
+            self.compile_expr(arg);
+            self.code.emit(OpCode::Pop);
+            self.compile_call_arg_with_escape(&Expr::Var(name), escaping);
+            return;
+        }
         // Read-and-clear immediately: this call is the *direct* bind-target
         // compile iff the caller just set the flag for us. Clearing it up
         // front (before any nested `compile_expr`/`compile_call_arg`
@@ -1171,6 +1191,73 @@ impl Compiler {
         None
     }
 
+    /// Whether a parameter's declared type is one of Raku's *native* types —
+    /// the ones whose storage is a machine value rather than a `Scalar`, so an
+    /// `is rw` parameter of that type binds a native reference.
+    pub(crate) fn is_native_type_constraint(constraint: &str) -> bool {
+        matches!(
+            constraint,
+            "int"
+                | "int8"
+                | "int16"
+                | "int32"
+                | "int64"
+                | "uint"
+                | "uint8"
+                | "uint16"
+                | "uint32"
+                | "uint64"
+                | "num"
+                | "num32"
+                | "num64"
+                | "str"
+        )
+    }
+
+    /// Record this routine's native-typed `is rw` parameters, which
+    /// [`Compiler::native_rw_param_incdec_operand`] gates on. See the field
+    /// doc on `native_rw_params`.
+    pub(crate) fn seed_native_rw_params(&mut self, param_defs: &[crate::ast::ParamDef]) {
+        self.native_rw_params = param_defs
+            .iter()
+            .filter(|pd| {
+                !pd.name.is_empty()
+                    && pd
+                        .type_constraint
+                        .as_deref()
+                        .is_some_and(Self::is_native_type_constraint)
+                    && pd.traits.iter().any(|t| t == "rw")
+            })
+            .map(|pd| pd.name.clone())
+            .collect();
+    }
+
+    /// A call argument spelled `++$p` / `--$p` whose operand is one of the
+    /// enclosing routine's native `is rw` parameters — the one shape rakudo
+    /// lets bind through to another native `is rw` parameter. Returns the
+    /// operand's name.
+    ///
+    /// Deliberately NOT matched: the postfix forms (`$p++` yields the old
+    /// value, and rakudo rejects it here with "Expected a modifiable native
+    /// int argument"), and any operand that is not such a parameter (a plain
+    /// `my int $x`, or a non-native `$p is rw`, both of which rakudo also
+    /// rejects). Keeping those on the existing value path preserves the error.
+    pub(super) fn native_rw_param_incdec_operand(&self, arg: &Expr) -> Option<String> {
+        let Expr::Unary { op, expr } = arg else {
+            return None;
+        };
+        if !matches!(
+            op,
+            crate::token_kind::TokenKind::PlusPlus | crate::token_kind::TokenKind::MinusMinus
+        ) {
+            return None;
+        }
+        let Expr::Var(name) = expr.as_ref() else {
+            return None;
+        };
+        self.native_rw_params.contains(name).then(|| name.clone())
+    }
+
     /// Check for assignment to native-typed read-only parameters inside a
     /// sub/method/block body. Returns an X::Assignment::RO::Comp error value
     /// if such an assignment is found.
@@ -1182,25 +1269,10 @@ impl Compiler {
         let readonly_native_params: std::collections::HashSet<&str> = param_defs
             .iter()
             .filter(|pd| {
-                let is_native = pd.type_constraint.as_deref().is_some_and(|c| {
-                    matches!(
-                        c,
-                        "int"
-                            | "int8"
-                            | "int16"
-                            | "int32"
-                            | "int64"
-                            | "uint"
-                            | "uint8"
-                            | "uint16"
-                            | "uint32"
-                            | "uint64"
-                            | "num"
-                            | "num32"
-                            | "num64"
-                            | "str"
-                    )
-                });
+                let is_native = pd
+                    .type_constraint
+                    .as_deref()
+                    .is_some_and(Self::is_native_type_constraint);
                 let has_rw_or_copy = pd
                     .traits
                     .iter()

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -318,6 +318,7 @@ impl Compiler {
                 .unwrap_or_else(|| self.current_package.clone()),
         );
         sub_compiler.set_current_package(state_scope);
+        sub_compiler.seed_native_rw_params(param_defs);
         // Pre-allocate locals for parameters
         for param in params {
             sub_compiler.declare_param(param);
@@ -1141,6 +1142,14 @@ impl Compiler {
                 .unwrap_or_else(|| self.current_package.clone()),
         );
         sub_compiler.set_current_package(closure_package);
+        // A routine body's own signature defines the native `is rw` parameters
+        // in scope; a plain block is lexically inside its enclosing routine, so
+        // that routine's parameters stay visible and its set carries down.
+        if is_routine {
+            sub_compiler.seed_native_rw_params(param_defs);
+        } else {
+            sub_compiler.native_rw_params = self.native_rw_params.clone();
+        }
         // Pre-allocate locals for parameters
         for param in params {
             sub_compiler.declare_param(param);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1200,6 +1200,19 @@ pub(crate) struct Compiler {
     hoisted_sub_plans: Vec<(crate::symbol::Symbol, u64, u32)>,
     /// Track type constraints for local variables (for compile-time literal checks).
     local_types: HashMap<String, String>,
+    /// Sigil-less names of the enclosing routine's NATIVE-typed `is rw`
+    /// parameters (`sub f(int $p is rw)` records `"p"`).
+    ///
+    /// Such a parameter is bound to a *native reference* to the caller's
+    /// location rather than to a `Scalar`, which is why rakudo lets `++$p`
+    /// be handed straight on to another native `is rw` parameter: the
+    /// increment writes through the reference and yields the reference again.
+    /// Every other operand shape rakudo rejects (`my int $x; f(++$x)` and a
+    /// non-native `$p is rw` both die), so this set is the exact gate that
+    /// keeps [`Compiler::native_rw_param_incdec_operand`] as narrow as
+    /// rakudo is. Seeded per routine body; a nested non-routine block
+    /// inherits it, since the parameter stays lexically visible there.
+    native_rw_params: HashSet<String>,
     compiled_functions: CompiledFns,
     current_package: String,
     /// True when compiling inside a `unit module`/`unit class`/`unit role`
@@ -1635,6 +1648,7 @@ impl Compiler {
             lexical_dup_routines: HashSet::new(),
             hoisted_sub_plans: Vec::new(),
             local_types: HashMap::new(),
+            native_rw_params: HashSet::new(),
             compiled_functions: CompiledFns::default(),
             current_package: "GLOBAL".to_string(),
             in_unit_package: false,

--- a/t/routines/signature/rw-param-incdec-arg-container.t
+++ b/t/routines/signature/rw-param-incdec-arg-container.t
@@ -1,0 +1,110 @@
+use Test;
+
+# `++$p` / `--$p` handed straight to another `is rw` parameter.
+#
+# A NATIVE-typed `is rw` parameter is bound to a native reference to the
+# caller's location, nonnative-outer rakudo's native prefix increment writes through that
+# reference and yields the reference again -- which means the callee's own
+# `is rw` parameter binds the ORIGINAL caller's storage, two frames up.
+# JSON::Fast's whitespace scanner relies on exactly this: `nom-comment($text,
+# ++$pos)` has to be able to un-eat the character it just consumed.
+#
+# The shape is narrow: rakudo accepts it ONLY when the operand is itself a
+# native `is rw` parameter. Every other spelling is an error there, nonnative-outer the
+# rejections below are as much a part of the pin as the acceptance.
+
+plan 11;
+
+# --- accepted: the increment and the callee's decrement cancel ---------------
+
+{
+    sub inner(int $p is rw) { --$p }
+    sub outer(int $p is rw) { inner(++$p) }
+    my int $pos = 5;
+    outer($pos);
+    is $pos, 5, '++$p to a native is-rw parameter binds the caller container';
+}
+
+{
+    sub inner(int $p is rw) { ++$p }
+    sub outer(int $p is rw) { inner(--$p) }
+    my int $pos = 5;
+    outer($pos);
+    is $pos, 5, '--$p binds through the same way';
+}
+
+{
+    sub c(int $p is rw) { --$p }
+    sub b(int $p is rw) { c(++$p) }
+    sub a(int $p is rw) { b(++$p) }
+    my int $v = 0;
+    a($v);
+    is $v, 1, 'the native reference relays across three frames';
+}
+
+# The increment is still performed -- binding the container must not skip it.
+{
+    sub inner(int $p is rw) { }
+    sub outer(int $p is rw) { inner(++$p) }
+    my int $pos = 5;
+    outer($pos);
+    is $pos, 6, 'the increment itself still happens';
+}
+
+# A non-rw callee takes the incremented VALUE, and the caller still sees the
+# increment (it happened through the reference before the call).
+{
+    my $seen;
+    sub inner(int $x) { $seen = $x }
+    sub outer(int $p is rw) { inner(++$p) }
+    my int $pos = 5;
+    outer($pos);
+    is $seen, 6, 'a read-only callee receives the incremented value';
+    is $pos, 6, 'and the caller sees the increment';
+}
+
+# The parameter stays lexically visible inside a nested block.
+{
+    sub inner(int $p is rw) { --$p }
+    sub outer(int $p is rw) { if True { inner(++$p) } }
+    my int $pos = 5;
+    outer($pos);
+    is $pos, 5, 'the shape works from inside a nested block';
+}
+
+# --- refused, exactly as rakudo refuses them --------------------------------
+
+# A plain `my int` lexical is not a native reference: rakudo dies with
+# "Expected a modifiable native int argument for '$p'".
+sub plain-native-callee(int $p is rw) { --$p }
+dies-ok {
+    my int $m = 5;
+    plain-native-callee(++$m);
+}, '++ on a plain native lexical is still refused';
+
+# ... while passing that same lexical WITHOUT the increment is fine, nonnative-outer the
+# refusal above is about the argument shape and not about native binding.
+{
+    sub plain-pass-callee(int $p is rw) { --$p }
+    my int $m = 5;
+    plain-pass-callee($m);
+    is $m, 4, 'the same lexical passed plainly still binds';
+}
+
+# A non-native `$p is rw` holds a Scalar, and `prefix:<++>` returns its value:
+# rakudo dies with "expects a writable container ... as a value without a
+# container".
+sub nonnative-inner($p is rw) { $p-- }
+sub nonnative-outer($p is rw) { nonnative-inner(++$p) }
+dies-ok {
+    my $s = 5;
+    nonnative-outer($s);
+}, '++ on a non-native rw parameter is still refused';
+
+# Postfix `$p++` yields the OLD value, never a reference; rakudo refuses it.
+sub postfix-inner(int $p is rw) { --$p }
+sub postfix-outer(int $p is rw) { postfix-inner($p++) }
+dies-ok {
+    my int $q = 5;
+    postfix-outer($q);
+}, 'postfix $p++ is still refused';


### PR DESCRIPTION
`sub outer(int $p is rw) { inner(++$p) }` died with

```
Parameter '$p' expects a writable container (variable) as an argument,
but got '6' (Int) as a value without a container.
```

where rakudo binds the reference straight through, so `inner`'s `--$p` reaches
`outer`'s caller and the two operations cancel.

## Root cause

A *native*-typed `is rw` parameter is bound to a native reference to the
caller's storage, not to a `Scalar`. Rakudo's native `prefix:<++>` writes
through that reference and hands the reference back, so the result is still a
writable location and the next callee's own `is rw` parameter binds it.

mutsu compiled the argument as an ordinary expression, which leaves the
incremented *value* on the stack. `compile_call_arg_with_escape` — the single
place every positional argument passes — handles `Expr::Var`, `Expr::Index` and
the ADR-0067 accessor shapes; a prefix increment is none of them, so it arrived
as a plain value and the callee refused it.

## Fix

In that same chokepoint, recognise `++$p` / `--$p` whose operand is one of the
*enclosing routine's* native `is rw` parameters — compile-time information the
compiler already holds in the signature it is compiling — and split it into the
two things it means: emit the increment for its effect, discard its value, then
compile the bare variable as the argument. The bare-variable path already hands
a parameter the caller's container, so nothing new is needed on the binding
side and no runtime gate is involved.

A new `native_rw_params` set on `Compiler` is seeded per routine body (both
body-compile paths) and inherited by nested blocks, since the parameter stays
lexically visible there.

## The gate keeps it as narrow as rakudo is

| argument | rakudo | mutsu after this PR |
| --- | --- | --- |
| `++$p`, `$p` a native `is rw` parameter | accepted | accepted |
| `++$x`, `$x` a plain `my int` lexical | dies | dies |
| `++$p`, `$p` a non-native `$p is rw` | dies | dies |
| `$p++` (postfix), any operand | dies | dies |

Every shape rakudo refuses falls through to the pre-existing value path, so it
keeps failing.

## Test

`t/routines/signature/rw-param-incdec-arg-container.t`, 11 assertions covering
the four rows above, the relay across three frames, and the fact that the
increment still happens when the callee does not want a container at all. All
11 verified green under `raku` as well as mutsu. (The issue suggested
`t/vm/writeback/`; `make check-t-layout`'s rules place a `*-param-*` basename
under `t/routines/signature/`, and that is the authority per
`docs/t-directory-layout.md`.)

## What it unblocks

`JSON::Fast`'s whitespace scanner hands a pre-incremented position straight to
its comment scanner (`nom-comment($text, ++$pos)`), which un-eats the character
with `--$pos` when JSONC comments are not allowed. Without the reference
reaching back, `from-json(q<{"a":"b"}/>)` returned `{:a("b")}` instead of
complaining about trailing text. One of the two blockers on vendoring the real
distribution (#8226, ADR-0096 §D4/E2).

## Verification

- `cargo fmt --all`, `make lint` — clean.
- `make test` — 4179 files, 44540 tests, all pass.
- `make roast` — the only failures are the three documented container-only ones
  (`6.c/S32-io/file-tests.t` and `S16-filehandles/filetest.t` run as `uid 0`,
  `S32-io/IO-Socket-Async.t` sandboxed network), per
  `docs/agent-environments.md`.

Closes #8233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK)_