### PR TITLE
fix: parse nested-angle CORE stash lookups

### DIFF
--- a/news/2026-09/core-operator-stash-lookup.md
+++ b/news/2026-09/core-operator-stash-lookup.md
@@ -1,0 +1,1 @@
+Nested-angle `CORE::<&infix:<...>>` and `CORE::<&prefix:<...>>` stash lookups now parse correctly and return callable core operator routines.

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -167,6 +167,22 @@ fn split_dist_selectors_from_name(name: &str) -> (&str, String) {
     (name, String::new())
 }
 
+/// Find the `>` that closes a stash subscript whose body may contain a nested
+/// angle-bracket construct, such as `CORE::<&infix:<+>>`. The first `>` closes
+/// the inner `infix:<...>` name; it is not the end of the stash subscript.
+fn find_angle_subscript_end(input: &str) -> Option<usize> {
+    let mut nested = 0;
+    for (index, ch) in input.char_indices() {
+        match ch {
+            '<' => nested += 1,
+            '>' if nested > 0 => nested -= 1,
+            '>' => return Some(index),
+            _ => {}
+        }
+    }
+    None
+}
+
 fn parse_require_expr<'a>(input: &'a str, rest: &'a str) -> PResult<'a, Expr> {
     let (mut rest, _) = ws1(rest)?;
     let mut dist_selectors = String::new();
@@ -1366,7 +1382,7 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             // Handle ::<SYMBOL> subscript syntax (e.g., CORE::<&run>)
             if let Some(after_bracket) = after.strip_prefix('<')
                 && !after.starts_with("<<")
-                && let Some(end) = after_bracket.find('>')
+                && let Some(end) = find_angle_subscript_end(after_bracket)
             {
                 let symbol = &after_bracket[..end];
                 if matches!(symbol.chars().next(), Some('$' | '@' | '%' | '&')) {

--- a/t/lang/operators/core-operator-stash.t
+++ b/t/lang/operators/core-operator-stash.t
@@ -1,0 +1,27 @@
+use v6.c;
+use Test;
+
+plan 8;
+
+my $plus = CORE::<&infix:<+>>;
+ok $plus.defined, 'CORE stash exposes the infix addition routine';
+is CORE::<&infix:<+>>(1, 2), 3,
+    'the CORE infix addition routine is callable';
+ok CORE::<&prefix:<->>.defined, 'CORE stash exposes the prefix negation routine';
+is CORE::<&prefix:<->>(3), -3,
+    'the CORE prefix negation routine is callable';
+ok CORE::<&say>.defined, 'CORE stash still exposes ordinary routines';
+
+if CORE::<&infix:<+>> {
+    pass 'nested-angle CORE stash lookup parses in conditional position';
+}
+else {
+    flunk 'nested-angle CORE stash lookup parses in conditional position';
+}
+
+my $assigned = CORE::<&infix:<+>>;
+ok $assigned.defined, 'nested-angle CORE stash lookup parses after assignment';
+
+my %hash = '&infix:<+>' => 'present';
+is %hash<&infix:<+>>, 'present',
+    'nested-angle operator names remain valid in ordinary hash subscripts';


### PR DESCRIPTION
Fixes #8220.

The `PKG::<...>` parser now balances nested angle brackets, so operator names such as `&infix:<+>` remain inside the stash subscript. This enables the existing CORE lazy resolver to expose callable infix and prefix operator routines in conditional, assignment, and call positions. Adds focused regression coverage and a news entry.