### PR TITLE
fix: preserve OUR-bound trait handlers

### DIFF
--- a/news/2026-09/our-trait-mod-reexport.md
+++ b/news/2026-09/our-trait-mod-reexport.md
@@ -1,0 +1,3 @@
+Fix `OUR::{'&trait_mod:<is>'} := &trait_mod:<is>` re-exports so the bound multi
+candidate remains visible to modules that import the package.  Custom attribute
+traits re-exported this way now work when an importing class declares the trait.

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -805,7 +805,11 @@ impl Interpreter {
                         let base =
                             crate::runtime::dispatch_resolve::function_key_strip_arity_suffix(name);
                         // Only remove operator subs (infix:<...>, prefix:<...>, etc.)
-                        base.contains(":<") && !exported_op_names.contains(base)
+                        // An OUR-bound code alias is package-owned too, even when
+                        // the source routine was not marked `is export` here.
+                        base.contains(":<")
+                            && !exported_op_names.contains(base)
+                            && !self.registry().our_scoped_functions.contains_key(k)
                     } else {
                         false
                     }

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -8,7 +8,7 @@ impl Interpreter {
     /// suffix to the base key, then walk base, `__m1`, `__m2`, ... and insert
     /// at the first vacant slot. A slot already holding this exact `Arc`
     /// (same-module re-import) makes the call a no-op.
-    fn import_multi_candidate_merged(&mut self, target_key: &str, def: Arc<FunctionDef>) {
+    fn import_multi_candidate_merged(&mut self, target_key: &str, def: Arc<FunctionDef>) -> Symbol {
         let base = match target_key.rfind("__m") {
             Some(pos)
                 if pos + 3 < target_key.len()
@@ -29,16 +29,86 @@ impl Interpreter {
             };
             match funcs.entry(Symbol::intern(&key)) {
                 std::collections::hash_map::Entry::Vacant(entry) => {
+                    let key = *entry.key();
                     entry.insert(def);
-                    return;
+                    return key;
                 }
                 std::collections::hash_map::Entry::Occupied(entry) => {
                     if Arc::ptr_eq(entry.get(), &def) {
-                        return;
+                        return *entry.key();
                     }
                 }
             }
             idx += 1;
+        }
+    }
+
+    /// Publish a multi routine bound through an `OUR::` code stash entry.
+    ///
+    /// A binding such as `OUR::{'&trait_mod:<is>'} := &trait_mod:<is>` creates
+    /// the code value in the package stash, but the normal name-based dispatcher
+    /// still searches `Registry::functions`.  The RHS is a materialized multi
+    /// dispatcher, so copy the currently visible candidate definitions into the
+    /// package's registry namespace as well. Keep those aliases in the persistent
+    /// `our_scoped_functions` table: an import scope may otherwise remove the
+    /// temporary `GLOBAL::` aliases installed while the binding's source module
+    /// was loaded, making the stash entry callable but invisible to later users.
+    pub(crate) fn register_our_code_alias(&mut self, name: &str, value: &Value) {
+        let ValueView::Sub(data) = value.view() else {
+            return;
+        };
+        if !data.env.contains_key("__mutsu_multi_dispatch_candidates") {
+            return;
+        }
+        let Some(name) = name.strip_prefix("&OUR::") else {
+            return;
+        };
+        if name.is_empty() {
+            return;
+        }
+
+        let candidates = self.resolve_all_multi_candidates(name);
+        if candidates.is_empty() {
+            return;
+        }
+        let target_pkg = self.current_package();
+        let source_prefixes: Vec<String> = self
+            .bare_name_packages()
+            .into_iter()
+            .map(|pkg| format!("{pkg}::{name}/"))
+            .collect();
+        let entries: Vec<(String, Arc<FunctionDef>)> = self
+            .registry()
+            .functions
+            .iter()
+            .filter_map(|(key, def)| {
+                let key_str = key.as_str();
+                let source_prefix = source_prefixes
+                    .iter()
+                    .find(|prefix| key_str.starts_with(prefix.as_str()))?;
+                if !candidates
+                    .iter()
+                    .any(|candidate| Arc::ptr_eq(candidate, def))
+                {
+                    return None;
+                }
+                let suffix = key_str.strip_prefix(source_prefix)?;
+                Some((format!("{target_pkg}::{name}/{suffix}"), def.clone()))
+            })
+            .collect();
+
+        let mut changed = false;
+        for (target_key, def) in entries {
+            let installed_key = self.import_multi_candidate_merged(&target_key, def.clone());
+            self.registry_mut()
+                .our_scoped_functions
+                .insert(installed_key, def);
+            crate::runtime::cow_table_mut(&mut self.module_registered_functions)
+                .insert(installed_key);
+            changed = true;
+        }
+        if changed {
+            self.fn_resolve_gen += 1;
         }
     }
 

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1335,6 +1335,9 @@ impl Interpreter {
                     Some((source_name, inner, _)) => (inner.clone(), Some(source_name.resolve())),
                     None => (raw_val, None),
                 };
+                if is_rebind && name_str.starts_with("&OUR::") {
+                    self.register_our_code_alias(name_str, &raw_val);
+                }
                 let mut val = if raw_mode && name.starts_with('@') {
                     // Constants with @ sigil coerce to List (not Array).
                     // `constant @x = 42` gives `(42,)`, not `[42]`.

--- a/t/lib/TodoTicket7989TraitA.rakumod
+++ b/t/lib/TodoTicket7989TraitA.rakumod
@@ -1,0 +1,9 @@
+module TodoTicket7989TraitA {
+    role Marked {
+        method todo_ticket_7989_marked { True }
+    }
+
+    multi sub trait_mod:<is> (Attribute $attr, :$marked!) is export {
+        $attr does Marked;
+    }
+}

--- a/t/lib/TodoTicket7989TraitB.rakumod
+++ b/t/lib/TodoTicket7989TraitB.rakumod
@@ -1,0 +1,3 @@
+use TodoTicket7989TraitA;
+OUR::{'&trait_mod:<is>'} := &trait_mod:<is>;
+role TodoTicket7989TraitB is export { }

--- a/t/modules/import-export/our-trait-mod-reexport.t
+++ b/t/modules/import-export/our-trait-mod-reexport.t
@@ -1,0 +1,13 @@
+use lib 't/lib';
+use Test;
+
+plan 1;
+
+use TodoTicket7989TraitB;
+
+class TodoTicket7989Consumer {
+    has $.value is marked;
+}
+
+ok TodoTicket7989Consumer.^attributes[0].todo_ticket_7989_marked,
+    'a trait_mod re-exported through OUR:: handles an importer attribute';


### PR DESCRIPTION
Closes #7989

Preserve the multi candidates behind an OUR:: code alias in the package function registry so importers can resolve re-exported trait_mod handlers after the defining module has finished loading. Add a focused three-module regression test and news entry.