### PR TITLE
fix: let user so and not subs win in parenthesized calls

### DIFF
--- a/news/2026-09/user-so-not-parenthesized-calls.md
+++ b/news/2026-09/user-so-not-parenthesized-calls.md
@@ -1,0 +1,2 @@
+Fix parenthesized calls to user-defined `so` and `not` routines. Their
+whitespace-separated forms continue to use the builtin unary operators.

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -417,9 +417,7 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
         }
     }
     // not(expr) — tight-binding form: not followed by ( without space
-    if input.starts_with("not(")
-        && !crate::parser::stmt::simple::is_user_declared_sub("not")
-    {
+    if input.starts_with("not(") && !crate::parser::stmt::simple::is_user_declared_sub("not") {
         let r = &input[3..];
         let (r, _) = parse_char(r, '(')?;
         let (r, _) = ws(r)?;
@@ -435,9 +433,7 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
         ));
     }
     // so(expr) — tight-binding form: so followed by ( without space
-    if input.starts_with("so(")
-        && !crate::parser::stmt::simple::is_user_declared_sub("so")
-    {
+    if input.starts_with("so(") && !crate::parser::stmt::simple::is_user_declared_sub("so") {
         let r = &input[2..];
         let (r, _) = parse_char(r, '(')?;
         let (r, _) = ws(r)?;

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -417,7 +417,9 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
         }
     }
     // not(expr) — tight-binding form: not followed by ( without space
-    if input.starts_with("not(") {
+    if input.starts_with("not(")
+        && !crate::parser::stmt::simple::is_user_declared_sub("not")
+    {
         let r = &input[3..];
         let (r, _) = parse_char(r, '(')?;
         let (r, _) = ws(r)?;
@@ -433,7 +435,9 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
         ));
     }
     // so(expr) — tight-binding form: so followed by ( without space
-    if input.starts_with("so(") {
+    if input.starts_with("so(")
+        && !crate::parser::stmt::simple::is_user_declared_sub("so")
+    {
         let r = &input[2..];
         let (r, _) = parse_char(r, '(')?;
         let (r, _) = ws(r)?;

--- a/t/oo/class/parenthesized-so-not-user-sub.t
+++ b/t/oo/class/parenthesized-so-not-user-sub.t
@@ -1,0 +1,16 @@
+use Test;
+
+# A user routine named `so` or `not` wins for the tight parenthesized call
+# spelling, while the whitespace form remains the builtin unary operator.
+plan 6;
+
+sub so($value) { 42 } #OK shadow
+sub not($value) { 42 } #OK shadow
+
+is so(1), 42, 'parenthesized so() calls the user sub';
+is so 1, True, 'spaced so remains the builtin unary operator';
+is &so(1), 42, '&so() calls the user sub';
+
+is not(1), 42, 'parenthesized not() calls the user sub';
+is not 1, False, 'spaced not remains the builtin unary operator';
+is &not(1), 42, '&not() calls the user sub';


### PR DESCRIPTION
Fixes #8253

Make parenthesized calls to user-defined `so` and `not` routines bypass the builtin tight-call parser. Keep whitespace-separated `so` and `not` as the builtin unary operators, and cover both forms plus ampersand calls with a regression test.