### PR TITLE
fix: make NativeCall::Types loadable

### DIFF
--- a/news/2026-09/nativecall-types-is-loadable.md
+++ b/news/2026-09/nativecall-types-is-loadable.md
@@ -1,0 +1,3 @@
+`NativeCall::Types` is now recognized as a loadable NativeCall provider. Code
+that only needs NativeCall's type declarations can use the submodule directly,
+including `Pointer`, `CArray`, `int32`, and `size_t`.

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -163,7 +163,12 @@ fn import_is_pragma_like(module: &str) -> bool {
     }
     matches!(
         module,
-        "MONKEY" | "MONKEY-SEE-NO-EVAL" | "MONKEY-TYPING" | "MONKEY-GUTS" | "NativeCall"
+        "MONKEY"
+            | "MONKEY-SEE-NO-EVAL"
+            | "MONKEY-TYPING"
+            | "MONKEY-GUTS"
+            | "NativeCall"
+            | "NativeCall::Types"
     )
 }
 

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -459,10 +459,12 @@ impl Interpreter {
                     | "fatal"
                     | "oo"
                     | "class"
-                    // NativeCall: the `is native(...)` trait machinery is built
-                    // into the VM (see runtime/nativecall.rs); `use NativeCall`
-                    // only needs to be a recognized no-op.
+                    // NativeCall: the `is native(...)` trait machinery and the
+                    // NativeCall::Types declarations are built into the VM
+                    // (see runtime/nativecall.rs); these uses only need to be
+                    // recognized no-ops.
                     | "NativeCall"
+                    | "NativeCall::Types"
         ) {
             // Track MONKEY-TYPING pragma
             if module == "MONKEY-TYPING" || module == "MONKEY" {

--- a/t/nativecall/nativecall-types-module.t
+++ b/t/nativecall/nativecall-types-module.t
@@ -1,0 +1,27 @@
+use Test;
+use NativeCall::Types;
+
+# NativeCall::Types is a separately loadable upstream module. mutsu provides
+# its declarations through the same NativeCall prelude, so consumers that only
+# need the type surface do not have to import the NativeCall provider itself.
+
+plan 8;
+
+ok Pointer.^name.ends-with('Pointer'),
+    'NativeCall::Types makes Pointer visible';
+ok CArray.^name.ends-with('CArray'),
+    'NativeCall::Types makes CArray visible';
+ok int32.^name eq 'int32',
+    'NativeCall::Types makes int32 visible';
+ok size_t.^name eq 'NativeCall::Types::size_t',
+    'NativeCall::Types makes size_t visible';
+
+my int32 $number = 42;
+is $number, 42, 'int32 remains usable as a native scalar';
+my size_t $size = 4096;
+is $size, 4096, 'size_t remains usable as a native scalar';
+
+isa-ok CArray[int32].new, CArray[int32],
+    'CArray is usable after loading NativeCall::Types';
+isa-ok Pointer.new(0), Pointer,
+    'Pointer is usable after loading NativeCall::Types';


### PR DESCRIPTION
Closes #8217

Recognize NativeCall::Types as the VM-provided NativeCall type module in both runtime module loading and parser type-index bookkeeping. The existing NativeCall prelude then supplies Pointer, CArray, and native scalar types when the submodule is used directly.

Validation:
- cargo fmt --all
- make lint
- make test
- make roast
- make check-t-layout