### PR TITLE
fix: parse comma-list given and when expressions

### DIFF
--- a/news/2026-09/when-comma-list-matcher.md
+++ b/news/2026-09/when-comma-list-matcher.md
@@ -1,0 +1,1 @@
+`when` matchers and `given` topics now accept unparenthesized comma lists, including Whatever and literal list matchers.

--- a/src/parser/stmt/control/conditionals.rs
+++ b/src/parser/stmt/control/conditionals.rs
@@ -18,7 +18,7 @@ pub(crate) struct ElseClause {
     body: Vec<Stmt>,
 }
 
-fn conditional_expr(input: &str) -> PResult<'_, Expr> {
+pub(super) fn conditional_expr(input: &str) -> PResult<'_, Expr> {
     match parse_comma_or_expr(input) {
         Ok((rest, cond)) => {
             let (tail, _) = ws(rest)?;

--- a/src/parser/stmt/control/given_when.rs
+++ b/src/parser/stmt/control/given_when.rs
@@ -4,7 +4,7 @@ use super::*;
 pub(crate) fn given_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("given", input).ok_or_else(|| PError::expected("given statement"))?;
     let (rest, _) = ws1(rest)?;
-    let (rest, topic) = expression(rest)?;
+    let (rest, topic) = parse_comma_or_expr(rest)?;
     let (rest, _) = ws(rest)?;
     // Check for pointy block: given EXPR -> $param { ... }
     let (rest, pointy_param) = if let Some(r) = rest.strip_prefix("->") {
@@ -33,7 +33,10 @@ pub(crate) fn given_stmt(input: &str) -> PResult<'_, Stmt> {
 pub(crate) fn when_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("when", input).ok_or_else(|| PError::expected("when statement"))?;
     let (rest, _) = ws1(rest)?;
-    let (rest, cond) = condition_expr(rest)?;
+    // A `when` matcher is a full comma expression. This is the same parsing
+    // rule used by `if` conditions, and is required for element-wise
+    // smartmatching of list topics (`when * == 1, * { ... }`).
+    let (rest, cond) = super::conditionals::conditional_expr(rest)?;
     let (rest, _) = ws(rest)?;
     // An undeclared bareword in term position immediately followed by a block is
     // treated by raku as a function call that gobbles the block (e.g.

--- a/t/control/when-comma-list-matcher.t
+++ b/t/control/when-comma-list-matcher.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 3;
+
+my $whatever-curry;
+given 1, 2 {
+    when * == 1, * {
+        $whatever-curry = 'matched';
+    }
+}
+is $whatever-curry, 'matched',
+    'a Whatever-curry comma-list matcher matches a list topic';
+
+my $bare-whatever;
+given 1, 2 {
+    when *, * {
+        $bare-whatever = 'matched';
+    }
+}
+is $bare-whatever, 'matched',
+    'a bare Whatever comma-list matcher matches a list topic';
+
+my $literal-list;
+given 1, 2 {
+    when 1, 2 {
+        $literal-list = 'matched';
+    }
+}
+is $literal-list, 'matched',
+    'a literal comma-list matcher matches a list topic';


### PR DESCRIPTION
Fixes #8219.

`given` topics and `when` matchers now use the full comma-expression parser, so unparenthesized Whatever and literal list matchers parse and smartmatch list topics correctly. Adds focused regression coverage and a news entry.