### PR TITLE
fix(vm): raise on deep recursion instead of aborting the process

### DIFF
--- a/docs/adr/0100-deep-recursion-raises-on-native-stack-headroom.md
+++ b/docs/adr/0100-deep-recursion-raises-on-native-stack-headroom.md
@@ -1,0 +1,168 @@
+# ADR-0100: Deep recursion raises a catchable error, guarded by native stack headroom
+
+- Status: Accepted (implemented)
+- Date: 2026-09-13
+- Issue: [#8232](https://github.com/tokuhirom/mutsu/issues/8232)
+
+## Context
+
+mutsu executes a Raku routine call as a **Rust** call: the VM's `exec_one`
+dispatch frame, the call-op handler, signature binding, and — for a re-entrant
+construct — a whole `eval_block_value` frame all sit on the native stack, and
+the callee's body loop runs nested inside them. Raku recursion is therefore
+native recursion.
+
+When the native stack runs out, the thread hits its guard page and the Rust
+runtime **aborts the process**. There is no unwinding, so:
+
+- `try` / `CATCH` cannot contain it,
+- `END` phasers do not run,
+- there is no backtrace and no exit code a script can act on,
+- and the rest of a test file after the offending statement never runs.
+
+```raku
+my $d = 0;
+sub rec($n) { $d = $n; rec($n+1) unless $n >= 20000 }
+END { note "depth reached: $d" }
+rec(1);
+```
+
+rakudo prints `depth reached: 20000`; mutsu printed
+`fatal runtime error: stack overflow, aborting` and nothing else.
+
+This is not only a diagnostics problem. Any program whose input nesting depth
+is attacker-controlled — a JSON or XML document, a recursive-descent parser
+over user text — turns a deeply nested input into an unconditional process
+abort that no amount of defensive `try` can contain. `JSON::Fast`'s
+`t/01-parse.t` feeds its parser `Q«[{"":» x 10_000` (≈20,000 Raku frames)
+precisely to check that this is survivable.
+
+rakudo has no fixed recursion limit: it grows the call stack on the **heap**
+and eventually fails with an ordinary, catchable out-of-memory exception.
+mutsu cannot copy that without moving call frames off the Rust stack, which is
+a VM redesign (see "Rejected alternatives").
+
+## Decision
+
+**Guard on remaining native stack headroom at the VM's call boundary, and
+raise an ordinary catchable Raku exception when it is exhausted.**
+
+1. **The measurement is the stack, not a frame count.** Each thread that runs
+   user VM code records, at start-up, the lowest address it may safely touch
+   (`stack top − stack size + reserve`). At a call boundary the VM takes the
+   address of a stack local and compares. That is one load, one subtract and
+   one branch, with no counter to keep coherent across the several call paths
+   and no state to unwind.
+
+2. **The chokepoints are the VM's call entry points.** The seven functions
+   that carry a `SafepointKind::Call` GC safepoint or push a call frame —
+   `call_compiled_function_fast`, the two light paths,
+   `call_compiled_function_named_inner`, `call_compiled_closure_in_unit`, and
+   the two `call_compiled_method*` entries. All seven already return
+   `Result<_, RuntimeError>`, and all seven are already established as points
+   that hold no container borrow, which is what a raise needs. Between them
+   they cover every shape of Raku recursion: sub, method, closure/block, and
+   both JIT-on and JIT-off dispatch.
+
+3. **The check is amortized over 32 calls.** Reading the stack pointer needs
+   the address of a local, which forces a stack slot and acts as an
+   optimization barrier in the hottest functions mutsu has. The hot path is
+   therefore a countdown on an `Interpreter` field, and the real read happens
+   once per `STACK_CHECK_INTERVAL` calls. The reserve absorbs the overshoot.
+
+4. **The reserve is 16 MiB of a 256 MiB stack (6%).** The guard fires while
+   there is still room for three things: an interval's worth of overshoot
+   (32 frames of the fattest kind measured — ~156 KiB each, an interpreted
+   non-JIT frame in a debug build — is ~5 MiB), the native recursion a
+   *single* Raku call can perform between two checks (a deep regex match,
+   dropping a deeply nested value), and then constructing the error,
+   unwinding, and running the `END` phasers the unwind reaches.
+
+5. **The error is `X::AdHoc`**, message
+   `Too deep recursion (out of stack space)`. rakudo has no dedicated
+   `X::Recursion` to match, and inventing a mutsu-only type would make the
+   obvious `CATCH { when X::Whatever { } }` miss it. `X::AdHoc` is what every
+   generic handler already catches, and the message is what a user sees.
+
+6. **Not configurable.** The knob that matters is the stack size itself, and
+   it is already uniform (below). A recursion-depth setting would be a promise
+   mutsu cannot keep, because the per-call stack cost is not a constant: a
+   plain compiled call is cheap and a re-entrant `eval_block_value` is not, so
+   the same "depth" buys different amounts of stack in different programs.
+
+7. **Every thread that runs user VM code already has the same 256 MiB stack**,
+   so the guard fires at comparable depth everywhere. `main.rs` spawns
+   `mutsu-main` with `stack_size(256 MiB)` and
+   `builtins_system::USER_THREAD_STACK_SIZE` (the `start` / Promise / Supply
+   worker stack) is the same 256 MiB constant. The two
+   `stack_size(16 * 1024 * 1024)` spawns in `src/runtime/mod.rs` are
+   `#[test]` helpers, not user-visible threads — #8232 read them as a 16×
+   lower ceiling for user code, and that part of the report is wrong. Service
+   threads (timer, socket pump, signal reader) keep the default stack because
+   they run no user VM code.
+
+## Consequences
+
+- Deep recursion now raises where it used to abort. `try`, `CATCH`, `END` and
+  a normal exit status all work, and a test file continues past the failure.
+- **It costs about 3% on a call-only microbenchmark.** Local A/B on this
+  container measured `bench-fib` and `method-call` 2-4% slower and `bench-tak`
+  flat. A control build with the guard's *body* replaced by `Ok(())`, call
+  sites unchanged, measured the same delta, and two independently built
+  baselines measured the same as each other — so the cost is the per-call-site
+  overhead in those functions, not the countdown arithmetic, and there is no
+  cheaper arrangement of the same check. The authoritative numbers are the
+  bench CI's (`bench-history.tsv` on `bench-data`), not these. Paying it buys
+  the removal of an *uncatchable process abort*, which by the repository's own
+  gain/risk definition is the trade to take.
+- **The depth at which it raises is a property of the build, not of the
+  language.** A debug frame is several times larger than a release one, so a
+  debug run raises earlier. Nothing may assert a specific depth; the
+  regression pin (`t/vm/deep-recursion-raises-instead-of-aborting.t`) asserts
+  only that the failure is *catchable* and that execution continues. Measured
+  for scale: ~5,700 frames on a debug build with JIT on, ~1,500 without.
+- mutsu still raises where rakudo would keep going. The pure-Raku repro above
+  reaches its 20,000 under rakudo and raises earlier under a debug mutsu. That
+  is a real remaining compatibility gap, and the lever for it is reducing the
+  per-call native stack cost — a separate, worthwhile perf/architecture
+  question that this ADR does not settle and does not depend on.
+- **Known gap: the guard is inert where mutsu does not own the thread.** An
+  `Interpreter` driven from a `#[test]`, or from the wasm library build, never
+  runs the per-thread initialisation, so the limit stays zero and the check is
+  skipped — today's behaviour, unchanged. Those threads have no stack bound
+  mutsu can discover portably (`pthread_getattr_np` is glibc-only and `libc`
+  is an optional dependency here). The initialisation entry point is public,
+  so an embedder that knows its own stack size can opt in.
+
+## Rejected alternatives
+
+**A bigger stack.** Moves the cliff without removing it, and cannot be sized
+correctly for the reason in point 6: the per-call cost depends on the
+construct. It also does nothing about the failure *mode*, which is the actual
+complaint — an abort is uncatchable at any stack size.
+
+**A fixed recursion-depth counter.** Deterministic across builds, which is its
+one real advantage, but it cannot be both safe and generous. It must be sized
+for the worst case (a debug build, whose frames are the largest), which then
+makes it needlessly strict for release, and it would still miss native
+recursion that is not a routine call at all — a deeply nested regex, or
+dropping a deeply nested value. A counter also has to be kept coherent across
+five call paths and every unwind, where the stack pointer needs no maintenance
+because it *is* the state.
+
+**Moving call frames off the native stack** (rakudo/MoarVM's model: an
+explicit heap-allocated frame chain, so depth is bounded by memory). This is
+the only design that would match rakudo's behaviour rather than approximate
+it, and it is a full VM redesign — the same class of change ADR-0001 §"level 2"
+rejects without a measured ceiling forcing it. The guard here is not an
+obstacle to it: if frames ever move to the heap, the headroom check simply
+stops firing.
+
+**Segmented / growable stacks (the `stacker` crate).** Allocates a fresh stack
+segment when headroom runs low, so recursion is bounded by memory rather than
+by the initial stack. It removes the limit rather than reporting it, which is
+attractive, but it adds an allocation on a hot boundary, interacts with the
+GC's notion of thread stacks, and — because the depth is then bounded by
+memory — turns the failure back into an OOM whose catchability is exactly the
+thing being fixed. Reconsider only if the compatibility gap above is measured
+to matter.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -125,3 +125,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0097](0097-a-binding-descriptor-addressed-by-slot.md) | A binding's own metadata lives on a slot-addressed descriptor, not under a key derived from its name | Proposed |
 | [0098](0098-if-pragma-actions-slang.md) | mutsu answers `Raku.legacy` with `False`, and a slang's *actions*-role method is an override name (the `if` pragma) | Accepted (implemented 2026-09-13) |
 | [0099](0099-regex-engine-performance-strategy.md) | Regex engine performance — fix the ceremony first; a prefilter above the unchanged walk | Accepted (Stage 0 and Stage 1 filed; Stage 2/3 deferred — see §8) |
+| [0100](0100-deep-recursion-raises-on-native-stack-headroom.md) | Deep recursion raises a catchable error, guarded by native stack headroom | Accepted (implemented) |

--- a/news/2026-09/deep-recursion-raises-instead-of-aborting-the-process.md
+++ b/news/2026-09/deep-recursion-raises-instead-of-aborting-the-process.md
@@ -1,0 +1,73 @@
+# Deep recursion raises instead of aborting the process
+
+```raku
+my $d = 0;
+sub rec($n) { $d = $n; rec($n+1) unless $n >= 20000 }
+END { note "depth reached: $d" }
+rec(1);
+```
+
+used to print
+
+```
+thread 'mutsu-main' has overflowed its stack
+fatal runtime error: stack overflow, aborting
+```
+
+and nothing else — no `END` phaser, no backtrace, no exit status a script could
+act on, and nothing for `try` or `CATCH` to contain. It now prints
+`depth reached: 5751` and raises an ordinary catchable exception.
+
+## Why it aborted
+
+mutsu executes a Raku call as a **Rust** call: the `exec_one` dispatch frame,
+the call-op handler, signature binding, and for a re-entrant construct a whole
+`eval_block_value` frame all sit on the native stack, with the callee's body
+loop running nested inside them. Raku recursion is native recursion, and when
+the native stack runs out the thread hits its guard page and the Rust runtime
+aborts. There is no unwinding, so no amount of defensive `try` helps — which
+matters most for a program whose input depth is attacker-controlled, where one
+deeply nested document is an unconditional process kill.
+
+The 256 MB stack `main.rs` already asks for was never the issue: it moves the
+cliff without removing it.
+
+## The guard
+
+[ADR-0100](../../docs/adr/0100-deep-recursion-raises-on-native-stack-headroom.md)
+records the decision. Each thread that runs user VM code notes, at start-up,
+the lowest stack address it may still make a call from (its stack top, minus
+its size, plus a 16 MiB reserve). The VM's seven call entry points — the ones
+that already carry a `SafepointKind::Call` GC safepoint or push a call frame —
+compare against it and raise `X::AdHoc` with
+`Too deep recursion (out of stack space)` rather than proceed. That covers sub,
+method, closure and block recursion, with JIT on or off.
+
+The measurement is the stack pointer rather than a frame count on purpose: the
+per-call cost is not a constant (measured at ~42 KiB for a JIT-on debug frame
+and ~156 KiB for an interpreted one), so a depth limit generous enough for one
+program would be unsafe for another. The stack pointer needs no maintenance
+because it *is* the state. Reading it at every call cost ~3% on a call-only
+microbenchmark, so the hot path is a countdown on an `Interpreter` field and
+the read happens once per 32 calls; the reserve is sized to absorb the
+overshoot.
+
+The depth at which it fires is therefore a property of the build, not of the
+language, and `t/vm/deep-recursion-raises-instead-of-aborting.t` asserts only
+what is invariant: the failure is catchable, a `try` contains it, and execution
+continues afterwards.
+
+## What is still different from rakudo
+
+rakudo has no recursion limit — it grows its call stack on the heap and fails
+with an ordinary out-of-memory exception — so it reaches the 20,000 frames
+above where mutsu raises earlier. Closing that gap means reducing the per-call
+native stack cost, or moving frames off the native stack entirely; the ADR
+records both as separate questions, and the guard is not an obstacle to either.
+
+Two corrections to what [#8232](https://github.com/tokuhirom/mutsu/issues/8232)
+recorded, established while implementing this: the two 16 MB
+`stack_size` spawns it names in `src/runtime/mod.rs` are `#[test]` helpers, not
+user-visible threads — `start`/Promise/Supply workers already get the same
+256 MB stack as `mutsu-main` (`builtins_system::USER_THREAD_STACK_SIZE`), so
+there was no 16× lower ceiling for threaded user code to audit.

--- a/scripts/migrate-t-layout.py
+++ b/scripts/migrate-t-layout.py
@@ -107,6 +107,9 @@ OVERRIDES: dict[str, str] = {
     "generics-nominalizable-class": "types",
     # `is-eqv` compares values structurally: an equivalence-semantics test.
     "is-eqv": "types",
+    # Running out of native stack is a VM-execution property (mutsu runs a Raku
+    # call as a Rust call), not a property of recursion as a language feature.
+    "deep-recursion-raises-instead-of-aborting": "vm",
     # A `my $x = $x` style alias must not leak its name outward: scoping.
     "nested-alias-name-no-leak": "vm",
     # A nested `Any` type constraint on a parameter.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,19 @@ pub(crate) mod with_desugar;
 pub use interpreter::Interpreter;
 pub use value::{HashKey, RuntimeError, RuntimeErrorCode, Value};
 
+/// Arm the deep-recursion guard (ADR-0100) for the calling thread, which must
+/// have `stack_size` bytes of stack and must call this near the *top* of it.
+///
+/// mutsu runs a Raku call as a Rust call, so Raku recursion is native
+/// recursion; once armed, a call made with too little stack left raises an
+/// ordinary catchable exception instead of letting the guard page abort the
+/// process. The `mutsu` binary and the `start`/Promise workers arm themselves;
+/// an embedder driving an [`Interpreter`] on its own thread opts in here.
+/// A thread that never calls this keeps the unguarded behaviour.
+pub fn arm_stack_guard(stack_size: usize) {
+    vm::vm_stack_guard::init_thread_stack_floor(stack_size);
+}
+
 /// Print VM -> interpreter fallback statistics to stderr.
 ///
 /// No-op unless the `MUTSU_VM_STATS` environment variable is set. Used to track

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,12 @@ fn handle_negated_long_option(
     })
 }
 
+/// Stack for the `mutsu-main` thread the interpreter actually runs on. Matches
+/// `builtins_system::USER_THREAD_STACK_SIZE`, the stack a `start`/Promise
+/// worker gets, so the ADR-0100 recursion guard fires at a comparable depth
+/// wherever user code runs.
+const MAIN_THREAD_STACK_SIZE: usize = 256 * 1024 * 1024;
+
 fn main() {
     // Before anything else: a fatal signal from here on writes a crash report
     // (tmp/crash/<pid>.txt) naming the signal, fault address, pid and argv,
@@ -146,7 +152,7 @@ fn main() {
     // 120-deep directory tree — needs far more than the default 8MB).
     let builder = std::thread::Builder::new()
         .name("mutsu-main".to_string())
-        .stack_size(256 * 1024 * 1024);
+        .stack_size(MAIN_THREAD_STACK_SIZE);
     let handler = builder
         .spawn(run_main)
         .expect("failed to spawn main thread");
@@ -157,6 +163,11 @@ fn main() {
 }
 
 fn run_main() {
+    // ADR-0100: arm the deep-recursion guard for this thread, from the top of
+    // its stack and with the size the spawn above asked for. Without it, deep
+    // Raku recursion walks off the end of the stack and the Rust runtime
+    // aborts, which no `try` can contain and no `END` phaser survives.
+    mutsu::arm_stack_guard(MAIN_THREAD_STACK_SIZE);
     // GC STW accounting: this big-stack thread is the interpreter's main
     // mutator; register it so a worker-side collector can count its
     // quiescence (blocked in await/.finish/sleep) toward the rendezvous.

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -79,6 +79,12 @@ where
         // can be guarded -- a default-stack service thread runs no user VM
         // code, so it has no Raku recursion to bound and no size to measure
         // against.
+        //
+        // On wasm there is no new thread to arm: `spawn_thread` queues the
+        // closure on the single browser thread, whose stack is neither this
+        // size nor mutsu's to measure. That thread stays unguarded, as
+        // `vm_stack_guard`'s module docs describe.
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(size) = stack_size {
             crate::vm::vm_stack_guard::init_thread_stack_floor(size);
         }

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -74,6 +74,14 @@ where
     // `gc::stw::preregister_worker_quiescent`.
     crate::gc::preregister_worker_quiescent();
     crate::runtime::thread_compat::spawn_thread(name, stack_size, move || {
+        // ADR-0100: arm the deep-recursion guard, from the top of this
+        // thread's stack. Only a worker that was given an explicit stack size
+        // can be guarded -- a default-stack service thread runs no user VM
+        // code, so it has no Raku recursion to bound and no size to measure
+        // against.
+        if let Some(size) = stack_size {
+            crate::vm::vm_stack_guard::init_thread_stack_floor(size);
+        }
         struct WorkerGuard;
         impl Drop for WorkerGuard {
             fn drop(&mut self) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3586,6 +3586,17 @@ pub struct Interpreter {
     /// `GetLocal` read of the outer name sees the loop's last iteration value.
     pub(crate) for_param_restore_stack: Vec<(String, Option<Value>, Option<u32>)>,
     pub(crate) call_frames: Vec<crate::vm::VmCallFrame>,
+    /// Calls left before the next ADR-0100 native-stack headroom check.
+    ///
+    /// Reading the stack pointer at every call boundary cost ~4% on a
+    /// call-dominated workload (`fib(32)`), because the address-of forces a
+    /// stack slot and acts as an optimization barrier in the hottest
+    /// functions mutsu has. Counting down an integer field instead keeps the
+    /// hot path to a decrement and a predictable branch, and the real check
+    /// runs once per [`crate::vm::vm_stack_guard::STACK_CHECK_INTERVAL`]
+    /// calls -- which is why the guard's reserve has to absorb a whole
+    /// interval's worth of frames. See `vm::vm_stack_guard`.
+    pub(crate) stack_check_countdown: u32,
     /// Active CONTROL handlers on the dynamic call stack (one per executing
     /// `CONTROL { }` block). Kept in lock-step with `control_handler_depth` so
     /// a `warn` raised deep inside a protected body can find the innermost

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -3324,6 +3324,7 @@ impl Interpreter {
             quanthash_bind_params: Vec::new(),
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
+            stack_check_countdown: 0,
             control_handlers: Vec::new(),
             catch_handlers: Vec::new(),
             catch_handler_seq: 0,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -921,6 +921,7 @@ impl Interpreter {
             quanthash_bind_params: Vec::new(),
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
+            stack_check_countdown: 0,
             control_handlers: Vec::new(),
             catch_handlers: Vec::new(),
             catch_handler_seq: 0,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -245,6 +245,7 @@ mod vm_set_arith_ops;
 mod vm_set_ops;
 pub(crate) mod vm_smart_match;
 mod vm_smartmatch_ops;
+pub(crate) mod vm_stack_guard;
 pub(crate) mod vm_stats;
 pub(crate) mod vm_string_regex_ops;
 mod vm_subscript_invocant_ref;

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -32,6 +32,10 @@ impl Interpreter {
         fn_name_sym: Symbol,
         compiled_fns: &CompiledFns,
     ) -> Result<Value, RuntimeError> {
+        // ADR-0100: refuse the call while there is still stack left to raise
+        // with, so deep recursion becomes a catchable exception instead of a
+        // guard-page abort. Same boundary as this path's `Call` GC safepoint.
+        self.guard_native_stack()?;
         // GC safepoint (§9.2a `call`): this fast path skips push_call_frame,
         // so it emits the call safepoint itself.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -103,6 +103,10 @@ impl Interpreter {
         func_name: &str,
         func_name_sym: Symbol,
     ) -> Result<Value, RuntimeError> {
+        // ADR-0100: refuse the call while there is still stack left to raise
+        // with, so deep recursion becomes a catchable exception instead of a
+        // guard-page abort. Same boundary as this path's `Call` GC safepoint.
+        self.guard_native_stack()?;
         // GC safepoint (§9.2a `call`): this fast path skips push_call_frame,
         // so it emits the call safepoint itself.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -38,6 +38,10 @@ impl Interpreter {
         func_name_sym: Symbol,
         named_spec: Option<&crate::opcode::NamedArgsSpec>,
     ) -> Result<Value, RuntimeError> {
+        // ADR-0100: refuse the call while there is still stack left to raise
+        // with, so deep recursion becomes a catchable exception instead of a
+        // guard-page abort. Same boundary as this path's `Call` GC safepoint.
+        self.guard_native_stack()?;
         // GC safepoint (§9.2a `call`): the light-call boundary skips
         // push_call_frame, so it emits the call safepoint itself.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -9,6 +9,10 @@ impl Interpreter {
         fn_package: &str,
         fn_name: &str,
     ) -> Result<Value, RuntimeError> {
+        // ADR-0100: refuse the call while there is still stack left to raise
+        // with, so deep recursion becomes a catchable exception instead of a
+        // guard-page abort. Same boundary as this path's `Call` GC safepoint.
+        self.guard_native_stack()?;
         // Slice 6.3 step 2: signal env_dirty *precisely* (like
         // call_compiled_function_fast) instead of relying on a blanket post-call
         // mark at the call site. Save the caller's incoming dirtiness; the body's

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -208,6 +208,10 @@ impl Interpreter {
         capture_rw_topic: bool,
         compiled_fns: &CompiledFns,
     ) -> Result<Value, RuntimeError> {
+        // ADR-0100: refuse the call while there is still stack left to raise
+        // with, so deep recursion becomes a catchable exception instead of a
+        // guard-page abort. Same boundary as this path's `Call` GC safepoint.
+        self.guard_native_stack()?;
         // RAII (`MarkContextGuard`,
         // `todo/deep/mark-context-flags-leak-across-live-call-boundary.md`):
         // isolate the "mark context" one-shot flag family (bind_context et

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -20,6 +20,10 @@ impl Interpreter {
         invocant: Option<Value>,
         compiled_fns: &CompiledFns,
     ) -> Result<(Value, Option<AttrMap>), RuntimeError> {
+        // ADR-0100: refuse the call while there is still stack left to raise
+        // with, so deep recursion becomes a catchable exception instead of a
+        // guard-page abort. Same boundary as this path's `Call` GC safepoint.
+        self.guard_native_stack()?;
         crate::alloc_scope!("call-compiled-method");
         // Slice F: the rw-writeback source list is drained by the CallMethod /
         // CallMethodMut op right after this dispatch returns, so it must hold
@@ -1514,6 +1518,10 @@ impl Interpreter {
         compiled_fns: &CompiledFns,
         can_skip_merge: bool,
     ) -> Result<(Value, Option<AttrMap>), RuntimeError> {
+        // ADR-0100: refuse the call while there is still stack left to raise
+        // with, so deep recursion becomes a catchable exception instead of a
+        // guard-page abort. Same boundary as this path's `Call` GC safepoint.
+        self.guard_native_stack()?;
         crate::alloc_scope!("mfast");
         crate::alloc_scope_named!(_sc_pro, "mfast:prologue");
         let attrs_cell = self.method_attr_cell(&base, owner_class);

--- a/src/vm/vm_stack_guard.rs
+++ b/src/vm/vm_stack_guard.rs
@@ -66,9 +66,21 @@ pub fn init_thread_stack_floor(stack_size: usize) {
     if stack_size < MIN_GUARDABLE_STACK_BYTES {
         return;
     }
-    let floor = approx_stack_pointer()
-        .saturating_sub(stack_size)
-        .saturating_add(STACK_RESERVE_BYTES);
+    let top = approx_stack_pointer();
+    // `stack_size` is a claim about the caller's stack, and a wrong one must
+    // leave the thread unguarded rather than arm it into an already-exhausted
+    // state. Saturating the subtraction instead of rejecting it did exactly
+    // that on wasm32, where `usize` is 32 bits and the stack pointer sits a
+    // megabyte or two into linear memory: `sp - 256 MiB` clamped to 0, and the
+    // reserve then placed the floor ABOVE `sp`, so the very first check fired
+    // and every `start {}` block died with "Too deep recursion".
+    let Some(floor) = top
+        .checked_sub(stack_size)
+        .and_then(|bottom| bottom.checked_add(STACK_RESERVE_BYTES))
+        .filter(|floor| *floor < top)
+    else {
+        return;
+    };
     STACK_FLOOR.with(|c| c.set(floor));
 }
 
@@ -154,6 +166,18 @@ mod tests {
         })
         .join()
         .unwrap();
+    }
+
+    #[test]
+    fn a_stack_size_bigger_than_the_address_below_us_leaves_the_thread_unguarded() {
+        // The wasm32 shape: a 32-bit `usize` whose stack pointer is far below
+        // the claimed stack size. Arming must decline, not compute a floor
+        // above the current stack pointer — that made `headroom_exhausted()`
+        // true immediately and killed every `start {}` block in the wasm
+        // build with "Too deep recursion (out of stack space)".
+        init_thread_stack_floor(usize::MAX);
+        assert!(!headroom_exhausted());
+        assert_eq!(STACK_FLOOR.with(|c| c.get()), 0);
     }
 
     #[test]

--- a/src/vm/vm_stack_guard.rs
+++ b/src/vm/vm_stack_guard.rs
@@ -1,0 +1,193 @@
+//! Native-stack headroom guard (ADR-0100).
+//!
+//! A Raku call is a Rust call in mutsu: the `exec_one` dispatch frame, the
+//! call-op handler, signature binding and (for a re-entrant construct) a whole
+//! `eval_block_value` frame all sit on the native stack, and the callee's body
+//! loop runs nested inside them. So Raku recursion is native recursion, and
+//! when it runs out the thread hits its guard page and the Rust runtime
+//! **aborts** — no unwinding, nothing for `try`/`CATCH` to catch, no `END`
+//! phaser, no backtrace.
+//!
+//! This module turns that into an ordinary catchable exception by checking, at
+//! the VM's call boundary, how much stack is left. The measurement is the
+//! stack pointer rather than a frame count on purpose: the per-call cost is
+//! not a constant (a plain compiled call is cheap, a re-entrant one is not),
+//! so a depth limit generous enough for one program is unsafe for another,
+//! while the stack pointer needs no maintenance because it *is* the state.
+//!
+//! Each thread that runs user VM code records its floor once at start-up
+//! ([`init_thread_stack_floor`]). A thread that never does — an `Interpreter`
+//! driven from a `#[test]`, or the wasm library build — leaves the floor at
+//! zero, which disables the check and keeps that thread's pre-ADR-0100
+//! behaviour; there is no portable way to discover a stack bound mutsu did not
+//! choose itself (`pthread_getattr_np` is glibc-only and `libc` is an optional
+//! dependency here).
+
+use std::cell::Cell;
+
+/// Stack kept below the guard, out of the 256 MiB every VM-running thread
+/// gets (`main.rs`'s `mutsu-main`, and
+/// `builtins_system::USER_THREAD_STACK_SIZE` for `start`/Promise/Supply
+/// workers). It has to cover three things once the guard fires: building the
+/// error, unwinding, and running the `END` phasers that unwind reaches — plus
+/// the native recursion a *single* Raku call can do between two checks (a deep
+/// regex match, dropping a deeply nested value), which the call-boundary check
+/// by construction cannot see.
+const STACK_RESERVE_BYTES: usize = 16 * 1024 * 1024;
+
+/// A stack at most this large is left unguarded: the reserve would eat most of
+/// it, so the guard would refuse calls a thread of that size handles fine.
+const MIN_GUARDABLE_STACK_BYTES: usize = STACK_RESERVE_BYTES * 4;
+
+thread_local! {
+    /// Lowest stack address this thread may still make a call from, or 0 when
+    /// this thread is unguarded. Stacks grow down, so "headroom left" is
+    /// `stack pointer - floor`.
+    static STACK_FLOOR: Cell<usize> = const { Cell::new(0) };
+}
+
+/// An address on the current thread's stack, close enough to the stack pointer
+/// for a megabyte-scale reserve. `black_box` keeps the local from being
+/// optimized into a register with no address of its own.
+#[inline(always)]
+fn approx_stack_pointer() -> usize {
+    let anchor = 0u8;
+    std::hint::black_box(&anchor) as *const u8 as usize
+}
+
+/// Arm the guard for the calling thread, which must have `stack_size` bytes of
+/// stack and must call this near the *top* of that stack (the first thing in a
+/// spawned thread's closure, or in the process's real entry point) — the floor
+/// is computed from where this is called.
+///
+/// Idempotent in effect but not in value: a later call from deeper in the same
+/// thread would lower the floor, so call it once.
+pub fn init_thread_stack_floor(stack_size: usize) {
+    if stack_size < MIN_GUARDABLE_STACK_BYTES {
+        return;
+    }
+    let floor = approx_stack_pointer()
+        .saturating_sub(stack_size)
+        .saturating_add(STACK_RESERVE_BYTES);
+    STACK_FLOOR.with(|c| c.set(floor));
+}
+
+/// Whether this thread is too close to the bottom of its stack to make another
+/// Raku call. Always false on an unguarded thread.
+#[inline]
+pub(crate) fn headroom_exhausted() -> bool {
+    let floor = STACK_FLOOR.with(|c| c.get());
+    floor != 0 && approx_stack_pointer() < floor
+}
+
+/// The message a user sees. rakudo has no dedicated `X::Recursion` to match
+/// (it grows its call stack on the heap and fails with an out-of-memory
+/// exception instead), so this rides `X::AdHoc`, which every generic handler
+/// already catches — see ADR-0100.
+pub(crate) const DEEP_RECURSION_MESSAGE: &str = "Too deep recursion (out of stack space)";
+
+/// Calls made between two headroom checks.
+///
+/// Checking at *every* call boundary cost ~4% on a call-dominated workload
+/// (`fib(32)`): reading the stack pointer needs the address of a local, which
+/// forces a stack slot and acts as an optimization barrier in the hottest
+/// functions mutsu has. Amortizing it over an interval puts a decrement and a
+/// predictable branch on the hot path instead, at the price of overshooting
+/// the floor by at most one interval's worth of frames — which is what
+/// [`STACK_RESERVE_BYTES`] is sized to absorb: 32 frames of the fattest kind
+/// observed (~156 KiB each, an interpreted non-JIT frame in a debug build) is
+/// ~5 MiB of the 16 MiB reserve.
+pub(crate) const STACK_CHECK_INTERVAL: u32 = 32;
+
+/// Refuse a Raku call that this thread no longer has the stack to make.
+///
+/// Called at the VM's call boundary — the same seven entry points that carry
+/// the `SafepointKind::Call` GC safepoint — so the error unwinds through the
+/// ordinary `Result` path and reaches `try` / `CATCH` / `END` like any other
+/// exception, instead of the guard page aborting the process.
+#[cold]
+#[inline(never)]
+pub(crate) fn check_now() -> Result<(), crate::value::RuntimeError> {
+    if headroom_exhausted() {
+        return Err(crate::value::RuntimeError::typed_msg(
+            "X::AdHoc",
+            DEEP_RECURSION_MESSAGE.to_string(),
+        ));
+    }
+    Ok(())
+}
+
+impl crate::interpreter::Interpreter {
+    /// The ADR-0100 call-boundary guard: raise rather than let deep recursion
+    /// walk this thread off the end of its native stack. One decrement on the
+    /// hot path; the actual stack read happens once per
+    /// [`STACK_CHECK_INTERVAL`] calls.
+    #[inline]
+    pub(crate) fn guard_native_stack(&mut self) -> Result<(), crate::value::RuntimeError> {
+        match self.stack_check_countdown.checked_sub(1) {
+            Some(left) => {
+                self.stack_check_countdown = left;
+                Ok(())
+            }
+            None => {
+                self.stack_check_countdown = STACK_CHECK_INTERVAL;
+                check_now()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unarmed_thread_is_never_reported_exhausted() {
+        assert!(!headroom_exhausted());
+    }
+
+    #[test]
+    fn a_stack_too_small_to_hold_the_reserve_is_left_unguarded() {
+        std::thread::spawn(|| {
+            init_thread_stack_floor(1024);
+            assert!(!headroom_exhausted());
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn an_armed_thread_has_headroom_right_after_arming() {
+        std::thread::Builder::new()
+            .stack_size(MIN_GUARDABLE_STACK_BYTES * 2)
+            .spawn(|| {
+                init_thread_stack_floor(MIN_GUARDABLE_STACK_BYTES * 2);
+                assert!(!headroom_exhausted());
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    #[test]
+    fn the_floor_sits_one_reserve_above_the_bottom_of_the_stack() {
+        std::thread::Builder::new()
+            .stack_size(MIN_GUARDABLE_STACK_BYTES * 2)
+            .spawn(|| {
+                let top = approx_stack_pointer();
+                init_thread_stack_floor(MIN_GUARDABLE_STACK_BYTES * 2);
+                let floor = STACK_FLOOR.with(|c| c.get());
+                // Usable headroom is the stack minus the reserve, give or take
+                // the few bytes between `top` and the arming call's own frame.
+                let usable = top - floor;
+                let expected = MIN_GUARDABLE_STACK_BYTES * 2 - STACK_RESERVE_BYTES;
+                assert!(
+                    usable.abs_diff(expected) < 64 * 1024,
+                    "usable {usable} vs expected {expected}"
+                );
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+}

--- a/t/vm/deep-recursion-raises-instead-of-aborting.t
+++ b/t/vm/deep-recursion-raises-instead-of-aborting.t
@@ -1,0 +1,44 @@
+use Test;
+
+# Deep recursion must RAISE, not abort the process (ADR-0100, #8232).
+#
+# mutsu runs a Raku call as a Rust call, so Raku recursion is native
+# recursion. Before the ADR-0100 guard, running out of native stack hit the
+# thread's guard page and the Rust runtime killed the process: no unwinding,
+# nothing for `try` to catch, no END phaser, no backtrace, and the rest of a
+# test file simply never ran.
+#
+# Nothing here asserts a DEPTH. The depth the guard fires at is a property of
+# the build -- a debug frame is several times larger than a release one, and a
+# JIT-compiled frame is smaller again (measured: ~5,700 frames debug+JIT,
+# ~1,500 debug without) -- so a depth assertion would be a flake waiting to
+# happen. What is invariant is that the failure is catchable and that
+# execution continues afterwards.
+
+plan 7;
+
+my $depth = 0;
+sub runaway($n) { $depth = $n; runaway($n + 1) }
+
+my $err;
+{
+    runaway(1);
+    CATCH { default { $err = $_ } }
+}
+
+ok $err.defined, 'runaway recursion raises instead of aborting the process';
+ok $err ~~ Exception, 'what it raises is an ordinary Exception';
+like $err.message, /recursion/, 'whose message says it was the recursion';
+ok $depth > 100, "and it got a useful way down first ($depth frames)";
+pass 'execution continues after the raise';
+
+# `try` contains it the same way, which is the shape a parser over
+# attacker-controlled input depends on (JSON::Fast's t/01-parse.t feeds its
+# parser a 10,000-deep document precisely to check this is survivable).
+my $r = try { runaway(1); 'no error' };
+nok $r.defined, 'try {} contains it too';
+
+# The guard is per-call, not a one-shot latch: after unwinding back to a
+# shallow frame the stack is free again and ordinary calls keep working.
+sub twice($n) { $n * 2 }
+is twice(21), 42, 'ordinary calls still work after the guard has fired';


### PR DESCRIPTION
```raku
my $d = 0;
sub rec($n) { $d = $n; rec($n+1) unless $n >= 20000 }
END { note "depth reached: $d" }
rec(1);
```

printed `fatal runtime error: stack overflow, aborting` and nothing else — no
`END` phaser, no backtrace, no exit status a script could act on, and nothing
for `try` or `CATCH` to contain. It now prints `depth reached: 5751` and raises
an ordinary catchable exception.

## Root cause

mutsu executes a Raku call as a **Rust** call: the `exec_one` dispatch frame,
the call-op handler, signature binding, and for a re-entrant construct a whole
`eval_block_value` frame all sit on the native stack, with the callee's body
loop running nested inside them. Raku recursion is native recursion, so running
out of it hits the thread's guard page and the Rust runtime aborts — there is no
unwinding, which is why no amount of defensive `try` helped. That matters most
for a program whose input depth is attacker-controlled, where one deeply nested
document is an unconditional process kill.

The 256 MB stack `main.rs` already asks for was never the fix: it moves the
cliff without removing it.

## The guard

Recorded as **ADR-0100** (new, `Accepted (implemented)`), which also writes down
what was rejected and why.

Each thread that runs user VM code notes, at start-up, the lowest stack address
it may still make a call from — its stack top, minus its size, plus a 16 MiB
reserve. The VM's seven call entry points (the ones that already carry a
`SafepointKind::Call` GC safepoint or push a call frame) compare against it and
raise `X::AdHoc` with `Too deep recursion (out of stack space)` rather than
proceed. Verified to cover sub, method, closure and block recursion, with JIT on
and off, and inside a `start {}` worker.

**The measurement is the stack pointer, not a frame count**, because the
per-call cost is not a constant — measured ~42 KiB for a JIT-on debug frame and
~156 KiB for an interpreted one, so a depth limit generous enough for one
program would be unsafe for another. The stack pointer needs no maintenance
because it *is* the state.

`X::AdHoc` because rakudo has no dedicated `X::Recursion` to match (it grows its
call stack on the heap and fails with an out-of-memory exception instead), and a
mutsu-only type would make the obvious generic `CATCH` miss it.

## Arming is a claim that has to be checkable

`init_thread_stack_floor(stack_size)` takes the caller's word for its stack
size, and a wrong word must leave the thread **unguarded** rather than arm it
into an already-exhausted state. Saturating the subtraction did the opposite,
which took `wasm-e2e` down on the first push of this branch: `usize` is 32 bits
on wasm32 and the stack pointer sits a megabyte or two into linear memory, so

```rust
approx_stack_pointer()                    // ~1_000_000
    .saturating_sub(stack_size)           // 256 MiB -> clamps to 0
    .saturating_add(STACK_RESERVE_BYTES)  // -> 16_777_216
```

placed the floor **above** the whole wasm stack and the very first check fired.
15 of 28 `site/concurrency.test.mjs` cases died on code as shallow as
`my $p = start { die "boom" }`.

Two fixes, both in the second commit:

1. `checked_sub` with a `floor < top` postcondition — an impossible claim now
   declines to arm, which is what this module already documented.
2. wasm does not arm at all. `thread_compat::spawn_thread` queues the closure
   on the single browser thread rather than creating one, so the
   `Some(USER_THREAD_STACK_SIZE)` it was handed described no stack that exists.

Pinned by `a_stack_size_bigger_than_the_address_below_us_leaves_the_thread_unguarded`,
confirmed to fail on the pre-fix arithmetic by reverting the hunk and re-running.
On a 64-bit host the bogus floor lands far *below* `sp` rather than above it, so
the `assert_eq!(floor, 0)` is what catches it there.

## Performance

Reading the stack pointer at every call boundary measured **~3–4% slower** on
`bench-fib` and `method-call`, because taking the address of a local forces a
stack slot and acts as an optimization barrier in the hottest functions mutsu
has. So the hot path is now a countdown on an `Interpreter` field and the real
read happens once per 32 calls; the 16 MiB reserve is sized to absorb a whole
interval of the fattest frames (~5 MiB) on top of the unwind and `END` phasers.

The residual is ~2–4% on the two call-only microbenchmarks and flat on
`bench-tak`. Two controls establish that it is **not** the countdown
arithmetic: a build with the guard's *body* replaced by `Ok(())` and the call
sites unchanged measured the same delta, and two independently built baselines
measured the same as each other. It is the per-call-site overhead itself, and
there is no cheaper arrangement of the same check. The authoritative numbers are
the bench CI's, not these locals. Paying it removes an uncatchable process
abort, which is the trade `CLAUDE.md`'s gain/risk definition asks for.

## Two corrections to the issue

- The two `stack_size(16 * 1024 * 1024)` spawns #8232 names in
  `src/runtime/mod.rs` are `#[test]` helpers, not user-visible threads.
  `start`/Promise/Supply workers already get the same 256 MB stack as
  `mutsu-main` (`builtins_system::USER_THREAD_STACK_SIZE`), so there was no 16×
  lower ceiling for threaded user code to audit — the guard fires at comparable
  depth everywhere by construction.
- The limit is deliberately **not** configurable: a recursion-depth setting
  would be a promise mutsu cannot keep, for the same non-constant-cost reason
  above. The stack size is the knob.

## Known gap

A thread mutsu does not own — an `Interpreter` driven from a `#[test]`, or the
wasm library build — is left unguarded, since there is no portable way to
discover its stack bound (`pthread_getattr_np` is glibc-only and `libc` is an
optional dependency here). That is today's behaviour, unchanged; the new public
`mutsu::arm_stack_guard(stack_size)` lets an embedder opt in.

## Test

`t/vm/deep-recursion-raises-instead-of-aborting.t`. The depth the guard fires at
is a property of the build (measured ~5,700 frames debug+JIT, ~1,500 debug
without), so nothing there asserts a depth — only that the failure is catchable,
that `try` contains it, and that execution continues afterwards. ~5.5s under
both the gc-stress and jit-stress environment settings.

Plus the four `vm_stack_guard` unit tests, including the wasm-shape one above.

## Rebase note

`main` landed its own ADR-0099 (`0099-regex-engine-performance-strategy.md`)
while this was open, so this one was renumbered **0099 → 0100** during the
rebase, file and every reference. `docs/adr/README.md` carries both rows.

## Verification

- `cargo fmt --all`, `make lint` (all four configurations) — clean, re-run after
  the rebase.
- `make test` — 4190 files, 44636 tests, all pass.
- `make roast` — the only failures are the three documented container-only ones
  (`6.c/S32-io/file-tests.t` `Failed: 4` and `S16-filehandles/filetest.t`
  `Failed: 25` run as `uid 0`, `S32-io/IO-Socket-Async.t` exit 124 sandboxed
  network), per `docs/agent-environments.md`.
- `wasm-pack` build + `node site/concurrency.test.mjs` locally: **28 passed, 0
  failed**, against CI's 13 passed / 15 failed on the first commit.

Closes #8232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK