### PR TITLE
fix(rakuast): retain array regex capture aliases

### DIFF
--- a/docs/adr/0088-rakuast-regex-boundary-tree.md
+++ b/docs/adr/0088-rakuast-regex-boundary-tree.md
@@ -1,9 +1,10 @@
 # ADR-0088: RakuAST and execution share a source-level regex tree
 
 - Status: Accepted (static source-tree, RakuAST, execution-lowering,
-  static-value-provenance, declaration-provenance, positional-capture, and
-  scalar-interpolation slices implemented 2026-09-12/13; other dynamic
-  contents and the complete execution-tree migration remain)
+  static-value-provenance, declaration-provenance, positional-capture,
+  scalar-interpolation, named-capture, and array-capture slices implemented
+  2026-09-12/13; other dynamic contents and the complete execution-tree
+  migration remain)
 - Date: 2026-09-12
 - Related: [ADR-0011](0011-rakuast-model-layer-and-phasing.md) (the RakuAST
   model layer and its bidirectional conversion),
@@ -492,3 +493,26 @@ The focused regression is `t/regex/match/regex-tree-named-captures.t`. It pins t
 source whitespace and quantified AST shapes, capture spans, constructor
 accessors, and constructed-tree EVAL execution. Subrule aliases, array/hash
 aliases, and code-bearing regex nodes remain separate follow-up slices.
+
+## 14. Array-sigil capture-alias slice (2026-09-13)
+
+Array-sigil aliases written as `@<name> = atom` now retain their list-context
+bit in the shared `RegexNode::NamedCapture` tree. The read direction emits the
+existing `RakuAST::Regex::NamedCapture` node with `array => True`; its accessor
+remains observable even though Rakudo omits this implementation detail from
+the constructor-form gist. The write direction accepts the same field and
+lowers it through the existing regex value and compiler pipeline.
+
+Execution preserves the matcher’s established distinction between aliasing a
+plain atom and aliasing a positional capture group. An array alias around a
+plain atom still produces one `Match`, while an alias around `( ... )` forces a
+list, and a quantified capturing group produces one `Match` per iteration. The
+tree lowerer pins this by setting the existing `RegexToken::force_list_capture`
+only for the capturing-group forms; it does not introduce a separate matcher
+path or evaluate any dynamic regex content.
+
+The focused regression is
+`t/regex/match/regex-tree-array-captures.t`. It covers source accessors and
+gist parity, single and quantified parser-created aliases, and constructed
+`RakuAST::Regex::NamedCapture` EVAL. Hash aliases, subrules, and code-bearing
+regex nodes remain explicit follow-up boundaries.

--- a/news/2026-09/rakuast-regex-array-captures.md
+++ b/news/2026-09/rakuast-regex-array-captures.md
@@ -1,0 +1,10 @@
+# Regex array capture aliases retain their RakuAST boundary
+
+Array-sigil regex capture aliases such as `@<word>=(a)` now retain their
+`array` flag in the shared `RegexTree` and are exposed as
+`RakuAST::Regex::NamedCapture`. Parser-created and constructed nodes lower
+through the existing capture matcher, preserving list results for capturing
+groups and their quantified iterations.
+
+Hash aliases, subrules, and code-bearing regex nodes remain explicit
+follow-up boundaries under ADR-0088.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2313,13 +2313,14 @@ fn regex_node(node: &RegexNode) -> Result<RakuAstNode, RuntimeError> {
             RakuAstClass::RegexCapturingGroup,
             vec![node_field(None, regex_node(child)?)],
         ),
-        RegexNode::NamedCapture { name, regex } => (
-            RakuAstClass::RegexNamedCapture,
-            vec![
-                leaf_field(Some("name"), Value::str(name.clone())),
-                node_field(Some("regex"), regex_node(regex)?),
-            ],
-        ),
+        RegexNode::NamedCapture { name, array, regex } => {
+            let mut fields = vec![leaf_field(Some("name"), Value::str(name.clone()))];
+            if *array {
+                fields.push(leaf_field(Some("array"), Value::truth(true)));
+            }
+            fields.push(node_field(Some("regex"), regex_node(regex)?));
+            (RakuAstClass::RegexNamedCapture, fields)
+        }
         RegexNode::Interpolation { name, sequential } => (
             RakuAstClass::RegexInterpolation,
             vec![

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1595,15 +1595,11 @@ fn lower_regex_node(node: &RakuAstNode) -> Result<RegexNode, RuntimeError> {
         RakuAstClass::RegexCapturingGroup => Ok(RegexNode::CapturingGroup(Box::new(
             lower_regex_node(named_child_or_positional(node)?)?,
         ))),
-        RakuAstClass::RegexNamedCapture => {
-            if bool_field(node, "array")? {
-                return Err(unsupported(node));
-            }
-            Ok(RegexNode::NamedCapture {
-                name: leaf_str(node, "name")?,
-                regex: Box::new(lower_regex_node(named_child(node, "regex")?)?),
-            })
-        }
+        RakuAstClass::RegexNamedCapture => Ok(RegexNode::NamedCapture {
+            name: leaf_str(node, "name")?,
+            array: bool_field(node, "array")?,
+            regex: Box::new(lower_regex_node(named_child(node, "regex")?)?),
+        }),
         RakuAstClass::RegexInterpolation => {
             let sequential = bool_field(node, "sequential")?;
             if sequential {

--- a/src/rakuast/render.rs
+++ b/src/rakuast/render.rs
@@ -42,15 +42,14 @@ pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
     // Inline when every field is a positional leaf or a colonpair adverb
     // (`Assignment.new(:item)`); any named field, child node, or list forces
     // the multi-line form.
-    if node
-        .fields
+    let fields = rendered_fields(node);
+    if fields
         .iter()
         .all(|f| f.name.is_none() && is_inline_field(f))
     {
-        let inner = node
-            .fields
+        let inner = fields
             .iter()
-            .map(render_inline_field)
+            .map(|field| render_inline_field(field))
             .collect::<Vec<_>>()
             .join(", ");
         return format!("{name}.{ctor}({inner})");
@@ -60,10 +59,10 @@ pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
     let mut s = format!("{name}.{ctor}(\n");
     let child_indent = indent + 2;
     let pad = " ".repeat(child_indent);
-    for (i, f) in node.fields.iter().enumerate() {
+    for (i, f) in fields.iter().enumerate() {
         s.push_str(&pad);
         s.push_str(&render_field_line(f, child_indent, width));
-        if i + 1 != node.fields.len() {
+        if i + 1 != fields.len() {
             s.push(',');
         }
         s.push('\n');
@@ -73,12 +72,24 @@ pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
     s
 }
 
+/// Rakudo keeps `Regex::NamedCapture.array` observable through its accessor,
+/// but omits that implementation-detail field from the constructor-form gist.
+/// Keep the field in the model so lowering and reflection retain the source
+/// sigil while matching Rakudo's renderer.
+fn rendered_fields(node: &RakuAstNode) -> Vec<&RakuAstField> {
+    node.fields
+        .iter()
+        .filter(|field| {
+            !(node.class == RakuAstClass::RegexNamedCapture && field.name == Some("array"))
+        })
+        .collect()
+}
+
 /// The `key => value` alignment width for a node: the max length over its
 /// *shown* named-field keys, floored by the class's `min_align_width` (which
 /// covers the few classes that pad to a declared-but-omitted attribute).
 fn field_align_width(node: &RakuAstNode) -> usize {
-    let shown = node
-        .fields
+    let shown = rendered_fields(node)
         .iter()
         .filter_map(|f| f.name.map(str::len))
         .max()

--- a/src/regex_tree.rs
+++ b/src/regex_tree.rs
@@ -47,6 +47,8 @@ pub(crate) enum RegexNode {
     CapturingGroup(Box<RegexNode>),
     NamedCapture {
         name: String,
+        #[serde(default)]
+        array: bool,
         regex: Box<RegexNode>,
     },
     Interpolation {
@@ -290,7 +292,7 @@ impl RegexTree {
                         ratchet,
                     )])
                 }
-                RegexNode::NamedCapture { name, regex } => {
+                RegexNode::NamedCapture { name, array, regex } => {
                     // A scalar alias around a non-capturing quantified atom
                     // captures the whole run as one Match. This mirrors the
                     // legacy parser's user-alias wrapper; an aliased
@@ -310,12 +312,22 @@ impl RegexTree {
                             ratchet,
                         );
                         outer.named_capture = Some(name.clone());
+                        outer.force_list_capture =
+                            *array && matches!(atom.as_ref(), RegexNode::CapturingGroup(_));
                         return Some(vec![outer]);
                     }
                     let mut tokens =
                         lower_node(regex, ratchet, ignore_case, ignore_mark, rule_sigspace)?;
                     let first = tokens.first_mut()?;
                     first.named_capture = Some(name.clone());
+                    first.force_list_capture = *array
+                        && match regex.as_ref() {
+                            RegexNode::CapturingGroup(_) => true,
+                            RegexNode::Quantified { atom, .. } => {
+                                matches!(atom.as_ref(), RegexNode::CapturingGroup(_))
+                            }
+                            _ => false,
+                        };
                     Some(tokens)
                 }
                 RegexNode::Interpolation { name, sequential } => {
@@ -432,8 +444,9 @@ impl RegexNode {
             }
             Self::Group(child) => format!("[{}]", child.to_source()),
             Self::CapturingGroup(child) => format!("({})", child.to_source()),
-            Self::NamedCapture { name, regex } => {
-                format!("$<{name}> = {}", regex.to_source())
+            Self::NamedCapture { name, array, regex } => {
+                let sigil = if *array { '@' } else { '$' };
+                format!("{sigil}<{name}> = {}", regex.to_source())
             }
             Self::Interpolation { name, .. } => format!("${name}"),
             Self::Quantified { atom, quantifier } => {
@@ -587,7 +600,8 @@ impl Parser {
                     sequence_for_multichar_literal(inner),
                 )))
             }
-            '$' if self.chars.get(self.pos + 1) == Some(&'<') => self.parse_named_capture(),
+            '$' if self.chars.get(self.pos + 1) == Some(&'<') => self.parse_named_capture(false),
+            '@' if self.chars.get(self.pos + 1) == Some(&'<') => self.parse_named_capture(true),
             '$' => self.parse_interpolation(),
             '@' | '%' => None,
             ')' | ']' if stops.contains(&ch) => None,
@@ -683,8 +697,8 @@ impl Parser {
         })
     }
 
-    fn parse_named_capture(&mut self) -> Option<RegexNode> {
-        self.pos += 2; // '$<'
+    fn parse_named_capture(&mut self, array: bool) -> Option<RegexNode> {
+        self.pos += 2; // '$<' or '@<'
         let start = self.pos;
         while self.chars.get(self.pos).is_some_and(|ch| *ch != '>') {
             self.pos += 1;
@@ -711,6 +725,7 @@ impl Parser {
             let rest: String = chars.collect();
             let mut nodes = vec![RegexNode::NamedCapture {
                 name,
+                array,
                 regex: Box::new(RegexNode::Literal(first.to_string())),
             }];
             if let Some(quantifier) = quantifier {
@@ -737,6 +752,7 @@ impl Parser {
         }
         Some(RegexNode::NamedCapture {
             name,
+            array,
             regex: Box::new(regex),
         })
     }

--- a/t/regex/match/regex-tree-array-captures.t
+++ b/t/regex/match/regex-tree-array-captures.t
@@ -1,0 +1,60 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# ADR-0088 issue #8033: an array-sigil named capture keeps its array context
+# in the shared RegexTree and lowers through the existing capture matcher.
+# Hash aliases, subrules, and code-bearing regex nodes remain separate
+# boundaries.
+
+plan 19;
+
+my $ast = Q[/@<word>=(a)/].AST;
+my $capture = $ast.statements[0].expression.body;
+is $capture.^name, 'RakuAST::Regex::NamedCapture',
+    'an array-sigil alias retains the NamedCapture node';
+is $capture.name, 'word', 'the array alias retains its name';
+ok $capture.array, 'the array alias retains array context';
+is $capture.regex.regex.text, 'a', 'the array alias retains its regex child';
+is $capture.gist, q:to/END/.chomp, 'array context does not change the node shape';
+    RakuAST::Regex::NamedCapture.new(
+      name  => "word",
+      regex => RakuAST::Regex::CapturingGroup.new(
+        RakuAST::Regex::Literal.new("a")
+      )
+    )
+    END
+
+my $plain = 'a' ~~ /@<plain>=a/;
+ok $plain, 'an array alias around a plain atom matches';
+is $plain<plain>.WHAT, Match,
+    'an array alias around a plain atom remains a single Match';
+is $plain<plain>.Str, 'a', 'the plain array alias stores its text';
+
+my $single = 'a' ~~ /@<word>=(a)/;
+ok $single, 'a parser-created array alias matches';
+is $single<word>.WHAT, Array, 'a non-quantified array alias returns an Array';
+is $single<word>.elems, 1, 'a non-quantified array alias has one entry';
+is $single<word>[0].Str, 'a', 'the array alias entry stores its text';
+
+my $quantified = 'aaa' ~~ /@<word>=(a)+/;
+ok $quantified, 'a quantified array alias matches';
+is $quantified<word>.WHAT, Array, 'a quantified array alias returns an Array';
+is $quantified<word>.elems, 3, 'a quantified array alias stores each iteration';
+is $quantified<word>[2].Str, 'a', 'the final array alias entry stores its text';
+
+my $node = RakuAST::Regex::NamedCapture.new(
+    name  => 'word',
+    array => True,
+    regex => RakuAST::Regex::CapturingGroup.new(
+        RakuAST::Regex::Literal.new('a'),
+    ),
+);
+my $constructed = EVAL(RakuAST::QuotedRegex.new(body => $node));
+my $constructed-match = 'a' ~~ $constructed;
+ok $constructed-match, 'a constructed array alias lowers through EVAL';
+is $constructed-match<word>.WHAT, Array,
+    'constructed array alias keeps array context through EVAL';
+is $constructed-match<word>[0].Str, 'a',
+    'constructed array alias keeps the captured text';


### PR DESCRIPTION
## Summary

- Preserve the array-sigil bit for @<name>=... aliases in the shared RegexTree.
- Convert the bit to and from RakuAST::Regex::NamedCapture, while keeping Rakudo-compatible constructor-form rendering.
- Lower array aliases through the existing capture matcher, preserving scalar results for plain atoms and list results for capturing groups and their quantified iterations.

## Validation

- cargo fmt --all
- make lint
- make test — 4,185 files / 44,609 tests, PASS
- make roast — 1,437 files / 219,658 tests, PASS
- Focused array and named capture regressions, plus static regex execution tests

Refs #8033