### PR TITLE
docs: accept ADR-0099, file Stage 1 (#8272), and retire PLAN §4's stale regex claims

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -177,16 +177,23 @@ DefiniteHow — is fully closed; no open roast-adjacent language-feature backlog
 
 ---
 
-## 4. perf — de-prioritized polish
+## 4. perf — mostly polish, but three measured losses
 
-mutsu beats raku on the whole roast whitelist and on every benchmark, so **do not pick up a perf item
-just because the profile shows a hot symbol** — first confirm a goal item needs it. Levers, targets
-and the measurement protocol: [ADR-0006](docs/adr/0006-baseline-interpreter-optimizations.md),
+**Do not pick up a perf item just because the profile shows a hot symbol** — first confirm a goal
+item needs it. Levers, targets and the measurement protocol:
+[ADR-0006](docs/adr/0006-baseline-interpreter-optimizations.md),
 [docs/perf-callpath-scouting.md](docs/perf-callpath-scouting.md); canonical numbers come from the
 bench CI, never a local run.
 
-- [ ] **The one axis where mutsu is genuinely slower than raku** — the interpreter function-call path
-      in hot loops (the JIT bails at the call boundary):
+This section used to open "mutsu beats raku on the whole roast whitelist and on every benchmark".
+[ADR-0099](docs/adr/0099-regex-engine-performance-strategy.md) §2 retired that claim: it held on
+one-shot wall clock, which charges rakudo its warm-up, and does not hold on steady-state or marginal
+cost. Compare warm before asserting a win.
+
+- [ ] **The interpreter function-call path in hot loops** (the JIT bails at the call boundary) —
+      until 2026-09-13 this bullet read "the one axis where mutsu is genuinely slower than raku";
+      [ADR-0099](docs/adr/0099-regex-engine-performance-strategy.md) found two more (grammar parsing
+      and a boolean `~~`), so it is one of three:
       [#7573](https://github.com/tokuhirom/mutsu/issues/7573). **Read that ticket's re-diagnosis
       first**; everything this file used to say about the blocker is closed. The `&`-sigil signature
       gate, the `nqp::` by-name resolve and the 83% `interpreter_fallbacks` figure are all fixed, and
@@ -197,14 +204,27 @@ bench CI, never a local run.
       per the ticket: collapse the double `multi` resolution per call, and reduce the flat
       interpretation cost of a module body (allocation traffic and env lookups), which is what the
       remaining ~16x against raku on an assertion actually is.
-- [ ] Grammar/regex per-subrule ceremony (~25× vs raku per matched character; the exponential and
-      accumulated-state halves are fixed):
-      [ADR-0007](docs/adr/0007-grammar-parse-trail-matcher.md) §Implementation outcome. **This one
-      has a goal-item consumer**, so it is not polish: it is the measured reason the JSON
-      `to-json`/`from-json` fast path still shadows the vendored module by name
-      ([#8183](https://github.com/tokuhirom/mutsu/issues/8183)) — the real grammar decodes 200
-      META-shaped documents in ~600s against 0.49s native, on a path zef walks for every metadata
-      read.
+- [ ] **Regex/grammar — read [ADR-0099](docs/adr/0099-regex-engine-performance-strategy.md) before
+      touching any of it**; it supersedes what this bullet used to say. The old text ("~25× vs raku
+      per matched character", citing ADR-0007 and a ~600s/200-document JSON consumer) is stale in
+      both halves: ADR-0007 measured 18 **ms**/char and the engine is three orders of magnitude past
+      that, and [#8183](https://github.com/tokuhirom/mutsu/issues/8183) was closed 2026-09-13 with
+      its figure already corrected to 12.6s (raku 0.84s) in `docs/batteries/json-tiny.md` — zef's
+      metadata path was never on it. What is actually open, in ADR-0099's order:
+    - [ ] Stage 0, the measured losses — all defects, no design risk, and they gate the rest:
+          [#8265](https://github.com/tokuhirom/mutsu/issues/8265) (`<sym>` kills the proto-candidate
+          memo; 3.3x on a grammar parse, which is nearly the whole ~1.9x-slower-than-warm-rakudo
+          gap), [#8262](https://github.com/tokuhirom/mutsu/issues/8262) (`:ignoremark` is O(n²)),
+          [#8263](https://github.com/tokuhirom/mutsu/issues/8263) and
+          [#8269](https://github.com/tokuhirom/mutsu/issues/8269) (Match truthiness and `$_`
+          interning: 31% of a boolean `~~`, which mutsu loses to warm rakudo 2.8x),
+          [#8270](https://github.com/tokuhirom/mutsu/issues/8270) (parse-cache defects).
+    - [ ] Stage 1, the declarative prefilter:
+          [#8272](https://github.com/tokuhirom/mutsu/issues/8272). The one *asymptotic* gap —
+          `~~ /literal/` is 212x mutsu's own `.index` on the same 640 KB subject — and the one item
+          that can be wrong without being incorrect, so its differential property test is the gate.
+    - [ ] Stage 2 (a fast-lane compiled matcher) and Stage 3 (ADR-0007's CPS→bytecode regex VM) are
+          deferred questions, not work. Do not start either without a superseding ADR.
 - [ ] Opcode leftovers: [docs/opcode-design-review.md](docs/opcode-design-review.md) §2/§5/§6.
 - [ ] Biased reference counting (ADR-0001 layer 3c) — frozen; start only on a measured trigger and an
       updated ADR.

--- a/docs/adr/0099-regex-engine-performance-strategy.md
+++ b/docs/adr/0099-regex-engine-performance-strategy.md
@@ -1,6 +1,6 @@
-# ADR-0099: Regex engine performance — fix the ceremony first; a prefilter and a fast lane above the unchanged walk
+# ADR-0099: Regex engine performance — fix the ceremony first; a prefilter above the unchanged walk
 
-- **Status**: Proposed (2026-09-13; revised the same day after review — see §8)
+- **Status**: Accepted (2026-09-13; drafted, reviewed and revised the same day — see §8)
 - **Context**: the eight regex benchmarks added on 2026-09-12/13 (`bench-regex-{match,capture,global,assertion,long-subject,split-subst}.raku`,
   `bench-grammar-parse-big.raku`, `bench-yaml-parse-big.raku`) gave the suite its first view of the
   regex engine. The question this ADR answers: is micro-benchmark-driven tuning of the present
@@ -144,6 +144,23 @@ Callgrind on a 65,536-position failing literal scan: **~983 instructions per sta
 of the 9.0 M instructions of `mutsu -e 'say 1'`) to establish that `chars[i] != 'z'`. The profile
 is the machinery, not the comparison: the five candidate-generator layers, candidate-`Vec`
 construction and drop, `memcpy`, `malloc`, and `RegexCaptures` construction/drop.
+
+The sharpest form of this is not the comparison against rakudo at all — it is mutsu against itself.
+The same question, asked two ways in the same interpreter, on the same 640 KB subject:
+
+| | mutsu | rakudo |
+|---|---:|---:|
+| `$big.index('zzzq-not-here')` | **0.4 ms** | 4.4 ms |
+| `$big ~~ / 'zzzq-not-here' /` | **84.7 ms** | 1.6 ms |
+| `$big.lc.index('zzzq')` | 14.1 ms | 10.1 ms |
+| `$big ~~ / :i 'ZZZQ' /` | **160.3 ms** | 6.6 ms |
+
+**212x between mutsu's own two answers.** mutsu already ships a substring search that is 10x faster
+than rakudo's; the regex engine simply does not use it. Rakudo's `~~ /literal/` beating its own
+`.index` is the same fact from the other side: it lowers a literal-only pattern onto a tuned scan.
+So Stage 1 below is not a new optimization to invent — it is wiring an existing primitive to the
+engine. (The `:i` rows also rule out the obvious shortcut: `.lc.index` costs 14.1 ms *because* it
+copies the whole subject, so "case-fold both sides" is not the design.)
 
 ### 2.5 Small-subject matching is ceremony-bound, and mutsu loses it to warm rakudo
 
@@ -300,7 +317,13 @@ Three constraints that are Raku-specific and non-negotiable:
 
 Scope, stated plainly so it is not over-sold: **this is a scan optimization.** It does nothing for
 `Grammar.parse` or for any anchored or subrule-entered match. It is load-bearing for §2.4's
-workload and for the `:g` / `.comb` / `.subst` / `split` scan loops, and for nothing else.
+workload and for the `:g` / `.comb` / `.subst` / `split` / `.contains` / `.grep` scan loops, and for
+nothing else. On the suite's short-line benchmarks the win is modest and Stage 0 owns the rest: over
+`bench-regex-match`'s workload an anchored pattern (zero scan) costs 8.3 ms against 11.1 ms for one
+that scans all ~110 positions and fails, so the scan is only ~34% above the per-call ceremony floor
+there.
+
+[#8272](https://github.com/tokuhirom/mutsu/issues/8272).
 
 ### Stage 2 — deferred, not decided
 
@@ -390,11 +413,12 @@ Nothing implemented. Stage 0 is fully filed, ordered as in §4:
 | 4. smartmatch interns `$_` twice per match | [#8269](https://github.com/tokuhirom/mutsu/issues/8269) | 16.4% of a boolean `~~` |
 | 5. parse-cache key, scan, and interpolated bypass | [#8270](https://github.com/tokuhirom/mutsu/issues/8270) | 4.5% of `bench-regex-match` |
 
-Stage 1 is deliberately **not** filed while this ADR is `Proposed`: it is the one part of the plan
-that is a design commitment rather than a defect, and filing an implementation ticket for an
-unaccepted decision would put it in the `todo:ticket` queue for an agent to pick up. File it as
-`todo:deep` when this ADR moves to `Accepted`. Stage 2 is a question, not work, until Stage 0
-lands and grammars are re-profiled.
+Stage 1 is [#8272](https://github.com/tokuhirom/mutsu/issues/8272) (`todo:deep`), filed when this
+ADR moved to `Accepted`. Its three constraints — reuse ADR-0022's litlen table rather than defining
+a second one, `:i` fold-closure first-sets rather than a folded needle, decline on anything
+non-declarative — are the work, not footnotes, and the differential property test against the
+prefilter-disabled engine is its gate. Stage 2 is a question, not work, until Stage 0 lands and
+grammars are re-profiled.
 
 Revision history: first draft 2026-09-13, reviewed the same day. The review inverted §2.2 (the
 grammar claim had been measured on a simplified grammar over five iterations including rakudo's
@@ -406,3 +430,8 @@ corrected §2.5's shares and added the `Symbol::intern` finding, established tha
 `~~` path (its callers are `.contains`/`.grep`/`.first`/hash-key smartmatch, not `~~`), and rewrote
 §5's rejection of the big-bang rewrite onto gain grounds. The staging survived; its contents and its
 centre of gravity did not.
+
+Accepted later the same day, with §2.4's mutsu-against-itself table added: `~~ /literal/` against
+`.index` on one 640 KB subject is 212x, which makes Stage 1 a wiring job onto a primitive mutsu
+already ships rather than an optimization to invent. The title lost "and a fast lane" at the same
+time, to match Stage 2's demotion from a decision to a question.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -124,4 +124,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0096](0096-batteries-adoption-policy.md) | A battery is the real upstream module; the interpreter is what grows (rung-3 native provision banned; a performance measurement justifies an optimization, never a substitution) | Accepted |
 | [0097](0097-a-binding-descriptor-addressed-by-slot.md) | A binding's own metadata lives on a slot-addressed descriptor, not under a key derived from its name | Proposed |
 | [0098](0098-if-pragma-actions-slang.md) | mutsu answers `Raku.legacy` with `False`, and a slang's *actions*-role method is an override name (the `if` pragma) | Accepted (implemented 2026-09-13) |
-| [0099](0099-regex-engine-performance-strategy.md) | Regex engine performance — fix the ceremony first; a prefilter and a fast lane above the unchanged walk | Proposed |
+| [0099](0099-regex-engine-performance-strategy.md) | Regex engine performance — fix the ceremony first; a prefilter above the unchanged walk | Accepted (Stage 0 and Stage 1 filed; Stage 2/3 deferred — see §8) |


### PR DESCRIPTION
Follow-up to #8271, which landed ADR-0099 as `Proposed`. Three things that belong in one change: the measurement that settles Stage 1, the decision it settles, and the PLAN text that still contradicted both. Documentation-only, so CI's build jobs skip by design.

## The measurement that settles it

The sharpest form of the scan gap is not mutsu against rakudo — it is **mutsu against itself**. Same 640 KB subject, same question, two paths through the same interpreter:

| | mutsu | rakudo |
|---|---:|---:|
| `$big.index('zzzq-not-here')` | **0.4 ms** | 4.4 ms |
| `$big ~~ / 'zzzq-not-here' /` | **84.7 ms** | 1.6 ms |
| `$big.lc.index('zzzq')` | 14.1 ms | 10.1 ms |
| `$big ~~ / :i 'ZZZQ' /` | **160.3 ms** | 6.6 ms |

**212x.** mutsu already ships a substring search that is 10x faster than rakudo's; the regex engine simply does not use it. Rakudo's `~~ /literal/` beating its own `.index` (1.6 vs 4.4 ms) is the same fact from the other side — it lowers a literal-only pattern onto a tuned scan. So Stage 1 is not an optimization to invent; it is wiring an existing primitive to the engine.

The `:i` rows rule out the obvious shortcut at the same time: `.lc.index` costs 14.1 ms *because* it copies the whole subject, so "case-fold both sides" is not the design — and multi-character folds (`ß`/`SS`, `ﬁ`/`fi`) make a folded needle unsound anyway.

Added to ADR §2.4, and **ADR-0099 moves to `Accepted`.**

## Stage 1's scope, stated more honestly

The first draft called the prefilter "the load-bearing change". §4 now bounds it: over `bench-regex-match`'s workload an anchored pattern (zero scan) costs 8.3 ms against 11.1 ms for one that scans all ~110 positions and fails — so on short lines the scan is only ~34% above the per-call ceremony floor, and Stage 0 owns the other ~75%. The prefilter is worth 30–200x on long subjects and ~10–25% on the suite's short-line benchmarks, and **nothing at all** on `Grammar.parse`.

The ADR title loses "and a fast lane", matching Stage 2's demotion from a decision to a question.

## Stage 1 filed: #8272 (`todo:deep`)

Its three constraints are written as the work rather than as footnotes:

1. **Reuse ADR-0022's `ltm_litlen_at` construction table** instead of defining a second notion of "declarative literal prefix". Two definitions will drift, and the drift is silent — a dropped valid match, not an error.
2. **`:i` needs fold-closure first-sets**, not a folded needle (see above). `:m` needs NFD-aware first-sets on the subject side.
3. **Decline on anything non-declarative.** A leading `{ }` block must keep running once per start position (ADR-0009); a prefix derived through `<subrule>` must be keyed by invocant package and `TOKEN_DEFS_GEN` — `H is G` overriding `token x` is legal — or decline.

The gate is a **differential property test** against a prefilter-disabled engine (`MUTSU_REGEX_PREFILTER=off`), because this is the one item in the whole plan that can be wrong without being incorrect.

## PLAN §4

It carried two claims this ADR disproved and one closed consumer:

- the preamble asserted mutsu "beats raku on every benchmark" — true only on one-shot wall clock, which charges rakudo its warm-up;
- the function-call bullet called itself "**the** one axis where mutsu is genuinely slower than raku"; there are three (that one, grammar parsing, and a boolean `~~`);
- the regex bullet cited ADR-0007's "~25× per matched character" and a ~600s/200-document JSON consumer. ADR-0007 measured 18 **ms**/char and the engine is three orders of magnitude past it; #8183 closed 2026-09-13 with its figure already corrected to 12.6s (raku 0.84s) in `docs/batteries/json-tiny.md`, and zef's metadata path was never on it.

The bullet now points at ADR-0099 and lists what is actually open, in its order (Stage 0: #8265, #8262, #8263, #8269, #8270 — Stage 1: #8272 — Stage 2/3: deferred, no work without a superseding ADR). The section heading stops calling all of §4 "de-prioritized polish", since two of its bullets are measured losses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_