### PR TITLE
fix(vm): a Pair reached through an expression is immutable, and a rw routine returning a plain value refuses

### DIFF
--- a/news/2026-09/a-pair-reached-through-an-expression-is-immutable.md
+++ b/news/2026-09/a-pair-reached-through-an-expression-is-immutable.md
@@ -1,0 +1,91 @@
+# A `Pair` reached through an expression is immutable, and an `is rw` routine that returns a plain value refuses
+
+Five general divergences from rakudo, all found re-measuring [#7539](https://github.com/tokuhirom/mutsu/issues/7539)'s
+`Config::TOML` + `Crane` battery pair. They share one theme: mutsu applied the
+"this is not a location, refuse the write" rule only where the target was spelled
+as a **variable**, and invented a container everywhere else. `Crane` is built
+entirely on the everywhere-else spellings, so each divergence turned a refusal
+Crane's `CATCH` depends on into a silent success.
+
+`Crane` v0.1.2 goes from **4/15 files to 7/15** — `set`, `replace` and `remove`
+now pass in full — with `Config::TOML` v0.1.3 unchanged at 14/19.
+
+## 1. A type-object `is rw` method that returns a plain value fell back to the setter convention
+
+`Crane::In.in(container, @path) = $value` is a class-method lvalue: mutsu runs
+the method, and when it hands back a container writes through it. When it handed
+back a *plain value* — which is exactly what a descent that has landed on an
+immutable leaf does — mutsu reported the shape as inapplicable and let the legacy
+`$obj.name($value)` setter convention take over. That convention **re-calls the
+method with the assigned value as its only argument**, and with a `*@steps`
+slurpy `in(9)` is a perfectly bindable call: the zero-step candidate handed `9`
+straight back and the assignment reported success while writing nowhere.
+
+The sub spelling of the same descent always refused. `try_rw_method_container_lvalue`
+now shares the sub form's write half (`assign_through_rw_result`), so both answer
+rakudo's `Cannot modify an immutable Int (1)`. A method that far in is rw-capable
+and computes its location, so a plain value coming back **is** the refusal.
+
+## 2. `return-rw <list>[i]` promoted an immutable `List`'s element to a private cell
+
+`sub g(\c) is rw { return-rw c[0] }; g((1, 2)) = 9` wrote into a cell nothing
+else could see; rakudo refuses with `Cannot modify an immutable Int (1)`, and an
+out-of-range index with `Cannot modify an immutable Nil value` rather than growing
+the `List`. The suppression already existed for a `:=` *declaration* bind
+(`my $x := (5, 6)[0]`), gated by `IndexAutovivifyLazyTerminal`'s `decl_bind` flag.
+A `return-rw` operand settles the caller's write from the element in exactly the
+same way, so the flag now covers both and is renamed `raw_list_elem` to say what
+it decides. A loop-parameter bind still keeps the promotion, which is what a
+chunked `for @flat -> \a, \b` and `.kv` on a mutable QuantHash depend on.
+
+An element that already IS a container is handed back untouched either way, so a
+`List` built by `take-rw` is still written through.
+
+## 3. A store into a `Pair` reached through an expression invented a container
+
+`my $p = (c => True); id($p){'c'} = 9` (and the accessor spelling,
+`Crane::At.at($root, @path){$step} = $value`) silently succeeded. A `Pair` DOES
+`Associative`, so an associative subscript descends into it and rakudo refuses at
+the value it reaches — the rule the chained-store walk on a variable already
+followed. That arm is now a shared helper (`pair_subscript_store_refusal`) wired
+into the computed-target store and the method-lvalue store as well.
+
+Two supporting bugs in the accessor path came out with it. Its
+`(root, @steps)` walk stepped through `Hash` and `Array` but answered `Nil` at a
+`Pair`, so a colonpair chain — Crane's own fixture shape — was never reached; and
+it unwrapped a `Scalar`/`ContainerRef` *inside* the per-step match, consuming a
+step without descending, so an itemized root (`my $root = %h.deepmap(...)`, how
+every non-in-place Crane operation builds its copy) came up one level short.
+
+## 4. `<k>:delete` on a `Pair` removed nothing and reported success
+
+Rakudo refuses every removal from a `Pair` with `X::AdHoc`
+"Can not remove values from a Pair", the same shape it uses for a `Map`.
+`Crane.remove` parses that payload back out (`Can not remove values from a (\w+)`)
+to raise `X::Crane::Remove::RO`. The existing `refuse_map_removal` chokepoint —
+which every delete path already calls — now covers `Pair` too.
+
+## 5. `deepmap` boxed an already-promoted leaf a second time
+
+`deepmap` passes each leaf to the block through a transient `ContainerRef` cell so
+a mutating callable writes through. When the source element was *already* a cell
+(promoted by an earlier `:=` bind or `is rw` descent), the block's `$_` became a
+container around a container, and every method dispatched on the raw `$_` missed
+it:
+
+```raku
+my %h = :a(:b(1)); my $x := %h<a>; %h.deepmap({ .clone })
+# rakudo: {:a(:b(1))}
+# mutsu:  No such method 'clone' for invocant of type 'Pair'
+```
+
+The leaf now goes into the transient cell decontainerized. Write-back is
+unaffected: the caller stores that cell's post-call value into the source slot
+itself.
+
+## Pins
+
+`t/vm/binding/rw-return-of-a-plain-value-is-refused.t` (16 assertions) and
+`t/collections/range-pair/pair-reached-through-an-expression-is-immutable.t`
+(14 assertions), each verified to fail without its fix and to pass under
+rakudo v2026.07.

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -449,15 +449,15 @@ impl Compiler {
         let lazy_op = if is_terminal {
             OpCode::IndexAutovivifyLazyTerminal {
                 is_positional,
-                decl_bind: self.decl_bind_terminal,
+                raw_list_elem: self.raw_list_elem_terminal,
             }
         } else {
             OpCode::IndexAutovivifyLazy { is_positional }
         };
         let saved_terminal = self.bind_terminal;
         self.bind_terminal = false; // inner `target` indices are intermediate
-        let saved_decl_bind_terminal = self.decl_bind_terminal;
-        self.decl_bind_terminal = false;
+        let saved_raw_list_elem_terminal = self.raw_list_elem_terminal;
+        self.raw_list_elem_terminal = false;
 
         // Special case: CALLERS::<$*x> stash-subscript access — the "any caller
         // scope" twin below. It carries the twigil case (roast `CALLERS::<$*foo>`)
@@ -478,7 +478,7 @@ impl Compiler {
             if depth == 1 && self.in_immediate_block() {
                 self.emit_outers_var_access(bare);
                 self.bind_terminal = saved_terminal;
-                self.decl_bind_terminal = saved_decl_bind_terminal;
+                self.raw_list_elem_terminal = saved_raw_list_elem_terminal;
                 return;
             }
             let cascade = Self::callers_name_cascades(&bare);
@@ -489,7 +489,7 @@ impl Compiler {
                 cascade,
             });
             self.bind_terminal = saved_terminal;
-            self.decl_bind_terminal = saved_decl_bind_terminal;
+            self.raw_list_elem_terminal = saved_raw_list_elem_terminal;
             return;
         }
 
@@ -512,7 +512,7 @@ impl Compiler {
             if depth == 1 && self.in_immediate_block() {
                 self.emit_caller_outer_var_access(bare, 1);
                 self.bind_terminal = saved_terminal;
-                self.decl_bind_terminal = saved_decl_bind_terminal;
+                self.raw_list_elem_terminal = saved_raw_list_elem_terminal;
                 return;
             }
             let name_idx = self.code.add_constant(Value::str(bare));
@@ -521,7 +521,7 @@ impl Compiler {
                 depth: depth as u32,
             });
             self.bind_terminal = saved_terminal;
-            self.decl_bind_terminal = saved_decl_bind_terminal;
+            self.raw_list_elem_terminal = saved_raw_list_elem_terminal;
             return;
         }
 
@@ -547,7 +547,7 @@ impl Compiler {
                 OuterStash::Any => self.emit_outers_var_access(bare),
             }
             self.bind_terminal = saved_terminal;
-            self.decl_bind_terminal = saved_decl_bind_terminal;
+            self.raw_list_elem_terminal = saved_raw_list_elem_terminal;
             return;
         }
 
@@ -589,7 +589,7 @@ impl Compiler {
             }
         }
         self.bind_terminal = saved_terminal;
-        self.decl_bind_terminal = saved_decl_bind_terminal;
+        self.raw_list_elem_terminal = saved_raw_list_elem_terminal;
     }
 
     /// Compile the *index* half of a subscript. The index selects which element
@@ -603,8 +603,8 @@ impl Compiler {
         let saved_terminal = self.bind_terminal;
         self.scalar_bind_autovivify = false;
         self.bind_terminal = false;
-        let saved_decl_bind = self.decl_bind_terminal;
-        self.decl_bind_terminal = false;
+        let saved_raw_list_elem = self.raw_list_elem_terminal;
+        self.raw_list_elem_terminal = false;
 
         match index {
             // A bare colon-pair/fat-arrow index (`R[:v<hi>]`) is a role
@@ -651,7 +651,7 @@ impl Compiler {
 
         self.scalar_bind_autovivify = saved_av;
         self.bind_terminal = saved_terminal;
-        self.decl_bind_terminal = saved_decl_bind;
+        self.raw_list_elem_terminal = saved_raw_list_elem;
     }
 
     /// In a container-producing (bind / `return-rw`) subscript chain, read a

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -36,11 +36,21 @@ impl Compiler {
             Expr::Index { .. } | Expr::MultiDimIndex { .. } => {
                 let saved_av = self.scalar_bind_autovivify;
                 let saved_terminal = self.bind_terminal;
+                let saved_raw_list_elem = self.raw_list_elem_terminal;
                 self.scalar_bind_autovivify = true;
                 self.bind_terminal = true;
+                // The caller writes through whatever comes back, so an
+                // immutable `List`'s scalar element must arrive raw: rakudo
+                // refuses `sub g(\c) is rw { return-rw c[0] }; g((1, 2)) = 9`
+                // with "Cannot modify an immutable Int (1)", where promoting the
+                // element to a private cell made the write silently succeed and
+                // reach nobody (`Crane::In`'s `Positional:D` descent, and hence
+                // `Crane.set` on an immutable `List`).
+                self.raw_list_elem_terminal = true;
                 self.compile_expr(arg);
                 self.scalar_bind_autovivify = saved_av;
                 self.bind_terminal = saved_terminal;
+                self.raw_list_elem_terminal = saved_raw_list_elem;
             }
             // `$flag ?? c<x> !! c<y>`: the condition is an ordinary value read;
             // each arm is itself a location the routine may hand back, so both

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1338,11 +1338,13 @@ pub(crate) struct Compiler {
     /// the only place that knows -- the trailing `MarkSigilless` compiles after
     /// the declaration. One-shot, like [`Self::bind_vardecl`].
     sigilless_bind_vardecl: bool,
-    /// True while compiling the RHS of a `:=` DECLARATION (`my \a := ...`,
-    /// `my $x := ...`), so the terminal index emits
-    /// `IndexAutovivifyLazyTerminal { decl_bind: true }` and leaves an
+    /// True while compiling a terminal subscript whose consumer settles its own
+    /// writability from the element it receives — the RHS of a `:=`
+    /// DECLARATION (`my \a := ...`, `my $x := ...`) and a `return-rw` operand —
+    /// so the terminal index emits
+    /// `IndexAutovivifyLazyTerminal { raw_list_elem: true }` and leaves an
     /// immutable `List`'s scalar element unpromoted (and hence immutable).
-    decl_bind_terminal: bool,
+    raw_list_elem_terminal: bool,
     /// True only while compiling the statement operand of `do`. `WheneverScope`
     /// reads this to leave its Tap on the ordinary value stack.
     do_stmt_yields_value: bool,
@@ -1689,7 +1691,7 @@ impl Compiler {
             self_is_signature_param: false,
             bind_vardecl: false,
             sigilless_bind_vardecl: false,
-            decl_bind_terminal: false,
+            raw_list_elem_terminal: false,
             do_stmt_yields_value: false,
             scalar_bind_autovivify: false,
             bind_terminal: false,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1550,12 +1550,12 @@ impl Compiler {
                     // declaration the parser itself tagged is a declaration
                     // bind. (`@`/`%` targets never carry the tag; they alias
                     // the whole container and keep the promotion too.)
-                    self.decl_bind_terminal = sigilless_bind_vardecl || scalar_bind_decont;
+                    self.raw_list_elem_terminal = sigilless_bind_vardecl || scalar_bind_decont;
                     self.bind_target_direct = true;
                     self.compile_call_arg(expr);
                     self.scalar_bind_autovivify = false;
                     self.bind_terminal = false;
-                    self.decl_bind_terminal = false;
+                    self.raw_list_elem_terminal = false;
                 } else if scalar_bind_decont
                     && (matches!(expr, Expr::ArrayVar(_) | Expr::HashVar(_))
                         || matches!(expr, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. }))

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1803,19 +1803,28 @@ pub(crate) enum OpCode {
     /// bind RHS. A container-valued (Array/Hash) leaf is promoted to a
     /// `ContainerRef` cell — not kept as a traversal back-reference.
     ///
-    /// `decl_bind` marks this terminal subscript as the source of a `:=`
-    /// DECLARATION — `my \a := (5, 6)[0]` (including each sigilless target of a
-    /// list-destructuring bind) and `my $x := (5, 6)[0]`. Such a name is bound
-    /// to whatever the element denotes, so rakudo settles its mutability from
-    /// the bound thing: an `Array` element is a container and writes through,
-    /// while a `List` element is a plain value and a later `a = 10` / `$x = 10`
-    /// dies. Promoting a `List`'s scalar leaf to a fresh cell would make the
-    /// second case look writable, so this flag suppresses the promotion for an
-    /// immutable `List` — an element that already IS a container (a captured
-    /// source cell from `($x, $y)`, a nested `Array`/`Hash`) is handed back
-    /// unchanged and stays writable.
+    /// `raw_list_elem` marks this terminal subscript as one whose CONSUMER
+    /// settles its own writability from the element it receives, so an
+    /// immutable `List`'s scalar leaf must be handed back raw rather than
+    /// promoted to a private cell. Two shapes qualify:
     ///
-    /// The flag is deliberately restricted to a declaration bind. The same
+    /// - a `:=` DECLARATION — `my \a := (5, 6)[0]` (including each sigilless
+    ///   target of a list-destructuring bind) and `my $x := (5, 6)[0]`. Such a
+    ///   name is bound to whatever the element denotes, so rakudo settles its
+    ///   mutability from the bound thing: an `Array` element is a container and
+    ///   writes through, while a `List` element is a plain value and a later
+    ///   `a = 10` / `$x = 10` dies.
+    /// - a `return-rw` OPERAND — `sub g(\c) is rw { return-rw c[0] }`. The
+    ///   caller's `g(...) = 9` writes through whatever came back, and for a
+    ///   `List` element rakudo refuses with "Cannot modify an immutable
+    ///   Int (1)". `Crane::In`'s `Positional:D` descent is this shape, and the
+    ///   promotion made `Crane.set` on an immutable `List` silently succeed.
+    ///
+    /// In both cases an element that already IS a container (a captured source
+    /// cell from `($x, $y)`, a `take-rw` cell, a nested `Array`/`Hash`) is
+    /// handed back unchanged and stays writable.
+    ///
+    /// The flag is deliberately NOT set for a loop-parameter bind. The same
     /// over-promotion also makes a `List`-element loop parameter wrongly
     /// writable, but suppressing it there breaks consumers that lean on the
     /// promotion (a chunked `for @flat -> \a, \b` binding, `.kv` on a mutable
@@ -1823,7 +1832,7 @@ pub(crate) enum OpCode {
     /// `news/2026-09/immutable-element-store-and-bind.md`.
     IndexAutovivifyLazyTerminal {
         is_positional: bool,
-        decl_bind: bool,
+        raw_list_elem: bool,
     },
     /// `%h<k>:delete` / `@a[i]:delete`. First field is the container variable's
     /// name (const-pool index); the optional second is its compile-time-resolved

--- a/src/runtime/builtins_collection_deepmap.rs
+++ b/src/runtime/builtins_collection_deepmap.rs
@@ -386,12 +386,23 @@ impl Interpreter {
     /// and mutations are visible in the source structure. Returns the
     /// block's (decontainerized) result plus the cell's post-call value for
     /// the caller to write back into the source slot.
+    ///
+    /// The leaf goes in DECONTAINERIZED. A source element that was already
+    /// promoted to a cell by an earlier `:=` bind or `is rw` descent would
+    /// otherwise be boxed a second time, and the block's `$_` would be a
+    /// container around a container — which every method dispatched on the raw
+    /// `$_` then misses: `my %h = :a(:b(1)); my $x := %h<a>;
+    /// %h.deepmap({ .clone })` died with "No such method 'clone' for invocant
+    /// of type 'Pair'". Writing back is unaffected: the caller stores this
+    /// cell's post-call value into the source slot itself.
     fn deepmap_leaf_call(
         &mut self,
         block: &Value,
         leaf: &Value,
     ) -> Result<(Value, Value), RuntimeError> {
-        let cell = crate::gc::Gc::new(crate::value::ContainerCell::new(leaf.clone()));
+        let cell = crate::gc::Gc::new(crate::value::ContainerCell::new(
+            leaf.deref_container().clone(),
+        ));
         let res = self.call_sub_value(
             block.clone(),
             vec![Value::container_ref(cell.clone())],

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -331,12 +331,12 @@ impl Interpreter {
         if let Some(stored) = self.store_into_aggregate_lvalue(&result, value) {
             return Ok(stored);
         }
-        let typename = crate::runtime::utils::value_type_name(&result);
         // Rakudo renders the refused value with `.gist`, so a `Pair` reads
         // `a => hash` rather than its tab-joined string coercion (`a\thash`),
-        // and a `List` reads `(1 2)`.
-        let repr = crate::runtime::utils::gist_value(&result);
-        Err(RuntimeError::assignment_ro_typename(typename, &repr))
+        // and a `List` reads `(1 2)`. `Nil` has its own wording, which
+        // `assignment_ro_value` knows and the typename form does not — an
+        // out-of-range `return-rw` index into an immutable `List` reaches it.
+        Err(RuntimeError::assignment_ro_value(result))
     }
 
     /// A real `Array`/`Hash` IS a container, so `f(@a) = (7, 8)` for

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -102,8 +102,15 @@ impl Interpreter {
         {
             let mut selected = root.clone();
             for step in steps.iter() {
+                // Unwrap the containers a step may be wrapped in FIRST: an
+                // itemized root (`my $root = %h.deepmap(...)`, which is how every
+                // non-in-place Crane operation builds its copy) is a `Scalar`
+                // around the Hash, and an element promoted by an earlier bind is
+                // a `ContainerRef`. Unwrapping inside the step match instead
+                // consumed the step without descending, so the walk came up one
+                // level short and answered `Nil`.
+                selected = Self::deref_lvalue_value(selected);
                 selected = match selected.view() {
-                    ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
                     ValueView::Hash(hash) => hash
                         .get(&step.to_string_value())
                         .cloned()
@@ -114,6 +121,18 @@ impl Interpreter {
                         .ok()
                         .and_then(|index| array.get(index).cloned())
                         .unwrap_or(Value::NIL),
+                    // A `Pair` DOES `Associative`, so the accessor's own descent
+                    // steps through it by key — a colonpair chain
+                    // (`:a(:b(:c(True)))`, Crane's own fixture shape) is a
+                    // nested `Pair`, not a nested `Hash`. Without this the walk
+                    // answered `Nil` at the first Pair and the store below
+                    // silently invented a container.
+                    ValueView::Pair(key, val) if *key == step.to_string_value() => val.clone(),
+                    ValueView::ValuePair(key, val)
+                        if key.to_string_value() == step.to_string_value() =>
+                    {
+                        val.clone()
+                    }
                     _ => Value::NIL,
                 };
             }
@@ -145,6 +164,31 @@ impl Interpreter {
                 &current,
             )
         });
+
+        // The accessor landed on a `Pair`. A `Pair` DOES `Associative`, so an
+        // associative subscript descends into it and rakudo refuses at the value
+        // it reaches — the same rule the chained-store walk and the
+        // computed-target store follow, and the one Crane's
+        // `CATCH { when X::Assignment::RO }` maps to `X::Crane::Replace::RO` /
+        // `X::Crane::Remove::RO` (`Crane::At.at($root, @path){$step} = $value`,
+        // the shape every non-in-place `Crane.replace`/`Crane.remove` is built
+        // on). Falling through instead found neither a Hash nor an Array to
+        // store into, reported success, and wrote a detached `Any` back over the
+        // caller's variable.
+        let index_is_positional = matches!(index.view(), ValueView::Int(_));
+        let index_key = match index.view() {
+            ValueView::Array(items, _) if items.len() == 1 => items[0].to_string_value(),
+            ValueView::Seq(items) if items.len() == 1 => items[0].to_string_value(),
+            ValueView::Slip(items) if items.len() == 1 => items[0].to_string_value(),
+            _ => index.to_string_value(),
+        };
+        if let Some(err) = Self::pair_subscript_store_refusal(
+            &current,
+            index_is_positional,
+            Some(index_key.as_str()),
+        ) {
+            return Err(err);
+        }
 
         // Package-level `is rw` accessors with arguments (for example
         // `Crane::At.at($root, @path)`) return the selected container itself.

--- a/src/runtime/lvalue_container_return.rs
+++ b/src/runtime/lvalue_container_return.rs
@@ -157,20 +157,23 @@ impl Interpreter {
         let Ok(result) = result else {
             return Ok(None);
         };
-        if let Some(assigned) = self.assign_lvalue_container(&result, value.clone()) {
-            return assigned.map(Some);
-        }
-        // An rw method whose tail names an `@`/`%` container hands back the
-        // aggregate itself, not a cell — there is no Scalar around an `@`/`%`
-        // variable to hand back. That is still an lvalue: the assignment stores
-        // into it, exactly as the sub form does. Without this the legacy
-        // setter/attribute chain below took over and quietly dropped the write
-        // (`Crane::In.in(%h, ()) = $value`, the root-path case of every
-        // `Crane.set`/`add`/`replace`).
-        if let Some(stored) = self.store_into_aggregate_lvalue(&result, value.clone()) {
-            return Ok(Some(stored));
-        }
-        Ok(None)
+        // The write half, shared with the sub form: store through a container or
+        // into an `@`/`%` aggregate the tail named (there is no Scalar around an
+        // `@`/`%` variable to hand back), and otherwise refuse with rakudo's
+        // `Cannot modify an immutable <Type> (<value>)`.
+        //
+        // The refusal is not a fallback to the legacy setter/attribute chain.
+        // That chain re-calls the method with the ASSIGNED VALUE as its only
+        // argument — `Crane::In.in(%h, @path) = 9` called `in(9)`, whose `\c`
+        // received `9` and whose `*@steps` was empty, so the `.elems == 0`
+        // candidate handed `9` straight back and the assignment reported success
+        // while writing nowhere. A method this far in is rw-capable and computes
+        // its location (`method_lvalue_returns_container`), so a plain value
+        // coming back IS raku's refusal, which is what
+        // `Crane::Set`'s `CATCH { when X::Assignment::RO }` maps to
+        // `X::Crane::OpSet::RO`.
+        self.assign_through_rw_result(result, value.clone())
+            .map(Some)
     }
 
     /// `Class.m($arg) = $v` where `m` is a declared method that is **not**

--- a/src/runtime/methods_subscript_protocol.rs
+++ b/src/runtime/methods_subscript_protocol.rs
@@ -32,6 +32,18 @@ pub(crate) fn refuse_map_removal(target: &Value) -> Result<(), RuntimeError> {
     if target.is_immutable_map() {
         return Err(RuntimeError::new(MAP_REMOVAL_REFUSED));
     }
+    // A `Pair` DOES `Associative` — so a `<k>:delete` reaches it rather than
+    // erroring as a non-container — but it is just as immutable as a `Map`, and
+    // rakudo refuses with the same wording naming `Pair`
+    // (`(c => True)<c>:delete`). Crane's `Crane.remove` reads exactly that
+    // payload back out (`Can not remove values from a (\w+)`) to raise
+    // `X::Crane::Remove::RO`; mutsu answered `Any` and removed nothing.
+    if matches!(
+        target.descalarize().view(),
+        ValueView::Pair(..) | ValueView::ValuePair(..)
+    ) {
+        return Err(RuntimeError::new("Can not remove values from a Pair"));
+    }
     Ok(())
 }
 

--- a/src/value/error_construct.rs
+++ b/src/value/error_construct.rs
@@ -390,19 +390,24 @@ impl RuntimeError {
     /// dedicated wording, which names no value.
     ///
     /// The value itself is retained in the `value` attribute for exception
-    /// matching (`X::Assignment::RO.value`).
+    /// matching (`X::Assignment::RO.value`), and its type name in `typename` —
+    /// rakudo derives that attribute from the value, and a consumer that reads
+    /// it (`Crane::Set`'s `X::Crane::OpSet::RO.new(:typename(.typename))`) must
+    /// see the same thing whichever constructor raised the refusal.
     pub(crate) fn assignment_ro_value(value: Value) -> Self {
+        let typename = crate::runtime::utils::value_type_name(&value);
         let message = if matches!(value.view(), super::ValueView::Nil) {
             "Cannot modify an immutable Nil value".to_string()
         } else {
             format!(
                 "Cannot modify an immutable {} ({})",
-                crate::runtime::utils::value_type_name(&value),
+                typename,
                 crate::runtime::utils::gist_value(&value)
             )
         };
         let mut attrs = HashMap::new();
         attrs.insert("message".to_string(), Value::str(message));
+        attrs.insert("typename".to_string(), Value::str(typename.to_string()));
         attrs.insert("value".to_string(), value);
         Self::typed("X::Assignment::RO", attrs)
     }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4098,9 +4098,13 @@ impl Interpreter {
             }
             OpCode::IndexAutovivifyLazyTerminal {
                 is_positional,
-                decl_bind,
+                raw_list_elem,
             } => {
-                self.exec_index_autovivify_lazy_op_decl_bind(true, *is_positional, *decl_bind)?;
+                self.exec_index_autovivify_lazy_op_raw_list_elem(
+                    true,
+                    *is_positional,
+                    *raw_list_elem,
+                )?;
                 *ip += 1;
             }
             OpCode::DeleteIndexNamed(name_idx, slot) => {

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3885,6 +3885,53 @@ impl Interpreter {
         Self::subscript_descent_refusal_at(slot, outer_positional, None)
     }
 
+    /// The `Pair` rule, shared by the chained-store walk above and by the
+    /// COMPUTED-target store (`f(){key} = v`, `OpCode::IndexAssignGeneric`).
+    ///
+    /// A `Pair` DOES `Associative`, so an ASSOCIATIVE subscript descends into it
+    /// and rakudo refuses at the VALUE it reaches — `my %h = :x(:y(1));
+    /// %h<x><y> = 2` is "Cannot modify an immutable Int (1)" — while a key the
+    /// one-entry `Pair` does not hold reads back undefined, giving rakudo's
+    /// "Cannot modify an immutable Nil value". Refusing on the Pair's TYPE
+    /// instead produced `X::AdHoc` "Type Pair does not support associative
+    /// indexing", which is what rakudo raises for a genuinely non-Associative
+    /// target (an `Int`, a `Seq`) and which Crane's
+    /// `CATCH { when X::Assignment::RO }` cannot map to `X::Crane::OpSet::RO`.
+    ///
+    /// A POSITIONAL subscript is a different question — a `Pair` is not
+    /// Positional — and rakudo names the Pair itself there
+    /// (`my @a = (a => 1), 3; @a[0][0] = 9` is "Cannot modify an immutable
+    /// Pair (a => 1)"), so this answers `None` and leaves that to the caller.
+    pub(crate) fn pair_subscript_store_refusal(
+        slot: &Value,
+        outer_positional: bool,
+        next_key: Option<&str>,
+    ) -> Option<RuntimeError> {
+        if outer_positional {
+            return None;
+        }
+        let (pair_key, pair_value) = match slot.view() {
+            ValueView::Pair(key, value) => (key.to_string(), value.clone()),
+            ValueView::ValuePair(key, value) => (key.to_string_value(), value.clone()),
+            _ => return None,
+        };
+        let addressed = match next_key {
+            Some(k) if k == pair_key => pair_value,
+            Some(_) => Value::NIL,
+            // No key threaded through: name the Pair, which is at least the
+            // right class and the right ballpark value.
+            None => slot.clone(),
+        };
+        Some(if addressed.is_nil() {
+            RuntimeError::assignment_ro_value(addressed)
+        } else {
+            RuntimeError::assignment_ro_typename(
+                crate::runtime::utils::value_type_name(&addressed),
+                &crate::runtime::utils::gist_value(&addressed),
+            )
+        })
+    }
+
     /// [`Interpreter::subscript_descent_refusal`] told which key the next
     /// subscript addresses, so a `Pair` slot can name the value the store would
     /// have had to modify (see the `Pair` arm below).
@@ -3893,43 +3940,8 @@ impl Interpreter {
         outer_positional: bool,
         next_key: Option<&str>,
     ) -> Option<RuntimeError> {
-        // A `Pair` DOES `Associative`, so an ASSOCIATIVE next subscript descends
-        // into it and refuses at the value it reaches — `my %h = :x(:y(1));
-        // %h<x><y> = 2` is "Cannot modify an immutable Int (1)", and a key the
-        // one-entry Pair does not hold reads back undefined, giving rakudo's
-        // "Cannot modify an immutable Nil value". Refusing on the SLOT's type
-        // instead produced `X::AdHoc` "Type Pair does not support associative
-        // indexing", which is what rakudo raises for a genuinely non-Associative
-        // slot (an `Int`, a `Seq`) and which Crane's
-        // `CATCH { when X::Assignment::RO }` cannot map to `X::Crane::OpSet::RO`.
-        //
-        // A POSITIONAL next subscript is a different question — a Pair is not
-        // Positional — and rakudo names the Pair itself there
-        // (`my @a = (a => 1), 3; @a[0][0] = 9` is "Cannot modify an immutable
-        // Pair (a => 1)"), which the type-based arm below already produces.
-        let pair_parts = (!outer_positional)
-            .then(|| match slot.view() {
-                ValueView::Pair(key, value) => Some((key.to_string(), value.clone())),
-                ValueView::ValuePair(key, value) => Some((key.to_string_value(), value.clone())),
-                _ => None,
-            })
-            .flatten();
-        if let Some((pair_key, pair_value)) = pair_parts {
-            let addressed = match next_key {
-                Some(k) if k == pair_key => pair_value,
-                Some(_) => Value::NIL,
-                // No key threaded through: name the Pair, which is at least the
-                // right class and the right ballpark value.
-                None => slot.clone(),
-            };
-            return Some(if addressed.is_nil() {
-                RuntimeError::assignment_ro_value(addressed)
-            } else {
-                RuntimeError::assignment_ro_typename(
-                    crate::runtime::utils::value_type_name(&addressed),
-                    &crate::runtime::utils::gist_value(&addressed),
-                )
-            });
+        if let Some(err) = Self::pair_subscript_store_refusal(slot, outer_positional, next_key) {
+            return Some(err);
         }
         let view = slot.view();
         let descendable = matches!(
@@ -4805,6 +4817,20 @@ impl Interpreter {
             ));
         }
         let key = idx.to_string_value();
+        // A `Pair` target reached through an EXPRESSION (`Crane::At.at($root,
+        // @path){$step} = $value`, the shape every non-in-place `Crane.replace`
+        // / `Crane.remove` is built on) follows the same rule as one the
+        // chained-store walk steps onto: rakudo refuses at the value the
+        // subscript reaches. The generic path used to treat it as a scalar to
+        // autovivify, so the store silently succeeded and left the caller's
+        // variable reading `Any`.
+        if let Some(err) = Self::pair_subscript_store_refusal(
+            target.deref_container().descalarize(),
+            is_positional,
+            Some(&key),
+        ) {
+            return Err(err);
+        }
         // A single scalar index names one element, so the assignment's rvalue is
         // itemized (like a scalar-variable / named single-index assignment);
         // `@z = (foo()[$b] = l, l)` => `@z.elems == 1`. A multi-element slice

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -755,7 +755,7 @@ impl Interpreter {
         // rule `OpCode::MarkSigillessBindSource` states for the sigilless
         // spelling. Without this, an immutable `List` element
         // (`my $x := (5, 6)[0]`, whose promotion `IndexAutovivifyLazyTerminal
-        // { decl_bind: true }` now declines) would look like a named bind.
+        // { raw_list_elem: true }` now declines) would look like a named bind.
         let synthetic_index_source = bind_source
             .as_deref()
             .is_some_and(|n| n.starts_with("__mutsu_bind_index_ref_"));

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -297,25 +297,28 @@ impl Interpreter {
         terminal: bool,
         is_positional: bool,
     ) -> Result<(), RuntimeError> {
-        self.exec_index_autovivify_lazy_op_decl_bind(terminal, is_positional, false)
+        self.exec_index_autovivify_lazy_op_raw_list_elem(terminal, is_positional, false)
     }
 
-    /// [`Self::exec_index_autovivify_lazy_op`] told whether this subscript is
-    /// the source of a `:=` DECLARATION.
+    /// [`Self::exec_index_autovivify_lazy_op`] told whether this subscript's
+    /// consumer settles its own writability from the element it receives.
     ///
-    /// `decl_bind` is set only by `OpCode::IndexAutovivifyLazyTerminal` for a
-    /// `my \a := ...` / `my $x := ...` bind (see that opcode's docs). It
-    /// suppresses the scalar-leaf promotion when the container is an immutable
-    /// `List`, so `my (\a, \b) := (5, 6); a = 10` and `my $x := (5, 6)[0];
-    /// $x = 10` die the way rakudo does instead of writing into a cell nothing
-    /// else can see. An element that already IS a container is handed back
-    /// untouched and stays writable, which is how `my (\a, \b) := ($x, $y)`
-    /// aliases `$x`/`$y`.
-    pub(super) fn exec_index_autovivify_lazy_op_decl_bind(
+    /// `raw_list_elem` is set only by `OpCode::IndexAutovivifyLazyTerminal`, for
+    /// a `my \a := ...` / `my $x := ...` declaration bind and for a `return-rw`
+    /// operand (see that opcode's docs). It suppresses the scalar-leaf
+    /// promotion when the container is an immutable `List`, so
+    /// `my (\a, \b) := (5, 6); a = 10`, `my $x := (5, 6)[0]; $x = 10` and
+    /// `sub g(\c) is rw { return-rw c[0] }; g((1, 2)) = 9` all die the way
+    /// rakudo does instead of writing into a cell nothing else can see. An
+    /// element that already IS a container is handed back untouched and stays
+    /// writable, which is how `my (\a, \b) := ($x, $y)` aliases `$x`/`$y` and
+    /// how an `is rw` routine still writes through a `List` that holds live
+    /// cells (`take-rw`).
+    pub(super) fn exec_index_autovivify_lazy_op_raw_list_elem(
         &mut self,
         terminal: bool,
         is_positional: bool,
-        decl_bind: bool,
+        raw_list_elem: bool,
     ) -> Result<(), RuntimeError> {
         let index = self.stack.pop().unwrap();
         let target = self.stack.pop().unwrap();
@@ -378,11 +381,12 @@ impl Interpreter {
             }
             // Terminal bind index into an Array leaf: promote the element to a
             // shared `ContainerRef` cell (container-valued leaves included).
-            // A DECLARATION bind of a single `List` element: hand back the raw
-            // element rather than promoting it (see the doc comment above).
+            // A single `List` element whose own writability is what the
+            // consumer sees: hand back the raw element rather than promoting it
+            // (see the doc comment above).
             ValueView::Array(ref items, kind)
                 if terminal
-                    && decl_bind
+                    && raw_list_elem
                     && kind.is_immutable_list()
                     && Self::index_to_usize(&index).is_some() =>
             {

--- a/t/collections/range-pair/pair-reached-through-an-expression-is-immutable.t
+++ b/t/collections/range-pair/pair-reached-through-an-expression-is-immutable.t
@@ -1,0 +1,110 @@
+use Test;
+
+# A `Pair` DOES `Associative`, so `<k>` descends into it -- but it is immutable,
+# and rakudo refuses both a store and a removal. mutsu applied that rule only to
+# a subscript chain written directly on a VARIABLE (`%h<x><y> = 2`); reached
+# through an EXPRESSION it invented a container instead, reported success, and
+# in the accessor case wrote a detached `Any` back over the caller's variable.
+#
+# Both spellings are what Crane's non-in-place operations are built on
+# (`Crane::At.at($root, @path){$step} = $value`, `... {$step}:delete`), and
+# `Crane.replace` / `Crane.remove` map the refusals to `X::Crane::Replace::RO` /
+# `X::Crane::Remove::RO`.
+
+plan 14;
+
+sub id($x) is rw { return-rw $x }
+
+class Walk {
+    method at($root, *@steps) is rw {
+        my $sel := $root;
+        for @steps -> $s { $sel := $sel{$s} }
+        return-rw $sel;
+    }
+}
+
+# --- store through a sub-call result ---------------------------------------
+
+{
+    my $p = (c => True);
+    throws-like { id($p){'c'} = 9 }, X::Assignment::RO,
+        'a store through a call result that is a Pair is refused',
+        message => 'Cannot modify an immutable Bool (True)';
+    is-deeply $p, (c => True), 'and the Pair is unchanged';
+}
+
+{
+    my $p = (c => True);
+    throws-like { id($p){'zz'} = 9 }, X::Assignment::RO,
+        'a key the one-entry Pair does not hold is refused as Nil',
+        message => 'Cannot modify an immutable Nil value';
+}
+
+{
+    # A real Hash behind the same call shape still stores.
+    my $h = {c => True};
+    id($h){'c'} = 9;
+    is-deeply $h, ${:c(9)}, 'a Hash call result still stores';
+}
+
+# --- store through a package-level path accessor ---------------------------
+
+{
+    my %i = :a(:b(:c(True)));
+    my $root = %i.deepmap({ .clone });
+    throws-like { Walk.at($root, 'a', 'b'){'c'} = {:d(True)} }, X::Assignment::RO,
+        'a store through a path accessor landing on a Pair is refused',
+        message => 'Cannot modify an immutable Bool (True)';
+    is-deeply $root, ${:a(:b(:c(True)))}, 'and the refused store left the copy alone';
+}
+
+{
+    my %i = :a({:b({:c(True)})});
+    my $root = %i.deepmap({ .clone });
+    Walk.at($root, 'a', 'b'){'c'} = {:d(True)};
+    is-deeply $root<a><b><c>, {:d(True)}, 'the Hash-leaf spelling still stores';
+}
+
+# --- removal ----------------------------------------------------------------
+
+{
+    my $p = (c => True);
+    throws-like { $p<c>:delete }, X::AdHoc,
+        'a removal from a Pair is refused',
+        message => 'Can not remove values from a Pair';
+    is-deeply $p, (c => True), 'and the Pair is unchanged';
+}
+
+{
+    my @a = (a => 1), 2;
+    throws-like { @a[0]<a>:delete }, X::AdHoc,
+        'a removal from a Pair element is refused too',
+        message => 'Can not remove values from a Pair';
+}
+
+{
+    my %h = :c(True);
+    my $gone = %h<c>:delete;
+    is $gone, True, 'a real Hash still deletes';
+    is-deeply %h, {}, 'and loses the entry';
+}
+
+# --- `deepmap` hands its block a value, not a container of a container ------
+
+{
+    # `my $x := %h<a>` promotes the element to a cell. `deepmap` boxed that cell
+    # a second time, so the block's `$_` was a container around a container and
+    # every method dispatched on it missed: this died with
+    # "No such method 'clone' for invocant of type 'Pair'".
+    my %h = :a(:b(1));
+    my $x := %h<a>;
+    is-deeply %h.deepmap({ .clone }), {:a(:b(1))},
+        'deepmap decontainerizes a promoted leaf before calling the block';
+}
+
+{
+    # A mutating block still writes back into the source structure.
+    my @a = 1, 2, 3;
+    @a.deepmap({ $_++ });
+    is-deeply @a, [2, 3, 4], 'a mutating deepmap block still writes through';
+}

--- a/t/vm/binding/rw-return-of-a-plain-value-is-refused.t
+++ b/t/vm/binding/rw-return-of-a-plain-value-is-refused.t
@@ -1,0 +1,133 @@
+use Test;
+
+# An `is rw` routine hands its caller a LOCATION. When the tail names something
+# that is not one, rakudo refuses the caller's assignment with
+# `Cannot modify an immutable <Type> (<value>)` -- and that refusal is what
+# `Crane::Set`'s `CATCH { when X::Assignment::RO }` maps to `X::Crane::OpSet::RO`.
+#
+# Two shapes were missing it:
+#
+# * a TYPE-OBJECT rw method (`Crane::In.in(%h, @path) = $v`) fell back to the
+#   legacy `$obj.name($value)` setter convention, which re-calls the method with
+#   the ASSIGNED VALUE as its only argument. With a `*@steps` slurpy that is a
+#   perfectly bindable call (`in(9)`), so the zero-step candidate handed `9`
+#   straight back and the assignment reported success while writing nowhere.
+# * `return-rw c[0]` on an immutable `List` promoted the element to a private
+#   cell, so the write landed somewhere nothing else could see.
+
+plan 16;
+
+# --- a type-object rw method whose tail is a plain value -------------------
+
+multi sub step(Associative:D \c, @s where { .elems > 1 }) is rw {
+    return-rw step(c{@s[0]}, @s[1..*]);
+}
+multi sub step(Associative:D \c, @s where { .elems == 1 }) is rw {
+    return-rw c{@s[0]};
+}
+multi sub step(\c, @s where { .elems == 0 }) is rw { return-rw c }
+
+class Walk {
+    method at(\c, *@s) is rw { return-rw step(c, @s) }
+}
+
+{
+    my %h = :a({:b({:c(1)})});
+    Walk.at(%h, <a b c>.Array) = 9;
+    is-deeply %h, {:a({:b({:c(9)})})}, 'a writable path still writes through';
+}
+
+{
+    # A `Pair` DOES `Associative`, so the descent steps into it and stops at a
+    # plain value. The re-called-as-a-setter fallback made this succeed.
+    my %h = :x(:y(1));
+    throws-like { Walk.at(%h, <x y>.Array) = 9 }, X::Assignment::RO,
+        'a rw method landing on a Pair value is refused',
+        message => 'Cannot modify an immutable Int (1)';
+    is-deeply %h, {:x(:y(1))}, 'and the store changed nothing';
+}
+
+{
+    my %i = :a(:pair(:is(:not(:a<hash>))));
+    throws-like { Walk.at(%i, <a pair is not>.Array) = {:a<Hash>} }, X::Assignment::RO,
+        'a four-level colonpair chain reached through a rw method is refused',
+        message => 'Cannot modify an immutable Pair (a => hash)';
+    is-deeply %i, {:a(:pair(:is(:not(:a<hash>))))}, 'and the chain is intact';
+}
+
+{
+    # The plain-sub spelling always refused; the two must agree.
+    my %h = :x(:y(1));
+    throws-like { step(%h, <x y>.Array) = 9 }, X::Assignment::RO,
+        'the sub spelling refuses identically',
+        message => 'Cannot modify an immutable Int (1)';
+}
+
+{
+    # `.typename` is what Crane reads back out of the refusal.
+    my %h = :x(:y(1));
+    my $ex;
+    { Walk.at(%h, <x y>.Array) = 9; CATCH { default { $ex = $_ } } }
+    is $ex.typename, 'Int', 'X::Assignment::RO carries the refused value type';
+}
+
+# --- `return-rw` into an immutable List ------------------------------------
+
+sub elem(\c) is rw { return-rw c[0] }
+sub past-end(\c) is rw { return-rw c[5] }
+
+{
+    my @a = 1, 2, 3;
+    elem(@a) = 9;
+    is-deeply @a, [9, 2, 3], 'an Array element is still written through';
+}
+
+{
+    my $l = (1, 2, 3);
+    throws-like { elem($l) = 9 }, X::Assignment::RO,
+        'a List element is refused',
+        message => 'Cannot modify an immutable Int (1)';
+    is-deeply $l, $(1, 2, 3), 'and the List is unchanged';
+}
+
+{
+    my $l = (1, 2, 3);
+    throws-like { past-end($l) = 9 }, X::Assignment::RO,
+        'an out-of-range List index is refused, not grown',
+        message => 'Cannot modify an immutable Nil value';
+    is $l.elems, 3, 'and the List did not grow';
+}
+
+{
+    # A `List` whose element IS a container stays writable -- that is what
+    # `take-rw` builds, and the refusal must not be keyed on the list kind.
+    my @spot = 10, 20, 30;
+    my $l = eager gather { take-rw @spot[1] };
+    elem($l) = 999;
+    is @spot[1], 999, 'a List holding a live cell is still written through';
+}
+
+# --- the `:=` declaration bind keeps its own (already correct) answer ------
+
+{
+    my $l = (5, 6);
+    my $x := $l[0];
+    throws-like { $x = 10 }, X::AdHoc,
+        'a declaration bind of a List element is still refused at the write',
+        message => 'Cannot assign to an immutable value';
+}
+
+{
+    my @a = 5, 6;
+    my $x := @a[0];
+    $x = 10;
+    is @a[0], 10, 'a declaration bind of an Array element still writes through';
+}
+
+{
+    # A chunked loop binding leans on the element promotion and must keep it.
+    my @flat = 1, 2, 3, 4;
+    my @seen;
+    for @flat -> \a, \b { @seen.push: a ~ '-' ~ b }
+    is-deeply @seen, ["1-2", "3-4"], 'a chunked sigilless loop bind is unaffected';
+}


### PR DESCRIPTION
Five general divergences from rakudo, found re-measuring
[#7539](https://github.com/tokuhirom/mutsu/issues/7539)'s `Config::TOML` + `Crane`
battery pair. They share one theme: mutsu applied the *"this is not a location,
refuse the write"* rule only where the target was spelled as a **variable**, and
invented a container everywhere else. `Crane` is built entirely on the
everywhere-else spellings, so each divergence turned a refusal Crane's `CATCH`
depends on into a silent success.

| Suite | raku | before | after |
| --- | --- | --- | --- |
| `Crane` v0.1.2 | 15/15 files | 4/15 | **7/15** |
| `Config::TOML` v0.1.3 | 19/19 files | 14/19 | 14/19 |

`set.rakutest`, `replace.rakutest` and `remove.rakutest` now pass in full;
`add`/`copy`/`move` each shed a failing subtest and are down to one
(positional-index bounds, a separate root cause). `Config::TOML` is unchanged,
with no regression.

## 1. A type-object `is rw` method that returns a plain value fell back to the setter convention

`Crane::In.in(container, @path) = $value` is a class-method lvalue: mutsu runs the
method, and when it hands back a container writes through it. When it handed back
a *plain value* — exactly what a descent that has landed on an immutable leaf
does — mutsu reported the shape as inapplicable and let the legacy
`$obj.name($value)` setter convention take over. That convention **re-calls the
method with the assigned value as its only argument**, and with a `*@steps`
slurpy `in(9)` is a perfectly bindable call: the zero-step candidate handed `9`
straight back and the assignment reported success while writing nowhere.

The sub spelling of the same descent always refused.
`try_rw_method_container_lvalue` now shares the sub form's write half
(`assign_through_rw_result`), so both answer rakudo's
`Cannot modify an immutable Int (1)`.

## 2. `return-rw <list>[i]` promoted an immutable `List`'s element to a private cell

```raku
sub g(\c) is rw { return-rw c[0] }
g((1, 2)) = 9   # rakudo: Cannot modify an immutable Int (1)   mutsu: wrote nowhere
```

An out-of-range index grew the `List` instead of raising
`Cannot modify an immutable Nil value`. The suppression already existed for a
`:=` *declaration* bind (`my $x := (5, 6)[0]`), gated by
`IndexAutovivifyLazyTerminal`'s `decl_bind` flag. A `return-rw` operand settles
the caller's write from the element in exactly the same way, so the flag now
covers both and is renamed `raw_list_elem` to say what it decides. A
loop-parameter bind still keeps the promotion, which is what a chunked
`for @flat -> \a, \b` and `.kv` on a mutable QuantHash depend on, and an element
that already IS a container is handed back untouched either way (so a `List`
built by `take-rw` is still written through).

## 3. A store into a `Pair` reached through an expression invented a container

`my $p = (c => True); id($p){'c'} = 9` — and the accessor spelling,
`Crane::At.at($root, @path){$step} = $value`, the shape every non-in-place
`Crane.replace` / `Crane.remove` is built on — silently succeeded, and the
accessor case wrote a detached `Any` back over the caller's variable. A `Pair`
DOES `Associative`, so an associative subscript descends into it and rakudo
refuses at the value it reaches. That arm is now a shared helper
(`pair_subscript_store_refusal`) wired into the computed-target store and the
method-lvalue store as well.

Two supporting bugs in the accessor path came out with it: its `(root, @steps)`
walk stepped through `Hash` and `Array` but answered `Nil` at a `Pair`, so a
colonpair chain — Crane's own fixture shape — was never reached; and it unwrapped
a `Scalar`/`ContainerRef` *inside* the per-step match, consuming a step without
descending, so an itemized root (`my $root = %h.deepmap(...)`) came up one level
short.

## 4. `<k>:delete` on a `Pair` removed nothing and reported success

Rakudo refuses every removal from a `Pair` with `X::AdHoc`
"Can not remove values from a Pair", the same shape it uses for a `Map`;
`Crane.remove` parses that payload back out to raise `X::Crane::Remove::RO`. The
existing `refuse_map_removal` chokepoint — which every delete path already calls
— now covers `Pair` too.

## 5. `deepmap` boxed an already-promoted leaf a second time

```raku
my %h = :a(:b(1)); my $x := %h<a>; %h.deepmap({ .clone })
# rakudo: {:a(:b(1))}
# mutsu:  No such method 'clone' for invocant of type 'Pair'
```

`deepmap` passes each leaf through a transient `ContainerRef` cell so a mutating
callable writes through. When the source element was *already* a cell (promoted by
an earlier `:=` bind or `is rw` descent), the block's `$_` became a container
around a container and every method dispatched on the raw `$_` missed it. The leaf
now goes into the transient cell decontainerized; write-back is unaffected,
since the caller stores that cell's post-call value into the source slot itself.

## Tests

- `t/vm/binding/rw-return-of-a-plain-value-is-refused.t` — 16 assertions
- `t/collections/range-pair/pair-reached-through-an-expression-is-immutable.t` — 14 assertions

Each was verified to fail without its fix and to pass under rakudo v2026.07.

## Validation

`cargo fmt --all`, `make lint`, `make test` (4,199 files / 44,745 assertions) and
`make roast` (1,437 files / 219,635 assertions) all green, bar the three failures
`docs/agent-environments.md` documents for this container (`uid 0`
file-permission tests ×2, sandboxed network ×1) — matched by name and by subtest
range.

Refs [#7539](https://github.com/tokuhirom/mutsu/issues/7539); the ticket stays
open (`Crane` at 7/15, so the vendoring steps remain parked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_