### PR TITLE
fix: enum accepts an anonymous role literal as a does argument

### DIFF
--- a/news/2026-09/enum-does-anonymous-role-literal.md
+++ b/news/2026-09/enum-does-anonymous-role-literal.md
@@ -1,0 +1,35 @@
+# `enum` accepts an anonymous role literal as a `does` argument
+
+`does` accepts an anonymous role *literal*, not just a role name.
+`enum Level <Off Fatal> does role { ... }` (the shape `Lumberjack` and its
+plugins use) took the `role` keyword as the name of a role to look up,
+found none, and died with `Unknown role: role`, so any distribution
+using this shape could not even load.
+
+Two orderings exist, and rakudo treats them genuinely differently:
+
+- `does Role` *before* the value list (`enum E does Role <a b>`) is a real
+  declarator trait — the role is actually composed (`.^does` is `True`) —
+  but an anonymous role *literal* is invalid even in rakudo there
+  ("Invalid typename 'role'"); only a role name is accepted in that slot.
+- `does Role` *after* the value list (`enum E <a b> does Role`, the
+  Lumberjack/reported shape) is not special enum grammar in rakudo at
+  all: `enum E <a b>` parses as an ordinary term (the type object), and
+  the trailing `does Role` is the general infix `does` operator applied
+  to it and then sunk — it never actually composes anything (`.^does`
+  stays `False`, `.^roles(:local)` stays empty), and a second trailing
+  `does` even errors as a non-associative operator.
+
+The fix mirrors both exactly: the before-the-values `does` loop
+(`parse_enum_trait_clauses`) is unchanged (still rejects a role literal
+the same way rakudo does, just via a different error), and a new
+`skip_trailing_enum_does_clause` consumes — but discards — a single
+`does <Role>` clause after the value list, so parsing no longer crashes
+or fragments into a stray `Unknown role: role` statement, without
+pretending to compose something rakudo itself does not.
+
+`enum_decl.rs` was split into `enum_decl.rs` +
+`enum_decl_traits.rs` to stay under the file-size convention.
+
+See [#8216](https://github.com/tokuhirom/mutsu/issues/8216) and the
+regression test `t/oo/role/enum-does-anonymous-role-literal.t`.

--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -15,12 +15,12 @@ mod reduction;
 
 pub(crate) use anon_decl::next_anon_role_name;
 pub(super) use anon_decl::{
-    anon_class_expr, anon_grammar_expr, anon_role_expr, indirect_method_call,
-    mark_anon_package_decl,
+    anon_class_expr, anon_grammar_expr, indirect_method_call, mark_anon_package_decl,
 };
 pub(super) use lambda::{arrow_lambda, capture_literal};
 pub(super) use reduction::reduction_op;
 
+pub(in crate::parser) use anon_decl::anon_role_expr;
 pub(in crate::parser) use colonpair::{colonpair_expr, wrap_colonpair_sink_source};
 pub(in crate::parser) use lambda::{
     block_or_hash_expr, double_closure_error, parse_block_body, parse_block_body_routine,

--- a/src/parser/stmt/decl/enum_decl.rs
+++ b/src/parser/stmt/decl/enum_decl.rs
@@ -1,8 +1,8 @@
 use super::super::super::expr::expression;
 use super::super::super::helpers::{skip_balanced_parens, ws, ws1};
 use super::super::super::parse_result::{PError, PResult, parse_char, take_while1};
-use super::super::{ident, keyword, qualified_ident};
-use super::helpers::{has_export_tag_argument, parse_export_trait_tags};
+use super::super::{keyword, qualified_ident};
+use super::enum_decl_traits::{parse_enum_trait_clauses, skip_trailing_enum_does_clause};
 use super::take_while_opt;
 use crate::ast::{EnumVariantForm, Expr, Stmt};
 use crate::symbol::Symbol;
@@ -77,7 +77,7 @@ fn register_dynamic_enum_values(body: &Expr) {
 
 /// Skip a balanced `[...]` role-parameterization argument. Returns the input
 /// past the closing `]`, or `None` when the input does not start with `[`.
-fn skip_balanced_brackets(input: &str) -> Option<&str> {
+pub(super) fn skip_balanced_brackets(input: &str) -> Option<&str> {
     let mut rest = input.strip_prefix('[')?;
     let mut depth = 1u32;
     while depth > 0 {
@@ -345,69 +345,12 @@ pub(super) fn parse_enum_decl_body_with_type(
     super::super::simple::register_user_type(&name_str);
     let (rest, _) = ws(rest)?;
 
-    // Parse the declaration's trait clauses — `is <trait>` (e.g. `is export`)
-    // and `does <Role>` — which may appear in any order and repeat
-    // (`enum E does A does B is export <x y>`). Without the `does` arm the
-    // clause was left unconsumed, the `(...)`/`<...>` body was never read as the
-    // enum's value list, and the leftover `does Role (A => 1, B => 2)` parsed as
-    // a plain expression statement — which is where the spurious
-    // "Useless use of '=>' in sink context" warning came from, and why the enum
-    // ended up with no values at all.
-    let mut rest = rest;
+    // Parse the declaration's trait clauses (`is export`, `does Role`) that
+    // precede the value list -- see `parse_enum_trait_clauses`.
     let mut is_export = false;
     let mut export_tags: Vec<String> = Vec::new();
     let mut roles: Vec<String> = Vec::new();
-    loop {
-        if let Some(r) = keyword("is", rest) {
-            let (r, _) = ws1(r)?;
-            let (r, trait_name) = ident(r)?;
-            if trait_name == "export" {
-                is_export = true;
-                let (r, tags) = if has_export_tag_argument(r) {
-                    parse_export_trait_tags(r)?
-                } else {
-                    (r, Vec::new())
-                };
-                if tags.is_empty() {
-                    if !export_tags.iter().any(|t| t == "DEFAULT") {
-                        export_tags.push("DEFAULT".to_string());
-                    }
-                } else {
-                    for tag in tags {
-                        if !export_tags.iter().any(|t| t == &tag) {
-                            export_tags.push(tag);
-                        }
-                    }
-                }
-                let (r, _) = ws(r)?;
-                rest = r;
-                continue;
-            }
-            // Consume an optional parenthesized argument for other traits.
-            let r = skip_balanced_parens(r);
-            let (r, _) = ws(r)?;
-            rest = r;
-            continue;
-        }
-        if let Some(r) = keyword("does", rest) {
-            let (r, _) = ws1(r)?;
-            let (r, role_name) = qualified_ident(r)?;
-            // A parameterized role (`does R[Int]`) keeps its argument list in
-            // the recorded name, the same spelling class composition uses.
-            let (r, role_name) = match skip_balanced_brackets(r) {
-                Some(after) => {
-                    let consumed = &r[..r.len() - after.len()];
-                    (after, format!("{role_name}{consumed}"))
-                }
-                None => (r, role_name),
-            };
-            roles.push(role_name);
-            let (r, _) = ws(r)?;
-            rest = r;
-            continue;
-        }
-        break;
-    }
+    let rest = parse_enum_trait_clauses(rest, &mut is_export, &mut export_tags, &mut roles)?;
 
     // Enum variants in << >>, « », <> or ()
     let (rest, variants, variant_form) = if rest.starts_with("<<") || rest.starts_with('\u{ab}') {
@@ -472,6 +415,11 @@ pub(super) fn parse_enum_decl_body_with_type(
     };
 
     let (rest, _) = ws(rest)?;
+    // A `does` clause AFTER the value list (#8216) is consumed and discarded,
+    // not composed -- see `skip_trailing_enum_does_clause` for why that
+    // (rather than genuinely composing it, as the BEFORE-the-value-list loop
+    // above does) is what actually matches rakudo here.
+    let (rest, ()) = skip_trailing_enum_does_clause(rest)?;
     // See parse_anon_enum_body: leave the trailing `;` for the statement layer
     // so `enum` in expression context does not swallow the next statement.
     register_enum_values(&variants);

--- a/src/parser/stmt/decl/enum_decl_traits.rs
+++ b/src/parser/stmt/decl/enum_decl_traits.rs
@@ -1,0 +1,132 @@
+//! Trait-clause parsing for `enum` declarations (`is export`, `does Role`),
+//! split out of `enum_decl.rs` to keep that file under the 500-line limit.
+//! See `parse_enum_trait_clauses` and `skip_trailing_enum_does_clause` for
+//! why the BEFORE-the-value-list and AFTER-the-value-list spellings of
+//! `does` need genuinely different handling (#8216).
+
+use super::super::super::helpers::{skip_balanced_parens, ws, ws1};
+use super::super::super::parse_result::{PError, PResult};
+use super::super::{ident, keyword, qualified_ident};
+use super::enum_decl::skip_balanced_brackets;
+use super::helpers::{has_export_tag_argument, parse_export_trait_tags};
+
+/// Parse a run of the declaration's trait clauses -- `is <trait>` (e.g. `is
+/// export`) and `does <Role>` -- BEFORE the enum's value list, which may
+/// appear in any order and repeat (`enum E does A does B is export <x y>`).
+/// Without the `does` arm at all, the clause was left unconsumed, the
+/// `(...)`/`<...>` body was never read as the enum's value list, and the
+/// leftover `does Role (A => 1, B => 2)` parsed as a plain expression
+/// statement -- which is where the spurious "Useless use of '=>' in sink
+/// context" warning came from, and why the enum ended up with no values at
+/// all.
+///
+/// A `does` clause AFTER the value list is a different grammar position
+/// entirely and does NOT reach this function -- see
+/// [`skip_trailing_enum_does_clause`].
+pub(super) fn parse_enum_trait_clauses<'a>(
+    input: &'a str,
+    is_export: &mut bool,
+    export_tags: &mut Vec<String>,
+    roles: &mut Vec<String>,
+) -> Result<&'a str, PError> {
+    let mut rest = input;
+    loop {
+        if let Some(r) = keyword("is", rest) {
+            let (r, _) = ws1(r)?;
+            let (r, trait_name) = ident(r)?;
+            if trait_name == "export" {
+                *is_export = true;
+                let (r, tags) = if has_export_tag_argument(r) {
+                    parse_export_trait_tags(r)?
+                } else {
+                    (r, Vec::new())
+                };
+                if tags.is_empty() {
+                    if !export_tags.iter().any(|t| t == "DEFAULT") {
+                        export_tags.push("DEFAULT".to_string());
+                    }
+                } else {
+                    for tag in tags {
+                        if !export_tags.iter().any(|t| t == &tag) {
+                            export_tags.push(tag);
+                        }
+                    }
+                }
+                let (r, _) = ws(r)?;
+                rest = r;
+                continue;
+            }
+            // Consume an optional parenthesized argument for other traits.
+            let r = skip_balanced_parens(r);
+            let (r, _) = ws(r)?;
+            rest = r;
+            continue;
+        }
+        if let Some(r) = keyword("does", rest) {
+            let (r, _) = ws1(r)?;
+            // An anonymous role LITERAL (`does role { ... }`) is invalid
+            // here, exactly as rakudo rejects it ("Invalid typename
+            // 'role'") -- unlike the AFTER-the-value-list spelling
+            // (`enum X <values> does role {...}`, see
+            // `skip_trailing_enum_does_clause`), this BEFORE-the-values
+            // `does` is a genuine declarator trait, and rakudo's trait slot
+            // only ever accepts a role NAME there, never a literal. Falling
+            // through to `qualified_ident` below (unchanged) reads `role`
+            // as an ordinary name and reports "Unknown role: role" at
+            // composition time -- a different error text than rakudo's, but
+            // the same rejection, not a silent mis-composition (#8216).
+            let (r, role_name) = qualified_ident(r)?;
+            // A parameterized role (`does R[Int]`) keeps its argument list in
+            // the recorded name, the same spelling class composition uses.
+            let (r, role_name) = match skip_balanced_brackets(r) {
+                Some(after) => {
+                    let consumed = &r[..r.len() - after.len()];
+                    (after, format!("{role_name}{consumed}"))
+                }
+                None => (r, role_name),
+            };
+            roles.push(role_name);
+            let (r, _) = ws(r)?;
+            rest = r;
+            continue;
+        }
+        break;
+    }
+    Ok(rest)
+}
+
+/// Consume (and discard) a single trailing `does <Role>` clause after an
+/// enum's value list (#8216). Unlike the `does`/`is` trait clauses BEFORE
+/// the value list -- genuine declarator traits that really compose the role
+/// (verified against rakudo: `.^does` is `True` there) -- `enum X <values>
+/// does Role` is not special enum grammar at all: `enum X <values>` parses
+/// as an ordinary TERM (the enum's type object) in this position, and the
+/// trailing `does Role` is the general infix `does` operator (the same one
+/// `$x does role {...}` uses to mix a role into a COPY of `$x`), applied to
+/// that term and then sunk with no lasting effect (verified against
+/// rakudo: `.^does`/`.^roles(:local)` stay `False`/empty for this ordering,
+/// and a SECOND trailing `does` errors "non-associative, requires
+/// parentheses" -- a real infix operator's fixity, not a repeatable
+/// declarator trait).
+///
+/// Mirroring that (an inert, single, non-repeating consumption) avoids two
+/// real bugs a naive "just don't error" fix would still have: leaving `does
+/// role { ... }` unconsumed crashed on `role` as an unknown role NAME looked
+/// up on the ENCLOSING scope (`Unknown role: role`, #8216's original
+/// report), and leaving its `{ ... }` body unconsumed split it into a
+/// stray, unrelated bare-block statement.
+pub(super) fn skip_trailing_enum_does_clause(input: &str) -> PResult<'_, ()> {
+    let Some(r) = keyword("does", input) else {
+        return Ok((input, ()));
+    };
+    let (r, _) = ws1(r)?;
+    if keyword("role", r).is_some() {
+        let (r, _role_expr) = crate::parser::primary::misc::anon_role_expr(r)?;
+        let (r, _) = ws(r)?;
+        return Ok((r, ()));
+    }
+    let (r, _role_name) = qualified_ident(r)?;
+    let r = skip_balanced_brackets(r).unwrap_or(r);
+    let (r, _) = ws(r)?;
+    Ok((r, ()))
+}

--- a/src/parser/stmt/decl/mod.rs
+++ b/src/parser/stmt/decl/mod.rs
@@ -1,6 +1,7 @@
 mod constant_subset;
 mod destructure;
 mod enum_decl;
+mod enum_decl_traits;
 mod handles;
 mod has_decl;
 mod helpers;

--- a/t/oo/role/enum-does-anonymous-role-literal.t
+++ b/t/oo/role/enum-does-anonymous-role-literal.t
@@ -1,0 +1,84 @@
+use v6;
+use Test;
+
+# #8216: `does` accepts an anonymous role LITERAL, not just a role name.
+# `enum Level <Off Fatal> does role { ... }` (the Lumberjack shape) took the
+# `role` keyword as the name of a role to look up, found none, and died
+# ("Unknown role: role") -- so any distribution using this shape could not
+# even load.
+#
+# Measured against rakudo throughout. Two orderings exist and behave
+# genuinely differently there:
+#
+# - `does Role` BEFORE the value list (`enum E does Role <a b>`) is a real
+#   declarator trait: the role is actually composed (`.^does` is True), but
+#   an anonymous LITERAL is invalid there even in rakudo ("Invalid typename
+#   'role'") -- only a role NAME is accepted in this trait slot.
+# - `does Role` AFTER the value list (`enum E <a b> does Role`, the
+#   Lumberjack/ticket shape) is NOT special enum grammar in rakudo at all:
+#   `enum E <a b>` parses as an ordinary term (the type object), and the
+#   trailing `does Role` is the general infix `does` operator applied to
+#   it and then sunk -- it never actually composes (`.^does` stays False,
+#   `.^roles(:local)` stays empty), and a second trailing `does` even
+#   errors as a non-associative operator. This file pins that the parser
+#   accepts the shape (no crash, "Unknown role" gone) WITHOUT pretending to
+#   compose something rakudo itself does not.
+
+plan 9;
+
+# --- the ticket's own repro: must load without dying -------------------
+{
+    my $ok = False;
+    class Holder {
+        enum Level <Off Fatal> does role {
+            multi method ACCEPTS($m) { True }
+        };
+    }
+    $ok = True;
+    ok $ok, 'enum <values> does role {...} parses without "Unknown role"';
+    is Holder::Level::Off.key, 'Off', 'the enum value is otherwise normal';
+}
+
+# --- values-then-does (AFTER the value list): matches rakudo's no-op ---
+{
+    role Marker { method greet-role { 'hi' } }
+    enum LevelAfter <Off Fatal> does Marker;
+    is LevelAfter.^does(Marker), False,
+        'does AFTER the value list does not actually compose (matches rakudo)';
+    is LevelAfter.^roles(:local).elems, 0,
+        'and adds no role to the enum (matches rakudo .^roles)';
+}
+
+{
+    # A repeat of the ticket's own anonymous-role-literal shape, but with a
+    # uniquely-named method, confirming it is likewise a no-op rather than
+    # a partial/wrong composition.
+    enum LevelAnon <Off Fatal> does role {
+        method anon-role-marker { 'should not be reachable' }
+    };
+    nok LevelAnon::Off.can('anon-role-marker'),
+        'the anonymous role literal after the value list is a no-op too';
+}
+
+# --- does-then-values (BEFORE the value list): genuinely composes -------
+{
+    role Marker2 { method greet-role { 'hi' } }
+    enum LevelBefore does Marker2 <Off Fatal>;
+    is LevelBefore.^does(Marker2), True,
+        'does BEFORE the value list still genuinely composes a named role';
+    is LevelBefore::Off.greet-role, 'hi',
+        'and its method is reachable from an enum value';
+}
+
+# --- an anonymous role literal BEFORE the value list is invalid, exactly
+#     as rakudo rejects it, not silently mis-composed -------------------
+throws-like 'enum LevelBad does role { method x { 1 } } <a b>; say "unreached"',
+    Exception, 'an anonymous role literal before the value list is rejected';
+
+# --- unaffected: a plain, already-working spelling ----------------------
+{
+    role Marker3 { method greet-role { 'hi' } }
+    enum LevelPlain does Marker3 <a b>;
+    is LevelPlain::a.greet-role, 'hi',
+        'the already-correct does-before-values spelling is unaffected';
+}


### PR DESCRIPTION
## Summary

`does` accepts an anonymous role *literal*, not just a role name.
`enum Level <Off Fatal> does role { ... }` (the shape `Lumberjack` and its
plugins use) took the `role` keyword as the name of a role to look up,
found none, and died with `Unknown role: role`, so any distribution using
this shape could not even load (5 affected distributions per the
ecosystem parity ledger).

```
$ raku  tmp/anonrole.raku
parsed and loaded ok
Off
$ mutsu tmp/anonrole.raku
Unknown role: role
```

Two clause orderings exist, and rakudo treats them genuinely
differently — measured against the oracle throughout:

- `does Role` **before** the value list (`enum E does Role <a b>`) is a
  real declarator trait — the role is actually composed (`.^does` is
  `True`) — but an anonymous role *literal* is invalid even in rakudo
  there ("Invalid typename 'role'"); only a role name is accepted in
  that slot.
- `does Role` **after** the value list (`enum E <a b> does Role`, the
  Lumberjack/reported shape) is not special enum grammar in rakudo at
  all: `enum E <a b>` parses as an ordinary term (the type object), and
  the trailing `does Role` is the general infix `does` operator applied
  to that term and then sunk — it never actually composes anything
  (`.^does` stays `False`, `.^roles(:local)` stays empty), and a second
  trailing `does` even errors as a non-associative operator.

The fix mirrors both exactly instead of guessing:

- The before-the-values `does` loop is **unchanged** — it still rejects
  a role literal (via a different error text than rakudo's, but the
  same rejection, not a silent mis-composition).
- A new `skip_trailing_enum_does_clause` consumes — but **discards** — a
  single `does <Role>` clause after the value list, so parsing no longer
  crashes on `role` as an unknown role name applied to the *enclosing*
  scope, and no longer fragments the role's body into a stray, unrelated
  bare-block statement, without pretending to compose something rakudo
  itself does not.

`enum_decl.rs` (541 lines before this change, over the file-size
convention) was split into `enum_decl.rs` + `enum_decl_traits.rs`.

Closes #8216

## Test plan

- Added `t/oo/role/enum-does-anonymous-role-literal.t`: the ticket's own
  repro (loads, `.key` works), the after-values no-op for both a named
  role and an anonymous literal (`.^does`/`.^roles` stay empty, matching
  rakudo), the before-values genuine composition (unaffected), and the
  before-values anonymous-literal rejection. Every assertion checked
  against `raku` directly — the whole file also passes unmodified under
  `raku -Ilib t/oo/role/enum-does-anonymous-role-literal.t` (all 9 ok).
- Ran `t/types/enum-subset/` + `t/oo/role/` (168 files) — all green.
- `cargo fmt --all`, `make lint`, `make test`, `make roast` all run
  locally. `make roast` comes back with only the three environment-only
  failures documented in `docs/agent-environments.md` for a remote
  container (`roast/6.c/S32-io/file-tests.t`,
  `roast/S16-filehandles/filetest.t` — both `uid 0` chmod-based file
  tests — and `roast/S32-io/IO-Socket-Async.t`, sandboxed network);
  everything else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_