### PR TITLE
fix(rakuast): retain named regex captures

### DIFF
--- a/docs/adr/0088-rakuast-regex-boundary-tree.md
+++ b/docs/adr/0088-rakuast-regex-boundary-tree.md
@@ -472,3 +472,23 @@ The focused regressions are in `t/rakuast/rakuast-regex.t` and
 `t/regex/regex-tree-interpolation.t`. They pin Rakudo's interpolation node
 shape, constructed-tree lowering, stored-value lookup after lexical mutation,
 type-sensitive fallback, and the declaration boundary.
+
+## 13. Ordinary named-capture source and execution slice (2026-09-13)
+
+Scalar named captures written as `$<name> = atom` now have a shared
+`RegexNode::NamedCapture` representation. The read direction emits
+`RakuAST::Regex::NamedCapture` with a string `name` and a structural `regex`
+child; the default `array => False` remains an absent model field, matching
+Rakudo's renderer. The write direction accepts the scalar form and rejects
+array captures until their list-context semantics have their own boundary.
+
+The execution lowerer attaches the alias to the existing `RegexToken` capture
+channel. For a non-capturing quantified atom it preserves the established
+whole-run scalar-alias wrapper, while an aliased positional capturing group
+continues to use the matcher's per-iteration capture behavior. No subrule
+lookup or code assertion is performed while converting the tree.
+
+The focused regression is `t/regex/match/regex-tree-named-captures.t`. It pins the
+source whitespace and quantified AST shapes, capture spans, constructor
+accessors, and constructed-tree EVAL execution. Subrule aliases, array/hash
+aliases, and code-bearing regex nodes remain separate follow-up slices.

--- a/news/2026-09/rakuast-regex-named-captures.md
+++ b/news/2026-09/rakuast-regex-named-captures.md
@@ -1,0 +1,9 @@
+# Regex named captures retain their RakuAST boundary
+
+Ordinary scalar named captures such as `$<word> = a` now remain in the shared
+`RegexTree` and are exposed as `RakuAST::Regex::NamedCapture`. Parser-created
+and constructed nodes lower to the existing named-capture matcher, including
+the whole-run semantics of a scalar alias around a quantified atom.
+
+Subrule aliases, array/hash aliases, and code-bearing regex nodes remain
+explicit follow-up boundaries under ADR-0088.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2313,6 +2313,13 @@ fn regex_node(node: &RegexNode) -> Result<RakuAstNode, RuntimeError> {
             RakuAstClass::RegexCapturingGroup,
             vec![node_field(None, regex_node(child)?)],
         ),
+        RegexNode::NamedCapture { name, regex } => (
+            RakuAstClass::RegexNamedCapture,
+            vec![
+                leaf_field(Some("name"), Value::str(name.clone())),
+                node_field(Some("regex"), regex_node(regex)?),
+            ],
+        ),
         RegexNode::Interpolation { name, sequential } => (
             RakuAstClass::RegexInterpolation,
             vec![

--- a/src/rakuast/fields.rs
+++ b/src/rakuast/fields.rs
@@ -152,6 +152,11 @@ pub(super) fn model_fields(class: RakuAstClass) -> &'static [(&'static str, Abse
         RegexLiteral => &[("text", Absent::Required)],
         RegexQuote => &[("quoted", Absent::Required)],
         RegexGroup | RegexCapturingGroup | RegexWithWhitespace => &[("regex", Absent::Required)],
+        RegexNamedCapture => &[
+            ("name", Absent::Required),
+            ("array", Absent::False),
+            ("regex", Absent::Required),
+        ],
         RegexInterpolation => &[("sequential", Absent::False), ("var", Absent::Required)],
         RegexQuantifiedAtom => &[
             ("atom", Absent::Required),

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1595,6 +1595,15 @@ fn lower_regex_node(node: &RakuAstNode) -> Result<RegexNode, RuntimeError> {
         RakuAstClass::RegexCapturingGroup => Ok(RegexNode::CapturingGroup(Box::new(
             lower_regex_node(named_child_or_positional(node)?)?,
         ))),
+        RakuAstClass::RegexNamedCapture => {
+            if bool_field(node, "array")? {
+                return Err(unsupported(node));
+            }
+            Ok(RegexNode::NamedCapture {
+                name: leaf_str(node, "name")?,
+                regex: Box::new(lower_regex_node(named_child(node, "regex")?)?),
+            })
+        }
         RakuAstClass::RegexInterpolation => {
             let sequential = bool_field(node, "sequential")?;
             if sequential {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -64,6 +64,7 @@ pub enum RakuAstClass {
     RegexWithWhitespace,
     RegexGroup,
     RegexCapturingGroup,
+    RegexNamedCapture,
     RegexInterpolation,
     RegexAlternation,
     RegexQuantifiedAtom,
@@ -268,6 +269,7 @@ impl RakuAstClass {
             RegexWithWhitespace => "RakuAST::Regex::WithWhitespace",
             RegexGroup => "RakuAST::Regex::Group",
             RegexCapturingGroup => "RakuAST::Regex::CapturingGroup",
+            RegexNamedCapture => "RakuAST::Regex::NamedCapture",
             RegexInterpolation => "RakuAST::Regex::Interpolation",
             RegexAlternation => "RakuAST::Regex::Alternation",
             RegexQuantifiedAtom => "RakuAST::Regex::QuantifiedAtom",
@@ -482,6 +484,7 @@ impl RakuAstClass {
             | RegexQuote
             | RegexGroup
             | RegexCapturingGroup
+            | RegexNamedCapture
             | RegexInterpolation
             | RegexWithWhitespace => &[
                 "RakuAST::Regex::Atom",
@@ -614,6 +617,7 @@ fn semantic_type_object_ancestors(class_name: &str) -> &'static [&'static str] {
         | "RakuAST::Regex::Quote"
         | "RakuAST::Regex::Group"
         | "RakuAST::Regex::CapturingGroup"
+        | "RakuAST::Regex::NamedCapture"
         | "RakuAST::Regex::Interpolation"
         | "RakuAST::Regex::WithWhitespace" => &[
             "RakuAST::Regex::Atom",
@@ -699,6 +703,7 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::RegexWithWhitespace,
     RakuAstClass::RegexGroup,
     RakuAstClass::RegexCapturingGroup,
+    RakuAstClass::RegexNamedCapture,
     RakuAstClass::RegexInterpolation,
     RakuAstClass::RegexAlternation,
     RakuAstClass::RegexQuantifiedAtom,
@@ -1351,6 +1356,43 @@ pub fn construct(
             ],
         }))));
     }
+    if class_name == "RakuAST::Regex::NamedCapture" && method == "new" {
+        let name = named_arg(args, "name")
+            .ok_or_else(|| RuntimeError::new("RakuAST::Regex::NamedCapture.new requires `name`"))?;
+        if !matches!(name.view(), ValueView::Str(_)) {
+            return Err(RuntimeError::new(
+                "RakuAST::Regex::NamedCapture.new expects `name` to be Str",
+            ));
+        }
+        let regex = named_arg(args, "regex").ok_or_else(|| {
+            RuntimeError::new("RakuAST::Regex::NamedCapture.new requires `regex`")
+        })?;
+        require_regex_node(&regex, class_name)?;
+        let array = named_arg(args, "array").unwrap_or_else(|| Value::truth(false));
+        if !matches!(array.view(), ValueView::Bool(_)) {
+            return Err(RuntimeError::new(
+                "RakuAST::Regex::NamedCapture.new expects `array` to be Bool",
+            ));
+        }
+        let mut fields = vec![RakuAstField {
+            name: Some("name"),
+            value: RakuAstFieldValue::Node(name),
+        }];
+        if matches!(array.view(), ValueView::Bool(true)) {
+            fields.push(RakuAstField {
+                name: Some("array"),
+                value: RakuAstFieldValue::Node(array),
+            });
+        }
+        fields.push(RakuAstField {
+            name: Some("regex"),
+            value: RakuAstFieldValue::Node(regex),
+        });
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::RegexNamedCapture,
+            fields,
+        }))));
+    }
     if class_name == "RakuAST::QuotedRegex" && method == "new" {
         let body = named_arg(args, "body")
             .ok_or_else(|| RuntimeError::new("RakuAST::QuotedRegex.new requires `body`"))?;
@@ -1566,6 +1608,7 @@ fn require_regex_node(value: &Value, constructor: &str) -> Result<(), RuntimeErr
                     | RakuAstClass::RegexWithWhitespace
                     | RakuAstClass::RegexGroup
                     | RakuAstClass::RegexCapturingGroup
+                    | RakuAstClass::RegexNamedCapture
                     | RakuAstClass::RegexInterpolation
                     | RakuAstClass::RegexAlternation
                     | RakuAstClass::RegexQuantifiedAtom
@@ -1873,6 +1916,7 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::RegexWithWhitespace
             | RakuAstClass::RegexGroup
             | RakuAstClass::RegexCapturingGroup
+            | RakuAstClass::RegexNamedCapture
             | RakuAstClass::RegexInterpolation
             | RakuAstClass::RegexQuantifiedAtom
             | RakuAstClass::RegexQuantifierZeroOrMore

--- a/src/regex_tree.rs
+++ b/src/regex_tree.rs
@@ -707,9 +707,7 @@ impl Parser {
             // belongs to the final character (`$<x>=ab+` is `$<x>=a` then
             // `b+`), matching the ordinary regex parser's literal splitting.
             let mut chars = text.chars();
-            let Some(first) = chars.next() else {
-                return None;
-            };
+            let first = chars.next()?;
             let rest: String = chars.collect();
             let mut nodes = vec![RegexNode::NamedCapture {
                 name,
@@ -717,9 +715,7 @@ impl Parser {
             }];
             if let Some(quantifier) = quantifier {
                 let mut rest_chars = rest.chars();
-                let Some(last) = rest_chars.next_back() else {
-                    return None;
-                };
+                let last = rest_chars.next_back()?;
                 let prefix: String = rest_chars.collect();
                 if !prefix.is_empty() {
                     nodes.push(RegexNode::Literal(prefix));

--- a/src/regex_tree.rs
+++ b/src/regex_tree.rs
@@ -45,6 +45,10 @@ pub(crate) enum RegexNode {
     Alternation(Vec<RegexNode>),
     Group(Box<RegexNode>),
     CapturingGroup(Box<RegexNode>),
+    NamedCapture {
+        name: String,
+        regex: Box<RegexNode>,
+    },
     Interpolation {
         name: String,
         sequential: bool,
@@ -286,6 +290,34 @@ impl RegexTree {
                         ratchet,
                     )])
                 }
+                RegexNode::NamedCapture { name, regex } => {
+                    // A scalar alias around a non-capturing quantified atom
+                    // captures the whole run as one Match. This mirrors the
+                    // legacy parser's user-alias wrapper; an aliased
+                    // CapturingGroup intentionally stays per-iteration.
+                    if let RegexNode::Quantified { atom, .. } = regex.as_ref()
+                        && !matches!(atom.as_ref(), RegexNode::CapturingGroup(_))
+                    {
+                        let inner =
+                            lower_node(regex, ratchet, ignore_case, ignore_mark, rule_sigspace)?;
+                        let mut outer = token(
+                            crate::runtime::RegexAtom::Group(pattern(
+                                inner,
+                                ignore_case,
+                                ignore_mark,
+                            )),
+                            crate::runtime::RegexQuant::One,
+                            ratchet,
+                        );
+                        outer.named_capture = Some(name.clone());
+                        return Some(vec![outer]);
+                    }
+                    let mut tokens =
+                        lower_node(regex, ratchet, ignore_case, ignore_mark, rule_sigspace)?;
+                    let first = tokens.first_mut()?;
+                    first.named_capture = Some(name.clone());
+                    Some(tokens)
+                }
                 RegexNode::Interpolation { name, sequential } => {
                     if *sequential {
                         return None;
@@ -350,6 +382,7 @@ impl RegexNode {
             | Self::CapturingGroup(child)
             | Self::Quantified { atom: child, .. }
             | Self::WithWhitespace(child) => child.collect_interpolation_names(names),
+            Self::NamedCapture { regex, .. } => regex.collect_interpolation_names(names),
             Self::Literal(_) | Self::Quote(_) | Self::CharClassDigit => {}
         }
     }
@@ -399,6 +432,9 @@ impl RegexNode {
             }
             Self::Group(child) => format!("[{}]", child.to_source()),
             Self::CapturingGroup(child) => format!("({})", child.to_source()),
+            Self::NamedCapture { name, regex } => {
+                format!("$<{name}> = {}", regex.to_source())
+            }
             Self::Interpolation { name, .. } => format!("${name}"),
             Self::Quantified { atom, quantifier } => {
                 let suffix = match quantifier {
@@ -551,6 +587,7 @@ impl Parser {
                     sequence_for_multichar_literal(inner),
                 )))
             }
+            '$' if self.chars.get(self.pos + 1) == Some(&'<') => self.parse_named_capture(),
             '$' => self.parse_interpolation(),
             '@' | '%' => None,
             ')' | ']' if stops.contains(&ch) => None,
@@ -643,6 +680,68 @@ impl Parser {
         Some(RegexNode::Interpolation {
             name,
             sequential: false,
+        })
+    }
+
+    fn parse_named_capture(&mut self) -> Option<RegexNode> {
+        self.pos += 2; // '$<'
+        let start = self.pos;
+        while self.chars.get(self.pos).is_some_and(|ch| *ch != '>') {
+            self.pos += 1;
+        }
+        if self.pos == start || !self.consume_if('>') {
+            return None;
+        }
+        let name: String = self.chars[start..self.pos - 1].iter().collect();
+        self.skip_whitespace();
+        if !self.consume_if('=') {
+            return None;
+        }
+        self.skip_whitespace();
+        let mut regex = self.parse_atom(&[])?;
+        let quantifier = self.parse_quantifier();
+        if let RegexNode::Literal(text) = &mut regex
+            && text.chars().count() > 1
+        {
+            // The alias binds to the first atom. A trailing quantifier still
+            // belongs to the final character (`$<x>=ab+` is `$<x>=a` then
+            // `b+`), matching the ordinary regex parser's literal splitting.
+            let mut chars = text.chars();
+            let Some(first) = chars.next() else {
+                return None;
+            };
+            let rest: String = chars.collect();
+            let mut nodes = vec![RegexNode::NamedCapture {
+                name,
+                regex: Box::new(RegexNode::Literal(first.to_string())),
+            }];
+            if let Some(quantifier) = quantifier {
+                let mut rest_chars = rest.chars();
+                let Some(last) = rest_chars.next_back() else {
+                    return None;
+                };
+                let prefix: String = rest_chars.collect();
+                if !prefix.is_empty() {
+                    nodes.push(RegexNode::Literal(prefix));
+                }
+                nodes.push(RegexNode::Quantified {
+                    atom: Box::new(RegexNode::Literal(last.to_string())),
+                    quantifier,
+                });
+            } else {
+                nodes.push(RegexNode::Literal(rest));
+            }
+            return Some(RegexNode::Sequence(nodes));
+        }
+        if let Some(quantifier) = quantifier {
+            regex = RegexNode::Quantified {
+                atom: Box::new(regex),
+                quantifier,
+            };
+        }
+        Some(RegexNode::NamedCapture {
+            name,
+            regex: Box::new(regex),
         })
     }
 

--- a/t/regex/match/regex-tree-named-captures.t
+++ b/t/regex/match/regex-tree-named-captures.t
@@ -1,0 +1,67 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# ADR-0088 issue #8033: ordinary scalar named captures retain their source
+# node and lower to the existing named-capture matcher. Subrule aliases,
+# array/hash aliases, and code-bearing regex nodes remain separate boundaries.
+
+plan 16;
+
+is Q[/ $<word> = a /].AST.gist, q:to/END/.chomp, 'a named capture keeps its whitespace and source node';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedRegex.new(
+          body => RakuAST::Regex::WithWhitespace.new(
+            RakuAST::Regex::NamedCapture.new(
+              name  => "word",
+              regex => RakuAST::Regex::Literal.new("a")
+            )
+          )
+        )
+      )
+    )
+    END
+
+is Q[/$<word>=a+/].AST.gist, q:to/END/.chomp, 'a named capture can contain a quantified atom';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedRegex.new(
+          body => RakuAST::Regex::NamedCapture.new(
+            name  => "word",
+            regex => RakuAST::Regex::QuantifiedAtom.new(
+              atom       => RakuAST::Regex::Literal.new("a"),
+              quantifier => RakuAST::Regex::Quantifier::OneOrMore.new
+            )
+          )
+        )
+      )
+    )
+    END
+
+my $single = 'a' ~~ /$<word>=a/;
+ok $single, 'a parser-created named capture matches';
+is $single<word>.Str, 'a', 'the named capture stores its text';
+is $single<word>.from, 0, 'the named capture stores its start';
+is $single<word>.to, 1, 'the named capture stores its end';
+
+my $quantified = 'aaa' ~~ /$<word>=a+/;
+ok $quantified, 'a quantified named capture matches';
+is $quantified<word>.Str, 'aaa', 'a scalar alias captures the whole run';
+is $quantified<word>.from, 0, 'the quantified alias starts at the atom';
+is $quantified<word>.to, 3, 'the quantified alias ends after the run';
+
+my $node = RakuAST::Regex::NamedCapture.new(
+    name  => 'word',
+    regex => RakuAST::Regex::Literal.new('a'),
+);
+is $node.name, 'word', 'NamedCapture exposes its name';
+nok $node.array, 'a scalar NamedCapture defaults to array False';
+ok $node ~~ RakuAST::Regex::Atom, 'NamedCapture retains its regex atom type';
+is $node.regex.text, 'a', 'NamedCapture exposes its regex child';
+
+my $constructed = EVAL(RakuAST::QuotedRegex.new(body => $node));
+my $constructed-match = 'a' ~~ $constructed;
+ok $constructed-match, 'a constructed named capture lowers through EVAL';
+is $constructed-match<word>.Str, 'a', 'the lowered named capture keeps its text';


### PR DESCRIPTION
Part of #8033.

This bounded ADR-0088 slice retains ordinary scalar named captures such as $<word> = atom in the shared RegexTree, exposes them as RakuAST::Regex::NamedCapture, and lowers parser-created and constructed nodes through the existing named-capture matcher. Quantified scalar aliases preserve whole-run capture semantics.

The regression test covers source AST shape, capture spans, constructor accessors, and constructed-tree EVAL execution. Subrule aliases, array/hash aliases, and code-bearing regex nodes remain follow-up boundaries.

Validation:
- cargo fmt --all
- make lint
- make test (PASS: 4181 files, 44566 tests)
- make roast (PASS: 1437 files, 219658 tests)
- make check-t-layout
- focused named-capture and existing regex/RakuAST tests