### PR TITLE
fix(modules): a module's own file-scope `my $*x` no longer leaks to the importer

### DIFF
--- a/news/2026-09/module-own-dynamic-does-not-leak.md
+++ b/news/2026-09/module-own-dynamic-does-not-leak.md
@@ -1,0 +1,38 @@
+# A module's own file-scope `my $*x` no longer leaks into the importer
+
+A module body executes against the *caller's* `env` for historical reasons.
+Nothing cleaned up a dynamic variable the module declared for **itself** at
+file scope, so it stuck around forever:
+
+```
+$ mutsu -I lib -e 'EVAL q[use Own]; say ($*MODULE_PRIVATE // "(undeclared)")'
+from-module          # real Raku: (undeclared)
+```
+
+Two existing mechanisms almost covered this, but neither actually did:
+
+- `collect_unit_lexical_names`, which moves a `unit` compunit's own
+  file-scope `my` out of `env` and into `unit_lexicals`, explicitly
+  *excludes* dynamics — a `$*x` is dynamically scoped by definition, not a
+  compunit lexical.
+- The plain-env restore that undoes the module's writes after it runs
+  explicitly *skips* dynamic keys (added for
+  [#8229](https://github.com/tokuhirom/mutsu/issues/8229), so that a
+  module's write to a dynamic the *caller* already owns — `$*PACKAGE_LOADED++`
+  reporting a load-time fact — survives the load).
+
+Between the two, a dynamic the module declares for **itself** fell through
+both nets and was simply left behind.
+
+The fix collects the module's own top-level `my $*x`/`@*x`/`%*x`
+declarations and, after the module body runs, restores or removes exactly
+those keys like any other plain name, while every dynamic the module only
+*wrote to* (never declared) keeps the #8229 behavior. The actual `env` key
+for a scalar dynamic keeps its `$` sigil at file scope (`$*x`), while the
+declaration's own AST name is already sigil-less — matching goes through a
+small sigil-stripped comparison rather than an exact key match. This applies
+whether or not the module has a `unit` declarator, since a bare-file module
+runs its whole body against the caller's `env` the same way.
+
+See [#8241](https://github.com/tokuhirom/mutsu/issues/8241) and the
+regression test `t/modules/module-own-dynamic-does-not-leak.t`.

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -903,6 +903,10 @@ impl Interpreter {
                 .iter()
                 .map(|n| (n.clone(), self.env.get(n).cloned()))
                 .collect();
+            // The module's own `my $*x` file-scope declarations (#8241) --
+            // collected regardless of `unit_name`, since a bare-file module
+            // leaks these the same way. See `collect_module_own_dynamic_names`.
+            let module_own_dynamic_names = Self::collect_module_own_dynamic_names(&stmts);
             let before_function_keys: std::collections::HashSet<crate::symbol::Symbol> =
                 self.registry().functions.keys().copied().collect();
             // Capture the module's compiled sub bodies (keyed by fingerprint) so a
@@ -1162,14 +1166,47 @@ impl Interpreter {
                 // scope, not to the module that assigned it: a mainline
                 // `$*PACKAGE_LOADED++` is how a module reports a load-time
                 // fact, and reverting it here threw that write away along with
-                // the module's own lexicals (#8229). A dynamic the module
-                // declared for itself never entered `saved_plain_env` (it is a
-                // compunit lexical, extracted into `unit_lexicals` above), so
-                // it still dies with the load.
-                if key.is_dynamic_var_env_key() {
+                // the module's own lexicals (#8229). But a `$*x` the module
+                // DECLARED FOR ITSELF (`my $*x = ...`, `module_own_dynamic_names`)
+                // is not that -- it is not a compunit lexical either (dynamics
+                // are excluded from `unit_lex_names` by definition), so restore
+                // it like any other plain name: back to whatever the importer had
+                // before (or removed entirely below if the importer had nothing,
+                // #8241).
+                if key.is_dynamic_var_env_key()
+                    && !module_own_dynamic_names
+                        .iter()
+                        .any(|n| Self::dynamic_var_names_match(n, &key.resolve()))
+                {
                     continue;
                 }
                 self.env.insert_sym(*key, value.clone());
+            }
+            // A dynamic the module declared for itself (`my $*x = ...`) that
+            // the importer never had is not restored by the loop above (it
+            // only walks `saved_plain_env`, which never held that key) --
+            // remove it outright so it does not survive as a permanent
+            // binding in the importer's scope (#8241). The actual `env` key a
+            // top-level `my $*x` writes under keeps its `$` sigil (`$*x`),
+            // unlike a plain `my $x`'s sigil-less key -- while `VarDecl.name`
+            // (what `module_own_dynamic_names` holds) is already sigil-less
+            // for a scalar. Comparing by `Self::dynamic_var_names_match`
+            // (both sides stripped of `$@%&`) avoids relying on either
+            // spelling exactly.
+            let stale_own_dynamic_keys: Vec<crate::symbol::Symbol> = self
+                .env
+                .keys()
+                .filter(|key| {
+                    key.is_dynamic_var_env_key()
+                        && module_own_dynamic_names
+                            .iter()
+                            .any(|n| Self::dynamic_var_names_match(n, &key.resolve()))
+                        && !saved_plain_env.contains_key(key)
+                })
+                .copied()
+                .collect();
+            for key in stale_own_dynamic_keys {
+                self.env.remove_sym(key);
             }
             match saved_qfile {
                 Some(f) => {
@@ -1410,6 +1447,17 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Whether `decl_name` (a `VarDecl.name`, sigil-less for a scalar -- see
+    /// [`Self::collect_module_own_dynamic_names`]) and `env_key` (an actual
+    /// `env` storage key, which keeps a scalar dynamic's `$` sigil at file
+    /// scope, e.g. `$*x` rather than `*x`) name the same dynamic variable.
+    /// Comparing both with every sigil character stripped sidesteps that
+    /// spelling difference instead of assuming either one (#8241).
+    fn dynamic_var_names_match(decl_name: &str, env_key: &str) -> bool {
+        decl_name.trim_start_matches(['$', '@', '%', '&'])
+            == env_key.trim_start_matches(['$', '@', '%', '&'])
+    }
+
     /// The env keys of a `unit` compunit's own file-scope `my`/`state` variables.
     /// These are lexical to the compunit, so they must not be left sharing an env
     /// key with the loading scope — see [`Interpreter::unit_lexicals`].
@@ -1480,6 +1528,51 @@ impl Interpreter {
                 .next()
                 .is_some_and(|c| c.is_ascii_alphabetic() || c == '_' || c == '@' || c == '%')
             {
+                continue;
+            }
+            if !names.iter().any(|n| n == name) {
+                names.push(name.clone());
+            }
+        }
+        names
+    }
+
+    /// The env keys of a compunit's own file-scope `my $*name`/`my @*name`/
+    /// `my %*name` declarations (#8241) -- the dynamic-variable mirror of
+    /// [`Self::collect_unit_lexical_names`], which explicitly EXCLUDES these
+    /// (a `$*dynamic` is "dynamically scoped by definition", so a plain `my`
+    /// vs `unit_lexicals` split does not apply to it).
+    ///
+    /// That exclusion is right for a module that only WRITES an existing
+    /// dynamic the *caller* already declared (`$*PACKAGE_LOADED++` mutating a
+    /// caller-owned `my $*PACKAGE_LOADED`, #8229) -- the write must survive
+    /// the load. But a module's OWN `my $*x = ...` declaration is a different
+    /// case entirely: the module body runs against the CALLER's `env` (see
+    /// the big comment above `saved_plain_env`), so with no cleanup at all a
+    /// dynamic the module declares for ITSELF is simply left behind as a
+    /// permanent binding in the importer's scope once the load returns --
+    /// `EVAL q[use Own]; say $*MODULE_PRIVATE` printed the module's value
+    /// forever after, when real Raku says the name was never declared in the
+    /// importing scope at all.
+    ///
+    /// Collected unconditionally (unlike `unit_lex_names`, which only matters
+    /// for a `unit`-declared compunit): a bare-file module with no `unit`
+    /// statement leaks its own dynamics the same way, for the same reason
+    /// (the whole body still runs against the caller's `env`).
+    fn collect_module_own_dynamic_names(stmts: &[crate::ast::Stmt]) -> Vec<String> {
+        let mut names: Vec<String> = Vec::new();
+        for s in stmts {
+            let crate::ast::Stmt::VarDecl {
+                name,
+                is_our,
+                is_dynamic,
+                is_export,
+                ..
+            } = s
+            else {
+                continue;
+            };
+            if !*is_dynamic || *is_our || *is_export || name.contains("::") {
                 continue;
             }
             if !names.iter().any(|n| n == name) {

--- a/t/lib/Issue8241/BareFileOwnDynamic.rakumod
+++ b/t/lib/Issue8241/BareFileOwnDynamic.rakumod
@@ -1,0 +1,1 @@
+my $*MODULE_PRIVATE = 'from-bare-file-module';

--- a/t/lib/Issue8241/UnitOwnDynamic.rakumod
+++ b/t/lib/Issue8241/UnitOwnDynamic.rakumod
@@ -1,0 +1,2 @@
+my $*MODULE_PRIVATE = 'from-unit-module';
+unit module UnitOwnDynamic;

--- a/t/modules/module-own-dynamic-does-not-leak.t
+++ b/t/modules/module-own-dynamic-does-not-leak.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+# A module's OWN file-scope `my $*x = ...` declaration must not leak into the
+# importing scope. The module body runs against the CALLER's env (see
+# `run_modules.rs`), and a dynamic the module declares for ITSELF was never
+# moved out into `unit_lexicals` (dynamics are dynamically scoped by
+# definition, so `collect_unit_lexical_names` explicitly excludes them) nor
+# reverted by the plain-env restore (which must NOT revert a dynamic the
+# CALLER itself owns and the module merely wrote to, #8229) -- so with no
+# further handling it was simply left behind as a permanent binding forever.
+#
+# https://github.com/tokuhirom/mutsu/issues/8241
+#
+# The loads go through EVAL so the `use` really happens at run time, inside
+# the importing dynamic scope; a plain top-level `use` runs at BEGIN, before
+# any of this machinery is even reachable from user code.
+
+plan 2;
+
+use lib 't/lib/Issue8241';
+
+{
+    EVAL q[use UnitOwnDynamic];
+    is $*MODULE_PRIVATE // "(undeclared)", "(undeclared)",
+        "a `unit module`'s own `my \$*x` does not leak into the importer";
+}
+
+{
+    EVAL q[use BareFileOwnDynamic];
+    is $*MODULE_PRIVATE // "(undeclared)", "(undeclared)",
+        "a bare-file module's own `my \$*x` does not leak into the importer";
+}


### PR DESCRIPTION
## Summary

- A module body runs against the *caller's* `env`, and nothing cleaned up a dynamic variable the module declares for **itself** at file scope (`my $*x = ...`): `collect_unit_lexical_names` excludes dynamics by design (they're dynamically scoped, not compunit lexicals), and the plain-env restore added by #8229 explicitly skips dynamic keys so a module's *write* to a caller-owned dynamic survives the load. With neither mechanism handling it, a module's own dynamic was simply left behind as a permanent binding in the importer's scope forever.
- Fix: collect the module's own top-level `my $*x`/`@*x`/`%*x` declarations (`collect_module_own_dynamic_names`, the dynamic mirror of `collect_unit_lexical_names`) and, after the module body runs, restore-or-remove exactly those keys like any other plain name — while every other dynamic (one the module only *wrote to*, never declared) keeps the #8229 behavior. The actual `env` key for a scalar dynamic keeps its `$` sigil at file scope (`$*x`) while the AST's `VarDecl.name` is already sigil-less, so matching goes through a small sigil-stripped comparison (`dynamic_var_names_match`) instead of an exact key match.
- Applies regardless of a `unit` declarator: a bare-file module runs its whole body against the caller's `env` the same way, so it leaked the same way for the same reason.

Closes #8241

## Test plan

- [x] New regression test `t/modules/module-own-dynamic-does-not-leak.t`, covering both the `unit module` and bare-file module shapes — passes under both mutsu and real `raku`.
- [x] Existing `t/modules/module-load-writes-caller-dynamic.t` (#8229) still passes — a module's write to a *caller-owned* dynamic still survives the load.
- [x] `cargo fmt --all`
- [x] `make lint` (all 4 configurations green)
- [x] `make test` (4190 files, 44631 tests — PASS)
- [x] `make roast` — the only failures are the three documented container-only exceptions (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t`), per `docs/agent-environments.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_