### PR TITLE
fix(rakuast): preserve subrule aliases

### DIFF
--- a/docs/adr/0088-rakuast-regex-boundary-tree.md
+++ b/docs/adr/0088-rakuast-regex-boundary-tree.md
@@ -514,5 +514,37 @@ path or evaluate any dynamic regex content.
 The focused regression is
 `t/regex/match/regex-tree-array-captures.t`. It covers source accessors and
 gist parity, single and quantified parser-created aliases, and constructed
-`RakuAST::Regex::NamedCapture` EVAL. Hash aliases, subrules, and code-bearing
-regex nodes remain explicit follow-up boundaries.
+`RakuAST::Regex::NamedCapture` EVAL. Hash aliases, remaining subrule forms,
+and code-bearing regex nodes remain explicit follow-up boundaries.
+
+## 15. Ordinary subrule alias slice (2026-09-13)
+
+Ordinary subrule aliases (`<alias=name>`) now retain their source shape in the
+shared tree as `RegexNode::SubruleAlias`. The read direction emits
+`RakuAST::Regex::Assertion::Alias` with an ordinary capturing
+`RakuAST::Regex::Assertion::Named` child; the child `capturing` field is
+present, matching Rakudo's constructor-form gist. The alias child is an
+ordinary capturing named assertion, so its two capture names remain observable
+through the existing model and matcher behavior.
+
+The model and write direction also support the standalone Named assertion node
+needed by the alias child and by constructed RakuAST trees. Bare and
+dot-suppressed source assertions (`<name>` and `<.name>`) remain on the
+existing parser path for now. This is deliberate: that path owns special
+subrules such as `<same>` and grammar-local shadowing, which must not be
+reduced to a generic static name lookup before those dispatch semantics have a
+dedicated tree representation.
+
+The execution lowerer maps these nodes directly to the existing
+`RegexAtom::Named` path. Runtime subrule resolution, alias/original capture
+sharing, dot-suppressed captures, and the Parser -> Compiler -> VM execution
+pipeline therefore remain unchanged. Conversion and RakuAST construction do
+not look up or execute a subrule.
+
+This bounded slice accepts only simple, unqualified names without arguments in
+the alias form. Qualified names, argumented subrules, code assertions, and
+alias forms with explicit capture suppression remain fallback boundaries until
+the model can retain their name-part and argument semantics. The focused
+regression is `t/rakuast/rakuast-regex.t`, which pins the alias source shape,
+assertion hierarchy and accessors, model construction, alias/original captures,
+and end-to-end grammar EVAL execution.

--- a/news/2026-09/rakuast-regex-subrule-aliases.md
+++ b/news/2026-09/rakuast-regex-subrule-aliases.md
@@ -1,0 +1,4 @@
+The RakuAST regex boundary now preserves ordinary subrule aliases
+(`<alias=name>`) as structured assertions with named target children. They
+lower through the existing regex matcher, including alias and original capture
+names. Bare and dot-suppressed subrules remain on their existing legacy path.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -2321,6 +2321,26 @@ fn regex_node(node: &RegexNode) -> Result<RakuAstNode, RuntimeError> {
             fields.push(node_field(Some("regex"), regex_node(regex)?));
             (RakuAstClass::RegexNamedCapture, fields)
         }
+        RegexNode::Subrule { name, capturing } => {
+            let mut fields = vec![node_field(Some("name"), name_from_identifier(name))];
+            if *capturing {
+                fields.push(leaf_field(Some("capturing"), Value::truth(true)));
+            }
+            (RakuAstClass::RegexAssertionNamed, fields)
+        }
+        RegexNode::SubruleAlias { alias, name } => (
+            RakuAstClass::RegexAssertionAlias,
+            vec![
+                leaf_field(Some("name"), Value::str(alias.clone())),
+                node_field(
+                    Some("assertion"),
+                    regex_node(&RegexNode::Subrule {
+                        name: name.clone(),
+                        capturing: true,
+                    })?,
+                ),
+            ],
+        ),
         RegexNode::Interpolation { name, sequential } => (
             RakuAstClass::RegexInterpolation,
             vec![

--- a/src/rakuast/fields.rs
+++ b/src/rakuast/fields.rs
@@ -157,6 +157,8 @@ pub(super) fn model_fields(class: RakuAstClass) -> &'static [(&'static str, Abse
             ("array", Absent::False),
             ("regex", Absent::Required),
         ],
+        RegexAssertionNamed => &[("name", Absent::Required), ("capturing", Absent::False)],
+        RegexAssertionAlias => &[("name", Absent::Required), ("assertion", Absent::Required)],
         RegexInterpolation => &[("sequential", Absent::False), ("var", Absent::Required)],
         RegexQuantifiedAtom => &[
             ("atom", Absent::Required),

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1600,6 +1600,40 @@ fn lower_regex_node(node: &RakuAstNode) -> Result<RegexNode, RuntimeError> {
             array: bool_field(node, "array")?,
             regex: Box::new(lower_regex_node(named_child(node, "regex")?)?),
         }),
+        RakuAstClass::RegexAssertionNamed => {
+            let name = named_child(node, "name")?;
+            if name.class != RakuAstClass::Name {
+                return Err(unsupported(node));
+            }
+            let name_value = positional_leaf(name)?;
+            let ValueView::Str(name) = name_value.view() else {
+                return Err(unsupported(node));
+            };
+            Ok(RegexNode::Subrule {
+                name: name.to_string(),
+                capturing: bool_field(node, "capturing")?,
+            })
+        }
+        RakuAstClass::RegexAssertionAlias => {
+            let assertion = named_child(node, "assertion")?;
+            if assertion.class != RakuAstClass::RegexAssertionNamed
+                || !bool_field(assertion, "capturing")?
+            {
+                return Err(unsupported(node));
+            }
+            let name = named_child(assertion, "name")?;
+            if name.class != RakuAstClass::Name {
+                return Err(unsupported(node));
+            }
+            let name_value = positional_leaf(name)?;
+            let ValueView::Str(name) = name_value.view() else {
+                return Err(unsupported(node));
+            };
+            Ok(RegexNode::SubruleAlias {
+                alias: leaf_str(node, "name")?,
+                name: name.to_string(),
+            })
+        }
         RakuAstClass::RegexInterpolation => {
             let sequential = bool_field(node, "sequential")?;
             if sequential {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -65,6 +65,8 @@ pub enum RakuAstClass {
     RegexGroup,
     RegexCapturingGroup,
     RegexNamedCapture,
+    RegexAssertionNamed,
+    RegexAssertionAlias,
     RegexInterpolation,
     RegexAlternation,
     RegexQuantifiedAtom,
@@ -270,6 +272,8 @@ impl RakuAstClass {
             RegexGroup => "RakuAST::Regex::Group",
             RegexCapturingGroup => "RakuAST::Regex::CapturingGroup",
             RegexNamedCapture => "RakuAST::Regex::NamedCapture",
+            RegexAssertionNamed => "RakuAST::Regex::Assertion::Named",
+            RegexAssertionAlias => "RakuAST::Regex::Assertion::Alias",
             RegexInterpolation => "RakuAST::Regex::Interpolation",
             RegexAlternation => "RakuAST::Regex::Alternation",
             RegexQuantifiedAtom => "RakuAST::Regex::QuantifiedAtom",
@@ -485,6 +489,8 @@ impl RakuAstClass {
             | RegexGroup
             | RegexCapturingGroup
             | RegexNamedCapture
+            | RegexAssertionNamed
+            | RegexAssertionAlias
             | RegexInterpolation
             | RegexWithWhitespace => &[
                 "RakuAST::Regex::Atom",
@@ -618,6 +624,8 @@ fn semantic_type_object_ancestors(class_name: &str) -> &'static [&'static str] {
         | "RakuAST::Regex::Group"
         | "RakuAST::Regex::CapturingGroup"
         | "RakuAST::Regex::NamedCapture"
+        | "RakuAST::Regex::Assertion::Named"
+        | "RakuAST::Regex::Assertion::Alias"
         | "RakuAST::Regex::Interpolation"
         | "RakuAST::Regex::WithWhitespace" => &[
             "RakuAST::Regex::Atom",
@@ -676,6 +684,7 @@ fn is_registered_type_object(class_name: &str) -> bool {
             | "RakuAST::Regex"
             | "RakuAST::Regex::Atom"
             | "RakuAST::Regex::Term"
+            | "RakuAST::Regex::Assertion"
             | "RakuAST::Regex::Quantifier"
             | "RakuAST::Regex::CharClass"
             | "RakuAST::ColonPair"
@@ -704,6 +713,8 @@ const RAKUAST_CLASSES: &[RakuAstClass] = &[
     RakuAstClass::RegexGroup,
     RakuAstClass::RegexCapturingGroup,
     RakuAstClass::RegexNamedCapture,
+    RakuAstClass::RegexAssertionNamed,
+    RakuAstClass::RegexAssertionAlias,
     RakuAstClass::RegexInterpolation,
     RakuAstClass::RegexAlternation,
     RakuAstClass::RegexQuantifiedAtom,
@@ -1393,6 +1404,67 @@ pub fn construct(
             fields,
         }))));
     }
+    if class_name == "RakuAST::Regex::Assertion::Named" && method == "new" {
+        let name = named_arg(args, "name").ok_or_else(|| {
+            RuntimeError::new("RakuAST::Regex::Assertion::Named.new requires `name`")
+        })?;
+        require_rakuast_class(
+            &name,
+            RakuAstClass::Name,
+            "RakuAST::Regex::Assertion::Named.new",
+        )?;
+        let capturing = named_arg(args, "capturing").unwrap_or_else(|| Value::truth(false));
+        if !matches!(capturing.view(), ValueView::Bool(_)) {
+            return Err(RuntimeError::new(
+                "RakuAST::Regex::Assertion::Named.new expects `capturing` to be Bool",
+            ));
+        }
+        let mut fields = vec![RakuAstField {
+            name: Some("name"),
+            value: RakuAstFieldValue::Node(name),
+        }];
+        if matches!(capturing.view(), ValueView::Bool(true)) {
+            fields.push(RakuAstField {
+                name: Some("capturing"),
+                value: RakuAstFieldValue::Node(capturing),
+            });
+        }
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::RegexAssertionNamed,
+            fields,
+        }))));
+    }
+    if class_name == "RakuAST::Regex::Assertion::Alias" && method == "new" {
+        let name = named_arg(args, "name").ok_or_else(|| {
+            RuntimeError::new("RakuAST::Regex::Assertion::Alias.new requires `name`")
+        })?;
+        if !matches!(name.view(), ValueView::Str(_)) {
+            return Err(RuntimeError::new(
+                "RakuAST::Regex::Assertion::Alias.new expects `name` to be Str",
+            ));
+        }
+        let assertion = named_arg(args, "assertion").ok_or_else(|| {
+            RuntimeError::new("RakuAST::Regex::Assertion::Alias.new requires `assertion`")
+        })?;
+        require_rakuast_class(
+            &assertion,
+            RakuAstClass::RegexAssertionNamed,
+            "RakuAST::Regex::Assertion::Alias.new",
+        )?;
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::RegexAssertionAlias,
+            fields: vec![
+                RakuAstField {
+                    name: Some("name"),
+                    value: RakuAstFieldValue::Node(name),
+                },
+                RakuAstField {
+                    name: Some("assertion"),
+                    value: RakuAstFieldValue::Node(assertion),
+                },
+            ],
+        }))));
+    }
     if class_name == "RakuAST::QuotedRegex" && method == "new" {
         let body = named_arg(args, "body")
             .ok_or_else(|| RuntimeError::new("RakuAST::QuotedRegex.new requires `body`"))?;
@@ -1609,6 +1681,8 @@ fn require_regex_node(value: &Value, constructor: &str) -> Result<(), RuntimeErr
                     | RakuAstClass::RegexGroup
                     | RakuAstClass::RegexCapturingGroup
                     | RakuAstClass::RegexNamedCapture
+                    | RakuAstClass::RegexAssertionNamed
+                    | RakuAstClass::RegexAssertionAlias
                     | RakuAstClass::RegexInterpolation
                     | RakuAstClass::RegexAlternation
                     | RakuAstClass::RegexQuantifiedAtom
@@ -1917,6 +1991,8 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::RegexGroup
             | RakuAstClass::RegexCapturingGroup
             | RakuAstClass::RegexNamedCapture
+            | RakuAstClass::RegexAssertionNamed
+            | RakuAstClass::RegexAssertionAlias
             | RakuAstClass::RegexInterpolation
             | RakuAstClass::RegexQuantifiedAtom
             | RakuAstClass::RegexQuantifierZeroOrMore

--- a/src/regex_tree.rs
+++ b/src/regex_tree.rs
@@ -51,6 +51,14 @@ pub(crate) enum RegexNode {
         array: bool,
         regex: Box<RegexNode>,
     },
+    Subrule {
+        name: String,
+        capturing: bool,
+    },
+    SubruleAlias {
+        alias: String,
+        name: String,
+    },
     Interpolation {
         name: String,
         sequential: bool,
@@ -330,6 +338,23 @@ impl RegexTree {
                         };
                     Some(tokens)
                 }
+                RegexNode::Subrule { name, capturing } => {
+                    let name = if *capturing {
+                        name.clone()
+                    } else {
+                        format!(".{name}")
+                    };
+                    Some(vec![token(
+                        crate::runtime::RegexAtom::Named(name.into()),
+                        crate::runtime::RegexQuant::One,
+                        ratchet,
+                    )])
+                }
+                RegexNode::SubruleAlias { alias, name } => Some(vec![token(
+                    crate::runtime::RegexAtom::Named(format!("{alias}={name}").into()),
+                    crate::runtime::RegexQuant::One,
+                    ratchet,
+                )]),
                 RegexNode::Interpolation { name, sequential } => {
                     if *sequential {
                         return None;
@@ -395,7 +420,11 @@ impl RegexNode {
             | Self::Quantified { atom: child, .. }
             | Self::WithWhitespace(child) => child.collect_interpolation_names(names),
             Self::NamedCapture { regex, .. } => regex.collect_interpolation_names(names),
-            Self::Literal(_) | Self::Quote(_) | Self::CharClassDigit => {}
+            Self::Literal(_)
+            | Self::Quote(_)
+            | Self::Subrule { .. }
+            | Self::SubruleAlias { .. }
+            | Self::CharClassDigit => {}
         }
     }
 
@@ -448,6 +477,11 @@ impl RegexNode {
                 let sigil = if *array { '@' } else { '$' };
                 format!("{sigil}<{name}> = {}", regex.to_source())
             }
+            Self::Subrule { name, capturing } => {
+                let prefix = if *capturing { "" } else { "." };
+                format!("<{prefix}{name}>")
+            }
+            Self::SubruleAlias { alias, name } => format!("<{alias}={name}>"),
             Self::Interpolation { name, .. } => format!("${name}"),
             Self::Quantified { atom, quantifier } => {
                 let suffix = match quantifier {
@@ -605,7 +639,8 @@ impl Parser {
             '$' => self.parse_interpolation(),
             '@' | '%' => None,
             ')' | ']' if stops.contains(&ch) => None,
-            '|' | '+' | '*' | '?' | '.' | '^' | '<' | '>' => None,
+            '|' | '+' | '*' | '?' | '.' | '^' | '>' => None,
+            '<' => self.parse_subrule(),
             _ => self.parse_literal(),
         }
     }
@@ -714,6 +749,12 @@ impl Parser {
         self.skip_whitespace();
         let mut regex = self.parse_atom(&[])?;
         let quantifier = self.parse_quantifier();
+        // Aggregate aliases have their own list-context semantics in the
+        // legacy matcher. Keep subrule-containing forms there until the
+        // shared tree has a representation for that combination.
+        if array && contains_subrule(&regex) {
+            return None;
+        }
         if let RegexNode::Literal(text) = &mut regex
             && text.chars().count() > 1
         {
@@ -755,6 +796,28 @@ impl Parser {
             array,
             regex: Box::new(regex),
         })
+    }
+
+    fn parse_subrule(&mut self) -> Option<RegexNode> {
+        self.pos += 1; // '<'
+        let start = self.pos;
+        while self.chars.get(self.pos).is_some_and(|ch| *ch != '>') {
+            self.pos += 1;
+        }
+        if self.pos == start || !self.consume_if('>') {
+            return None;
+        }
+        let contents: String = self.chars[start..self.pos - 1].iter().collect();
+        if let Some((alias, name)) = contents.split_once('=') {
+            if is_simple_subrule_name(alias) && is_simple_subrule_name(name) {
+                return Some(RegexNode::SubruleAlias {
+                    alias: alias.to_string(),
+                    name: name.to_string(),
+                });
+            }
+            return None;
+        }
+        None
     }
 
     fn parse_variable_name(&mut self) -> Option<String> {
@@ -807,6 +870,33 @@ impl Parser {
         } else {
             false
         }
+    }
+}
+
+fn is_simple_subrule_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_alphanumeric() || ch == '_' || ch == '-')
+}
+
+fn contains_subrule(node: &RegexNode) -> bool {
+    match node {
+        RegexNode::Subrule { .. } | RegexNode::SubruleAlias { .. } => true,
+        RegexNode::Sequence(nodes) | RegexNode::Alternation(nodes) => {
+            nodes.iter().any(contains_subrule)
+        }
+        RegexNode::Group(child)
+        | RegexNode::CapturingGroup(child)
+        | RegexNode::Quantified { atom: child, .. }
+        | RegexNode::WithWhitespace(child) => contains_subrule(child),
+        RegexNode::NamedCapture { regex, .. } => contains_subrule(regex),
+        RegexNode::Literal(_)
+        | RegexNode::Quote(_)
+        | RegexNode::Interpolation { .. }
+        | RegexNode::CharClassDigit => false,
     }
 }
 

--- a/t/rakuast/rakuast-regex.t
+++ b/t/rakuast/rakuast-regex.t
@@ -8,7 +8,7 @@ use Test;
 # shapes Rakudo exposes. Dynamic assertions and non-scalar interpolations
 # remain explicit follow-up boundaries.
 
-plan 21;
+plan 33;
 
 is Q[/a/].AST.gist, q:to/END/.chomp, 'a regex literal has a Literal body';
     RakuAST::StatementList.new(
@@ -236,3 +236,53 @@ my $constructed = RakuAST::QuotedRegex.new(
 $_ = 'TEST';
 is EVAL($constructed).raku, 'Match.new(:orig("TEST"), :from(0), :pos(4))',
     'a constructed match-immediate regex uses the existing matcher';
+
+is Q[/<alias=foo>/].AST.gist, q:to/END/.chomp, 'a subrule alias retains its assertion child';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedRegex.new(
+          body => RakuAST::Regex::Assertion::Alias.new(
+            name      => "alias",
+            assertion => RakuAST::Regex::Assertion::Named.new(
+              name      => RakuAST::Name.from-identifier("foo"),
+              capturing => True
+            )
+          )
+        )
+      )
+    )
+    END
+
+my $named-subrule = RakuAST::Regex::Assertion::Named.new(
+    name => RakuAST::Name.from-identifier('part'),
+    capturing => True,
+);
+ok $named-subrule ~~ RakuAST::Regex::Assertion,
+    'named subrule assertions retain their abstract assertion type';
+is $named-subrule.name.raku, 'RakuAST::Name.from-identifier("part")',
+    'named subrule assertions expose their Name child';
+is $named-subrule.capturing, True,
+    'named subrule assertions expose their capturing flag';
+
+my $alias-subrule = RakuAST::Regex::Assertion::Alias.new(
+    name => 'word',
+    assertion => $named-subrule,
+);
+ok $alias-subrule ~~ RakuAST::Regex::Assertion,
+    'subrule aliases retain their abstract assertion type';
+is $alias-subrule.name, 'word', 'subrule aliases expose their alias name';
+is $alias-subrule.assertion.name.raku, 'RakuAST::Name.from-identifier("part")',
+    'subrule aliases expose the named assertion child';
+
+my $subrule-grammar = EVAL(Q[grammar GRegexSubruleAlias {
+    token TOP { <word=part> };
+    token part { "a" };
+}].AST);
+is $subrule-grammar.^name, 'GRegexSubruleAlias',
+    'a grammar with a subrule alias lowers through the existing pipeline';
+my $subrule-match = $subrule-grammar.parse('a');
+ok $subrule-match, 'a lowered subrule alias matches its target token';
+is ~$subrule-match<word>, 'a', 'a subrule alias captures under its alias name';
+is ~$subrule-match<part>, 'a', 'a subrule alias retains the original capture name';
+is $subrule-match.hash.keys.sort.join(','), 'part,word',
+    'a subrule alias retains both alias and original captures';


### PR DESCRIPTION
## Summary

- Preserve ordinary `<alias=name>` subrule aliases in the shared RegexTree.
- Expose RakuAST::Regex::Assertion::Named and ::Alias with Rakudo-compatible structure.
- Lower alias and original captures through the existing Parser -> Compiler -> VM matcher path.
- Keep bare, dot-suppressed, qualified, argumented, aggregate, and code-bearing forms on their existing boundaries.

Part of #8033.

## Validation

- cargo fmt --all
- make lint
- make test (4197 files / 44728 tests, PASS)
- make roast (1437 files / 219658 tests, PASS)
- focused t/rakuast/rakuast-regex.t (33 tests, PASS)