### PR TITLE
fix(modules): load a `use`d module at BEGIN time when the `use` is nested in a block

### DIFF
--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -136,6 +136,7 @@ IO::Path::ChildSecure	01-operation.rakutest
 IO::Socket::Async::SSL	bad-incoming.rakutest
 JSON::JWT	01-decode.rakutest
 JSON::JWT	02-encode.rakutest
+JSON::Tiny	01-parse.t
 JSON::Tiny	02-structure.t
 JSON::Tiny	03-unicode.t
 JSON::Tiny	04-roundtrip.t

--- a/docs/batteries/json-tiny.md
+++ b/docs/batteries/json-tiny.md
@@ -140,9 +140,11 @@ ledger row all wait on those two.
 
 ## Upstream test suite
 
-5 of the 6 upstream files pass whole against the bundled `lib/`
-(`t/04-roundtrip.t` has 10 expected `TODO passed`). `t/01-parse.t` is **92/93**
-and is therefore not on `batteries-whitelist.txt`. Its last assertion is:
+All 6 upstream files pass whole against the bundled `lib/` and are on
+`batteries-whitelist.txt` (`t/04-roundtrip.t` has 10 expected `TODO passed`).
+
+`t/01-parse.t` was the last to get there. It sat at **92/93** from the
+interception retirement until 2026-09-13, on this assertion:
 
 ```raku
 throws-like {
@@ -152,13 +154,14 @@ throws-like {
 ```
 
 Both of `throws-like`'s arguments evaluate before the block is invoked, so
-`X::JSON::Tiny::Invalid` is read before the block's `use` has run. Raku
-performs `use` at BEGIN time and has the symbol; mutsu's `use` is a runtime
-opcode, so the reference gets a fabricated stub and the type comparison fails
-against the module's real `JSON::Tiny::X::JSON::Tiny::Invalid`. That is a
+`X::JSON::Tiny::Invalid` was read before the block's `use` had run. Raku
+performs `use` at BEGIN time and has the symbol; mutsu's `use` was a runtime
+opcode, so the reference got a fabricated stub and the type comparison failed
+against the module's real `JSON::Tiny::X::JSON::Tiny::Invalid`. That was a
 general `use`-is-not-BEGIN-time gap with a JSON-free repro, filed as
-[#8201](https://github.com/tokuhirom/mutsu/issues/8201); fixing it is what puts
-this file back on the whitelist.
+[#8201](https://github.com/tokuhirom/mutsu/issues/8201) and fixed by hoisting
+the *load* half of a nested `use` to the head of the compunit — see
+`news/2026-09/use-in-a-nested-block-loads-at-begin-time.md`.
 
 The assertion did pass under the old arrangement — but only because both sides
 were mutsu fabrications agreeing with each other: the native path threw an

--- a/news/2026-09/use-in-a-nested-block-loads-at-begin-time.md
+++ b/news/2026-09/use-in-a-nested-block-loads-at-begin-time.md
@@ -1,0 +1,93 @@
+# A `use` inside a nested block loads at BEGIN time
+
+Raku performs `use Foo` at BEGIN time: by the time any of the compunit's
+mainline runs, every package `Foo` contributes is already installed. mutsu
+compiles `use` to a runtime `OpCode::UseModule`, so a `use` written inside a
+block that has not executed yet was invisible to code that *ran* earlier — even
+when the `use` appeared earlier in **file** order. And because mutsu fabricates a
+stub type object for an unresolved `::`-qualified bareword rather than erroring,
+the divergence was silent: the reference answered the *written* name instead of
+the module-composed one.
+
+```raku
+use lib 'tmp';
+my &later = { use UseTypeFixture; };   # earlier in the file, not run yet
+say X::Fixture::Marker.^name;
+# raku:  UseTypeFixture::X::Fixture::Marker
+# mutsu: X::Fixture::Marker              (a stub)
+```
+
+## What changed
+
+`use` is now split into the two halves Raku actually has. The *load* is hoisted
+to the head of the compilation unit; the *import* stays exactly where it was,
+because Raku genuinely scopes a nested `use`'s imports to the block holding it
+(`{ use Foo } foo()` must still die — `roast/S11-modules/lexical.t`).
+
+The unit compile records every module `use`d anywhere inside it — including
+inside closure and sub bodies, which share the unit's context the same way the
+constant-fold state does. Subtracting the unit's own top-level `use`s leaves the
+nested ones, and the unit is recompiled with an `OpCode::PreloadModule` for each
+at its head. Only a unit that actually holds a nested `use` pays for that second
+pass; it rides the pass the refold path already had.
+
+`Interpreter::preload_module` is the load half: `use_module_with_tags` with the
+final `import_module` skipped. `need_module` was not a substitute — it loads with
+`suppress_exports` set, so the module's `is export` routines are never registered
+and the later in-position `use` of the (now already-loaded) module has nothing
+left to import.
+
+Three details make hoisting the load safe:
+
+- **`use lib` is replayed first.** A `use lib` written *later* in the file is a
+  BEGIN-time effect too, and a hoisted load may depend on it, so the unit's
+  literal `use lib` specs are emitted ahead of the preloads in source order.
+  Adding the spec that is already at the front of the search chain is now a
+  no-op, so the `use lib` at its own position recognizes the prologue's work
+  instead of doubling the entry. A path merely present *deeper* in the chain is
+  still promoted — `use lib` outranks `-I` and `MUTSULIB`
+  (`t/modules/compunit/lib-path-precedence.t`).
+- **The load runs inside a preload scope.** mutsu's sub hoisting installs every
+  exported routine under `GLOBAL::` while a module body loads, and those aliases
+  belong to whoever wrote the `use`. Until now they were contained by the import
+  scope of the very block holding it; hoisting the load out would have left an
+  exported `proto sub head(|)` shadowing the core listop for the whole file. The
+  preload scope rolls the routine and proto registries back the same way an
+  import scope does, but leaves the class registry alone — a package the module
+  declares is exactly what the preload exists to publish, and raku installs it
+  into GLOBAL at load time too.
+- **A preload that cannot find its module is discarded.** Raku rejects an
+  unresolvable `use` at BEGIN time whatever block it sits in; mutsu deliberately
+  does not. Hoisting must not change that, so the preload swallows its own
+  failure and the in-position `UseModule` still reports it if control reaches it.
+
+## What it unblocks
+
+`JSON::Tiny`'s upstream `t/01-parse.t` is back on `batteries-whitelist.txt` at
+93/93. Its last assertion is
+
+```raku
+throws-like {
+    use JSON::Tiny;
+    from-json '',
+}, X::JSON::Tiny::Invalid;
+```
+
+and `throws-like`'s two arguments both evaluate before the block is invoked, so
+the type reference was read before the block's `use` had run. mutsu handed
+`throws-like` a stub named `X::JSON::Tiny::Invalid` while the block threw the
+module's real `JSON::Tiny::X::JSON::Tiny::Invalid`, and 92 of the file's 93
+assertions passed. That assertion used to "pass" only because both sides were
+mutsu fabrications agreeing with each other; retiring the native JSON
+interception (#8183) stopped hiding the real gap.
+
+## Residual
+
+A top-level `use` still loads where it stands, not at the head of the unit, so
+code textually *before* it in the mainline still cannot see its packages. That is
+the same BEGIN-time gap one level up, but it needs no stub fabrication to be
+visible and is much rarer in practice; hoisting every top-level load ahead of the
+mainline is a considerably larger change in blast radius than this one.
+
+Pin: `t/modules/import-export/use-in-nested-block-is-begin-time.t`.
+Closes [#8201](https://github.com/tokuhirom/mutsu/issues/8201).

--- a/src/compiler/begin_use.rs
+++ b/src/compiler/begin_use.rs
@@ -1,0 +1,254 @@
+//! BEGIN-time module preloads for a `use` written inside a nested block.
+//!
+//! Raku performs `use Foo` at BEGIN time: by the time any of the compunit's
+//! mainline runs, every package `Foo` installs is already there. mutsu compiles
+//! `use` to the runtime [`OpCode::UseModule`], so a `use` inside a block that
+//! has not executed yet is invisible to code that *runs* earlier — even when the
+//! `use` appears earlier in file order:
+//!
+//! ```raku
+//! my &later = { use UseTypeFixture; };   # earlier in the file, not run yet
+//! say X::Fixture::Marker.^name;          # raku: UseTypeFixture::X::Fixture::Marker
+//! ```
+//!
+//! The gap is filled here without moving the *import*, which Raku genuinely does
+//! scope to the block holding the `use`. The unit compile records every module
+//! `use`d anywhere inside it ([`UnitUseCtx`]); whatever is left after subtracting
+//! the unit's own top-level `use`s is a nested one, and gets a
+//! [`OpCode::PreloadModule`] at the head of the unit. That op performs the load
+//! half only (`Interpreter::preload_module`), so the module's packages and types
+//! are reachable from the whole mainline while its exports still enter scope
+//! exactly where the `use` stands.
+//!
+//! Two details make the prologue safe to run that early:
+//!
+//! - The unit's literal `use lib` specs are replayed ahead of the preloads, in
+//!   source order, because a `use lib` written *later* in the file is also a
+//!   BEGIN-time effect that a hoisted load may depend on. Adding a path already
+//!   in the chain is a no-op, so the `use lib` at its own position still behaves
+//!   as before.
+//! - A preload that cannot find its module is silently discarded. Nothing in the
+//!   source asked for the module *here*, so a never-run block naming an absent
+//!   module must stay as non-fatal as it is today; the in-position `UseModule`
+//!   still reports the failure if control reaches it.
+//!
+//! See GH-8201.
+
+use super::Compiler;
+use crate::ast::{Expr, Stmt};
+use crate::opcode::OpCode;
+use crate::value::{Value, ValueView};
+use std::sync::Mutex;
+
+/// Per-compilation-unit record of the modules `use`d anywhere inside it,
+/// including inside nested blocks and sub bodies. Shared with every child
+/// compiler of the unit through `Compiler::inherit_fold_ctx`, which is why a
+/// `use` compiled into a closure body still reaches the unit-level pass.
+#[derive(Default)]
+pub(crate) struct UnitUseCtx {
+    modules: Mutex<Vec<String>>,
+}
+
+impl UnitUseCtx {
+    /// Record a module `use`d while compiling this unit. Called from the general
+    /// `Stmt::Use` arm, so it sees exactly the `use`s that compile to a real
+    /// [`OpCode::UseModule`] load.
+    pub(crate) fn note_use(&self, module: &str) {
+        if let Ok(mut modules) = self.modules.lock() {
+            modules.push(module.to_string());
+        }
+    }
+
+    /// The modules this unit `use`s from somewhere other than its own top level
+    /// — the ones whose load has to be hoisted. Computed as a multiset
+    /// difference so a module `use`d both at the top level and inside a block
+    /// still contributes the nested occurrence.
+    pub(crate) fn nested_modules(&self, stmts: &[Stmt]) -> Vec<String> {
+        let Ok(modules) = self.modules.lock() else {
+            return Vec::new();
+        };
+        if modules.is_empty() {
+            return Vec::new();
+        }
+        let mut top_level: Vec<&str> = stmts.iter().filter_map(preloadable_module).collect();
+        let mut nested = Vec::new();
+        for module in modules.iter() {
+            if let Some(pos) = top_level.iter().position(|m| *m == module) {
+                top_level.swap_remove(pos);
+                continue;
+            }
+            if !nested.contains(module) {
+                nested.push(module.clone());
+            }
+        }
+        nested
+    }
+}
+
+/// The module name a `use` statement contributes to the BEGIN-time preload set,
+/// or `None` when it is not a plain module load.
+///
+/// Mirrors the filter the general `Stmt::Use` compile arm applies, so the
+/// top-level subtraction in [`UnitUseCtx::nested_modules`] lines up with what
+/// was recorded. Excluded: pragmas (which install no packages), `Test` and its
+/// submodules (compiled by their own arm), a `:from<...>` foreign-language
+/// compunit, a `use Foo:if(EXPR)` whose load is deliberately conditional on a
+/// runtime value, and a `use Foo <args>` whose arguments feed the module's
+/// `sub EXPORT` — that argument list is evaluated at the `use`'s own position,
+/// so hoisting the load ahead of it would run `EXPORT` against the wrong input.
+pub(crate) fn preloadable_module(stmt: &Stmt) -> Option<&str> {
+    match stmt {
+        Stmt::Use {
+            module,
+            tags,
+            condition,
+            arg,
+        } => preloadable_module_name(module, tags, condition.as_deref(), arg.as_ref()),
+        _ => None,
+    }
+}
+
+pub(crate) fn preloadable_module_name<'a>(
+    module: &'a str,
+    tags: &[String],
+    condition: Option<&Expr>,
+    arg: Option<&Expr>,
+) -> Option<&'a str> {
+    if condition.is_some() || arg.is_some() {
+        return None;
+    }
+    if tags.iter().any(|t| t == "from") {
+        return None;
+    }
+    if is_pragma_like(module) || module == "Test" || module.starts_with("Test::") {
+        return None;
+    }
+    Some(module)
+}
+
+/// A `use` of something that loads no compunit of its own. The same rule the
+/// parser's module scan uses (`module_exports::import_is_pragma_like`): a
+/// lowercase-initial name is a pragma, plus the handful of uppercase ones that
+/// are built into the VM.
+fn is_pragma_like(module: &str) -> bool {
+    if module.starts_with(|c: char| !c.is_ascii_uppercase()) {
+        return true;
+    }
+    matches!(
+        module,
+        "MONKEY" | "MONKEY-SEE-NO-EVAL" | "MONKEY-TYPING" | "MONKEY-GUTS" | "NativeCall"
+    )
+}
+
+/// The literal repository specs the unit's `use lib` statements add, in source
+/// order. Only literal spellings are collected: an expression form
+/// (`use lib $dir`) cannot be replayed ahead of the mainline that computes it,
+/// and a preload that then fails to resolve is discarded anyway.
+pub(crate) fn literal_lib_paths(stmts: &[Stmt]) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_lib_paths(stmts, &mut out);
+    out
+}
+
+fn collect_lib_paths(stmts: &[Stmt], out: &mut Vec<String>) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::Use {
+                module,
+                arg: Some(arg),
+                ..
+            } if module == "lib" => push_literals(arg, out),
+            Stmt::Block(body) | Stmt::SyntheticBlock(body) | Stmt::Package { body, .. } => {
+                collect_lib_paths(body, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn push_literals(expr: &Expr, out: &mut Vec<String>) {
+    match expr {
+        Expr::Literal(v) => {
+            if let ValueView::Str(s) = v.view() {
+                let path = s.to_string();
+                if !path.is_empty() && !out.contains(&path) {
+                    out.push(path);
+                }
+            }
+        }
+        Expr::ArrayLiteral(items) => {
+            for item in items {
+                push_literals(item, out);
+            }
+        }
+        Expr::Grouped(inner) => push_literals(inner, out),
+        _ => {}
+    }
+}
+
+impl Compiler {
+    /// Emit the unit's BEGIN-time prologue: the replayed `use lib` specs, then
+    /// one [`OpCode::PreloadModule`] per nested `use`. Both lists are empty
+    /// unless the unit's first compile pass found a nested `use`, so a unit
+    /// without one emits nothing at all.
+    pub(super) fn emit_begin_preloads(&mut self) {
+        if self.begin_preloads.is_empty() {
+            return;
+        }
+        for path in std::mem::take(&mut self.begin_preload_lib_paths) {
+            let idx = self.code.add_constant(Value::str(path));
+            self.code.emit(OpCode::LoadConst(idx));
+            self.code.emit(OpCode::UseLibPath);
+        }
+        for module in std::mem::take(&mut self.begin_preloads) {
+            let idx = self.code.add_constant(Value::str(module));
+            self.code.emit(OpCode::PreloadModule(idx));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn use_stmt(module: &str) -> Stmt {
+        Stmt::Use {
+            module: module.to_string(),
+            arg: None,
+            tags: Vec::new(),
+            condition: None,
+        }
+    }
+
+    #[test]
+    fn pragmas_and_test_are_not_preloaded() {
+        for name in ["v6", "lib", "strict", "MONKEY-TYPING", "NativeCall", "Test"] {
+            assert!(
+                preloadable_module(&use_stmt(name)).is_none(),
+                "{name} should not be preloaded"
+            );
+        }
+        assert_eq!(
+            preloadable_module(&use_stmt("JSON::Tiny")),
+            Some("JSON::Tiny")
+        );
+    }
+
+    #[test]
+    fn only_the_nested_use_is_hoisted() {
+        let ctx = UnitUseCtx::default();
+        ctx.note_use("Top::Level");
+        ctx.note_use("Nested::One");
+        let stmts = vec![use_stmt("Top::Level")];
+        assert_eq!(ctx.nested_modules(&stmts), vec!["Nested::One".to_string()]);
+    }
+
+    #[test]
+    fn a_module_used_both_places_still_hoists_the_nested_copy() {
+        let ctx = UnitUseCtx::default();
+        ctx.note_use("Both");
+        ctx.note_use("Both");
+        let stmts = vec![use_stmt("Both")];
+        assert_eq!(ctx.nested_modules(&stmts), vec!["Both".to_string()]);
+    }
+}

--- a/src/compiler/const_fold.rs
+++ b/src/compiler/const_fold.rs
@@ -290,6 +290,10 @@ impl Compiler {
     pub(super) fn inherit_fold_ctx(&self, child: &mut Compiler) {
         child.fold_ctx = Arc::clone(&self.fold_ctx);
         child.fold_root = false;
+        // The unit's `use` record travels with the fold state, and for the same
+        // reason: a `use` compiled into a closure or sub body belongs to this
+        // unit's BEGIN-time preload set (GH-8201).
+        child.unit_use_ctx = Arc::clone(&self.unit_use_ctx);
         child.outer_constant_values = self
             .outer_constant_values
             .iter()

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1103,6 +1103,7 @@ mod declaration_plan_tests {
     }
 }
 mod adverb_interp;
+mod begin_use;
 mod const_fold;
 pub(crate) mod control_block;
 mod control_block_scope;
@@ -1603,6 +1604,16 @@ pub(crate) struct Compiler {
     /// True only for the compiler that owns `fold_ctx` (the unit-level one).
     /// Child compilers inherit the Arc and must not trigger the refold pass.
     fold_root: bool,
+    /// The modules `use`d anywhere in this compilation unit, shared with every
+    /// child compiler alongside `fold_ctx`. Drives the BEGIN-time preload
+    /// prologue — see [`begin_use`].
+    unit_use_ctx: std::sync::Arc<begin_use::UnitUseCtx>,
+    /// Modules whose load this unit hoists to its head (GH-8201). Populated
+    /// only on the second compile pass, from the first pass's record.
+    begin_preloads: Vec<String>,
+    /// Literal `use lib` specs replayed ahead of `begin_preloads` so a hoisted
+    /// load resolves against the search path the unit sets up.
+    begin_preload_lib_paths: Vec<String>,
     /// Compile-time values of in-scope `constant`s whose initializer is itself a
     /// constant scalar (ADR-0006 §2.2). Reads of these compile to `LoadConst`
     /// instead of a package lookup, and an `if`/`unless` on one resolves its
@@ -1709,6 +1720,9 @@ impl Compiler {
             next_try_is_bare_block: false,
             fold_ctx: std::sync::Arc::new(const_fold::FoldCtx::enabled()),
             fold_root: true,
+            unit_use_ctx: std::sync::Arc::new(begin_use::UnitUseCtx::default()),
+            begin_preloads: Vec::new(),
+            begin_preload_lib_paths: Vec::new(),
             constant_values: HashMap::new(),
             outer_constant_values: HashMap::new(),
         }
@@ -3871,17 +3885,34 @@ impl Compiler {
     /// something had already been folded. Only files that declare operators pay
     /// the second pass.
     pub(crate) fn compile(self, stmts: &[Stmt]) -> (CompiledCode, CompiledFns) {
-        if !self.fold_root || !self.fold_ctx.is_enabled() {
+        if !self.fold_root {
             return self.compile_unit(stmts);
         }
         let pristine = self.clone();
         let ctx = std::sync::Arc::clone(&self.fold_ctx);
+        let uses = std::sync::Arc::clone(&self.unit_use_ctx);
         let compiled = self.compile_unit(stmts);
-        if !ctx.needs_refold_pass() {
+        let needs_refold = ctx.is_enabled() && ctx.needs_refold_pass();
+        // The same second pass also carries the BEGIN-time preload prologue
+        // (GH-8201): a `use` nested in a block is only discovered once that
+        // block has been compiled, which is after the head of the unit has
+        // been emitted. Only a unit that actually holds a nested `use` — or
+        // that folded against a later operator declaration — pays for it.
+        let preloads = uses.nested_modules(stmts);
+        if !needs_refold && preloads.is_empty() {
             return compiled;
         }
         let mut retry = pristine;
-        retry.fold_ctx = std::sync::Arc::new(const_fold::FoldCtx::disabled());
+        retry.fold_ctx = std::sync::Arc::new(if needs_refold {
+            const_fold::FoldCtx::disabled()
+        } else {
+            const_fold::FoldCtx::enabled()
+        });
+        retry.unit_use_ctx = std::sync::Arc::new(begin_use::UnitUseCtx::default());
+        if !preloads.is_empty() {
+            retry.begin_preload_lib_paths = begin_use::literal_lib_paths(stmts);
+            retry.begin_preloads = preloads;
+        }
         retry.compile_unit(stmts)
     }
 
@@ -3978,6 +4009,10 @@ impl Compiler {
         // If the top-level body contains a CATCH or CONTROL block, wrap in
         // an implicit try so the phaser can observe exceptions / control
         // signals from the surrounding statements.
+        // Raku loads every `use`d compunit at BEGIN time. A `use` nested in a
+        // block compiles to a runtime load at the block's own position, so its
+        // packages are hoisted here instead — see [`begin_use`].
+        self.emit_begin_preloads();
         let has_catch = stmts
             .iter()
             .any(|s| matches!(s, Stmt::Catch(_) | Stmt::Control(_)));

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3998,6 +3998,18 @@ impl Compiler {
                 // (`v6`, `strict`, `nqp`, ...) are matched by earlier arms and
                 // never reach here, so they keep folding.
                 self.fold_ctx.note_operator_decl();
+                // Raku's `use` is BEGIN-time. Record the module so the unit-level
+                // pass can hoist the *load* of a `use` nested in a block ahead of
+                // the mainline, leaving this in-position import where Raku scopes
+                // it (GH-8201, `compiler::begin_use`).
+                if let Some(name) = super::begin_use::preloadable_module_name(
+                    module,
+                    tags,
+                    condition.as_deref(),
+                    arg.as_ref(),
+                ) {
+                    self.unit_use_ctx.note_use(name);
+                }
                 let name_idx = self.code.add_constant(Value::str(module.clone()));
                 // The native JSON modules read their import list at run time to
                 // select per-scope defaults (`use JSON::Fast <immutable !pretty>`).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2595,6 +2595,19 @@ pub(crate) enum OpCode {
     NoModule(u32),
     /// `need Module;` — load module without importing exports.
     NeedModule(u32),
+    /// BEGIN-time preload of a module `use`d inside a nested block.
+    ///
+    /// Raku performs `use` at BEGIN time, so the packages a module installs are
+    /// visible to *every* statement of the compunit, including the ones that run
+    /// before the block holding the `use` is ever entered. mutsu's `UseModule` is
+    /// a runtime op, so the compiler additionally emits one of these at the head
+    /// of the unit for each nested `use` (see `Compiler::emit_begin_preloads`).
+    /// It performs only the *load* half — the lexical import stays at the `use`'s
+    /// own run position, where Raku scopes it. A load failure is swallowed: the
+    /// in-position `UseModule` reports it if control ever reaches it, so a
+    /// never-run block referring to an absent module stays as non-fatal as it is
+    /// today.
+    PreloadModule(u32),
     UseLibPath,
     /// Save current function/class registries for lexical import scoping.
     PushImportScope,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4389,6 +4389,15 @@ pub(crate) struct ImportScopeSnapshot {
     pub(crate) strict_mode: bool,
     pub(crate) fatal_mode: bool,
     pub(crate) monkey_typing: bool,
+    /// Whether the pop also rolls the class registry back to `classes`.
+    ///
+    /// True for a `use`-containing block, whose class imports are lexical to it.
+    /// False for the BEGIN-time preload scope (`push_preload_scope`), which
+    /// exists only to contain the `GLOBAL::` routine and proto aliases mutsu's
+    /// sub hoisting installs while a module body loads: a package a module
+    /// declares is installed into GLOBAL by the load itself in raku, and it is
+    /// precisely what the preload is hoisting the load in order to publish.
+    pub(crate) scope_classes: bool,
 }
 
 impl Default for Interpreter {

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -616,6 +616,20 @@ impl Interpreter {
     /// before it. This is `use lib`'s semantics: Raku unshifts the repository onto
     /// `$*REPO`'s chain, so a `use lib` outranks `-I`/`MUTSULIB` and the installed
     /// repositories, and within one statement the last-listed path ends up first.
+    /// Whether `path` is already the *front* entry of the search chain, so
+    /// prepending it again would change nothing.
+    ///
+    /// This is what makes the BEGIN-time preload prologue's replay of a unit's
+    /// literal `use lib` specs invisible: the prologue puts the spec at the head
+    /// of the chain, and the `use lib` at its own position then recognizes it
+    /// rather than adding a second copy. Deliberately NOT "present anywhere":
+    /// `use lib` outranks `-I` and `MUTSULIB`, so re-specifying a path that is
+    /// already deeper in the chain must still promote it to the front
+    /// (`t/modules/compunit/lib-path-precedence.t`).
+    pub(crate) fn lib_path_is_front(&self, path: &str) -> bool {
+        self.lib_paths.first().is_some_and(|p| p == path)
+    }
+
     pub fn prepend_lib_path(&mut self, path: String) {
         if !path.is_empty() {
             crate::runtime::cow_table_mut(&mut self.lib_paths).insert(0, path);

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -38,6 +38,22 @@ impl Interpreter {
 
     /// Save current function/class/proto keys for lexical import scoping.
     pub(crate) fn push_import_scope(&mut self) {
+        self.push_import_scope_scoping_classes(true);
+    }
+
+    /// The scope the BEGIN-time module preload runs its load inside.
+    ///
+    /// Same rollback as an import scope for the routine and proto registries —
+    /// mutsu's sub hoisting installs every exported routine under `GLOBAL::`
+    /// while a module body loads, and those aliases belong to whoever wrote the
+    /// `use`, not to the whole file — but the class registry is left alone: a
+    /// package the module declares is exactly what the preload hoists the load
+    /// in order to publish, and raku installs it into GLOBAL at load time too.
+    pub(crate) fn push_preload_scope(&mut self) {
+        self.push_import_scope_scoping_classes(false);
+    }
+
+    fn push_import_scope_scoping_classes(&mut self, scope_classes: bool) {
         let snapshot = {
             let reg = self.registry();
             crate::runtime::ImportScopeSnapshot {
@@ -54,6 +70,7 @@ impl Interpreter {
                 strict_mode: self.strict_mode,
                 fatal_mode: self.fatal_mode,
                 monkey_typing: self.monkey_typing,
+                scope_classes,
             }
         };
         self.import_scope_stack.push(snapshot);
@@ -107,6 +124,7 @@ impl Interpreter {
                 strict_mode,
                 fatal_mode,
                 monkey_typing,
+                scope_classes,
             } = snapshot;
             // Remove functions added since the push, EXCEPT a module's own
             // fully-qualified source definitions (`Fancy::Utilities::lolgreet`,
@@ -153,9 +171,12 @@ impl Interpreter {
             // dying with X::Method::NotFound in the second block
             // (t/module-reuse-class-in-block.t). Bare imported aliases are
             // still removed with the import scope.
-            self.registry_mut().classes.retain(|key, _| {
-                class_snapshot.contains(key) || (key.contains("::") && !key.starts_with("GLOBAL::"))
-            });
+            if scope_classes {
+                self.registry_mut().classes.retain(|key, _| {
+                    class_snapshot.contains(key)
+                        || (key.contains("::") && !key.starts_with("GLOBAL::"))
+                });
+            }
             // `proto sub name(|) is export` imports under the importing package
             // (`GLOBAL::skip`) into BOTH proto tables, and `has_proto` reads the
             // name set. Left behind, an imported proto kept a bare call on the
@@ -268,10 +289,37 @@ impl Interpreter {
         (&module[..bare_end], selectors)
     }
 
+    /// Load a module the way `use` does — registering its exports, package
+    /// globals and types — but *without* importing anything into the current
+    /// lexical scope.
+    ///
+    /// This is the BEGIN-time half of `use` (see
+    /// [`crate::opcode::OpCode::PreloadModule`]): Raku loads every `use`d
+    /// compunit before the importing unit's mainline runs, so its packages are
+    /// visible everywhere, while the import itself stays lexical to the scope
+    /// holding the `use`. `need_module` is not a substitute — it loads with
+    /// `suppress_exports` set, so the module's `is export` routines are never
+    /// registered and a later `use` of the (now already-loaded) module has
+    /// nothing left to import.
+    pub(crate) fn preload_module(&mut self, module: &str) -> Result<(), RuntimeError> {
+        self.use_module_with_tags_scoped(module, &[], false)
+    }
+
     pub fn use_module_with_tags(
         &mut self,
         module: &str,
         tags: &[String],
+    ) -> Result<(), RuntimeError> {
+        self.use_module_with_tags_scoped(module, tags, true)
+    }
+
+    /// `import`: whether the module's exports are installed into the current
+    /// lexical scope. False only for the BEGIN-time preload above.
+    fn use_module_with_tags_scoped(
+        &mut self,
+        module: &str,
+        tags: &[String],
+        import: bool,
     ) -> Result<(), RuntimeError> {
         // The parser rides dist selectors on the module name
         // (`JSON::Class:auth<zef:jonathanstowe>:api<1.0>`). Split them off here
@@ -292,7 +340,7 @@ impl Interpreter {
         // always wants ordinary export semantics regardless of an ambient
         // `need`, so suspend the flag for exactly this nested load.
         let saved_suppress_exports = std::mem::replace(&mut self.suppress_exports, false);
-        let result = self.use_module_with_tags_inner(module, tags);
+        let result = self.use_module_with_tags_inner(module, tags, import);
         self.suppress_exports = saved_suppress_exports;
         self.pending_dist_selectors = saved;
         // `load_module` consumes `pending_use_export_args`; clear any residue
@@ -306,6 +354,7 @@ impl Interpreter {
         &mut self,
         module: &str,
         tags: &[String],
+        import: bool,
     ) -> Result<(), RuntimeError> {
         // `use JSON::Fast <immutable !pretty>`: the import list selects
         // per-scope defaults for the native provider. Every `use` re-selects
@@ -394,6 +443,9 @@ impl Interpreter {
             // A module with a `sub EXPORT` runs it on every import — its map
             // may depend on the `use` arguments (the Slangify pattern) — even
             // though the module body itself is not re-run.
+            if !import {
+                return Ok(());
+            }
             self.rerun_module_export(module)?;
             return match self.import_module(module, tags) {
                 Ok(()) => Ok(()),
@@ -878,7 +930,8 @@ impl Interpreter {
                     .or_default()
                     .extend(package_globals);
             }
-            if let Err(err) = self.import_module(module, tags)
+            if import
+                && let Err(err) = self.import_module(module, tags)
                 && !err.message.starts_with("No exports found for module:")
             {
                 return Err(err);

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -5455,6 +5455,11 @@ impl Interpreter {
                 self.exec_need_module_op(code, *name_idx)?;
                 *ip += 1;
             }
+            OpCode::PreloadModule(name_idx) => {
+                self.sync_source_line(code, *ip);
+                self.exec_preload_module_op(code, *name_idx);
+                *ip += 1;
+            }
             OpCode::UseLibPath => {
                 self.exec_use_lib_path_op(code)?;
                 *ip += 1;

--- a/src/vm/vm_module_ops.rs
+++ b/src/vm/vm_module_ops.rs
@@ -139,6 +139,33 @@ impl Interpreter {
         Ok(())
     }
 
+    /// BEGIN-time preload emitted at the head of a unit for a module `use`d
+    /// inside a nested block (see [`crate::opcode::OpCode::PreloadModule`]).
+    ///
+    /// Performs the load half of `use` only, so the packages the module installs
+    /// are reachable from statements that run before the block is entered, while
+    /// the lexical import stays at the `use`'s own position. Errors are
+    /// deliberately discarded: nothing in the source asked for the module *here*,
+    /// so a module that cannot be found must not abort a program whose `use` may
+    /// never run. The in-position `UseModule` still reports it if reached.
+    pub(super) fn exec_preload_module_op(&mut self, code: &CompiledCode, name_idx: u32) {
+        let module = Self::const_str(code, name_idx).to_string();
+        // The load runs inside a preload scope, which contains the
+        // `GLOBAL::`-prefixed routine and proto aliases mutsu's sub hoisting
+        // installs while a module body loads. Those are lexical to whoever asked
+        // for the module, and until now they were contained by the import scope
+        // of the very block holding the `use`. Hoisting the load out of that
+        // block would otherwise leave an exported `proto sub head(|)` shadowing
+        // the core listop for the whole file, where raku keeps the import lexical
+        // to the block (`t/modules/import-export/use-in-do-block-is-scoped.t`).
+        // The pop keeps every `::`-qualified definition the module owns, and the
+        // classes it declares — which is the whole point of the preload — and the
+        // in-position `use` re-aliases from those.
+        self.push_preload_scope();
+        let _ = self.preload_module(&module);
+        self.pop_import_scope();
+    }
+
     pub(super) fn exec_need_module_op(
         &mut self,
         code: &CompiledCode,
@@ -190,6 +217,17 @@ impl Interpreter {
             return Err(RuntimeError::new(
                 "X::LibEmpty: Repository specification can not be an empty string",
             ));
+        }
+        // Re-prepending the path that is already at the front of the chain
+        // changes nothing, so skip it. That is what makes the BEGIN-time preload
+        // prologue's replay of this unit's literal `use lib` specs invisible:
+        // the prologue put the spec at the head so a hoisted load could resolve,
+        // and this in-position `use lib` recognizes its own work instead of
+        // doubling the entry and chaining `$*REPO` twice. A path merely present
+        // deeper in the chain is still promoted — `use lib` outranks `-I` and
+        // `MUTSULIB`.
+        if self.lib_path_is_front(&path) {
+            return Ok(());
         }
         // An `inst#PREFIX` spec selects a CompUnit::Repository::Installation as
         // the current `$*REPO`, chained in front of whatever was there before.

--- a/t/lib/BeginUseFixture.rakumod
+++ b/t/lib/BeginUseFixture.rakumod
@@ -1,0 +1,8 @@
+unit module BeginUseFixture;
+
+# A type whose composed name (`BeginUseFixture::X::BeginUse::Marker`) differs
+# from the short name the importer writes, so a stub fabricated for the short
+# name is distinguishable from the real type object.
+class X::BeginUse::Marker is Exception { }
+
+sub begin-use-probe() is export { 'imported' }

--- a/t/modules/import-export/use-in-nested-block-is-begin-time.t
+++ b/t/modules/import-export/use-in-nested-block-is-begin-time.t
@@ -1,0 +1,46 @@
+# Raku performs `use` at BEGIN time, so a module `use`d inside a block that has
+# not run yet is still visible to code that runs first. mutsu compiles `use` to
+# a runtime `OpCode::UseModule`, so the load used to happen only when control
+# reached the block -- and because an unresolved `::`-qualified bareword is
+# answered with a fabricated stub rather than an error, the divergence was
+# silent: `X::BeginUse::Marker.^name` answered the *written* name instead of the
+# module-composed one (GH #8201).
+#
+# The fix hoists only the *load* (`OpCode::PreloadModule`, `compiler::begin_use`).
+# The import stays at the `use`'s own run position, where Raku scopes it -- the
+# constraint `roast/S11-modules/lexical.t` pins and this file re-asserts below.
+use lib 't/lib';
+use Test;
+
+plan 5;
+
+# The issue's repro: the `use` is earlier in FILE order but later in RUN order.
+my &later = { use BeginUseFixture; };
+
+is X::BeginUse::Marker.^name, 'BeginUseFixture::X::BeginUse::Marker',
+   'a type from a module used in a not-yet-run block resolves to its composed name';
+
+ok X::BeginUse::Marker ~~ Exception,
+   'the preloaded type is the real type object, not a fabricated stub';
+
+# The load is hoisted; the import is not.
+nok defined(::('&begin-use-probe')),
+    'the nested use does not leak its import into the enclosing scope';
+
+later();
+
+# `throws-like`'s two arguments both evaluate before the block is invoked, so
+# the type reference is read before the block's `use` has run. This is the shape
+# that kept JSON::Tiny's upstream `t/01-parse.t` at 92/93.
+throws-like {
+    use BeginUseFixture;
+    die X::BeginUse::Marker.new,
+}, X::BeginUse::Marker;
+
+# Raku rejects an unresolvable `use` at BEGIN time whatever block it sits in;
+# mutsu deliberately does not (a missing module only fails where the `use`
+# actually runs). The preload must not quietly change that: it discards its own
+# load failure, so hoisting cannot turn a program that used to run into one that
+# dies before its first statement.
+my &never = { use No::Such::Module::For::BeginUse::Preload; };
+ok &never.defined, 'a preload that cannot resolve its module does not abort the unit';


### PR DESCRIPTION
Raku performs `use Foo` at BEGIN time: by the time any of the compunit's mainline runs, every package `Foo` contributes is installed. mutsu compiled `use` to a runtime `OpCode::UseModule`, so a `use` written inside a block that had not executed yet was invisible to code that *ran* earlier — even when the `use` appeared earlier in **file** order. Because mutsu fabricates a stub type object for an unresolved `::`-qualified bareword rather than erroring, the divergence was silent: the reference answered the *written* name instead of the module-composed one.

```raku
use lib 'tmp';
my &later = { use UseTypeFixture; };   # earlier in the file, not run yet
say X::Fixture::Marker.^name;
# raku:  UseTypeFixture::X::Fixture::Marker
# mutsu: X::Fixture::Marker              (a stub)
```

## What changed

`use` is split into the two halves Raku actually has. The **load** is hoisted to the head of the compilation unit; the **import** stays exactly where it was, because Raku genuinely scopes a nested `use`'s imports to the block holding it (`{ use Foo } foo()` must still die — `roast/S11-modules/lexical.t`).

The unit compile records every module `use`d anywhere inside it — including inside closure and sub bodies, which share the unit's context the same way the constant-fold state does. Subtracting the unit's own top-level `use`s leaves the nested ones, and the unit is recompiled with an `OpCode::PreloadModule` for each at its head. It rides the second pass the refold path already had, so only a unit that actually holds a nested `use` pays for it.

`Interpreter::preload_module` is the load half: `use_module_with_tags` with the final `import_module` skipped. `need_module` was **not** a substitute — it loads with `suppress_exports` set, so the module's `is export` routines are never registered and the later in-position `use` of the (now already-loaded) module has nothing left to import.

Three details make hoisting the load safe:

- **`use lib` is replayed first.** A `use lib` written *later* in the file is a BEGIN-time effect too, and a hoisted load may depend on it, so the unit's literal `use lib` specs are emitted ahead of the preloads in source order. Re-adding the spec already at the **front** of the search chain is now a no-op, so the `use lib` at its own position recognizes the prologue's work instead of doubling the entry. A path merely present *deeper* in the chain is still promoted — `use lib` outranks `-I` and `MUTSULIB` (`t/modules/compunit/lib-path-precedence.t` caught this).
- **The load runs inside a preload scope.** mutsu's sub hoisting installs every exported routine under `GLOBAL::` while a module body loads, and those aliases belong to whoever wrote the `use`. Until now they were contained by the import scope of the very block holding it; hoisting the load out would have left an exported `proto sub head(|)` shadowing the core listop for the whole file (`t/modules/import-export/use-in-do-block-is-scoped.t` caught this). The preload scope rolls the routine and proto registries back the same way an import scope does, but leaves the class registry alone — a package the module declares is exactly what the preload exists to publish, and raku installs it into GLOBAL at load time too (`t/modules/enum-member-nested-module-load.t` caught the over-rollback).
- **A preload that cannot find its module is discarded.** Raku rejects an unresolvable `use` at BEGIN time whatever block it sits in; mutsu deliberately does not. Hoisting must not change that, so the preload swallows its own failure and the in-position `UseModule` still reports it if control reaches it.

## What it unblocks

`JSON::Tiny`'s upstream `t/01-parse.t` is back on `batteries-whitelist.txt` at **93/93** (verified against the pinned upstream commit `a5ef8c17` with the bundled `modules/JSON-Tiny/lib`). Its last assertion is

```raku
throws-like {
    use JSON::Tiny;
    from-json '',
}, X::JSON::Tiny::Invalid;
```

and `throws-like`'s two arguments both evaluate before the block is invoked, so the type reference was read before the block's `use` had run.

## Residual

A **top-level** `use` still loads where it stands, so code textually *before* it in the mainline still cannot see its packages. That is the same gap one level up, but it needs no stub fabrication to be visible and is far rarer; hoisting every top-level load ahead of the mainline has a considerably larger blast radius than this change. Recorded in the news entry.

## Verification

- New pin `t/modules/import-export/use-in-nested-block-is-begin-time.t` (5 assertions); its four raku-comparable assertions were checked against rakudo 2026.07 and agree.
- `make test`: **PASS** (4181 files, 44554 tests).
- `make roast`: green apart from the three documented container-only reds (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t` — `uid 0` / sandboxed network, per `docs/agent-environments.md`).
- `make lint`: all four configurations clean.

Closes #8201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoRrJgwXv3pryDCnR3aYKS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoRrJgwXv3pryDCnR3aYKS)_