### PR TITLE
fix(vm): an `is rw` alias of an aggregate has no Scalar to box

### DIFF
--- a/news/2026-09/rw-alias-of-an-aggregate-has-no-scalar.md
+++ b/news/2026-09/rw-alias-of-an-aggregate-has-no-scalar.md
@@ -1,0 +1,186 @@
+# An `is rw` alias of an aggregate has no Scalar to box
+
+Another measurement pass on [#7539](https://github.com/tokuhirom/mutsu/issues/7539)'s
+`Config::TOML` + `Crane` battery pair turned up eight general interpreter bugs.
+Both suites were re-fetched from upstream and re-run against a fresh build; the
+raku oracle passes 34/34 on the same checkouts.
+
+| Suite | raku | before | after |
+| --- | --- | --- | --- |
+| `Config::TOML` v0.1.3 | 19/19 files | 14/19 | 14/19 |
+| `Crane` v0.1.2 | 15/15 files | 4/15 | 4/15 |
+
+The file counts did not move, but the failing-assertion counts did, sharply:
+`Crane`'s `set.rakutest` went from 5 failing subtests to 1, `remove.rakutest`
+from 2 to 1, and `add`/`copy`/`move`/`replace`/`transform` each shed failures.
+Every fix below is a general divergence from rakudo, each pinned by its own
+regression test, each verified to fail without its fix and to pass under
+rakudo v2026.07.
+
+## 1. A sigilless alias of an aggregate was boxed into a Scalar that does not exist
+
+Raku gives an `@`/`%` variable no `Scalar` container of its own. A sigilless
+alias of one — `\c` bound to `%a` — *is* that aggregate: `c = {...}` is
+`%a.STORE(...)`, a write every holder sees, and `return-rw c` hands the caller
+the aggregate itself.
+
+mutsu's `CaptureVarCell` boxed such an alias into a fresh scalar cell, modelling
+a container Raku does not have. The caller then assigned into a cell owned by a
+frame that had already returned, and the write reached nobody:
+
+```raku
+sub leaf(\c) is rw { return-rw c }
+sub hop(\c)  is rw { return-rw leaf(c) }
+my %a = :k(1);
+hop(%a) = {:z(9)};   # rakudo: {:z(9)}   mutsu: {:k(1)}
+```
+
+One hop happened to work — a `%`-named argument never reached the boxing
+branch — and two did not, because the second hop's argument is the sigilless
+`c`. `exec_capture_var_cell_op` now declines for a real `Array`/`Hash`, the same
+aggregate exclusion `exec_attr_container_ref_op` already makes, and
+`assign_through_rw_result`'s existing "replace the aggregate's contents in
+place" arm takes over. That arm was also factored out
+(`store_into_aggregate_lvalue`) and wired into the **type-object rw-method**
+lvalue path, which previously only accepted a `ContainerRef` and let the legacy
+setter chain quietly drop the write — the root-path case of every `Crane.set` /
+`add` / `replace`.
+
+This is `Crane::In.in(container, @path) = $value`, which every mutating Crane
+operation is built on.
+
+## 2. A sigilless argument to an lvalue call carried no source name
+
+`f(c) = 1` lowers to `__mutsu_assign_named_sub_lvalue("f", (c), 1)`. The
+argument list is a List literal, whose elements are tagged with `WrapVarRef` so
+the callee's raw parameter binds the caller's container — but only for
+`Expr::Var`, the `$`-sigiled spelling. A **sigilless** lexical is
+`Expr::BareWord`, which is also how a type name is spelled, so it was left
+untagged: the callee's `\c` got a bare value with no source name, the binder
+marked it a readonly non-lvalue, and the assignment died with
+`Cannot modify an immutable Int (0)` — while the identical call written with
+`$`-sigils worked.
+
+`sigilless_local_container_name`'s `local_map` probe is what settles bareword
+ambiguity, and it is now consulted at the List-element capture site too.
+
+## 3. A sigilless parameter's declared type leaked into assignment
+
+A `\c` parameter's declared type is checked once, when the argument binds; a
+later write through the alias goes into the *caller's* container and is checked
+against that container's constraint. mutsu registered the parameter's type in
+the assignment-time lane as well, inventing a constraint rakudo does not have:
+
+```raku
+sub h(Associative \container) { container = Empty }
+my $root = {:a(1)}; h($root);
+# mutsu: Type check failed in assignment to $container; expected Associative but got Slip
+```
+
+`bind_param_type_constraint_sym` now takes the untyped path for a sigilless
+name, which also keeps the shadowing behaviour the untyped case documents. This
+is Crane's `remove-from-associative(\container, :in-place)`, which empties a
+container with exactly that statement.
+
+## 4. `deepmap` did not itemize a nested Hash
+
+`deepmap` itemizes what a descend returns — the `Array` and `Seq` arms honoured
+the flag, the `Hash` arm silently dropped it. `%(:x({:a(1)})).deepmap({$_})`
+answered `{:x({:a(1)})}` where rakudo answers `{:x(${:a(1)})}`. Without the
+itemization nothing can be bound to a mapped copy's nested hash, which is how
+`Crane::At.at($root, @path){$step}:delete` on a `container.deepmap({ .clone })`
+copy deleted from a temporary instead of from `$root`.
+
+The itemization has to be the per-holder flag on the same `HashData` (`.item`),
+not a `Scalar` wrapper: a wrapper hands back a copy nothing can mutate in place.
+
+## 5. `:delete` on a call-result subscript deleted from a temporary
+
+`<expr>{key}:delete` compiled the target onto the stack and ran the generic
+`DeleteIndexExpr` over the popped value, so a `return-rw` call's result was
+mutated as a temporary and the deletion vanished — while binding the identical
+expression to a variable and deleting through *that* worked. The nested-subscript
+case already had a temp-bind rewrite for this reason; it is now the generic
+fallback, so `Crane::At.at($root, @path){$step}:delete` reaches the real
+container.
+
+## 6. `splice` ignored a `Callable` index on a by-value invocant
+
+`splice`'s start/elems positions take `Int`, `Whatever` or `Callable`, and a
+from-the-end index (`*-1`) is a `WhateverCode`. The lvalue path resolved it
+against the array's length; the by-value invocant path (a function result, an
+element read, a literal) did not, so the callable read as index 0 and
+`f().splice(*-1, 1)` cut the array's **first** element. The two paths now share
+one `resolve_splice_callable_args`.
+
+## 7. `.clone` kept its invocant's itemization
+
+Itemization is a property of the container, not of the object, and `.clone`
+copies the object: `my $v = <a b c>; $v.raku` is `$("a", "b", "c")` but
+`$v.clone.raku` is `("a", "b", "c")`, which is why `my @a = $v.clone` flattens
+where `@a = $v` does not. mutsu carried the `ArrayKind`'s itemization through
+verbatim. Crane's `Crane::In.in(container, @path) = $value.clone` depends on the
+flattening.
+
+## 8. A nested store into a `Pair` clobbered it — and destroyed the variable
+
+A `Pair` does `Associative`, so rakudo descends into it on a nested store and
+refuses at the value the next subscript reaches
+(`my %h = :x(:y(1)); %h<x><y> = 2` is `Cannot modify an immutable Int (1)`).
+mutsu refused on the *slot's* type with `X::AdHoc` "Type Pair does not support
+associative indexing" — the class rakudo raises for a genuinely non-Associative
+slot — and the deeper walk did worse: finding neither an Array nor a Hash to
+step through, it overwrote the `Pair` with a fresh `Hash` and reported success,
+rebuilding a whole colonpair chain as nested hashes.
+
+Both nested-store ops also invalidate the target's local slot to `Nil` before
+walking and refresh it from `env` when they finish. Returning early on a refusal
+skipped that refresh, so a **failed** assignment left the caller's `%h` reading
+`Nil` — the variable was destroyed by a store that was supposed to change
+nothing. The restore now runs on the error path too.
+
+Crane's `CATCH { when X::Assignment::RO }` maps the refusal to
+`X::Crane::OpSet::RO`, and its fixtures are colonpair chains
+(`:a(:pair(:is(:not(:a<hash>))))`), so both halves mattered.
+
+## 9. `{ :when(...) }` parsed as a Block
+
+A statement can never start with a `:`, so a block body whose first token is a
+colonpair is unambiguously a hash composer — whatever the pair's key spells.
+mutsu excluded a list of statement keywords there (`when`, `if`, `for`, `my`,
+`return`, …), so `{:when(1)}` and eleven others parsed as `Block` where rakudo
+answers `Hash`. `Crane`'s `t/remove.rakutest` builds a literal
+`:me({:when({:im(7)})})`, and the `when` entry alone turned a nested hash into a
+closure, aborting the file.
+
+## Pins
+
+- `t/vm/binding/rw-alias-of-an-aggregate-has-no-scalar.t` (1, 2, 3)
+- `t/collections/transform/deepmap-nested-hash-itemization.t` (4)
+- `t/collections/subscript/delete-through-a-call-result-subscript.t` (5)
+- `t/routines/splice-callable-index-by-value-invocant.t` (6)
+- `t/oo/construct/clone-decontainerizes-its-result.t` (7)
+- `t/collections/range-pair/pair-subscript-store-is-refused.t` (8)
+- `t/lang/adverbs/colonpair-keyword-key-hash-composer.t` (9)
+
+## What is left on #7539
+
+`Crane` is still 4/15 files, so the vendoring steps stay parked. The residue:
+
+- **`Crane::In`'s descent through a `Pair` is still writable.** The direct
+  subscript spelling now refuses, and so does a hand-written recursive
+  `inn(c{@s[0]}, @s[1..*])`, but the real `Crane::In.in` — reached through a
+  class method with a `*@steps` slurpy and `Associative:D`-constrained multis —
+  still promotes the Pair's element to a writable location, so `set`'s two
+  "operation fails when … is immutable" subtests do not throw. That is
+  `set.rakutest`'s only remaining failure.
+- **`X::Assignment::RO` on a Pair names the wrong Pair.** The refusal fires at
+  the first Pair the walk meets rather than descending to the leaf, so a
+  four-level chain reports the outer pair's value where rakudo reports the
+  innermost. The class is right; only the rendered value differs.
+- `flatten` / `list` are still the object-hash blocker
+  ([#7539](https://github.com/tokuhirom/mutsu/issues/7539)'s item 5), and
+  `add` / `copy` / `in` / `move` / `patch` / `transform` each have their own
+  positional/error-handling residue.
+- `Config::TOML`'s `grammar-actions/01`, `02`, `04` and the two dumper files are
+  untouched.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -157,6 +157,29 @@ pub(crate) fn scalar_var_expr(name: String) -> Expr {
 }
 
 impl ParamDef {
+    /// The type constraint to register in the **assignment-time** lane when this
+    /// parameter binds (`Interpreter::bind_param_type_constraint`).
+    ///
+    /// `None` for a SIGILLESS parameter (`Associative \container`), which is a
+    /// raw alias rather than a container of its own: Rakudo checks its declared
+    /// type once, when the argument binds, and every later write through the
+    /// alias goes straight into the CALLER's container and is checked against
+    /// *that* container's constraint. Registering the declared type here invents
+    /// a constraint Rakudo does not have — `sub h(Associative \c) { c = Empty }`
+    /// died with "Type check failed in assignment to $container; expected
+    /// Associative but got Slip" where Rakudo stores the Slip into the caller's
+    /// untyped scalar.
+    ///
+    /// The decision has to be made from `sigilless`, not from the name: a scalar
+    /// parameter's env key drops its `$`, so `$p` and `\p` reach the binder
+    /// spelled identically.
+    pub(crate) fn assignment_type_constraint(&self) -> Option<String> {
+        if self.sigilless {
+            return None;
+        }
+        self.type_constraint.clone()
+    }
+
     /// True when the *source* declares a parameter spelled `$self` — an explicit
     /// invocant (`method m($self: $n)`, `method symbol(::?CLASS $self: ...)`) or
     /// an ordinary parameter (`sub ($self)`, `-> $self, $x`). A parser-synthesized

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -285,9 +285,18 @@ pub(super) fn dispatch(
                             *item = clone_rows(item);
                         }
                     }
+                    // Itemization is a property of the CONTAINER, not of the
+                    // object, and `.clone` copies the object. So the clone comes
+                    // back de-itemized, exactly as rakudo has it:
+                    // `my $v = <a b c>; $v.raku` is `$("a", "b", "c")` but
+                    // `$v.clone.raku` is `("a", "b", "c")` — which is why
+                    // `my @a; @a = $v.clone` flattens where `@a = $v` does not.
+                    // (Crane's `Crane::In.in(container, @path) = $value.clone`
+                    // depends on exactly that: a List value must land in the
+                    // target array as elements, not as one nested list.)
                     Some(Some(Ok(Value::array_with_kind(
                         crate::gc::Gc::new(data),
-                        kind,
+                        kind.decontainerize(),
                     ))))
                 }
                 ValueView::Hash(map) => Some(Some(Ok(Value::hash_with_data(Value::hash_arc(

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -371,9 +371,24 @@ impl Compiler {
                         // Consumers that decontainerize (`@arr = (...)`, param
                         // binding, single-scalar push) deref the cell to its value.
                         if let Some(name) = Self::scalar_container_alias_name(elem)
+                            .map(str::to_string)
+                            // A SIGILLESS lexical (`\c`, `my \y := ...`) names the
+                            // same kind of storage a `$`-sigiled one does, but the
+                            // parser spells it `Expr::BareWord` — which is also how
+                            // a type name is spelled, so only its presence in
+                            // `local_map` settles it. Without the tag, an lvalue
+                            // call's argument list (`leaf(c) = 1`, lowered to
+                            // `__mutsu_assign_named_sub_lvalue("leaf", (c), 1)`)
+                            // handed `leaf`'s `\c` a bare value with no source
+                            // name, so the binder marked it a readonly non-lvalue
+                            // and the assignment died with "Cannot modify an
+                            // immutable Int (0)" — the `$`-sigiled spelling of the
+                            // same call worked. Crane reaches this on every
+                            // `Crane::In.in(container, @path) = $value` inside a
+                            // `\container` routine.
+                            .or_else(|| c.sigilless_local_container_name(elem))
                             && !c.suppress_list_var_alias
                         {
-                            let name = name.to_string();
                             c.emit_wrap_var_ref(&name);
                         } else if Self::expr_is_scalar_var(elem) {
                             c.code.emit(OpCode::Itemize);

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -575,6 +575,52 @@ impl Compiler {
         matches!(arg, Expr::AnonSub { is_block: true, .. })
     }
 
+    /// Compile `<delete_target>[<delete_index>]:delete` by BINDING the target to
+    /// a temp and deleting through it: `my $t := <delete_target>; $t[<index>]
+    /// :delete`.
+    ///
+    /// The bind shares the target's `ContainerRef` cell, so the removal reaches
+    /// the real container; evaluating the target onto the stack and running
+    /// `DeleteIndexExpr` over the popped value instead deletes from a temporary
+    /// and silently loses it. The rewritten inner delete names a plain variable,
+    /// so it takes the `DeleteIndexNamed` path and cannot recurse back here.
+    fn compile_delete_through_bound_temp(
+        &mut self,
+        delete_target: &Expr,
+        delete_index: &Expr,
+        is_positional: bool,
+    ) {
+        let tmp = format!("__mutsu_nested_del_{}", self.code.constants.len());
+        let bind_decl = Stmt::VarDecl {
+            name: tmp.clone(),
+            expr: delete_target.clone(),
+            type_constraint: None,
+            is_state: false,
+            is_our: false,
+            is_dynamic: false,
+            is_export: false,
+            export_tags: Vec::new(),
+            custom_traits: vec![("__scalar_bind".to_string(), None)],
+            where_constraint: None,
+        };
+        let delete_through = Expr::MethodCall {
+            target: Box::new(Expr::Index {
+                target: Box::new(Expr::Var(tmp)),
+                index: Box::new(delete_index.clone()),
+                is_positional,
+            }),
+            name: Symbol::intern("DELETE-KEY"),
+            args: Vec::new(),
+            modifier: None,
+            quoted: false,
+        };
+        self.compile_expr(&Expr::desugar_block(vec![
+            Stmt::MarkBind,
+            bind_decl,
+            Stmt::Expr(delete_through),
+        ]));
+    }
+
     /// Compile method call on non-variable target (no writeback needed).
     pub(super) fn compile_expr_method_generic(
         &mut self,
@@ -602,35 +648,11 @@ impl Compiler {
             // (`my $t := %h<a>`) — which shares its `ContainerRef` cell — and delete
             // through it, so the deletion reaches the real inner container.
             if matches!(delete_target.as_ref(), Expr::Index { .. }) {
-                let tmp = format!("__mutsu_nested_del_{}", self.code.constants.len());
-                let bind_decl = Stmt::VarDecl {
-                    name: tmp.clone(),
-                    expr: (**delete_target).clone(),
-                    type_constraint: None,
-                    is_state: false,
-                    is_our: false,
-                    is_dynamic: false,
-                    is_export: false,
-                    export_tags: Vec::new(),
-                    custom_traits: vec![("__scalar_bind".to_string(), None)],
-                    where_constraint: None,
-                };
-                let delete_through = Expr::MethodCall {
-                    target: Box::new(Expr::Index {
-                        target: Box::new(Expr::Var(tmp)),
-                        index: delete_index.clone(),
-                        is_positional: *delete_positional,
-                    }),
-                    name: Symbol::intern("DELETE-KEY"),
-                    args: Vec::new(),
-                    modifier: None,
-                    quoted: false,
-                };
-                self.compile_expr(&Expr::desugar_block(vec![
-                    Stmt::MarkBind,
-                    bind_decl,
-                    Stmt::Expr(delete_through),
-                ]));
+                self.compile_delete_through_bound_temp(
+                    delete_target,
+                    delete_index,
+                    *delete_positional,
+                );
                 return;
             }
             if let Some(var_name) = Self::postfix_index_name(delete_target) {
@@ -664,9 +686,22 @@ impl Compiler {
                     ],
                 });
             } else {
-                self.compile_expr(delete_target);
-                self.compile_expr(delete_index);
-                self.code.emit(OpCode::DeleteIndexExpr);
+                // Last resort: the delete target is an arbitrary expression, most
+                // often an `is rw`/`return-rw` CALL whose result is the very
+                // container to delete from (`Crane::At.at($root, @path){$step}
+                // :delete`, and `at-rw(%h)<do>:delete` reduced). Pushing that
+                // result on the stack and running `DeleteIndexExpr` over it
+                // deletes from the popped temporary, so the deletion is lost —
+                // even though binding the identical expression to a variable and
+                // deleting through THAT reaches the real container. So take the
+                // same temp-bind route the nested-subscript case above takes,
+                // rather than the stack form. `DeleteIndexExpr` survives for the
+                // `:exists:delete` compiler path, which has its own target.
+                self.compile_delete_through_bound_temp(
+                    delete_target,
+                    delete_index,
+                    *delete_positional,
+                );
             }
             return;
         }

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -116,11 +116,11 @@ impl Compiler {
     /// of the frame being compiled. That is exactly what `local_map` records, so
     /// consult it rather than guessing from the spelling.
     ///
-    /// Scoped to the `return-rw` / rw-tail site (`return_rw_container_name`) and
-    /// deliberately NOT folded into `scalar_container_alias_name`, whose other
-    /// callers (List literal elements, fat-arrow Pair values) see barewords that
-    /// are type names in ordinary code.
-    fn sigilless_local_container_name(&self, arg: &Expr) -> Option<String> {
+    /// Deliberately NOT folded into `scalar_container_alias_name`: that is an
+    /// associated function, and only the `local_map` probe here can tell a
+    /// sigilless *variable* from the type name / enum value / listop-less call a
+    /// bareword otherwise spells.
+    pub(super) fn sigilless_local_container_name(&self, arg: &Expr) -> Option<String> {
         let Expr::BareWord(name) = arg else {
             return None;
         };

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -832,21 +832,15 @@ fn is_hash_literal_start(input: &str) -> bool {
             return true;
         }
         // :name or :name(expr) or :name[expr]
+        //
+        // A statement can never START with a `:`, so a leading colonpair is
+        // unambiguously a hash composer no matter what the pair's KEY spells.
+        // A list of statement keywords used to be excluded here, which made
+        // `{ :when({...}) }`, `{ :if(1) }`, `{ :my(1) }` and the like parse as
+        // blocks — rakudo answers `Hash` for every one of them, and Crane's
+        // `t/remove.rakutest` builds a literal `:me({:when({:im(7)})})`, so the
+        // `when` entry alone turned a nested hash into a `Block`.
         if let Ok((_r, name)) = crate::parser::stmt::ident_pub(r)
-            && !matches!(
-                name.as_str(),
-                "my" | "our"
-                    | "has"
-                    | "if"
-                    | "unless"
-                    | "for"
-                    | "while"
-                    | "until"
-                    | "loop"
-                    | "given"
-                    | "when"
-                    | "return"
-            )
             && !name.starts_with(|c: char| c.is_ascii_digit())
         {
             return true;

--- a/src/runtime/builtins_collection_deepmap.rs
+++ b/src/runtime/builtins_collection_deepmap.rs
@@ -563,7 +563,27 @@ impl Interpreter {
                         Err(e) => return Err(e),
                     }
                 }
-                Ok(Value::hash_with_data(Value::hash_arc(result)))
+                let hash = Value::hash_with_data(Value::hash_arc(result));
+                // A descended-into Hash is itemized in its parent exactly like a
+                // descended-into sublist (the `Array`/`Seq` arms above already
+                // honour `itemize_result`; this arm silently dropped it).
+                // Rakudo: `%(:x({:a(1)})).deepmap({$_})` is `{:x(${:a(1)})}`, and
+                // `(1, {:a(2)}).deepmap({$_})` is `(1, ${:a(2)})`. Without the
+                // itemization the mapped copy's nested hashes are bare values, so
+                // nothing can be BOUND to one — which is how Crane's
+                // `Crane::At.at($root, @path){$step}:delete` (on a
+                // `container.deepmap({ .clone })` copy) deleted from a temporary
+                // instead of from `$root`.
+                //
+                // `.item()` — NOT `Value::scalar(...)`: a hash's itemization is a
+                // per-holder flag on the same `HashData` `Gc`, so `.item()` keeps
+                // the store shared, while a `Scalar` wrapper would hand back a
+                // copy nothing can mutate in place.
+                if itemize_result {
+                    Ok(hash.item())
+                } else {
+                    Ok(hash)
+                }
             }
             // Leaf value: apply the block (through a transient container so
             // mutating callables write through to a bare top-level leaf too).

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -328,33 +328,49 @@ impl Interpreter {
         if let Some(assigned) = self.assign_lvalue_container(&result, value.clone()) {
             return assigned;
         }
-        // A real `Array`/`Hash` IS a container, so `f(@a) = (7, 8)` for
-        // `sub f(\x) is raw { x }` is a *list assignment into it* — the same
-        // rule `@a = (7, 8)` follows — not a rebinding of the routine's result.
-        // Replacing the contents in place keeps every other share of the
-        // container (the caller's `@a`) pointing at the new elements. An
-        // immutable `List`/`ItemList` is deliberately excluded: Rakudo refuses
-        // `f((1, 2)) = 3` with "Cannot modify an immutable List".
+        if let Some(stored) = self.store_into_aggregate_lvalue(&result, value) {
+            return Ok(stored);
+        }
+        let typename = crate::runtime::utils::value_type_name(&result);
+        // Rakudo renders the refused value with `.gist`, so a `Pair` reads
+        // `a => hash` rather than its tab-joined string coercion (`a\thash`),
+        // and a `List` reads `(1 2)`.
+        let repr = crate::runtime::utils::gist_value(&result);
+        Err(RuntimeError::assignment_ro_typename(typename, &repr))
+    }
+
+    /// A real `Array`/`Hash` IS a container, so `f(@a) = (7, 8)` for
+    /// `sub f(\x) is raw { x }` is a *list assignment into it* — the same rule
+    /// `@a = (7, 8)` follows — not a rebinding of the routine's result.
+    /// Replacing the contents in place keeps every other share of the container
+    /// (the caller's `@a`) pointing at the new elements. An immutable
+    /// `List`/`ItemList` is deliberately excluded: Rakudo refuses `f((1, 2)) = 3`
+    /// with "Cannot modify an immutable List".
+    ///
+    /// `None` when `result` is not such an aggregate, so a caller that has a
+    /// further chain to try can go on trying it.
+    pub(crate) fn store_into_aggregate_lvalue(
+        &mut self,
+        result: &Value,
+        value: Value,
+    ) -> Option<Value> {
         match result.view() {
             ValueView::Array(_, kind)
                 if kind.is_real_array() || kind == crate::value::ArrayKind::Shaped =>
             {
                 let coerced = crate::runtime::utils::coerce_to_array(value);
-                if result.replace_container_contents(&coerced) {
-                    return Ok(result);
-                }
+                result
+                    .replace_container_contents(&coerced)
+                    .then(|| result.clone())
             }
             ValueView::Hash(_) => {
                 let coerced = self.coerce_object_to_hash(value);
-                if result.replace_container_contents(&coerced) {
-                    return Ok(result);
-                }
+                result
+                    .replace_container_contents(&coerced)
+                    .then(|| result.clone())
             }
-            _ => {}
+            _ => None,
         }
-        let typename = crate::runtime::utils::value_type_name(&result);
-        let repr = result.to_string_value();
-        Err(RuntimeError::assignment_ro_typename(typename, &repr))
     }
 
     pub(crate) fn assign_proxy_lvalue(

--- a/src/runtime/lvalue_container_return.rs
+++ b/src/runtime/lvalue_container_return.rs
@@ -157,10 +157,20 @@ impl Interpreter {
         let Ok(result) = result else {
             return Ok(None);
         };
-        match self.assign_lvalue_container(&result, value.clone()) {
-            Some(assigned) => assigned.map(Some),
-            None => Ok(None),
+        if let Some(assigned) = self.assign_lvalue_container(&result, value.clone()) {
+            return assigned.map(Some);
         }
+        // An rw method whose tail names an `@`/`%` container hands back the
+        // aggregate itself, not a cell — there is no Scalar around an `@`/`%`
+        // variable to hand back. That is still an lvalue: the assignment stores
+        // into it, exactly as the sub form does. Without this the legacy
+        // setter/attribute chain below took over and quietly dropped the write
+        // (`Crane::In.in(%h, ()) = $value`, the root-path case of every
+        // `Crane.set`/`add`/`replace`).
+        if let Some(stored) = self.store_into_aggregate_lvalue(&result, value.clone()) {
+            return Ok(Some(stored));
+        }
+        Ok(None)
     }
 
     /// `Class.m($arg) = $v` where `m` is a declared method that is **not**

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -1689,6 +1689,24 @@ impl Interpreter {
             // `Callable`) — a `Num`/`Str`/`Array` there matches no candidate and
             // must throw X::Multi::NoMatch (roast .../multi-no-match.t) rather
             // than being coerced. Mirrors the lvalue path in methods_mut_dispatch.
+            // A from-the-end start/count (`*-1`) arrives as a `WhateverCode`;
+            // resolve it against the invocant's length before anything reads
+            // those positions as integers. The lvalue path does the same (see
+            // `resolve_splice_callable_args`).
+            let args = if method == "splice"
+                && args
+                    .iter()
+                    .take(2)
+                    .any(|v| matches!(v.view(), ValueView::Sub(..) | ValueView::WeakSub(..)))
+            {
+                let arr_len = match target.view() {
+                    ValueView::Array(items, ..) => items.len(),
+                    _ => 0,
+                };
+                self.resolve_splice_callable_args(arr_len, &args)
+            } else {
+                args
+            };
             if method == "splice" {
                 fn is_valid_splice_index(v: &Value) -> bool {
                     match v.view() {

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -228,6 +228,54 @@ impl Interpreter {
         Ok(Some(Value::truth(super::to_int(&count) > 0)))
     }
 
+    /// Resolve `splice`'s start/elems arguments when they are `Callable`s —
+    /// which is what a from-the-end index (`*-1`, a `WhateverCode`) is.
+    ///
+    /// Rakudo's `splice` candidates take `Int`, `Whatever` or `Callable` in
+    /// those two positions, and a `Callable` is called with the number of
+    /// elements still available: `len` for the start, and `len - start` for the
+    /// count. Nothing downstream can do this — `splice_array_data` and
+    /// `do_splice` hold the array's items mutably and have no interpreter to
+    /// call a sub with — so it has to happen here, before the borrow. A
+    /// callable left unresolved read as index 0, so `f().splice(*-1, 1)` cut
+    /// the array's FIRST element instead of its last.
+    ///
+    /// Returns the arguments with positions 0/1 replaced by their results; a
+    /// callable that fails to run is left as is, for the arity/type check that
+    /// follows to reject.
+    pub(crate) fn resolve_splice_callable_args(
+        &mut self,
+        arr_len: usize,
+        args: &[Value],
+    ) -> Vec<Value> {
+        let is_callable =
+            |v: &Value| matches!(v.view(), ValueView::Sub(..) | ValueView::WeakSub(..));
+        let mut resolved = args.to_vec();
+        if let Some(arg) = args.first().filter(|a| is_callable(a))
+            && let Ok(result) =
+                self.call_sub_value(arg.clone(), vec![Value::int(arr_len as i64)], true)
+        {
+            resolved[0] = result;
+        }
+        if let Some(arg) = args.get(1).filter(|a| is_callable(a)) {
+            let resolved_start = resolved
+                .first()
+                .and_then(|v| match v.view() {
+                    ValueView::Int(i) => Some(i.max(0) as usize),
+                    ValueView::Whatever => Some(arr_len),
+                    _ => None,
+                })
+                .unwrap_or(0)
+                .min(arr_len);
+            let remaining = arr_len.saturating_sub(resolved_start) as i64;
+            if let Ok(result) = self.call_sub_value(arg.clone(), vec![Value::int(remaining)], true)
+            {
+                resolved[1] = result;
+            }
+        }
+        resolved
+    }
+
     /// Mutate an Array value in place for push/pop/shift/unshift/append/
     /// prepend/splice on a by-value invocant (function results, element
     /// reads, literals). Container identity (§3.2): the mutation writes

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1383,35 +1383,10 @@ impl Interpreter {
                             }
                         }
                     }
-                    let mut resolved_args = args.clone();
-                    // Resolve callable for offset (arg 0) with array length
-                    if let Some(arg) = args.first()
-                        && matches!(arg.view(), ValueView::Sub(..) | ValueView::WeakSub(..))
-                        && let Ok(result) =
-                            self.call_sub_value(arg.clone(), vec![Value::int(arr_len as i64)], true)
-                    {
-                        resolved_args[0] = result;
-                    }
-                    // Resolve callable for count (arg 1) with (array_len - offset)
-                    if let Some(arg) = args.get(1)
-                        && matches!(arg.view(), ValueView::Sub(..) | ValueView::WeakSub(..))
-                    {
-                        let resolved_start = resolved_args
-                            .first()
-                            .and_then(|v| match v.view() {
-                                ValueView::Int(i) => Some(i.max(0) as usize),
-                                ValueView::Whatever => Some(arr_len),
-                                _ => None,
-                            })
-                            .unwrap_or(0)
-                            .min(arr_len);
-                        let remaining = arr_len.saturating_sub(resolved_start) as i64;
-                        if let Ok(result) =
-                            self.call_sub_value(arg.clone(), vec![Value::int(remaining)], true)
-                        {
-                            resolved_args[1] = result;
-                        }
-                    }
+                    // Resolve a callable offset/count (`*-1`) against the array's
+                    // length. Shared with the by-value invocant path so the two
+                    // cannot drift.
+                    let resolved_args = self.resolve_splice_callable_args(arr_len, &args);
                     // Type-check the offset/size arguments. splice's candidates
                     // take `Int` (plus `Whatever`/`Callable`, already resolved
                     // above) for the start and elems positions — a `Num`, `Str`,

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -371,23 +371,11 @@ impl Interpreter {
             return;
         }
         let meta_key = Self::type_meta_key_for_sym(name_sym);
-        // A SIGILLESS parameter (`Associative \container`) is a raw alias, not a
-        // container of its own: Rakudo checks its declared type once, when the
-        // argument binds, and every later write through the alias goes straight
-        // into the CALLER's container and is checked against *that* container's
-        // constraint. Registering the declared type in the assignment-time lane
-        // therefore invents a constraint Rakudo does not have — `sub h(Associative
-        // \c) { c = Empty }` died with "Type check failed in assignment to
-        // $container; expected Associative but got Slip" where Rakudo happily
-        // stores the Slip into the caller's untyped scalar. This is exactly
-        // Crane's `remove-from-associative(\container, :in-place)`, which empties
-        // a container with `container = Empty`.
-        //
-        // Falling into the `None` arm also keeps the shadowing behaviour the
-        // untyped case documents: the callee's `container` hides any same-named
-        // outer lexical's constraint for the duration of the frame.
-        let sigilless = !name.starts_with(['$', '@', '%', '&']);
-        match constraint.filter(|_| !sigilless) {
+        // A SIGILLESS parameter passes `None` here — see
+        // [`crate::ast::ParamDef::assignment_type_constraint`] — and so lands in
+        // the `None` arm below, which is also what keeps the shadowing behaviour
+        // that arm documents.
+        match constraint {
             Some(c) => {
                 let info = Self::parse_container_constraint(name, &c);
                 if info.value_type == "atomicint" || c.contains("atomicint") {

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -371,7 +371,23 @@ impl Interpreter {
             return;
         }
         let meta_key = Self::type_meta_key_for_sym(name_sym);
-        match constraint {
+        // A SIGILLESS parameter (`Associative \container`) is a raw alias, not a
+        // container of its own: Rakudo checks its declared type once, when the
+        // argument binds, and every later write through the alias goes straight
+        // into the CALLER's container and is checked against *that* container's
+        // constraint. Registering the declared type in the assignment-time lane
+        // therefore invents a constraint Rakudo does not have — `sub h(Associative
+        // \c) { c = Empty }` died with "Type check failed in assignment to
+        // $container; expected Associative but got Slip" where Rakudo happily
+        // stores the Slip into the caller's untyped scalar. This is exactly
+        // Crane's `remove-from-associative(\container, :in-place)`, which empties
+        // a container with `container = Empty`.
+        //
+        // Falling into the `None` arm also keeps the shadowing behaviour the
+        // untyped case documents: the callee's `container` hides any same-named
+        // outer lexical's constraint for the duration of the frame.
+        let sigilless = !name.starts_with(['$', '@', '%', '&']);
+        match constraint.filter(|_| !sigilless) {
             Some(c) => {
                 let info = Self::parse_container_constraint(name, &c);
                 if info.value_type == "atomicint" || c.contains("atomicint") {

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1225,7 +1225,7 @@ impl Interpreter {
                                 format!("@{}", pd.name)
                             };
                             self.bind_param_value(&key, lazy_value.clone());
-                            self.bind_param_type_constraint(&key, pd.type_constraint.clone());
+                            self.bind_param_type_constraint(&key, pd.assignment_type_constraint());
                         }
                     }
                     if let Some(sub_params) = &pd.sub_signature {
@@ -1341,7 +1341,7 @@ impl Interpreter {
                         format!("@{}", pd.name)
                     };
                     self.bind_param_value(&key, slurpy_value.clone());
-                    self.bind_param_type_constraint(&key, pd.type_constraint.clone());
+                    self.bind_param_type_constraint(&key, pd.assignment_type_constraint());
                 }
                 if let Some(sub_params) = &pd.sub_signature {
                     bind_sub_signature_from_value(self, sub_params, &slurpy_value)?;
@@ -1382,7 +1382,7 @@ impl Interpreter {
                         self.bind_param_type_constraint_sym(
                             &pd.name,
                             pd_name_sym(),
-                            pd.type_constraint.clone(),
+                            pd.assignment_type_constraint(),
                         );
                     }
                     if let Some(sub_params) = &pd.sub_signature {
@@ -1447,7 +1447,7 @@ impl Interpreter {
                         self.bind_param_type_constraint_sym(
                             &pd.name,
                             pd_name_sym(),
-                            pd.type_constraint.clone(),
+                            pd.assignment_type_constraint(),
                         );
                     }
                 } else if pd.double_slurpy {
@@ -1467,7 +1467,7 @@ impl Interpreter {
                             format!("@{}", pd.name)
                         };
                         self.bind_param_value(&key, Value::real_array(items));
-                        self.bind_param_type_constraint(&key, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&key, pd.assignment_type_constraint());
                     }
                 } else if !pd.name.starts_with('@') {
                     // *$x -- slurpy scalar: captures what would otherwise be the
@@ -1493,7 +1493,7 @@ impl Interpreter {
                         self.bind_param_type_constraint_sym(
                             &pd.name,
                             pd_name_sym(),
-                            pd.type_constraint.clone(),
+                            pd.assignment_type_constraint(),
                         );
                     }
                 } else {
@@ -1551,7 +1551,7 @@ impl Interpreter {
                             self.bind_param_value(&slurpy_key, slurpy_value.clone());
                             self.bind_param_type_constraint(
                                 &slurpy_key,
-                                pd.type_constraint.clone(),
+                                pd.assignment_type_constraint(),
                             );
                         }
                         if let Some(sub_params) = &pd.sub_signature {
@@ -1691,7 +1691,7 @@ impl Interpreter {
                             format!("@{}", pd.name)
                         };
                         self.bind_param_value(&key, slurpy_value.clone());
-                        self.bind_param_type_constraint(&key, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&key, pd.assignment_type_constraint());
                     }
                     // Check where constraint for slurpy params
                     if let Some(where_expr) = &pd.where_constraint {
@@ -1966,7 +1966,7 @@ impl Interpreter {
                                 self.bind_param_type_constraint_sym(
                                     &pd.name,
                                     pd_name_sym(),
-                                    pd.type_constraint.clone(),
+                                    pd.assignment_type_constraint(),
                                 );
                                 bind_sub_signature_from_value(self, sub_params, &bound_value)?;
                             } else {
@@ -1981,7 +1981,7 @@ impl Interpreter {
                             self.bind_param_type_constraint_sym(
                                 &pd.name,
                                 pd_name_sym(),
-                                pd.type_constraint.clone(),
+                                pd.assignment_type_constraint(),
                             );
                         }
                         found = true;
@@ -2044,7 +2044,7 @@ impl Interpreter {
                             self.bind_param_type_constraint_sym(
                                 &pd.name,
                                 pd_name_sym(),
-                                pd.type_constraint.clone(),
+                                pd.assignment_type_constraint(),
                             );
                         }
                     } else if !pd.name.is_empty() && !is_rename {
@@ -2052,7 +2052,7 @@ impl Interpreter {
                         self.bind_param_type_constraint_sym(
                             &pd.name,
                             pd_name_sym(),
-                            pd.type_constraint.clone(),
+                            pd.assignment_type_constraint(),
                         );
                     }
                     // For renamed named params like :foo($y) = $x, also bind the
@@ -2090,7 +2090,7 @@ impl Interpreter {
                         self.bind_param_type_constraint_sym(
                             &pd.name,
                             pd_name_sym(),
-                            pd.type_constraint.clone(),
+                            pd.assignment_type_constraint(),
                         );
                     }
                     // A `:color(:$colour)` alias chain declares its inner
@@ -2391,9 +2391,15 @@ impl Interpreter {
                                 .flatten()
                         })
                     });
+                    // The SOURCE variable's constraint wins, and for a sigilless
+                    // parameter it is the only one that applies: `\c` is a raw
+                    // alias, so a write through it lands in the caller's
+                    // container and is checked against that container's `of`,
+                    // never against the alias's own declared type. See
+                    // [`crate::ast::ParamDef::assignment_type_constraint`].
                     let bound_type_constraint = source_type_constraint
                         .clone()
-                        .or_else(|| pd.type_constraint.clone());
+                        .or_else(|| pd.assignment_type_constraint());
                     let mut value = unwrap_varref_value(raw_arg.clone());
                     // Container identity (§3): an `is copy` container param owns
                     // a DISTINCT container. Mutations now write through the
@@ -2843,7 +2849,7 @@ impl Interpreter {
                         self.bind_param_type_constraint_sym(
                             &pd.name,
                             pd_name_sym(),
-                            pd.type_constraint.clone(),
+                            pd.assignment_type_constraint(),
                         );
                     }
                     if let Some(sub_params) = &pd.sub_signature {
@@ -2891,7 +2897,7 @@ impl Interpreter {
                         self.bind_param_type_constraint_sym(
                             &pd.name,
                             pd_name_sym(),
-                            pd.type_constraint.clone(),
+                            pd.assignment_type_constraint(),
                         );
                     }
                 }

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -798,6 +798,25 @@ impl Interpreter {
             self.stack.push(inner.into_deref());
             return;
         }
+        // A real `Array`/`Hash` IS the container. Raku gives an `@`/`%` variable
+        // no Scalar of its own, and a sigilless alias of one (`\c` bound to
+        // `%a`) names that aggregate directly — `c = {...}` is `%a.STORE(...)`,
+        // seen by every holder. Boxing it into a fresh scalar cell mints a
+        // container nobody else shares: `sub hop(\c) is rw { return-rw leaf(c) };
+        // hop(%a) = {...}` assigned into a cell owned by a frame that had
+        // already returned, so `%a` never changed (one hop happened to work;
+        // two did not). `assign_through_rw_result` already knows what to do with
+        // a bare aggregate — replace its contents in place.
+        //
+        // This is the same aggregate exclusion `exec_attr_container_ref_op`
+        // makes, for the same reason: an `@`/`%`-shaped value is already a
+        // shared container and a scalar cell would disagree with that storage.
+        if matches!(inner.view(), ValueView::Hash(..))
+            || matches!(inner.view(), ValueView::Array(_, kind) if kind.is_real_array())
+        {
+            self.stack.push(inner);
+            return;
+        }
         let slot_hint = val.varref_slot();
         let captured =
             self.capture_var_cell_inner(code, &source_name, inner.clone(), true, slot_hint);

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3217,7 +3217,43 @@ impl Interpreter {
         }
     }
 
+    /// Both nested-store ops invalidate the target's local slot to `Nil` before
+    /// walking (so the env root's `Gc` refcount is 1 and the in-place mutation
+    /// does not COW-detach), and refresh it from `env` when they finish. A
+    /// REFUSED store — `my %h = :x(:y(1)); %h<x><y> = 2` now dies, as rakudo
+    /// does — returned before that refresh, leaving the caller's `%h` reading
+    /// `Nil`: the failed assignment destroyed the variable. Restore the slot on
+    /// the error path too, so a refusal changes nothing.
+    fn restore_nested_store_local(&mut self, code: &CompiledCode, name_idx: u32) {
+        let var_name = Self::const_str(code, name_idx).to_string();
+        if let Some(slot) = self.find_local_slot(code, &var_name)
+            && matches!(self.locals[slot].view(), ValueView::Nil)
+            && let Some(updated) = self.env().get(&var_name).cloned()
+        {
+            self.locals[slot] = updated;
+        }
+    }
+
     pub(super) fn exec_index_assign_expr_nested_op(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        outer_positional: bool,
+        inner_positional: bool,
+    ) -> Result<(), RuntimeError> {
+        let result = self.exec_index_assign_expr_nested_op_body(
+            code,
+            name_idx,
+            outer_positional,
+            inner_positional,
+        );
+        if result.is_err() {
+            self.restore_nested_store_local(code, name_idx);
+        }
+        result
+    }
+
+    fn exec_index_assign_expr_nested_op_body(
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
@@ -3602,9 +3638,11 @@ impl Interpreter {
                     // A slot that already holds a DEFINED non-container value
                     // is not autovivifiable: rakudo refuses the store instead
                     // of clobbering the value.
-                    if let Some(err) =
-                        Self::subscript_descent_refusal(&arr[inner_i], outer_positional)
-                    {
+                    if let Some(err) = Self::subscript_descent_refusal_at(
+                        &arr[inner_i],
+                        outer_positional,
+                        Some(&outer_key),
+                    ) {
                         return Err(err);
                     }
                     // Autovivify the slot if it's not already a container. A
@@ -3720,8 +3758,11 @@ impl Interpreter {
                     // `a => 1` dies in rakudo, and mutsu used to drop the
                     // write silently (`assign_into_nested_container` no-ops on
                     // a non-container target).
-                    if let Some(err) = Self::subscript_descent_refusal(inner_val, outer_positional)
-                    {
+                    if let Some(err) = Self::subscript_descent_refusal_at(
+                        inner_val,
+                        outer_positional,
+                        Some(&outer_key),
+                    ) {
                         return Err(err);
                     }
                     Self::assign_into_nested_container(inner_val, &outer_key, val.clone())?;
@@ -3841,6 +3882,45 @@ impl Interpreter {
         slot: &Value,
         outer_positional: bool,
     ) -> Option<RuntimeError> {
+        Self::subscript_descent_refusal_at(slot, outer_positional, None)
+    }
+
+    /// [`Interpreter::subscript_descent_refusal`] told which key the next
+    /// subscript addresses, so a `Pair` slot can name the value the store would
+    /// have had to modify (see the `Pair` arm below).
+    pub(crate) fn subscript_descent_refusal_at(
+        slot: &Value,
+        outer_positional: bool,
+        next_key: Option<&str>,
+    ) -> Option<RuntimeError> {
+        // A `Pair` DOES `Associative`, so rakudo descends into it and refuses at
+        // the VALUE the next subscript reaches — `my %h = :x(:y(1)); %h<x><y> = 2`
+        // is "Cannot modify an immutable Int (1)", and Crane's
+        // `:a(:pair(:is(:not(:a<hash>))))` chain is "Cannot modify an immutable
+        // Pair (a => hash)". Refusing on the SLOT's type instead produced
+        // `X::AdHoc` "Type Pair does not support associative indexing", which is
+        // what rakudo raises for a genuinely non-Associative slot (an `Int`,
+        // a `Seq`) and which Crane's `CATCH { when X::Assignment::RO }` cannot
+        // map to `X::Crane::OpSet::RO`.
+        let pair_parts = match slot.view() {
+            ValueView::Pair(key, value) => Some((key.to_string(), value.clone())),
+            ValueView::ValuePair(key, value) => Some((key.to_string_value(), value.clone())),
+            _ => None,
+        };
+        if let Some((pair_key, pair_value)) = pair_parts {
+            let addressed = match next_key {
+                Some(k) if k == pair_key => pair_value,
+                // Any other key is absent from a one-entry Pair; rakudo's
+                // `Any.AT-KEY` hands back an undefined value, and storing into
+                // that is "Cannot modify an immutable Nil value".
+                Some(_) => Value::NIL,
+                None => slot.clone(),
+            };
+            return Some(RuntimeError::assignment_ro_typename(
+                crate::runtime::utils::value_type_name(&addressed),
+                &crate::runtime::utils::gist_value(&addressed),
+            ));
+        }
         let view = slot.view();
         let descendable = matches!(
             view,
@@ -4238,6 +4318,22 @@ impl Interpreter {
         depth: u32,
         positional_flags_idx: u32,
     ) -> Result<(), RuntimeError> {
+        let result =
+            self.exec_index_assign_deep_nested_op_body(code, name_idx, depth, positional_flags_idx);
+        if result.is_err() {
+            // See `restore_nested_store_local`.
+            self.restore_nested_store_local(code, name_idx);
+        }
+        result
+    }
+
+    fn exec_index_assign_deep_nested_op_body(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        depth: u32,
+        positional_flags_idx: u32,
+    ) -> Result<(), RuntimeError> {
         // As in the two-level op: a deferred token target has no container at
         // any level, so walk-create the whole chain from the token's path.
         let flags_for_token: Vec<bool> = match code.constants[positional_flags_idx as usize].view()
@@ -4521,6 +4617,20 @@ impl Interpreter {
                     }) {
                         current = next;
                     } else {
+                        // Neither a Positional nor an Associative step target.
+                        // Only a genuinely UNDEFINED value autovivifies here; a
+                        // defined one is refused, exactly as the two-level chain
+                        // refuses it. Overwriting it instead silently replaced
+                        // the value with a fresh container and reported success —
+                        // `my %h = :x(:y(1)); %h<x><y> = 2` rebuilt the Pair
+                        // chain as nested Hashes (and left `%h` itself holding
+                        // the discarded root), where rakudo dies with
+                        // "Cannot modify an immutable Int (1)".
+                        if let Some(err) =
+                            Self::subscript_descent_refusal_at(cur, next_positional, Some(key))
+                        {
+                            return Err(err);
+                        }
                         // Autovivify the root itself if needed
                         if is_positional {
                             *cur = Value::real_array(Vec::new());

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3893,33 +3893,43 @@ impl Interpreter {
         outer_positional: bool,
         next_key: Option<&str>,
     ) -> Option<RuntimeError> {
-        // A `Pair` DOES `Associative`, so rakudo descends into it and refuses at
-        // the VALUE the next subscript reaches — `my %h = :x(:y(1)); %h<x><y> = 2`
-        // is "Cannot modify an immutable Int (1)", and Crane's
-        // `:a(:pair(:is(:not(:a<hash>))))` chain is "Cannot modify an immutable
-        // Pair (a => hash)". Refusing on the SLOT's type instead produced
-        // `X::AdHoc` "Type Pair does not support associative indexing", which is
-        // what rakudo raises for a genuinely non-Associative slot (an `Int`,
-        // a `Seq`) and which Crane's `CATCH { when X::Assignment::RO }` cannot
-        // map to `X::Crane::OpSet::RO`.
-        let pair_parts = match slot.view() {
-            ValueView::Pair(key, value) => Some((key.to_string(), value.clone())),
-            ValueView::ValuePair(key, value) => Some((key.to_string_value(), value.clone())),
-            _ => None,
-        };
+        // A `Pair` DOES `Associative`, so an ASSOCIATIVE next subscript descends
+        // into it and refuses at the value it reaches — `my %h = :x(:y(1));
+        // %h<x><y> = 2` is "Cannot modify an immutable Int (1)", and a key the
+        // one-entry Pair does not hold reads back undefined, giving rakudo's
+        // "Cannot modify an immutable Nil value". Refusing on the SLOT's type
+        // instead produced `X::AdHoc` "Type Pair does not support associative
+        // indexing", which is what rakudo raises for a genuinely non-Associative
+        // slot (an `Int`, a `Seq`) and which Crane's
+        // `CATCH { when X::Assignment::RO }` cannot map to `X::Crane::OpSet::RO`.
+        //
+        // A POSITIONAL next subscript is a different question — a Pair is not
+        // Positional — and rakudo names the Pair itself there
+        // (`my @a = (a => 1), 3; @a[0][0] = 9` is "Cannot modify an immutable
+        // Pair (a => 1)"), which the type-based arm below already produces.
+        let pair_parts = (!outer_positional)
+            .then(|| match slot.view() {
+                ValueView::Pair(key, value) => Some((key.to_string(), value.clone())),
+                ValueView::ValuePair(key, value) => Some((key.to_string_value(), value.clone())),
+                _ => None,
+            })
+            .flatten();
         if let Some((pair_key, pair_value)) = pair_parts {
             let addressed = match next_key {
                 Some(k) if k == pair_key => pair_value,
-                // Any other key is absent from a one-entry Pair; rakudo's
-                // `Any.AT-KEY` hands back an undefined value, and storing into
-                // that is "Cannot modify an immutable Nil value".
                 Some(_) => Value::NIL,
+                // No key threaded through: name the Pair, which is at least the
+                // right class and the right ballpark value.
                 None => slot.clone(),
             };
-            return Some(RuntimeError::assignment_ro_typename(
-                crate::runtime::utils::value_type_name(&addressed),
-                &crate::runtime::utils::gist_value(&addressed),
-            ));
+            return Some(if addressed.is_nil() {
+                RuntimeError::assignment_ro_value(addressed)
+            } else {
+                RuntimeError::assignment_ro_typename(
+                    crate::runtime::utils::value_type_name(&addressed),
+                    &crate::runtime::utils::gist_value(&addressed),
+                )
+            });
         }
         let view = slot.view();
         let descendable = matches!(

--- a/t/collections/range-pair/pair-subscript-store-is-refused.t
+++ b/t/collections/range-pair/pair-subscript-store-is-refused.t
@@ -1,0 +1,63 @@
+use Test;
+
+# A `Pair` DOES `Associative`, so rakudo descends into it on a nested store and
+# refuses at the VALUE the next subscript reaches. mutsu refused on the SLOT's
+# type with `X::AdHoc` "Type Pair does not support associative indexing" -- the
+# class rakudo raises for a genuinely non-Associative slot -- and then, on the
+# deeper walk, overwrote the Pair with a fresh Hash and reported success.
+#
+# Both mattered to Crane, whose `CATCH { when X::Assignment::RO }` maps the
+# refusal to `X::Crane::OpSet::RO`, and whose fixtures are colonpair chains
+# (`:a(:pair(:is(:not(:a<hash>))))`).
+
+plan 10;
+
+{
+    my %h = :x(:y(1));
+    throws-like { %h<x><y> = 2 }, X::Assignment::RO,
+        'a nested store into a Pair is refused',
+        message => /'Cannot modify an immutable Int (1)'/;
+    is-deeply %h, {:x(:y(1))}, 'and the refused store changed nothing';
+}
+
+{
+    # A REFUSED store must not destroy the variable. mutsu invalidates the
+    # target's local slot before walking and refreshes it from `env` when it
+    # finishes; returning early left the caller's `%h` reading `Nil`.
+    # An `Int` slot is not Associative at all, so this one is rakudo's
+    # `Any.AT-KEY` X::AdHoc rather than an RO refusal.
+    my %g = :x(1);
+    throws-like { %g<x><y> = 2 }, X::AdHoc,
+        'a nested store through a defined non-container is refused',
+        message => /'does not support associative indexing'/;
+    is-deeply %g, {:x(1)}, 'and the variable survives';
+}
+
+{
+    my %i = :a(:pair(:is(:not(:a<hash>))));
+    throws-like { %i<a><pair><is><not> = {:a<Hash>} }, X::Assignment::RO,
+        'a four-level colonpair chain is refused';
+    is-deeply %i, {:a(:pair(:is(:not(:a<hash>))))}, 'and the chain is intact';
+}
+
+{
+    # Reading through a Pair still works, and so does storing where there IS a
+    # container.
+    my %h = :x(:y(1));
+    is %h<x><y>, 1, 'reading through a Pair still works';
+    %h<x> = 5;
+    is-deeply %h, {:x(5)}, 'replacing the Pair itself still works';
+}
+
+{
+    my $p = (a => 1);
+    throws-like { $p<a> = 2 }, X::Assignment::RO,
+        'a direct Pair element store is refused (unchanged)';
+}
+
+{
+    # Autovivification through a genuinely UNDEFINED slot is untouched.
+    my %v;
+    %v<a><b> = 7;
+    is-deeply %v, {:a({:b(7)})}, 'an undefined slot still autovivifies';
+}

--- a/t/collections/subscript/delete-through-a-call-result-subscript.t
+++ b/t/collections/subscript/delete-through-a-call-result-subscript.t
@@ -1,0 +1,64 @@
+use Test;
+
+# `<expr>{key}:delete` where `<expr>` is an `is rw` CALL must delete from the
+# container the call hands back. mutsu pushed that result on the stack and ran
+# the generic `DeleteIndexExpr` over the popped value, so the deletion landed in
+# a temporary and vanished -- while binding the identical expression to a
+# variable and deleting through THAT worked. Crane does the direct form:
+# `Crane::At.at($root, @path){$step}:delete`.
+
+plan 9;
+
+sub at-rw($c) is rw { return-rw $c<why> }
+
+{
+    my %h = :why({:do(1), :x(2)});
+    at-rw(%h){'do'}:delete;
+    is-deeply %h, {:why({:x(2)})}, 'delete through a return-rw sub result';
+}
+{
+    my %h = :why({:do(1), :x(2)});
+    at-rw(%h)<do>:delete;
+    is-deeply %h, {:why({:x(2)})}, 'the angle-bracket spelling too';
+}
+{
+    my %h = :why({:do(1), :x(2)});
+    class At { method at($c) is rw { return-rw $c<why> } }
+    At.at(%h){'do'}:delete;
+    is-deeply %h, {:why({:x(2)})}, 'and through an rw method result';
+}
+{
+    my %h = :why([10, 11, 12]);
+    sub arr-rw($c) is rw { return-rw $c<why> }
+    arr-rw(%h)[1]:delete;
+    is %h<why>[1]:exists, False, 'a positional delete through a call result';
+}
+
+# The shapes that already worked must keep working.
+{
+    my %h = :why({:do(1), :x(2)});
+    my $t := at-rw(%h);
+    $t<do>:delete;
+    is-deeply %h, {:why({:x(2)})}, 'delete through a bound temp (unchanged)';
+}
+{
+    my %h = :why({:do(1), :x(2)});
+    %h<why><do>:delete;
+    is-deeply %h, {:why({:x(2)})}, 'a nested subscript delete (unchanged)';
+}
+{
+    my %h = :a(1), :b(2);
+    %h<a>:delete;
+    is-deeply %h, {:b(2)}, 'a plain one-level delete (unchanged)';
+}
+
+# The delete still yields the removed value, and `:exists:delete` still reports
+# existence.
+{
+    my %h = :why({:do(1), :x(2)});
+    is (at-rw(%h){'do'}:delete), 1, 'the removed value is returned';
+}
+{
+    my %h = :a(1);
+    is (%h<a>:exists:delete), True, ':exists:delete still reports existence';
+}

--- a/t/collections/transform/deepmap-nested-hash-itemization.t
+++ b/t/collections/transform/deepmap-nested-hash-itemization.t
@@ -1,0 +1,44 @@
+use Test;
+
+# `deepmap` itemizes what a DESCEND returns, exactly as it does for a sublist.
+# The Hash arm dropped the flag, so a mapped copy's nested hashes came back as
+# bare values -- nothing could be bound to one, which is how
+# `Crane::At.at($root, @path){$step}:delete` on a `container.deepmap({ .clone })`
+# copy deleted from a temporary instead of from `$root`.
+#
+# The itemization must be the per-holder flag on the same `HashData` (`.item`),
+# not a `Scalar` wrapper: a wrapper hands back a copy nothing can mutate in place.
+
+plan 10;
+
+is %(:x({:a(1)})).deepmap({ $_ }).raku, '{:x(${:a(1)})}',
+    'a nested Hash comes back itemized';
+is %(:x({:a({:b(1)})})).deepmap({ $_ }).raku, '{:x(${:a(${:b(1)})})}',
+    'and so does one two levels down';
+is (1, {:a(2)}).deepmap({ $_ }).raku, '(1, ${:a(2)})',
+    'a Hash element of a List is itemized too';
+
+# A real Array parent does NOT itemize what a descend returns -- the same rule
+# the sublist arm already followed.
+is [1, {:a(2)}].deepmap({ $_ }).raku, '[1, {:a(2)}]',
+    'a real Array parent leaves the descended Hash bare';
+is [[1, 2], 3].deepmap({ $_ }).raku, '[[1, 2], 3]',
+    'and leaves a sublist bare (unchanged)';
+is %(:x([1, 2])).deepmap({ $_ }).raku, '{:x($[1, 2])}',
+    'an Array under a Hash was already itemized (unchanged)';
+
+# The itemized element must still share its backing store, so the mapped copy
+# is a real structure that can be written into.
+my %src = :why({:do(1), :x(2)});
+my $copy = %src.deepmap({ .clone });
+$copy<why><do>:delete;
+is-deeply $copy, {:why({:x(2)})}, 'a nested delete reaches the mapped copy';
+is-deeply %src, {:why({:do(1), :x(2)})}, 'and leaves the source alone';
+
+my $copy2 = %src.deepmap({ .clone });
+my $inner = $copy2<why>;
+$inner<do> = 99;
+is $copy2<why><do>, 99, 'a write through a read-out nested hash reaches the copy';
+
+# duckmap/nodemap were already right; pin them so the three stay in step.
+is %(:x({:a(1)})).duckmap({ $_ }).raku, '{:x(${:a(1)})}', 'duckmap itemizes too';

--- a/t/lang/adverbs/colonpair-keyword-key-hash-composer.t
+++ b/t/lang/adverbs/colonpair-keyword-key-hash-composer.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A statement can never START with a `:`, so a block body whose first token is a
+# colonpair is unambiguously a hash composer -- whatever the pair's KEY spells.
+# mutsu excluded a list of statement keywords there, so `{ :when(...) }` and
+# friends parsed as a Block. Rakudo answers Hash for every one of them, and
+# Crane's `t/remove.rakutest` builds a literal `:me({:when({:im(7)})})`, where
+# the `when` entry alone turned a nested hash into a `Block`.
+
+plan 18;
+
+is {:when(1)}.^name,    'Hash', '{:when(1)} is a Hash';
+is {:if(1)}.^name,      'Hash', '{:if(1)} is a Hash';
+is {:unless(1)}.^name,  'Hash', '{:unless(1)} is a Hash';
+is {:for(1)}.^name,     'Hash', '{:for(1)} is a Hash';
+is {:while(1)}.^name,   'Hash', '{:while(1)} is a Hash';
+is {:until(1)}.^name,   'Hash', '{:until(1)} is a Hash';
+is {:loop(1)}.^name,    'Hash', '{:loop(1)} is a Hash';
+is {:given(1)}.^name,   'Hash', '{:given(1)} is a Hash';
+is {:my(1)}.^name,      'Hash', '{:my(1)} is a Hash';
+is {:our(1)}.^name,     'Hash', '{:our(1)} is a Hash';
+is {:has(1)}.^name,     'Hash', '{:has(1)} is a Hash';
+is {:return(1)}.^name,  'Hash', '{:return(1)} is a Hash';
+
+is {:when(1)}<when>, 1, 'the keyword-named key is readable';
+is {:my<x>}<my>, 'x', 'a keyword key with a word-quoted value';
+
+# The shape that found this: a keyword key nested several colonpairs deep.
+is-deeply
+    {:why({:do({:you({:always({:kick({:me({:when({:im(7)})})})})})})})},
+    {:why({:do({:you({:always({:kick({:me({:when({:im(7)})})})})})})})},
+    'a `when` key seven levels down still composes hashes';
+
+my %n = :why({:do({:you({:always({:kick({:me({:when({:im(7)})})})})})})});
+is %n<why><do><you><always><kick><me><when><im>, 7, 'and the deep value reads back';
+is %n<why><do><you><always><kick><me><when>.^name, 'Hash', 'the `when` value is a Hash, not a Block';
+
+# A block whose body is NOT a leading colonpair is still a block.
+is { $_ * 2 }.^name, 'Block', 'an ordinary block is still a Block';

--- a/t/oo/construct/clone-decontainerizes-its-result.t
+++ b/t/oo/construct/clone-decontainerizes-its-result.t
@@ -1,0 +1,48 @@
+use Test;
+
+# Itemization is a property of the CONTAINER, not of the object, and `.clone`
+# copies the object -- so the clone comes back de-itemized. mutsu carried the
+# `ArrayKind`'s itemization through verbatim, so `my @a = $v.clone` nested the
+# list instead of flattening it. Crane's `Crane::In.in(container, @path) =
+# $value.clone` depends on exactly that.
+
+plan 8;
+
+{
+    my $v = <a b c>;
+    is $v.raku, '$("a", "b", "c")', 'the itemized source renders itemized';
+    is $v.clone.raku, '("a", "b", "c")', 'its clone does not';
+}
+
+{
+    my $v = <a b c>;
+    my @a = $v.clone;
+    is-deeply @a, ['a', 'b', 'c'], 'assigning the clone to an array flattens it';
+}
+
+{
+    # `= $v` (no clone) keeps the itemization, so it does NOT flatten.
+    my $v = <a b c>;
+    my @a = $v;
+    is @a.elems, 1, 'assigning the itemized value itself still nests';
+}
+
+{
+    my $a = [1, 2];
+    is $a.raku, '$[1, 2]', 'an itemized Array renders itemized';
+    is $a.clone.raku, '[1, 2]', 'and its clone does not';
+}
+
+{
+    # The clone is still an independent copy of the elements.
+    my $v = [1, 2];
+    my $c = $v.clone;
+    $c[0] = 9;
+    is-deeply $v, $[1, 2], 'the clone is independent of the source';
+}
+
+{
+    # A plain (non-itemized) array clones unchanged.
+    my @a = 1, 2;
+    is @a.clone.raku, '[1, 2]', 'a plain array clones unchanged';
+}

--- a/t/routines/splice-callable-index-by-value-invocant.t
+++ b/t/routines/splice-callable-index-by-value-invocant.t
@@ -1,0 +1,62 @@
+use Test;
+
+# `splice`'s start/elems positions take `Int`, `Whatever` or `Callable`, and a
+# from-the-end index (`*-1`) is a `Callable` -- a `WhateverCode`. The lvalue
+# path resolved it against the array's length; the BY-VALUE invocant path (a
+# function result, an element read, a literal) did not, so the callable read as
+# index 0 and `f().splice(*-1, 1)` cut the array's FIRST element.
+#
+# Crane reaches it as `Crane::At.at($root, @path).splice($step, 1)` with
+# `$step` a `*-1` handed down from the caller's path.
+
+plan 9;
+
+sub at-rw($c) is rw { return-rw $c<k> }
+
+{
+    my %h = :k([1, 2, 3, 4]);
+    at-rw(%h).splice(*-1, 1);
+    is-deeply %h<k>, [1, 2, 3], 'a *-1 start on a call-result invocant';
+}
+{
+    my %h = :k([1, 2, 3, 4]);
+    at-rw(%h).splice(*-2, 1);
+    is-deeply %h<k>, [1, 2, 4], 'a *-2 start on a call-result invocant';
+}
+{
+    my %h = :k([1, 2, 3, 4]);
+    at-rw(%h).splice(*-0, 0, 9);
+    is-deeply %h<k>, [1, 2, 3, 4, 9], 'a *-0 start appends';
+}
+{
+    my %h = :k([1, 2, 3, 4]);
+    # The count callable is called with the number of elements still available
+    # after the start (here 3), so `*-2` is 1.
+    my $removed = at-rw(%h).splice(1, *-2);
+    is-deeply $removed, [2], 'a callable ELEMS count resolves against the remainder';
+    is-deeply %h<k>, [1, 3, 4], 'and removes exactly that many';
+}
+{
+    my %h = :k([1, 2, 3, 4]);
+    at-rw(%h).splice(2, 1);
+    is-deeply %h<k>, [1, 2, 4], 'a plain Int start still works';
+}
+
+# The named-variable (lvalue) spelling was already right; keep the two in step.
+{
+    my @a = 1, 2, 3, 4;
+    @a.splice(*-1, 1);
+    is-deeply @a, [1, 2, 3], 'the named spelling (unchanged)';
+}
+{
+    my @a = 1, 2, 3, 4;
+    my $step = *-1;
+    @a.splice($step, 1);
+    is-deeply @a, [1, 2, 3], 'with the WhateverCode in a variable (unchanged)';
+}
+{
+    my @a = 1, 2, 3, 4;
+    sub through(\c, :$step!) { c.splice($step, 1); |c }
+    through(@a, :step(*-1));
+    is-deeply @a, [1, 2, 3], 'passed down through a routine (unchanged)';
+}

--- a/t/vm/binding/rw-alias-of-an-aggregate-has-no-scalar.t
+++ b/t/vm/binding/rw-alias-of-an-aggregate-has-no-scalar.t
@@ -1,0 +1,119 @@
+use Test;
+
+# Raku gives an `@`/`%` variable no Scalar container of its own: a sigilless
+# alias of one (`\c` bound to `%a`) IS that aggregate, so `c = {...}` is
+# `%a.STORE(...)`, a write every holder sees, and `return-rw c` hands the caller
+# the aggregate itself.
+#
+# mutsu boxed such an alias into a fresh scalar cell at the `return-rw` site,
+# modelling a container Raku does not have: the caller then assigned into a cell
+# owned by a frame that had already returned, and the write reached nobody. One
+# hop happened to work; two did not. Every `Crane::In.in(container, @path) = $value`
+# descent is this shape.
+
+plan 14;
+
+sub leaf(\c)  is rw { return-rw c }
+sub hop(\c)   is rw { return-rw leaf(c) }
+
+{
+    my %a = :k(1);
+    my %alias := %a;
+    hop(%a) = {:z(9)};
+    is-deeply %a, {:z(9)}, 'a whole-hash store through two rw hops reaches the caller';
+    is-deeply %alias, {:z(9)}, 'and every other holder of the container';
+}
+
+{
+    my @b = 1, 2;
+    my @alias := @b;
+    hop(@b) = [9];
+    is-deeply @b, [9], 'the same for an array';
+    is-deeply @alias, [9], 'and its aliases';
+}
+
+{
+    # A `$` scalar is genuinely a container: the cell route is right there.
+    my $s = 1;
+    hop($s) = 9;
+    is $s, 9, 'a scalar still rebinds through the cell';
+}
+
+{
+    # Element writes through the alias chain were already fine; keep them so.
+    my %c = :k(1);
+    sub probe(\c) is rw { c<probe> = 7; return-rw leaf(c) }
+    probe(%c);
+    is %c<probe>, 7, 'an element write through the alias reaches the caller';
+}
+
+# An intermediate hop with a slurpy, an extra array parameter, or a `where`-
+# constrained multi is the Crane::In shape; none of them may lose the write.
+sub hop-slurpy(\c, *@s)  is rw { return-rw leaf(c) }
+sub hop-array(\c, @s)    is rw { return-rw leaf(c) }
+multi sub leaf-multi(Associative:D \c, @s where { .elems == 0 }) is rw { return-rw c }
+sub hop-multi(\c, *@s)   is rw { return-rw leaf-multi(c, @s) }
+
+{
+    my %d = :k(1);
+    hop-slurpy(%d) = {:z(9)};
+    is-deeply %d, {:z(9)}, 'through a slurpy-carrying hop';
+}
+{
+    my %e = :k(1);
+    my @empty;
+    hop-array(%e, @empty) = {:z(9)};
+    is-deeply %e, {:z(9)}, 'through a hop with an array parameter';
+}
+{
+    my %f = :k(1);
+    hop-multi(%f) = {:z(9)};
+    is-deeply %f, {:z(9)}, 'through a `where`-constrained multi';
+}
+
+# An rw METHOD whose tail names an `@`/`%` container hands back the aggregate,
+# not a cell -- that is still an lvalue.
+class In { method in(\c, *@s) is rw { return-rw leaf-multi(c, @s) } }
+{
+    my %g = :k(1);
+    In.in(%g) = {:z(9)};
+    is-deeply %g, {:z(9)}, 'an rw class method is an lvalue for an aggregate too';
+}
+
+# A SIGILLESS argument to an lvalue call names a container just as a `$`-sigiled
+# one does. Without the tag the callee's `\c` got a bare value with no source
+# name, was marked a readonly non-lvalue, and the assignment died with
+# "Cannot modify an immutable Int (0)".
+{
+    my $a = 0;
+    sub write-through(\c) { leaf(c) = 1 }
+    write-through($a);
+    is $a, 1, 'an lvalue call taking a sigilless alias writes through';
+}
+multi sub leaf-any(\c, @s where { .elems == 0 }) is rw { return-rw c }
+class InAny { method in(\c, *@s) is rw { return-rw leaf-any(c, @s) } }
+{
+    my $b = 0;
+    sub write-method(\c) { InAny.in(c) = 2 }
+    write-method($b);
+    is $b, 2, 'the same through an rw method';
+}
+{
+    my $c = 0;
+    sub write-nested(\c, :@path!, :$value!) { InAny.in(c, @path) = $value; c }
+    write-nested($c, :path(), :value(3));
+    is $c, 3, 'and with the path/value shape Crane.set uses';
+}
+
+# A sigilless parameter's DECLARED type is checked once, when the argument
+# binds; a later write through the alias goes into the caller's container and is
+# checked against that container's own constraint. mutsu registered the
+# parameter's type in the assignment-time lane instead, so
+# `sub h(Associative \c) { c = Empty }` died with "expected Associative but got
+# Slip" where Rakudo stores the Slip into the caller's untyped scalar. That is
+# Crane's `remove-from-associative(\container, :in-place)`.
+{
+    sub empty-it(Associative \container) { container = Empty; container }
+    my $root = {:a(1)};
+    is empty-it($root).raku, 'Empty', 'a typed sigilless alias may be assigned a Slip';
+}


### PR DESCRIPTION
A measurement pass on #7539's `Config::TOML` + `Crane` battery pair turned up
eight general divergences from rakudo. Both suites were re-fetched from upstream
and re-run against a fresh build; `raku` passes 34/34 on the same checkouts.

| Suite | raku | before | after |
| --- | --- | --- | --- |
| `Config::TOML` v0.1.3 | 19/19 files | 14/19 | 14/19 |
| `Crane` v0.1.2 | 15/15 files | 4/15 | 4/15 |

The file counts did not move, but the failing-assertion counts did, sharply:
`Crane`'s `set.rakutest` went from 5 failing subtests to 1, `remove.rakutest`
from 2 to 1, and `add` / `copy` / `move` / `replace` / `transform` each shed
failures. Every fix below is a general bug, each verified to fail without its fix
and to pass under rakudo v2026.07.

## 1. A sigilless alias of an aggregate was boxed into a Scalar that does not exist

Raku gives an `@`/`%` variable no `Scalar` of its own, so `\c` bound to `%a` *is*
that aggregate: `c = {...}` is `%a.STORE(...)`, and `return-rw c` hands the
caller the aggregate itself. `CaptureVarCell` boxed it into a fresh cell, so the
caller assigned into a cell owned by a frame that had already returned and the
write reached nobody:

```raku
sub leaf(\c) is rw { return-rw c }
sub hop(\c)  is rw { return-rw leaf(c) }
my %a = :k(1);
hop(%a) = {:z(9)};   # rakudo: {:z(9)}   mutsu: {:k(1)}
```

One hop happened to work — a `%`-named argument never reached the boxing branch —
and two did not, because the second hop's argument is the sigilless `c`.
`exec_capture_var_cell_op` now declines for a real `Array`/`Hash`, the same
aggregate exclusion `exec_attr_container_ref_op` already makes.
`assign_through_rw_result`'s "replace the aggregate's contents in place" arm was
factored out (`store_into_aggregate_lvalue`) and wired into the **type-object
rw-method** lvalue path, which previously accepted only a `ContainerRef` and let
the legacy setter chain quietly drop the write.

This is `Crane::In.in(container, @path) = $value`, which every mutating Crane
operation is built on.

## 2. A sigilless argument to an lvalue call carried no source name

`f(c) = 1` lowers to `__mutsu_assign_named_sub_lvalue("f", (c), 1)`, whose
argument list is a List literal. Its elements are tagged with `WrapVarRef` so the
callee's raw parameter binds the caller's container — but only for `Expr::Var`. A
sigilless lexical is `Expr::BareWord`, which is also how a type name is spelled,
so it was left untagged: the callee's `\c` got a bare value with no source name,
was marked a readonly non-lvalue, and the assignment died with
`Cannot modify an immutable Int (0)` — while the `$`-sigiled spelling of the same
call worked. `sigilless_local_container_name`'s `local_map` probe is what settles
bareword ambiguity, and it is now consulted at that site too.

## 3. A sigilless parameter's declared type leaked into assignment

A `\c` parameter's declared type is checked once, when the argument binds; a
later write goes into the *caller's* container and is checked against that
container's constraint:

```raku
sub h(Associative \container) { container = Empty }
my $root = {:a(1)}; h($root);
# mutsu: Type check failed in assignment to $container; expected Associative but got Slip
```

The site that registers a positional parameter's constraint (`bound_type_constraint`)
already prefers the **source variable's** constraint over the parameter's declared
type, and for a raw alias that source constraint is the only one that applies, so
only the `pd.type_constraint` fallback is dropped. The decision reads
`pd.sigilless`, not the name: a scalar parameter's env key drops its `$`, so `$p`
and `\p` reach the binder spelled identically.

This is Crane's `remove-from-associative(\container, :in-place)`.

## 4. `deepmap` did not itemize a nested Hash

The `Array` and `Seq` arms honoured `itemize_result`; the `Hash` arm dropped it,
so `%(:x({:a(1)})).deepmap({$_})` answered `{:x({:a(1)})}` where rakudo answers
`{:x(${:a(1)})}`. Without the itemization nothing can be bound to a mapped copy's
nested hash, which is how `Crane::At.at($root, @path){$step}:delete` on a
`container.deepmap({ .clone })` copy deleted from a temporary instead of from
`$root`. Uses `.item()` (the per-holder flag on the same `HashData`), not a
`Scalar` wrapper, which would hand back a copy nothing can mutate in place.

## 5. `:delete` on a call-result subscript deleted from a temporary

`<expr>{key}:delete` compiled the target onto the stack and ran the generic
`DeleteIndexExpr` over the popped value, so a `return-rw` call's result was
mutated as a temporary and the deletion vanished — while binding the identical
expression to a variable and deleting through *that* worked. The
nested-subscript case already had a temp-bind rewrite for this reason; it is now
the generic fallback.

## 6. `splice` ignored a `Callable` index on a by-value invocant

A from-the-end index (`*-1`) is a `WhateverCode`. The lvalue path resolved it
against the array's length; the by-value invocant path did not, so the callable
read as index 0 and `f().splice(*-1, 1)` cut the array's **first** element. The
two paths now share one `resolve_splice_callable_args`.

## 7. `.clone` kept its invocant's itemization

Itemization belongs to the container, not the object, and `.clone` copies the
object: `my $v = <a b c>; $v.clone.raku` is `("a", "b", "c")`, which is why
`my @a = $v.clone` flattens where `@a = $v` does not. Crane's
`Crane::In.in(container, @path) = $value.clone` depends on that.

## 8. A nested store into a `Pair` clobbered it — and destroyed the variable

A `Pair` does `Associative`, so rakudo descends into it on an associative nested
store and refuses at the value the next subscript reaches. mutsu refused on the
*slot's* type with `X::AdHoc` "Type Pair does not support associative indexing",
and the deeper walk overwrote the `Pair` with a fresh `Hash` and reported
success, rebuilding a whole colonpair chain as nested hashes. All four shapes now
match rakudo:

| | rakudo / mutsu |
| --- | --- |
| `@a[0][0]` (positional) | `Cannot modify an immutable Pair (a => 1)` |
| `@a[0]<a>` (key matches) | `Cannot modify an immutable Int (1)` |
| `@a[0]<zz>` (key absent) | `Cannot modify an immutable Nil value` |
| `%h<x><zz>` | `Cannot modify an immutable Nil value` |

Both nested-store ops also invalidate the target's local slot to `Nil` before
walking and refresh it from `env` when they finish. Returning early on a refusal
skipped that refresh, so a **failed** assignment left the caller's `%h` reading
`Nil` — the variable was destroyed by a store that was supposed to change
nothing. The restore now runs on the error path too.

Crane's `CATCH { when X::Assignment::RO }` maps the refusal to
`X::Crane::OpSet::RO`, and its fixtures are colonpair chains, so both halves
mattered.

## 9. `{ :when(...) }` parsed as a Block

A statement can never start with a `:`, so a block body whose first token is a
colonpair is unambiguously a hash composer — whatever the key spells. mutsu
excluded a list of statement keywords there, so `{:when(1)}` and eleven others
parsed as `Block`. `Crane`'s `t/remove.rakutest` builds a literal
`:me({:when({:im(7)})})`, and the `when` entry alone turned a nested hash into a
closure, aborting the file.

## Pins

`t/vm/binding/rw-alias-of-an-aggregate-has-no-scalar.t` (1, 2, 3),
`t/collections/transform/deepmap-nested-hash-itemization.t` (4),
`t/collections/subscript/delete-through-a-call-result-subscript.t` (5),
`t/routines/splice-callable-index-by-value-invocant.t` (6),
`t/oo/construct/clone-decontainerizes-its-result.t` (7),
`t/collections/range-pair/pair-subscript-store-is-refused.t` (8),
`t/lang/adverbs/colonpair-keyword-key-hash-composer.t` (9) — 78 assertions, all
green under rakudo v2026.07 as well.

## Validation

`cargo fmt --all`, `make lint`, `make test` (4,187 files / 44,627 assertions) and
`make roast` (1,437 files / 219,635 assertions) all green, bar the two `uid 0`
file-permission failures `docs/agent-environments.md` documents for this
container (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`).

Refs #7539 — the ticket stays open: `Crane` is still 4/15, so the vendoring steps
remain parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_