### PR TITLE
fix: keep package-scoped my classes private

### DIFF
--- a/news/2026-09/my-class-in-package-stays-private.md
+++ b/news/2026-09/my-class-in-package-stays-private.md
@@ -1,0 +1,4 @@
+`my` classes declared inside a `module`, `package`, or class body no longer
+leak through that package's qualified name after the declaration scope ends.
+Qualified inheritance parents also resolve to the existing package type when a
+lexical class shadows the same source-facing name.

--- a/src/compiler/helpers_dynamic.rs
+++ b/src/compiler/helpers_dynamic.rs
@@ -23,6 +23,8 @@ pub(super) struct LexicalScopeSnapshot {
     constant_values: std::collections::HashMap<String, Value>,
     my_vars_current_scope: std::collections::HashSet<String>,
     class_names_current_scope: std::collections::HashSet<String>,
+    lexical_class_names_current_scope: std::collections::HashSet<String>,
+    qualified_class_names_current_scope: std::collections::HashSet<String>,
     accessed_dynamic_vars: std::collections::HashSet<String>,
     /// True when this push left `accessed_dynamic_vars` untouched (a
     /// transparent synthetic-wrapper inlining, not a real scope) — see
@@ -68,6 +70,12 @@ impl Compiler {
             // Likewise a same-named class inside an inner block shadows rather
             // than redeclares the outer one.
             class_names_current_scope: std::mem::take(&mut self.class_names_current_scope),
+            lexical_class_names_current_scope: std::mem::take(
+                &mut self.lexical_class_names_current_scope,
+            ),
+            qualified_class_names_current_scope: std::mem::take(
+                &mut self.qualified_class_names_current_scope,
+            ),
             // The entered block starts with no dynamic-var reads recorded of
             // its own: X::Dynamic::Postdeclaration must only fire for a `my
             // $*x` that follows an earlier read of `$*x` in the SAME block —
@@ -105,6 +113,8 @@ impl Compiler {
         self.constant_values = saved.constant_values;
         self.my_vars_current_scope = saved.my_vars_current_scope;
         self.class_names_current_scope = saved.class_names_current_scope;
+        self.lexical_class_names_current_scope = saved.lexical_class_names_current_scope;
+        self.qualified_class_names_current_scope = saved.qualified_class_names_current_scope;
         // A transparent push (see `push_dynamic_scope_lexical`) never touched
         // `accessed_dynamic_vars`, so the matching pop must not touch it
         // either — restoring the (empty, unused) snapshot value here would

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1456,6 +1456,14 @@ pub(crate) struct Compiler {
     /// (`class A {...}`) followed by its real definition is NOT a redeclaration,
     /// and a same-named class in an inner block shadows rather than redeclares.
     class_names_current_scope: std::collections::HashSet<String>,
+    /// The subset of `class_names_current_scope` declared with `my`. A lexical
+    /// class may shadow an outer package class with the same qualified source
+    /// name, while two lexical declarations in one scope still redeclare.
+    lexical_class_names_current_scope: std::collections::HashSet<String>,
+    /// The declarations in the current scope whose source spelling was
+    /// qualified. This allows a bare lexical declaration inside a package to
+    /// shadow an earlier outer `class Pkg::Name`, the shape Rakudo permits.
+    qualified_class_names_current_scope: std::collections::HashSet<String>,
     /// Names of constants declared in an *enclosing* compiler (i.e. visible at a
     /// nested closure's definition point). Propagated into child closure
     /// compilers (which otherwise start with empty constant state). Used ONLY to
@@ -1686,6 +1694,8 @@ impl Compiler {
             constant_vars_current_scope: std::collections::HashSet::new(),
             my_vars_current_scope: std::collections::HashSet::new(),
             class_names_current_scope: std::collections::HashSet::new(),
+            lexical_class_names_current_scope: std::collections::HashSet::new(),
+            qualified_class_names_current_scope: std::collections::HashSet::new(),
             outer_constant_names: std::collections::HashSet::new(),
             sigilless_locals: std::collections::HashSet::new(),
             enclosing_sigilless: std::collections::HashSet::new(),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -4112,6 +4112,7 @@ impl Compiler {
                 name,
                 body,
                 custom_traits,
+                is_lexical,
                 ..
             } => {
                 // Declaring the same class name twice in one lexical scope is an
@@ -4140,7 +4141,19 @@ impl Compiler {
                     } else {
                         format!("{}::{}", self.current_package, cname)
                     };
-                    if !self.class_names_current_scope.insert(redeclaration_key) {
+                    let already_declared =
+                        self.class_names_current_scope.contains(&redeclaration_key);
+                    let already_lexical = self
+                        .lexical_class_names_current_scope
+                        .contains(&redeclaration_key);
+                    let may_shadow_outer_package_class = *is_lexical
+                        && !cname.contains("::")
+                        && self.current_package != "GLOBAL"
+                        && !already_lexical
+                        && self
+                            .qualified_class_names_current_scope
+                            .contains(&redeclaration_key);
+                    if already_declared && !may_shadow_outer_package_class {
                         let sym = cname.rsplit("::").next().unwrap_or(&cname).to_string();
                         let mut attrs = std::collections::HashMap::new();
                         attrs.insert("symbol".to_string(), Value::str(sym));
@@ -4150,6 +4163,16 @@ impl Compiler {
                         self.code.emit(OpCode::LoadConst(cidx));
                         self.code.emit(OpCode::Die { user_throw: false });
                         return;
+                    }
+                    self.class_names_current_scope
+                        .insert(redeclaration_key.clone());
+                    if *is_lexical {
+                        self.lexical_class_names_current_scope
+                            .insert(redeclaration_key.clone());
+                    }
+                    if cname.contains("::") {
+                        self.qualified_class_names_current_scope
+                            .insert(redeclaration_key);
                     }
                 }
                 // A method installed by RegisterClass outlives this frame and has

--- a/src/runtime/accessors_stash.rs
+++ b/src/runtime/accessors_stash.rs
@@ -834,8 +834,12 @@ impl Interpreter {
             {
                 continue;
             }
-            // Skip my-scoped items (they should not appear in the package stash)
-            if self.is_my_scoped_package_item(&key_s) {
+            // Skip my-scoped items (they should not appear in the package stash).
+            // A lexical type is registered in the env under its source-facing
+            // qualified name (`M::C`) but marked under its mangled registry
+            // storage name (`M::C\0<decl-id>`), so the package-item marker alone
+            // cannot identify this env entry.
+            if self.is_my_scoped_package_item(&key_s) || self.is_my_scoped_type_name(&key_s) {
                 continue;
             }
             // GLOBAL's env scan sees the self-qualified mirror of a root

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -731,6 +731,22 @@ impl Interpreter {
         {
             return format!("{}{}", lookup, suffix);
         }
+        // A lexical class can shadow a package class with the same
+        // source-facing qualified name (`module M { my class C is M::C {} }`).
+        // For a qualified parent spelling, prefer the actual package member
+        // over the lexical env binding that the declaration installed for its
+        // own source name. Bare parent names still go through the lexical env
+        // remapping in the VM, so explicit `my class C is C` remains a genuine
+        // self-inheritance error.
+        if lookup.contains("::") {
+            let registry = self.registry();
+            if registry.classes.contains_key(lookup)
+                || registry.roles.contains_key(lookup)
+                || registry.enum_types.contains_key(lookup)
+            {
+                return format!("{}{}", lookup, suffix);
+            }
+        }
         if let ValueView::Package(pkg) = self.resolve_indirect_type_name(lookup).view() {
             return format!("{}{}", pkg.resolve(), suffix);
         }

--- a/src/runtime/registration_class_parents.rs
+++ b/src/runtime/registration_class_parents.rs
@@ -112,6 +112,7 @@ impl Interpreter {
         // Foobar { }` never trips X::Inheritance::SelfInherit because the
         // mangled storage name can never equal the bare parent name it is
         // supposed to collide with.
+        let storage_name = name;
         let name = crate::value::user_facing_type_name(name);
         let self_short = short_of(&name);
         let mut non_inheritance_parents: HashSet<String> = HashSet::new();
@@ -142,7 +143,11 @@ impl Interpreter {
                 non_inheritance_parents.insert(parent.clone());
                 continue;
             }
-            if resolved_parent == name.as_ref() {
+            let lexical_class_shadows_package_type = storage_name.contains('\u{0}')
+                && (self.registry().classes.contains_key(name.as_ref())
+                    || self.registry().roles.contains_key(name.as_ref())
+                    || self.registry().enum_types.contains_key(name.as_ref()));
+            if resolved_parent == name.as_ref() && !lexical_class_shadows_package_type {
                 let mut attrs = HashMap::new();
                 attrs.insert("name".to_string(), Value::str(name.to_string()));
                 attrs.insert(

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -262,6 +262,22 @@ impl Interpreter {
     /// env binds the bare name to that storage name, so `is Foo` links to the Foo
     /// visible in *this* scope rather than a same-named class from another scope.
     pub(crate) fn lexical_env_remap_name(&self, name: &str) -> String {
+        // A qualified parent name addresses a package member before lexical
+        // aliases. When a lexical child shadows that same source-facing name
+        // (`module M { my class C is M::C {} }`), the env contains `M::C` as
+        // the child's mangled binding, but the qualified spelling still names
+        // the existing package class. Keep the qualified name when that
+        // package member exists; namespaced lexical types with no package
+        // member continue through the env remap below.
+        if name.contains("::") {
+            let registry = self.registry();
+            if registry.classes.contains_key(name)
+                || registry.roles.contains_key(name)
+                || registry.enum_types.contains_key(name)
+            {
+                return name.to_string();
+            }
+        }
         if let Some(ValueView::Package(p)) = self.env().get(name).map(Value::view) {
             let resolved = p.resolve();
             // Only trust this as an ADR-0047 lexical-class remap when `resolved`
@@ -424,6 +440,17 @@ impl Interpreter {
             })
         {
             return true;
+        }
+        // A lexical type declared inside a `module`/`package`/`class` body is
+        // still in the same compilation unit, but its package-qualified name
+        // is only available while code is running in that package. A same-file
+        // lookup after the package block must not turn the lexical declaration
+        // into a package symbol (`module M { my class C {} }; M::C`). The
+        // package-kind table distinguishes this from a namespaced lexical
+        // declaration at file scope (`my class M::C {}`), whose qualified name
+        // remains visible within its own compilation unit.
+        if type_package.is_some_and(|package| self.registry().package_kinds.contains_key(package)) {
+            return false;
         }
         if type_package.is_some_and(|package| {
             let registry = self.registry();

--- a/t/modules/my-class-in-package-stays-private.t
+++ b/t/modules/my-class-in-package-stays-private.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 4;
+
+module Sto {
+    my class Client {
+        method who { 'private' }
+    }
+
+    our sub private-client-name() is export {
+        Client.^name
+    }
+}
+
+is Sto::private-client-name(), 'Sto::Client',
+    'the declaring package can still use its lexical class';
+dies-ok { Sto::Client.^name },
+    'a my class inside a package is not a package-qualified symbol outside it';
+ok !Sto::.keys.grep(* eq 'Client'),
+    'a my class is absent from the package stash';
+
+class Outer::Thing {
+    method who { 'outer' }
+}
+
+module Outer {
+    my class Thing is Outer::Thing { }
+
+    our sub consumer-state() is export {
+        Thing.new.who ~ '/' ~ Thing.^name
+    }
+}
+
+is Outer::consumer-state(), 'outer/Outer::Thing',
+    'a package-qualified parent resolves to the outer class, not the lexical child';


### PR DESCRIPTION
Closes #8218

## Summary
- keep `my` classes declared inside package bodies out of package-qualified lookup and stash enumeration
- resolve qualified inheritance parents against the existing package member when a lexical child has the same source-facing name
- add compiler and runtime regression coverage

## Tests
- `make lint`
- `make test`
- `make roast`