### PR TITLE
bench: measure the regex engine, which the suite did not

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -9,6 +9,36 @@ cargo build --release
 ./benchmarks/run-all.sh
 ```
 
+Every `benchmarks/*.raku` file is measured by the bench CI automatically (two
+configurations each, wall clock and simulated instruction counts — see
+`scripts/bench-ci.sh` and `scripts/bench-det.sh`), so adding a file is all it
+takes to add a series. Keep a new one deterministic, self-checking (print a
+checksum), and in the 0.1-0.4 s range on a release build: the deterministic
+series resolves ~0.1%, while the wall-clock series needs the file to be well
+clear of the ~8 ms startup without paying 90x for it under callgrind.
+
+### Regex and grammar coverage
+
+The regex engine was effectively unmeasured until 2026-09-13 (one 5000-iteration
+`~~ /\d+/` loop inside `bench-string.raku`). Eight files now cover it, each
+isolating one mechanism: `bench-regex-match` (matching with no `Match` built),
+`bench-regex-capture` (captures and `Match` accessors), `bench-regex-global`
+(`:g` / `comb` / `subst`), `bench-regex-assertion` (look-around, word
+boundaries, backtracking, `:r`), `bench-regex-long-subject` (per-position reject
+cost on a 128 KB subject), `bench-regex-split-subst` (the superlinear
+result-assembly paths), plus `bench-grammar-parse-big` and `bench-yaml-parse-big`
+for grammar growth rate at a realistic document size. Each file's header says
+what it measures and why. Two open perf issues came out of writing them:
+[#8247](https://github.com/tokuhirom/mutsu/issues/8247) (`.split(rx)` /
+`.subst(rx, :g)` quadratic in subject length) and
+[#8248](https://github.com/tokuhirom/mutsu/issues/8248) (scanning is linear but
+~8x rakudo's per-position constant, so mutsu loses above ~0.5 MB).
+
+Note the size dependence when quoting any regex ratio: on ~100-character
+subjects mutsu measures 0.2-0.4x rakudo, and the same operations measure 1.0x and
+worse on multi-hundred-kilobyte ones. A ratio without its subject size says
+nothing.
+
 ## Current Status (bench CI, main commit `c8955d2e`, 2026-07-13)
 
 > Source of truth: the **bench CI history** (`bench-history.tsv` on the

--- a/benchmarks/bench-grammar-parse-big.raku
+++ b/benchmarks/bench-grammar-parse-big.raku
@@ -1,0 +1,59 @@
+# Grammar parsing over a BIG document: growth rate, not per-parse setup.
+#
+# `bench-grammar-parse.raku` parses a ~250-byte document three times and
+# `bench-grammar-parse-deep.raku` one ~200-byte nested document once; both now
+# run in ~16 ms on CI, which is a few times the 8 ms startup. At that size the
+# measurement is dominated by fixed per-parse cost, so neither can see the thing
+# that actually matters about a grammar engine: how its cost grows with the
+# length of the input. (The header of bench-grammar-parse-deep.raku still claims
+# it is "sized so the current interpreter runs it in a few seconds" -- that was
+# true when it was written and the engine has since gained two orders of
+# magnitude on it. It is kept at its size so its history stays continuous; this
+# file is the re-sized one.)
+#
+# Same JSON-like grammar, ~13 KB of document: 320 pairs whose values are nested
+# arrays. Measured locally (release, 2026-09-13) against rakudo 2026.07, scaling
+# the pair count:
+#
+#     5 pairs    22 ms vs 716 ms      20 pairs    23 ms vs 471 ms
+#    80 pairs    50 ms vs 462 ms     320 pairs   156 ms vs 595 ms
+#
+# i.e. linear from 80 pairs up (4x the document for 3.6x the time), which is the
+# property to defend: any change that reintroduces a per-node cost proportional
+# to the whole match tree turns this file quadratic long before the two small
+# grammar files notice anything.
+grammar JsonLike {
+    token TOP       { \s* <value> \s* }
+    rule object     { '{' ~ '}' <pairlist>     }
+    rule pairlist   { <pair> * % \,            }
+    rule pair       { <string> ':' <value>     }
+    rule array      { '[' ~ ']' <arraylist>    }
+    rule arraylist  {  <value> * % [ \, ]        }
+
+    proto token value {*};
+    token value:sym<number> {
+        '-'?
+        [ 0 | <[1..9]> <[0..9]>* ]
+        [ \. <[0..9]>+ ]?
+        [ <[eE]> [\+|\-]? <[0..9]>+ ]?
+    }
+    token value:sym<true>    { <sym>    };
+    token value:sym<false>   { <sym>    };
+    token value:sym<null>    { <sym>    };
+    token value:sym<object>  { <object> };
+    token value:sym<array>   { <array>  };
+    token value:sym<string>  { <string> }
+
+    token string { ('"') ~ \" [ <str> | \\ <str=.str_escape> ]* }
+    token str { <-["\\\t\x[0A]]>+ }
+    token str_escape { <["\\/bfnrt]> | 'u' <utf16_codepoint>+ % '\u' }
+    token utf16_codepoint { <.xdigit>**4 }
+}
+
+my $PAIRS = 320;
+my $inner = '[' ~ (1..4).map({ "[$_,$_]" }).join(',') ~ ']';
+my $doc   = '{' ~ (1..$PAIRS).map({ "\"k$_\":$inner" }).join(',') ~ '}';
+
+my $m = JsonLike.parse($doc);
+die "parse failed" unless $m;
+say "grammar-parse-big: ok (doc {$doc.chars} chars, matched {$m.chars})";

--- a/benchmarks/bench-regex-assertion.raku
+++ b/benchmarks/bench-regex-assertion.raku
@@ -1,0 +1,50 @@
+# Zero-width assertions and backtracking: the two costs that are invisible in
+# the matched text.
+#
+# Look-around is evaluated by running a whole sub-pattern at the current
+# position and then throwing the result away, so its cost is per *candidate
+# position*, not per match -- and a NEGATIVE one is the expensive case, because
+# establishing that nothing matches means exhausting the search. Look-behind is
+# worse still: `<?after X>` asks whether X ends exactly here, which is answered
+# by running X forward from some earlier start, so a naive implementation pays
+# O(pos) per evaluation. That shape is exactly what made the bundled YAMLish
+# grammar superlinear in document size (#7576), and nothing in the suite
+# measured it.
+#
+#   1/2. positive and negative look-ahead
+#   3/4. positive and negative look-behind
+#   5.   a negative look-behind that FAILS at its one candidate and so makes the
+#        engine scan the rest of the subject, paying a look-behind per position
+#   6/7. word boundaries (<< and >>), the zero-width assertions real patterns
+#        use most
+#   8.   a greedy class run that must give characters back for the literal tail
+#        ('kg' is inside the class, so the first try overshoots)
+#   9.   a scan that cannot match: every start position is tried and the
+#        quantifier exhausted at each
+#   10.  the same shape under :r, where the quantifier may not give back --
+#        the contrast is what makes a ratchet regression visible
+#   11.  a separated quantifier (`+ %`), whose ratcheted form used to backtrack
+#        exponentially
+
+my @lines;
+for ^30 -> $i {
+    @lines.push("  indent{$i % 4}: alpha beta{$i} gamma_{$i * 3} 12{$i}kg price=4{$i}USD a,b,c,d tail");
+}
+
+my $acc = 0;
+for ^20 {
+    for @lines -> $l {
+        $acc++ if $l ~~ / \d+ <?before 'kg' > /;
+        $acc++ if $l ~~ / \d+ <!before 'kg' > /;
+        $acc++ if $l ~~ / <?after 'price=' > \d+ /;
+        $acc++ if $l ~~ / <!after 'price=' > 'USD' /;
+        $acc++ if $l ~~ / 'USD' <!after \d > /;
+        $acc++ if $l ~~ / << 'gamma_' /;
+        $acc++ if $l ~~ / 'beta' \d+ >> /;
+        $acc++ if $l ~~ / <[0..9a..z]>+ 'kg' /;
+        $acc++ if $l ~~ / \w+ 'QQQ' /;
+        $acc++ if $l ~~ / :r \w+ 'QQQ' /;
+        $acc++ if $l ~~ / \w+ % ',' /;
+    }
+}
+say "regex-assertion: acc=$acc";

--- a/benchmarks/bench-regex-capture.raku
+++ b/benchmarks/bench-regex-capture.raku
@@ -1,0 +1,44 @@
+# Captures and Match access: what a successful match has to build and hand back.
+#
+# The matcher work here is deliberately cheap and the *result* is the point.
+# Since ADR-0016 a Match is a span into a shared subject that materializes
+# lazily, so the cost of a capturing match is split between recording spans
+# during the match and materializing them when something reads them -- and only
+# a benchmark that actually reads them can see the second half. Every branch
+# below therefore consumes what it captured.
+#
+#   1. named captures, then $/.from / $/.to   (span reads, no Str needed)
+#   2. positional captures coerced to Str and Int (forces materialization)
+#   3. a quantified capture group, read through .elems and an index
+#      (the list-valued capture shape: one node per repetition)
+#   4. nested captures, read through the inner capture of an outer one
+#   5. a capturing match that FAILS, so the spans recorded along the way are
+#      all discarded -- the cost of bookkeeping that buys nothing
+
+my @lines;
+for ^40 -> $i {
+    @lines.push("key{$i % 11}=value-{$i}; n={$i * 13 % 400}; words=the quick brown fox {$i}");
+}
+
+my $acc = 0;
+for ^30 {
+    for @lines -> $l {
+        if $l ~~ / $<key> = [ \w+ ] '=' $<val> = [ <[\w\-]>+ ] / {
+            $acc += $<key>.chars + $<val>.chars;
+            $acc += $/.from + $/.to;
+        }
+        if $l ~~ / (\w+) '=' (\d+) / {
+            $acc += $0.Str.chars + $1.Int;
+        }
+        if $l ~~ / 'words=' [ (\w+) \s* ]+ / {
+            $acc += $0.elems + $0[0].Str.chars;
+        }
+        if $l ~~ / ( 'key' (\d+) ) / {
+            $acc += $0[0].Str.chars;
+        }
+        if $l ~~ / ( \w+ ) '=' ( \w+ ) '=' ( \w+ ) '=' /  {
+            $acc += 1000000;
+        }
+    }
+}
+say "regex-capture: acc=$acc";

--- a/benchmarks/bench-regex-global.raku
+++ b/benchmarks/bench-regex-global.raku
@@ -1,0 +1,38 @@
+# Repeated matching across a whole subject: :g, comb, subst.
+#
+# These share one mechanism the single-match benchmark never reaches -- resume-
+# from-the-last-end scanning over a multi-kilobyte subject, producing one result
+# per occurrence -- and differ in what they build from it:
+#
+#   .match(:g)   a list of Match objects (N materializations)
+#   .comb(rx)    a list of Str                (no Match survives)
+#   .subst(:g)   a rebuilt Str, replacement computed per occurrence
+#   s:g///       the same, in place, through the assignment/container path
+#   .subst with a closure replacement, which reads $0 per occurrence and so
+#              forces that capture to materialize on every hit
+#
+# A regression in the scan loop moves all of them; a regression in Match
+# construction or in the replacement path moves only its own line.
+#
+# The subject here is ~2.6 KB and each op runs many times. `split` deliberately
+# lives in bench-regex-split-subst.raku instead: it is superlinear in subject
+# length today, so at any interesting size it would dominate this file and mask
+# everything else in it.
+
+my @lines;
+for ^40 -> $i {
+    @lines.push("user{$i % 13}=alpha-{$i} score={$i * 17 % 500} note=\"the quick brown fox {$i}\" flags=a,b,c");
+}
+my $text = @lines.join("\n");
+
+my $n = 0;
+for ^45 {
+    $n += $text.match(/ \d+ /, :g).elems;
+    $n += $text.comb(/ <[a..z]>+ /).elems;
+    $n += $text.subst(/ 'score=' \d+ /, 'score=0', :g).chars;
+    $n += $text.subst(/ 'user' (\d+) /, { 'u' ~ $0 }, :g).chars;
+    my $copy = $text;
+    $copy ~~ s:g/ <[0..9]>+ /#/;
+    $n += $copy.chars;
+}
+say "regex-global: n=$n";

--- a/benchmarks/bench-regex-long-subject.raku
+++ b/benchmarks/bench-regex-long-subject.raku
@@ -1,0 +1,50 @@
+# Regex scanning over a LONG subject: per-position cost, measured once.
+#
+# Every other regex benchmark here runs small patterns over ~100-character
+# lines many times, so what it measures is dominated by per-call setup. This one
+# inverts that: one 128 KB subject, one call per pattern. What is left is the
+# cost of *advancing one position and failing*, multiplied by the length of the
+# subject -- and that is the quantity that decides whether mutsu keeps up on
+# real input.
+#
+# It is the axis on which mutsu is currently weakest, and the suite was blind to
+# it. Measured locally (release, 2026-09-13) on a subject of repeated 46-char
+# units, one failing alternation scan, mutsu vs rakudo 2026.07:
+#
+#      40 KB   50 ms  vs  234 ms   0.21x
+#     160 KB  167 ms  vs  331 ms   0.50x
+#     640 KB  635 ms  vs  508 ms   1.25x
+#
+# mutsu is linear here and so is rakudo, but with a much larger constant: the
+# apparent win at small sizes is rakudo's ~200 ms startup, and it is spent by
+# ~0.5 MB. A change that lowers the per-position constant shows up here and
+# almost nowhere else in the suite.
+#
+# 128 KB is chosen so the whole file costs a few hundred milliseconds today; the
+# ratio against raku is expected to be unflattering compared to the short-line
+# benchmarks, which is the point of keeping it.
+#
+#   1. failing literal scan        the cheapest possible per-position reject
+#   2. failing alternation scan    four literals ranked at every position
+#   3. failing :i literal scan     case folding on the reject path
+#   4. failing greedy-run scan     \w+ grown and given back at every position
+#   5. the same under :r           ratchet: grown once, no give-back
+#   6. failing negative look-behind  an assertion evaluated per position
+#   7. end anchor                  the engine must walk to the tail
+#   8. succeeding scan near the end  the win case, for contrast
+#   9. comb over the whole subject  the linear all-occurrences path
+
+my $unit = "abc def ghi jkl mno pqr stu vwx yz01 2345 67-8 \n";
+my $big  = $unit x (131072 div $unit.chars);
+
+my $acc = 0;
+$acc++ if $big ~~ / 'zzzq-not-here' /;
+$acc++ if $big ~~ / [ 'zzq' | 'yyq' | 'xxq' | 'wwq' ] /;
+$acc++ if $big ~~ / :i 'ZZZQ' /;
+$acc++ if $big ~~ / \w+ 'QQQ' /;
+$acc++ if $big ~~ / :r \w+ 'QQQ' /;
+$acc++ if $big ~~ / 'QQ' <!after \d > /;
+$acc++ if $big ~~ / '67-8' \s $ /;
+$acc++ if $big ~~ / 'yz01 2345' /;
+$acc += $big.comb(/ \d+ /).elems;
+say "regex-long-subject: chars={$big.chars} acc=$acc";

--- a/benchmarks/bench-regex-match.raku
+++ b/benchmarks/bench-regex-match.raku
@@ -1,0 +1,45 @@
+# Regex matching core: boolean `~~` over many short subjects.
+#
+# Deliberately capture-free and Match-free: every condition is used only for
+# its truth value, so what this measures is the *matcher* -- candidate
+# generation, the find loop that retries every start position, character-class
+# and quantifier stepping, and LTM ranking of an alternation -- with none of
+# the Match-object construction that bench-regex-capture.raku isolates.
+#
+# The dimensions, one per line of the inner loop:
+#   1. literal + quantified class    'code=' \d+
+#   2. anchored, bounded quantifier   ^ \d ** 4 ...
+#   3. alternation (LTM ranking)      [ debug | info | warn | error | fatal ]
+#   4. :i case folding                :i 'MSG='
+#   5. a scan that CANNOT match       every start position tried and rejected
+#   6. end anchor after a class run   <[a..z]>+ '-' \d+ $
+#   7. a pattern interpolated from a Str variable
+#   8. a pattern interpolated from a Regex variable (<$rx>)
+#
+# (5) matters as much as the successes: failing scans are what real code spends
+# its time on, and they are the only case where the whole subject is walked.
+# (7)/(8) exercise the interpolated-subpattern path, which has its own parse
+# and cache behaviour that a literal regex never reaches.
+
+my @lines;
+for ^60 -> $i {
+    @lines.push("2026-09-{10 + $i % 20} 1{$i}:{$i % 60}:00 host{$i % 7} level=info code={$i * 37 % 900} msg=\"request {$i} handled in {$i * 3}ms\" tag=alpha-{$i % 5}");
+}
+
+my $needle = 'host';
+my $rx = / 'handled in' \s \d+ 'ms' /;
+
+my $hits = 0;
+for ^20 {
+    for @lines -> $l {
+        $hits++ if $l ~~ / 'code=' \d+ /;
+        $hits++ if $l ~~ / ^ \d ** 4 '-' \d\d '-' \d\d /;
+        $hits++ if $l ~~ / 'level=' [ 'debug' | 'info' | 'warn' | 'error' | 'fatal' ] /;
+        $hits++ if $l ~~ / :i 'MSG=' /;
+        $hits++ if $l ~~ / 'no-such-token-here' /;
+        $hits++ if $l ~~ / <[a..z]>+ '-' \d+ $ /;
+        $hits++ if $l ~~ / $needle \d+ /;
+        $hits++ if $l ~~ / <$rx> /;
+    }
+}
+say "regex-match: hits=$hits";

--- a/benchmarks/bench-regex-split-subst.raku
+++ b/benchmarks/bench-regex-split-subst.raku
@@ -1,0 +1,39 @@
+# Building a result from EVERY occurrence: split and global substitution.
+#
+# `.split(rx)` and `.subst(rx, :g)` walk the subject once like `.comb` does, but
+# unlike comb they assemble a result out of the gaps between the matches. In
+# mutsu that assembly is currently superlinear in subject length, which no
+# benchmark measured -- so this file exists to measure it, and to make the fix
+# visible when it lands. Measured locally (release, 2026-09-13), subject of
+# repeated 46-char units, mutsu vs rakudo 2026.07, one call each:
+#
+#   .split(/\s+/)     5 KB    52 ms vs 590 ms    10 KB   153 ms vs 229 ms
+#                    20 KB   545 ms vs 241 ms    40 KB  2074 ms vs 590 ms
+#                    80 KB 11877 ms vs 257 ms   (46x)
+#   .subst(/\d+/,:g) 20 KB    29 ms              40 KB    77 ms
+#                    80 KB   260 ms             640 KB 23174 ms  (29x)
+#
+# Doubling the subject roughly quadruples the time in both: each occurrence pays
+# a cost proportional to the whole subject, not to its own span. `.comb` over the
+# same subject is flat (18 ms at 80 KB), so the scan is not the problem -- the
+# result assembly is. Filed as its own issue; this benchmark is the regression
+# guard either way, and the sizes below are picked so that the file costs a few
+# hundred milliseconds at TODAY's cost (a fix should drop it by ~10x, which the
+# deterministic instruction-count series will show unambiguously).
+
+my $unit = "alpha beta gamma delta epsilon zeta eta theta iota 12345\n";
+
+# 12 KB: ~2100 fields out of split, the superlinear term already dominant.
+my $split_subject = $unit x (12288 div $unit.chars);
+my $fields = $split_subject.split(/ \s+ /).elems;
+
+# 64 KB: one occurrence per line, so the same quadratic term with ~12x fewer
+# occurrences -- keeps the substitution side measurable without dominating.
+my $subst_subject = $unit x (65536 div $unit.chars);
+my $chars = $subst_subject.subst(/ \d+ /, '#', :g).chars;
+
+# The same 12 KB text split on a single-char literal regex, which has no
+# gap-assembly shortcut to fall back on either.
+my $lines = $split_subject.split(/ \n /).elems;
+
+say "regex-split-subst: fields=$fields chars=$chars lines=$lines";

--- a/benchmarks/bench-yaml-parse-big.raku
+++ b/benchmarks/bench-yaml-parse-big.raku
@@ -1,0 +1,32 @@
+# Parsing a realistically-sized YAML document with the bundled YAMLish battery.
+#
+# `bench-yaml-parse.raku` parses a 6-row document (~0.07 s on CI) and is the
+# regression guard for the two specific bugs its header names. It is NOT a guard
+# for the thing #7576 is actually about -- how YAMLish's cost grows with document
+# size -- because at 6 rows it cannot see growth at all.
+#
+# 60 rows, which is the size #7576's own measurements are quoted at. Locally
+# (release, 2026-09-13), this shape scales:
+#
+#     30 rows  0.157 s     60 rows  0.310 s     90 rows  0.559 s
+#    160 rows  1.154 s    640 rows 15.168 s
+#
+# Linear would be 0.147 s -> 3.1 s at 640 rows; it is 15.2 s, so there is still
+# a superlinear term (~n^1.25 over this range, steepening at the top end) even
+# after the 22 rounds of #7576. A document this size is completely ordinary --
+# any CI config, any lockfile-shaped data -- so this is the series that says
+# whether mutsu can read one.
+#
+# No raku baseline: YAMLish is a bundled battery, not installed for the system
+# rakudo, so the ratio column records NA exactly as it does for
+# bench-yaml-parse. The absolute and deterministic series are the signal here.
+use YAMLish;
+
+my $ROWS = 60;
+my $text = "---\n"
+    ~ (1..$ROWS).map({ "key$_: 'value $_ padded   here'\n" }).join
+    ~ "...\n";
+
+my $doc = load-yaml($text);
+die "parse failed" unless $doc.elems == $ROWS;
+say "yaml-parse-big: {$doc.elems} keys, {$text.chars} chars";

--- a/news/2026-09/regex-benchmark-coverage.md
+++ b/news/2026-09/regex-benchmark-coverage.md
@@ -1,0 +1,60 @@
+# The benchmark suite learns to measure regexes
+
+Until now the `benchmarks/` suite had essentially no regex coverage. Of its 26
+files, exactly one touched the engine directly: `bench-string.raku`, whose third
+section runs `"hello world 42 foo" ~~ /\d+/` 5000 times alongside 10000 string
+concatenations and 1000 splits, so a regex change moves that row by a fraction
+of its own noise. The grammar files (`bench-grammar-parse`,
+`bench-grammar-parse-deep`, `bench-yaml-parse`) do exercise the matcher, but
+through grammar machinery and at sizes of a few hundred bytes -- all three run in
+16-70 ms on CI, a few times the 8 ms startup.
+
+That is a poor fit for where the work actually goes. Substitution, global
+matching, `split` on a pattern, captures and `Match` accessors, look-around, word
+boundaries, backtracking, interpolated patterns and ratchet semantics had no
+series at all, and #7576 -- twenty-two rounds of regex and grammar performance
+work -- had been measured the whole way on a 6-row YAML document plus ad-hoc
+local runs.
+
+Eight new files close that:
+
+| file | what it isolates |
+| --- | --- |
+| `bench-regex-match` | the matcher with no Match built: classes, quantifiers, alternation/LTM, `:i`, anchors, a failing scan, interpolated patterns |
+| `bench-regex-capture` | what a *successful* match has to hand back -- named and positional captures, quantified and nested groups, `$/.from`/`.to`, and a capturing match that fails |
+| `bench-regex-global` | resume-from-last-end scanning: `.match(:g)`, `.comb`, `.subst(:g)`, `s:g///`, and a closure replacement that reads `$0` per hit |
+| `bench-regex-assertion` | zero-width assertions and backtracking: `<?before>`/`<!before>`, `<?after>`/`<!after>`, `<<`/`>>`, give-back, `:r`, separated quantifiers |
+| `bench-regex-long-subject` | per-position reject cost: one 128 KB subject, nine single-call scans, eight of them failing |
+| `bench-regex-split-subst` | the paths that assemble a result from every occurrence, which are superlinear today |
+| `bench-grammar-parse-big` | the same JSON-like grammar as the small files, on a 10 KB document, so growth rate is visible |
+| `bench-yaml-parse-big` | YAMLish on the 60-row document #7576's own numbers are quoted at |
+
+Every file prints a checksum and produces byte-identical output under rakudo
+2026.07, so each is a correctness check as well as a measurement, and none uses
+randomness or wall-clock time. Each costs 0.15-0.33 s locally, which keeps the
+added bench-CI time (wall-clock pass x2 configurations, plus the callgrind
+instruction-count pass x2) to a few minutes.
+
+## Two findings the new files were written around
+
+Writing them turned up two things the old suite could not see.
+
+**`.split(rx)` and `.subst(rx, :g)` are quadratic in subject length**
+([#8247](https://github.com/tokuhirom/mutsu/issues/8247)). Doubling the subject
+roughly quadruples the time: an 80 KB `split(/\s+/)` takes 11.9 s against
+rakudo's 0.26 s (46x), and a 640 KB global substitution 23.2 s against 0.79 s
+(29x). `.comb` over the same subject is flat (18 ms at 80 KB), so the scan is
+fine; the per-match result assembly is not. Each match builds its own
+`MatchTarget`, and that allocates a fresh `Arc<String>` *plus* an `Arc<[char]>`
+of the whole subject -- about 5 bytes per character, per match.
+
+**Scanning is linear but its per-position constant is ~8x rakudo's**
+([#8248](https://github.com/tokuhirom/mutsu/issues/8248)). A failing alternation
+scan is 0.21x rakudo at 40 KB, 0.50x at 160 KB and 1.25x at 640 KB: the apparent
+win at small sizes is rakudo's ~200 ms startup, and it is spent by about half a
+megabyte. Succeeding scans that stop early stay at 0.05x at every size, so the
+cost is specifically on the reject path -- the work to advance one position and
+fail, which is also the inner loop of every grammar parse.
+
+Both are perf issues rather than wrong answers, and both now have a benchmark
+that will show the fix.


### PR DESCRIPTION
## Why

Of the suite's 26 files, exactly one touched the regex engine directly:
`bench-string.raku`, whose third section runs `~~ /\d+/` 5000 times next to 10000
string concatenations and 1000 splits, so a regex change moves that row by less
than its own noise. The three grammar files do exercise the matcher, but through
grammar machinery and on documents of a few hundred bytes — all three run in
16-70 ms on CI, a few times the 8 ms startup.

Substitution, global matching, `split` on a pattern, captures and `Match`
accessors, look-around, word boundaries, backtracking, interpolated patterns and
ratchet semantics had **no series at all** — and #7576, twenty-two rounds of
regex and grammar performance work, was measured the whole way on a 6-row YAML
document plus ad-hoc local runs.

## What

Eight files, each isolating one mechanism, each documenting in its own header what
it measures and why:

| file | what it isolates | local (release) |
| --- | --- | --- |
| `bench-regex-match` | matching with no `Match` built: classes, quantifiers, alternation/LTM, `:i`, anchors, a failing scan, interpolated patterns | 0.21 s (raku 0.83) |
| `bench-regex-capture` | what a successful match hands back: named/positional captures, quantified and nested groups, `$/.from`/`.to`, a capturing match that fails | 0.26 s (0.99) |
| `bench-regex-global` | resume-from-last-end scanning: `.match(:g)`, `.comb`, `.subst(:g)`, `s:g///`, a closure replacement reading `$0` per hit | 0.20 s (0.47) |
| `bench-regex-assertion` | zero-width assertions and backtracking: `<?before>`/`<!before>`, `<?after>`/`<!after>`, `<<`/`>>`, give-back, `:r`, separated quantifiers | 0.20 s (1.13) |
| `bench-regex-long-subject` | per-position reject cost: one 128 KB subject, nine single-call scans, eight failing | 0.33 s (0.87) |
| `bench-regex-split-subst` | the paths that assemble a result from every occurrence, superlinear today | 0.24 s (0.30) |
| `bench-grammar-parse-big` | the small files' JSON-like grammar on a 10 KB document, so growth rate is visible | 0.16 s (0.59) |
| `bench-yaml-parse-big` | YAMLish on the 60-row document #7576's own numbers are quoted at | 0.31 s (raku NA) |

Every file prints a checksum and produces byte-identical output under rakudo
2026.07 (verified for all eight; the YAMLish one has no raku baseline since
YAMLish is a bundled battery, exactly like the existing `bench-yaml-parse` row).
None uses randomness or wall-clock time, and all three of `MUTSU_JIT=off`/`on`
and the debug build agree.

Cost: the suite goes from 4.2 s to 5.8 s of native time, i.e. a few minutes added
to an 18-minute bench job with a 45-minute budget (two wall-clock configurations
plus the two callgrind passes). Deterministic instruction counts for the new rows
land between 1.26 G and 3.25 G Ir, in line with the existing files.

## Two findings that came out of writing them

Both filed as perf issues, each with the benchmark that will show its fix:

* **#8247 — `.split(rx)` and `.subst(rx, :g)` are quadratic in subject length.**
  Doubling the subject roughly quadruples the time: an 80 KB `split(/\s+/)` takes
  11.9 s against rakudo's 0.26 s (46x); a 640 KB global substitution 23.2 s
  against 0.79 s (29x). `.comb` over the same subject is flat (18 ms at 80 KB), so
  the scan is fine and the per-match result assembly is not — each match builds
  its own `MatchTarget`, which allocates a fresh `Arc<String>` *plus* an
  `Arc<[char]>` of the whole subject. Cost tracks match count: 1130 matches over
  64 KB is 85 ms, one match over the same 64 KB is 7 ms.
* **#8248 — scanning is linear but its per-position constant is ~8x rakudo's.** A
  failing alternation scan is 0.21x rakudo at 40 KB, 0.50x at 160 KB and **1.25x
  at 640 KB**: the apparent win at small sizes is rakudo's ~200 ms startup, and it
  is spent by about half a megabyte. Scans that succeed early stay at 0.05x at
  every size, so the cost is on the reject path — which is also the inner loop of
  every grammar parse.

`PERFORMANCE.md` gains the coverage summary, the rules for adding a benchmark, and
the rule those findings imply: a regex ratio quoted without its subject size says
nothing. `news/2026-09/regex-benchmark-coverage.md` records the whole thing.

## Testing

Benchmarks-only plus two documentation files — no `src/` change, so the TAP and
roast suites cannot move; CI runs them anyway (`benchmarks/` is deliberately not
on the docs-only allowlist). Verified locally: all 34 benchmark files run clean on
the release binary, all eight new ones match rakudo's output byte for byte, and
the callgrind pass both configurations use completes on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_