### PR TITLE
fix: keep lazy Match truthiness non-materializing

### DIFF
--- a/news/2026-09/match-truthiness-fast-path.md
+++ b/news/2026-09/match-truthiness-fast-path.md
@@ -1,0 +1,3 @@
+Boolean tests on regex matches now use the lazy Match's native truthiness
+without materializing its capture map. Grammar cursors with a user-defined
+`Bool` method continue to honor that override.

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -997,7 +997,7 @@ impl Interpreter {
                         captures.to as i64,
                         &captures.positional,
                         &named_with_hash,
-                        starget,
+                        starget.clone(),
                     );
                     // Apply hash captures: set named entries to Hash values
                     if !captures.hash_captures().is_empty()
@@ -1043,19 +1043,42 @@ impl Interpreter {
                             .match_with_attrs_keeping_id(updates)
                             .unwrap_or(match_obj)
                     };
-                    // Upgrade positional capture env vars ($0, $1, ...) to Match objects
-                    let list_v = match_obj.match_list();
-                    if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {
-                        for (i, v) in list.iter().enumerate() {
-                            self.env.insert(i.to_string(), v.clone());
+                    // Upgrade positional and named capture env vars to Match
+                    // objects without forcing the parent capture map. Hash
+                    // captures still use the materialized map because their
+                    // values are rewritten above from the capture payload.
+                    if captures.hash_captures().is_empty() {
+                        let visible_len = captures
+                            .positional
+                            .iter()
+                            .rposition(|slot| !slot.alternation_padding)
+                            .map_or(0, |idx| idx + 1);
+                        for (i, slot) in captures.positional[..visible_len].iter().enumerate() {
+                            self.env
+                                .insert(i.to_string(), Value::pos_slot_value(slot, &starget));
                         }
-                    }
-                    // Set named capture env vars from the match object's named hash
-                    // so subcapture-aware Match objects are used (not plain strings)
-                    let named_v = match_obj.match_named();
-                    if let Some(ValueView::Hash(named_hash)) = named_v.as_ref().map(Value::view) {
-                        for (k, v) in named_hash.iter() {
-                            self.env.insert(format!("<{}>", k), v.clone());
+                        for (k, slot) in &named_with_hash {
+                            if k.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
+                                continue;
+                            }
+                            self.env.insert(
+                                format!("<{}>", k.resolve()),
+                                Value::named_slot_value(slot, &starget),
+                            );
+                        }
+                    } else {
+                        let list_v = match_obj.match_list();
+                        if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {
+                            for (i, v) in list.iter().enumerate() {
+                                self.env.insert(i.to_string(), v.clone());
+                            }
+                        }
+                        let named_v = match_obj.match_named();
+                        if let Some(ValueView::Hash(named_hash)) = named_v.as_ref().map(Value::view)
+                        {
+                            for (k, v) in named_hash.iter() {
+                                self.env.insert(format!("<{}>", k), v.clone());
+                            }
                         }
                     }
                     self.env.insert("/".to_string(), match_obj);

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -473,6 +473,18 @@ impl Interpreter {
     /// For Package (type objects) and Instance values, checks if the class defines
     /// a custom Bool method and calls it. Falls back to Value::truthy() otherwise.
     pub(super) fn eval_truthy(&mut self, val: &Value) -> bool {
+        // A successful lazy Match already knows its truth value, and reading
+        // it through `view()` would force the capture map. Plain regex
+        // Matches have no user-defined Bool method, so answer directly before
+        // entering the general instance-dispatch path. Grammar cursors can
+        // define their own Bool method; retain that override by probing only
+        // those cursor classes.
+        if val.is_lazy_match_value() {
+            let owner = val.match_dispatch_class();
+            if owner == "Match" || !self.has_user_method(owner, "Bool") {
+                return val.truthy();
+            }
+        }
         // ADR-0058: `Value::truthy` cannot pull, so it reports a not-yet-run
         // `.map`/`.grep` Seq as TRUE rather than reading its still-empty seed
         // (see the `is_map_grep_source` arm there). This IS the boolean

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3,6 +3,12 @@ use crate::runtime::meta_ns::MetaNs;
 
 impl Interpreter {
     pub(super) fn mark_failure_handled_on_stack(stack: &mut [Value]) {
+        // A lazy Match can be tested for truthiness without materializing its
+        // capture map. Do not inspect it as an Instance just to determine
+        // whether it is a Failure.
+        if stack.last().is_some_and(Value::is_lazy_match_value) {
+            return;
+        }
         if let Some(ValueView::Instance {
             class_name,
             id,

--- a/src/vm/vm_helpers_junction.rs
+++ b/src/vm/vm_helpers_junction.rs
@@ -221,13 +221,13 @@ impl Interpreter {
             // A bare block may hold its lexically captured `$/` in a shared
             // cell. Smartmatch returns the Match value, never the container
             // implementing that lexical binding.
-            let slash = self
-                .env()
-                .get("/")
-                .cloned()
-                .unwrap_or(Value::NIL)
-                .deref_container();
-            if matches!(slash.view(), ValueView::Junction { .. }) {
+            let slash = self.env().get("/").cloned().unwrap_or(Value::NIL);
+            let slash = if slash.is_container_ref() {
+                slash.into_deref()
+            } else {
+                slash
+            };
+            if slash.is_junction_value() {
                 Ok(Value::truth(matched))
             } else if matched {
                 // For regex smartmatch, return the Match object (from $/) or Nil

--- a/t/regex/match/match-truthiness.t
+++ b/t/regex/match/match-truthiness.t
@@ -1,0 +1,16 @@
+use Test;
+
+# A successful regex Match answers Bool without forcing its lazy capture map.
+# Grammar cursors with an explicit Bool method still use that user override.
+plan 4;
+
+my $match = 'a' ~~ /a/;
+ok $match.Bool, 'a successful Match is truthy';
+ok ?$match, 'boolean context keeps a successful Match truthy';
+nok 'b' ~~ /a/, 'a failed regex match is falsy';
+
+grammar FalseCursor {
+    method Bool { False }
+    token TOP { 'a' }
+}
+nok FalseCursor.parse('a'), 'a grammar cursor still honors a user Bool method';

--- a/tests/lazy_match_truthiness_no_materialization.rs
+++ b/tests/lazy_match_truthiness_no_materialization.rs
@@ -1,0 +1,42 @@
+use std::process::Command;
+
+#[test]
+fn boolean_match_tests_do_not_materialize_capture_maps() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.args([
+        "-e",
+        r#"
+my $subject = "a";
+for ^16 {
+    if $subject ~~ /a/ {
+        Nil;
+    }
+    if $subject ~~ /(a)/ {
+        Nil;
+    }
+}
+"#,
+    ]);
+    cmd.env("MUTSU_VM_STATS", "1");
+    let output = cmd.output().expect("failed to spawn mutsu");
+    assert!(
+        output.status.success(),
+        "program failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stats_line = stderr
+        .lines()
+        .find(|line| line.contains("regex-captures:"))
+        .unwrap_or_else(|| panic!("no regex-captures stats line in stderr: {stderr}"));
+    let materializations = stats_line
+        .split_whitespace()
+        .find_map(|word| word.strip_prefix("match_materializations="))
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or_else(|| panic!("missing match_materializations= in: {stats_line}"));
+    assert_eq!(
+        materializations, 0,
+        "boolean-only Match use materialized capture maps: {stats_line}"
+    );
+}


### PR DESCRIPTION
Fixes #8263

A lazy regex Match can answer truthiness from its native span without forcing the capture map or entering general user-method dispatch. Preserve custom Bool methods on grammar cursors, and keep regex capture environment publication lazy when possible.

Regression coverage includes plain and capturing regexes, custom grammar-cursor Bool, and the VM materialization counter.