### PR TITLE
fix: memoize ignoremark match views

### DIFF
--- a/news/2026-09/ignoremark-memoized-view.md
+++ b/news/2026-09/ignoremark-memoized-view.md
@@ -1,0 +1,3 @@
+The regex engine now memoizes the mark-stripped subject view and pattern used
+by scoped `:ignoremark` subpatterns. Repeated matches over one subject no longer
+rebuild the remaining subject for every atom invocation.

--- a/src/regex_tree.rs
+++ b/src/regex_tree.rs
@@ -147,6 +147,7 @@ impl RegexTree {
                 anchor_end: false,
                 ignore_case,
                 ignore_mark,
+                stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
             }
         }
 

--- a/src/runtime/match_target.rs
+++ b/src/runtime/match_target.rs
@@ -11,6 +11,41 @@ use crate::symbol::Symbol;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
+/// A mark-stripped view of one match subject. `stripped_to_original` maps
+/// engine positions back to the original subject, while
+/// `original_to_stripped` maps an original boundary into the derived space so
+/// a scoped `:ignoremark` match can start at the right place without scanning
+/// the map on every atom invocation.
+pub(crate) struct StrippedMatchTarget {
+    chars: Arc<[char]>,
+    stripped_to_original: Arc<[usize]>,
+    original_to_stripped: Arc<[usize]>,
+}
+
+impl StrippedMatchTarget {
+    pub(crate) fn chars(&self) -> &[char] {
+        &self.chars
+    }
+
+    pub(crate) fn stripped_to_original(&self, pos: usize) -> usize {
+        self.stripped_to_original
+            .get(pos)
+            .copied()
+            .unwrap_or_else(|| self.original_to_stripped.len().saturating_sub(1))
+    }
+
+    pub(crate) fn original_to_stripped(&self, pos: usize) -> usize {
+        self.original_to_stripped
+            .get(pos)
+            .copied()
+            .unwrap_or_else(|| self.original_to_stripped.last().copied().unwrap_or(0))
+    }
+
+    pub(crate) fn stripped_map(&self) -> &[usize] {
+        &self.stripped_to_original
+    }
+}
+
 /// The subject of a regex match: the same string in both the forms consumers
 /// need. `text` answers `.orig` with an `Arc` bump; `chars` is the char-index
 /// space every recorded span points into, sliced without re-collecting the
@@ -41,6 +76,9 @@ pub(crate) struct MatchTarget {
     /// value. Threading a class down through the regex engine instead would
     /// touch every matcher entry point for a value the engine never uses.
     cursor_class: Arc<AtomicU32>,
+    /// Lazily materialized once per subject, then shared by all scoped
+    /// `:ignoremark` entries and repeated scans against this target.
+    stripped: Arc<std::sync::OnceLock<StrippedMatchTarget>>,
 }
 
 impl MatchTarget {
@@ -51,6 +89,7 @@ impl MatchTarget {
             chars: text.chars().collect(),
             ascii: text.is_ascii(),
             cursor_class: Arc::new(AtomicU32::new(0)),
+            stripped: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -66,7 +105,33 @@ impl MatchTarget {
             chars: chars.into(),
             ascii,
             cursor_class: Arc::new(AtomicU32::new(0)),
+            stripped: Arc::new(std::sync::OnceLock::new()),
         }
+    }
+
+    /// Return the subject with combining marks removed, building it only on
+    /// the first `:ignoremark` use for this match target.
+    pub(crate) fn stripped(&self) -> &StrippedMatchTarget {
+        self.stripped.get_or_init(|| {
+            let (chars, stripped_to_original) =
+                crate::runtime::regex::regex_helpers::strip_marks_text(&self.chars);
+            let stripped_len = chars.len();
+            let mut original_to_stripped = Vec::with_capacity(self.chars.len() + 1);
+            let mut stripped_pos = 0usize;
+            for original_pos in 0..=self.chars.len() {
+                while stripped_pos < stripped_to_original.len()
+                    && stripped_to_original[stripped_pos] < original_pos
+                {
+                    stripped_pos += 1;
+                }
+                original_to_stripped.push(stripped_pos.min(stripped_len));
+            }
+            StrippedMatchTarget {
+                chars: chars.into(),
+                stripped_to_original: stripped_to_original.into(),
+                original_to_stripped: original_to_stripped.into(),
+            }
+        })
     }
 
     /// The grammar class cursors of this parse report, or `None` for a plain

--- a/src/runtime/regex/regex_casefold.rs
+++ b/src/runtime/regex/regex_casefold.rs
@@ -88,6 +88,7 @@ pub(super) fn casefold_pattern(pattern: &RegexPattern) -> RegexPattern {
         anchor_end: pattern.anchor_end,
         ignore_case: pattern.ignore_case,
         ignore_mark: pattern.ignore_mark,
+        stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
     }
 }
 
@@ -140,6 +141,7 @@ fn casefold_token(token: &RegexToken) -> Vec<RegexToken> {
                 anchor_end: false,
                 ignore_case: false,
                 ignore_mark: false,
+                stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
             };
             vec![RegexToken {
                 atom: RegexAtom::Group(group),
@@ -281,9 +283,9 @@ fn casefold_char_class(class: &CharClass) -> RegexAtom {
             anchor_end: false,
             ignore_case: false,
             ignore_mark: false,
+            stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }));
-
     match branches.len() {
         0 => RegexAtom::CharClass(CharClass {
             negated: false,
@@ -319,5 +321,6 @@ fn one_atom_pattern(atom: RegexAtom) -> RegexPattern {
         anchor_end: false,
         ignore_case: false,
         ignore_mark: false,
+        stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
     }
 }

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -1,6 +1,7 @@
 use super::super::*;
 use rustc_hash::FxHashMap as HashMap;
 use std::cell::{Cell, RefCell};
+use std::sync::Arc;
 use unicode_normalization::UnicodeNormalization;
 use unicode_normalization::char::is_combining_mark;
 use unicode_segmentation::UnicodeSegmentation;
@@ -500,7 +501,7 @@ pub(super) fn strip_marks_char(ch: char) -> Vec<char> {
 /// grapheme cluster.  Returns stripped base chars and a position map from
 /// stripped index to original char index.  The sentinel for one-past-end is
 /// also appended.
-pub(super) fn strip_marks_text(orig_chars: &[char]) -> (Vec<char>, Vec<usize>) {
+pub(crate) fn strip_marks_text(orig_chars: &[char]) -> (Vec<char>, Vec<usize>) {
     let text: String = orig_chars.iter().collect();
     let mut stripped_chars: Vec<char> = Vec::new();
     let mut pos_map: Vec<usize> = Vec::new(); // stripped idx -> original idx
@@ -583,14 +584,26 @@ fn is_format_char(c: char) -> bool {
     )
 }
 
-/// Strip combining marks from all literal atoms in a RegexPattern (recursively).
-pub(super) fn strip_marks_pattern(pattern: &RegexPattern) -> RegexPattern {
+/// Strip combining marks from all literal atoms in a RegexPattern (recursively),
+/// memoized on the parsed pattern. A scoped `:ignoremark` token can be entered
+/// once per candidate while scanning a document; keeping the derived tree on
+/// the cached pattern removes that second per-invocation traversal as well.
+pub(super) fn strip_marks_pattern(pattern: &RegexPattern) -> Arc<RegexPattern> {
+    Arc::clone(
+        pattern
+            .stripped_pattern
+            .get_or_init(|| Arc::new(strip_marks_pattern_uncached(pattern))),
+    )
+}
+
+fn strip_marks_pattern_uncached(pattern: &RegexPattern) -> RegexPattern {
     RegexPattern {
         tokens: pattern.tokens.iter().map(strip_marks_token).collect(),
         anchor_start: pattern.anchor_start,
         anchor_end: pattern.anchor_end,
         ignore_case: pattern.ignore_case,
         ignore_mark: false,
+        stripped_pattern: Arc::new(std::sync::OnceLock::new()),
     }
 }
 
@@ -606,7 +619,7 @@ fn strip_marks_token(token: &RegexToken) -> RegexToken {
         frugal: token.frugal,
         separator: token.separator.as_ref().map(|s| {
             Box::new(RegexSeparatorSpec {
-                pattern: strip_marks_pattern(&s.pattern),
+                pattern: strip_marks_pattern_uncached(&s.pattern),
                 allow_trailing: s.allow_trailing,
             })
         }),
@@ -642,6 +655,7 @@ pub(crate) fn wrap_capture_isolated(pattern: RegexPattern) -> RegexPattern {
         anchor_end: false,
         ignore_case,
         ignore_mark,
+        stripped_pattern: Arc::new(std::sync::OnceLock::new()),
     }
 }
 
@@ -665,27 +679,27 @@ fn strip_marks_atom(atom: &RegexAtom) -> RegexAtom {
             let stripped: String = name.nfd().filter(|c| !is_combining_mark(*c)).collect();
             RegexAtom::Named(stripped.into())
         }
-        RegexAtom::Group(p) => RegexAtom::Group(strip_marks_pattern(p)),
-        RegexAtom::CaptureGroup(p) => RegexAtom::CaptureGroup(strip_marks_pattern(p)),
+        RegexAtom::Group(p) => RegexAtom::Group(strip_marks_pattern_uncached(p)),
+        RegexAtom::CaptureGroup(p) => RegexAtom::CaptureGroup(strip_marks_pattern_uncached(p)),
         RegexAtom::CaptureIsolatedGroup(p) => {
-            RegexAtom::CaptureIsolatedGroup(strip_marks_pattern(p))
+            RegexAtom::CaptureIsolatedGroup(strip_marks_pattern_uncached(p))
         }
         RegexAtom::Alternation(alts) => {
-            RegexAtom::Alternation(alts.iter().map(strip_marks_pattern).collect())
+            RegexAtom::Alternation(alts.iter().map(strip_marks_pattern_uncached).collect())
         }
-        RegexAtom::SequentialAlternation(alts) => {
-            RegexAtom::SequentialAlternation(alts.iter().map(strip_marks_pattern).collect())
-        }
+        RegexAtom::SequentialAlternation(alts) => RegexAtom::SequentialAlternation(
+            alts.iter().map(strip_marks_pattern_uncached).collect(),
+        ),
         RegexAtom::Conjunction(branches) => {
-            RegexAtom::Conjunction(branches.iter().map(strip_marks_pattern).collect())
+            RegexAtom::Conjunction(branches.iter().map(strip_marks_pattern_uncached).collect())
         }
         RegexAtom::GoalMatch {
             goal,
             inner,
             goal_text,
         } => RegexAtom::GoalMatch {
-            goal: strip_marks_pattern(goal),
-            inner: strip_marks_pattern(inner),
+            goal: strip_marks_pattern_uncached(goal),
+            inner: strip_marks_pattern_uncached(inner),
             goal_text: goal_text.clone(),
         },
         RegexAtom::Lookaround {
@@ -693,7 +707,7 @@ fn strip_marks_atom(atom: &RegexAtom) -> RegexAtom {
             negated,
             is_behind,
         } => RegexAtom::Lookaround {
-            pattern: strip_marks_pattern(pattern),
+            pattern: strip_marks_pattern_uncached(pattern),
             negated: *negated,
             is_behind: *is_behind,
         },
@@ -799,7 +813,29 @@ pub(super) fn remap_caps_spans_offset(
     orig_len: usize,
     offset: usize,
 ) {
-    let m = |p: usize| map_pos(p, pos_map, orig_len) + offset;
+    remap_caps_spans_mapped(caps, pos_map, orig_len, offset, 0);
+}
+
+/// Remap spans whose positions are relative to a suffix of a complete
+/// mark-stripped subject. Unlike `offset`, `derived_offset` shifts the lookup
+/// in the derived map; the resulting original positions are already absolute.
+pub(super) fn remap_caps_spans_derived_offset(
+    caps: &mut RegexCaptures,
+    pos_map: &[usize],
+    orig_len: usize,
+    derived_offset: usize,
+) {
+    remap_caps_spans_mapped(caps, pos_map, orig_len, 0, derived_offset);
+}
+
+fn remap_caps_spans_mapped(
+    caps: &mut RegexCaptures,
+    pos_map: &[usize],
+    orig_len: usize,
+    offset: usize,
+    derived_offset: usize,
+) {
+    let m = |p: usize| map_pos(p.saturating_add(derived_offset), pos_map, orig_len) + offset;
     if offset == 0 {
         caps.from = m(caps.from);
         caps.to = m(caps.to);
@@ -815,10 +851,16 @@ pub(super) fn remap_caps_spans_offset(
         .values_mut()
         .flat_map(|slot| slot.nodes.iter_mut())
     {
-        remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
+        remap_cap_node_spans_mapped(
+            std::sync::Arc::make_mut(sc),
+            pos_map,
+            orig_len,
+            offset,
+            derived_offset,
+        );
     }
     for slot in caps.positional.iter_mut() {
-        remap_pos_slot(slot, pos_map, orig_len, offset);
+        remap_pos_slot_mapped(slot, pos_map, orig_len, offset, derived_offset);
     }
 }
 
@@ -830,30 +872,51 @@ pub(super) fn remap_pos_slot(
     orig_len: usize,
     offset: usize,
 ) {
-    let m = |p: usize| map_pos(p, pos_map, orig_len) + offset;
+    remap_pos_slot_mapped(slot, pos_map, orig_len, offset, 0);
+}
+
+fn remap_pos_slot_mapped(
+    slot: &mut PosSlot,
+    pos_map: &[usize],
+    orig_len: usize,
+    offset: usize,
+    derived_offset: usize,
+) {
+    let m = |p: usize| map_pos(p.saturating_add(derived_offset), pos_map, orig_len) + offset;
     slot.from = m(slot.from);
     slot.to = m(slot.to);
     if let Some(sc) = &mut slot.subcap {
-        remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
+        remap_cap_node_spans_mapped(
+            std::sync::Arc::make_mut(sc),
+            pos_map,
+            orig_len,
+            offset,
+            derived_offset,
+        );
     }
     for entry in slot.quantified.iter_mut().flatten() {
         entry.0 = m(entry.0);
         entry.1 = m(entry.1);
         if let Some(sc) = &mut entry.2 {
-            remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
+            remap_cap_node_spans_mapped(
+                std::sync::Arc::make_mut(sc),
+                pos_map,
+                orig_len,
+                offset,
+                derived_offset,
+            );
         }
     }
 }
 
-/// [`remap_caps_spans`] over a stored capture node, recursively (same offset
-/// semantics as [`remap_caps_spans_offset`], applied to every span).
-pub(super) fn remap_cap_node_spans(
+fn remap_cap_node_spans_mapped(
     node: &mut CapNode,
     pos_map: &[usize],
     orig_len: usize,
     offset: usize,
+    derived_offset: usize,
 ) {
-    let m = |p: usize| map_pos(p, pos_map, orig_len) + offset;
+    let m = |p: usize| map_pos(p.saturating_add(derived_offset), pos_map, orig_len) + offset;
     node.from = m(node.from);
     node.to = m(node.to);
     let Some(children) = node.children.as_deref_mut() else {
@@ -864,10 +927,16 @@ pub(super) fn remap_cap_node_spans(
         .values_mut()
         .flat_map(|slot| slot.nodes.iter_mut())
     {
-        remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
+        remap_cap_node_spans_mapped(
+            std::sync::Arc::make_mut(sc),
+            pos_map,
+            orig_len,
+            offset,
+            derived_offset,
+        );
     }
     for slot in children.positional.iter_mut() {
-        remap_pos_slot(slot, pos_map, orig_len, offset);
+        remap_pos_slot_mapped(slot, pos_map, orig_len, offset, derived_offset);
     }
 }
 

--- a/src/runtime/regex/regex_lookbehind.rs
+++ b/src/runtime/regex/regex_lookbehind.rs
@@ -165,6 +165,7 @@ mod tests {
             anchor_end: false,
             ignore_case: false,
             ignore_mark: false,
+            stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 

--- a/src/runtime/regex/regex_ltm_rank.rs
+++ b/src/runtime/regex/regex_ltm_rank.rs
@@ -411,14 +411,16 @@ impl Interpreter {
             let (plen, stopped) = self.declarative_prefix_match_len(pattern, text);
             return (plen.map(|p| (p, 0)), stopped);
         };
-        let chars: Vec<char> = text.chars().collect();
+        let target = MatchTarget::new(text);
+        let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
+        let chars = target.chars();
         let pkg = self.current_package_sym();
-        let (plen, stopped) = self.ltm_prefix_len_at(&parsed, &chars, 0, pkg);
+        let (plen, stopped) = self.ltm_prefix_len_at(&parsed, chars, 0, pkg);
         let Some(plen) = plen else {
             return (None, stopped);
         };
         let mut seen = HashSet::new();
-        let litlen = self.ltm_litlen_at(&parsed, &chars, 0, pkg, &mut seen, 0);
+        let litlen = self.ltm_litlen_at(&parsed, chars, 0, pkg, &mut seen, 0);
         (Some((plen, litlen)), stopped)
     }
 

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -253,7 +253,41 @@ impl Interpreter {
         // from both text and pattern, match on the stripped versions, then
         // map positions back to the original text.
         if pattern.ignore_mark {
-            use super::regex_helpers::{map_pos, strip_marks_pattern, strip_marks_text};
+            use super::regex_helpers::{map_pos, remap_caps_spans_derived_offset};
+            if let Some(target) = super::regex_helpers::current_match_target() {
+                let stripped = target.stripped();
+                let derived_start = stripped.original_to_stripped(start);
+                let stripped_pattern = strip_marks_pattern(pattern);
+                let mut results = self.regex_match_ends_from_caps_in_pkg_impl(
+                    &stripped_pattern,
+                    &stripped.chars()[derived_start..],
+                    0,
+                    pkg,
+                    first_only,
+                    stop_at_full,
+                );
+                let orig_len = target.chars().len();
+                for (end, caps) in &mut results {
+                    *end = stripped.stripped_to_original(*end + derived_start);
+                    if let Some(cs) = caps.capture_start.as_mut() {
+                        *cs = stripped.stripped_to_original(*cs + derived_start);
+                    }
+                    if let Some(ce) = caps.capture_end.as_mut() {
+                        *ce = stripped.stripped_to_original(*ce + derived_start);
+                    }
+                    remap_caps_spans_derived_offset(
+                        caps,
+                        stripped.stripped_map(),
+                        orig_len,
+                        derived_start,
+                    );
+                }
+                return results;
+            }
+
+            // Direct internal callers outside a public match target retain the
+            // old local-coordinate fallback.
+            use super::regex_helpers::{strip_marks_pattern, strip_marks_text};
             let text_slice = &chars[start..];
             let (stripped_chars, pos_map) = strip_marks_text(text_slice);
             let stripped_pattern = strip_marks_pattern(pattern);

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use super::regex_helpers::{map_pos, strip_marks_pattern, strip_marks_text};
+use super::regex_helpers::{map_pos, strip_marks_pattern};
 
 /// One match's span plus every capture text it produced: the positional list
 /// (`$0`, `$1`, ...) and the per-name list (`$<name>`, which is a list because a
@@ -35,11 +35,12 @@ impl Interpreter {
         let orig_chars = target.chars();
 
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
+            let stripped = target.stripped();
+            let stripped_chars = stripped.chars();
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
             let mut matches =
-                self.regex_match_ends_stop_at_full(&stripped_parsed, &stripped_chars, 0, pkg);
+                self.regex_match_ends_stop_at_full(&stripped_parsed, stripped_chars, 0, pkg);
             if matches.is_empty() {
                 return None;
             }
@@ -55,7 +56,7 @@ impl Interpreter {
                 .find(|(end, _)| *end == stripped_chars.len())?;
             caps.from = caps.capture_start.unwrap_or(0);
             caps.to = caps.capture_end.unwrap_or(end);
-            super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+            super::regex_helpers::remap_caps_spans(&mut caps, stripped.stripped_map(), orig_len);
             caps.set_target(Some(target));
             return Some(caps);
         }
@@ -108,28 +109,30 @@ impl Interpreter {
             return None;
         }
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
+            let stripped = target.stripped();
+            let stripped_chars = stripped.chars();
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
             // Find the stripped position corresponding to `pos`
-            let stripped_pos = pos_map
-                .iter()
-                .position(|&p| p >= pos)
-                .unwrap_or(stripped_chars.len());
+            let stripped_pos = stripped.original_to_stripped(pos);
             if stripped_pos > stripped_chars.len() {
                 return None;
             }
             return self
                 .regex_match_end_from_caps_in_pkg(
                     &stripped_parsed,
-                    &stripped_chars,
+                    stripped_chars,
                     stripped_pos,
                     pkg,
                 )
                 .map(|(end, mut caps)| {
                     caps.from = caps.capture_start.unwrap_or(stripped_pos);
                     caps.to = caps.capture_end.unwrap_or(end);
-                    super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                    super::regex_helpers::remap_caps_spans(
+                        &mut caps,
+                        stripped.stripped_map(),
+                        orig_len,
+                    );
                     caps.set_target(Some(target.clone()));
                     caps
                 });
@@ -183,13 +186,11 @@ impl Interpreter {
             return None;
         }
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
+            let stripped = target.stripped();
+            let stripped_chars = stripped.chars();
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
-            let stripped_from = pos_map
-                .iter()
-                .position(|&p| p >= from_pos)
-                .unwrap_or(stripped_chars.len());
+            let stripped_from = stripped.original_to_stripped(from_pos);
             let start_pos = if stripped_parsed.anchor_start {
                 0
             } else {
@@ -198,13 +199,17 @@ impl Interpreter {
             for start in start_pos..=stripped_chars.len() {
                 if let Some((end, mut caps)) = self.regex_match_end_from_caps_in_pkg(
                     &stripped_parsed,
-                    &stripped_chars,
+                    stripped_chars,
                     start,
                     pkg,
                 ) {
                     caps.from = caps.capture_start.unwrap_or(start);
                     caps.to = caps.capture_end.unwrap_or(end);
-                    super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                    super::regex_helpers::remap_caps_spans(
+                        &mut caps,
+                        stripped.stripped_map(),
+                        orig_len,
+                    );
                     caps.set_target(Some(target.clone()));
                     return Some(caps);
                 }
@@ -277,7 +282,8 @@ impl Interpreter {
         let orig_chars = target.chars();
 
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
+            let stripped = target.stripped();
+            let stripped_chars = stripped.chars();
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
             let mut out = Vec::new();
@@ -300,7 +306,7 @@ impl Interpreter {
                 let ends = if canonical_only {
                     self.regex_match_end_from_caps_in_pkg(
                         &stripped_parsed,
-                        &stripped_chars,
+                        stripped_chars,
                         start,
                         pkg,
                     )
@@ -309,7 +315,7 @@ impl Interpreter {
                 } else {
                     self.regex_match_ends_from_caps_in_pkg(
                         &stripped_parsed,
-                        &stripped_chars,
+                        stripped_chars,
                         start,
                         pkg,
                     )
@@ -317,7 +323,11 @@ impl Interpreter {
                 for (end, mut caps) in ends {
                     caps.from = caps.capture_start.unwrap_or(start);
                     caps.to = caps.capture_end.unwrap_or(end);
-                    super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                    super::regex_helpers::remap_caps_spans(
+                        &mut caps,
+                        stripped.stripped_map(),
+                        orig_len,
+                    );
                     caps.set_target(Some(target.clone()));
                     if skip_covered {
                         if caps.from < last_end {
@@ -401,18 +411,17 @@ impl Interpreter {
     ) -> Option<MatchWithAllCaptures> {
         let parsed = self.parse_regex(pattern)?;
         let pkg = self.current_package_sym();
+        let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
         let orig_chars = target.chars();
         if parsed.anchor_start && min_pos > 0 {
             return None;
         }
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
+            let stripped = target.stripped();
+            let stripped_chars = stripped.chars();
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
-            let stripped_min = pos_map
-                .iter()
-                .position(|&p| p >= min_pos)
-                .unwrap_or(stripped_chars.len());
+            let stripped_min = stripped.original_to_stripped(min_pos);
             let search_start = if stripped_parsed.anchor_start {
                 0
             } else {
@@ -421,7 +430,7 @@ impl Interpreter {
             for start in search_start..=stripped_chars.len() {
                 if let Some((end, mut caps)) = self.regex_match_end_from_caps_in_pkg(
                     &stripped_parsed,
-                    &stripped_chars,
+                    stripped_chars,
                     start,
                     pkg,
                 ) {
@@ -429,11 +438,24 @@ impl Interpreter {
                     // the derived texts keep their combining marks (pre-P4 the
                     // stored text axis returned mark-stripped text here).
                     for slot in caps.positional.iter_mut() {
-                        super::regex_helpers::remap_pos_slot(slot, &pos_map, orig_len, 0);
+                        super::regex_helpers::remap_pos_slot(
+                            slot,
+                            stripped.stripped_map(),
+                            orig_len,
+                            0,
+                        );
                     }
                     return Some((
-                        map_pos(caps.capture_start.unwrap_or(start), &pos_map, orig_len),
-                        map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len),
+                        map_pos(
+                            caps.capture_start.unwrap_or(start),
+                            stripped.stripped_map(),
+                            orig_len,
+                        ),
+                        map_pos(
+                            caps.capture_end.unwrap_or(end),
+                            stripped.stripped_map(),
+                            orig_len,
+                        ),
                         super::regex_helpers::pos_slot_texts(&caps.positional, orig_chars),
                         super::regex_helpers::named_slot_texts(&caps.named, orig_chars),
                     ));
@@ -466,32 +488,35 @@ impl Interpreter {
     pub(crate) fn regex_find_first(&mut self, pattern: &str, text: &str) -> Option<(usize, usize)> {
         let parsed = self.parse_regex(pattern)?;
         let pkg = self.current_package_sym();
+        let target = MatchTarget::new(text);
+        let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
 
         // When :m (ignoremark) is set, strip combining marks from both text and
         // pattern literals, match on stripped forms, then map positions back.
         if parsed.ignore_mark {
-            let orig_chars: Vec<char> = text.chars().collect();
-            let (stripped_chars, pos_map) = strip_marks_text(&orig_chars);
+            let orig_chars = target.chars();
+            let stripped = target.stripped();
+            let stripped_chars = stripped.chars();
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
 
             if stripped_parsed.anchor_start {
                 return self
-                    .regex_match_end_from_in_pkg(&stripped_parsed, &stripped_chars, 0, pkg)
+                    .regex_match_end_from_in_pkg(&stripped_parsed, stripped_chars, 0, pkg)
                     .map(|end| {
                         (
-                            map_pos(0, &pos_map, orig_len),
-                            map_pos(end, &pos_map, orig_len),
+                            map_pos(0, stripped.stripped_map(), orig_len),
+                            map_pos(end, stripped.stripped_map(), orig_len),
                         )
                     });
             }
             for start in 0..=stripped_chars.len() {
                 if let Some(end) =
-                    self.regex_match_end_from_in_pkg(&stripped_parsed, &stripped_chars, start, pkg)
+                    self.regex_match_end_from_in_pkg(&stripped_parsed, stripped_chars, start, pkg)
                 {
                     return Some((
-                        map_pos(start, &pos_map, orig_len),
-                        map_pos(end, &pos_map, orig_len),
+                        map_pos(start, stripped.stripped_map(), orig_len),
+                        map_pos(end, stripped.stripped_map(), orig_len),
                     ));
                 }
             }

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::regex_casefold::{casefold_pattern, casefold_text, needs_casefold_expansion};
-use super::regex_helpers::{strip_marks_pattern, strip_marks_text};
+use super::regex_helpers::strip_marks_pattern;
 
 impl Interpreter {
     /// Write the current (never-restored) values of a `:my`/`:constant`
@@ -243,16 +243,21 @@ impl Interpreter {
         // Every recorded span (including sub-captures) is remapped from the
         // stripped space so captured text derives from the original subject.
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
+            let stripped = target.stripped();
+            let stripped_chars = stripped.chars();
             let stripped_parsed = strip_marks_pattern(parsed);
             let orig_len = orig_chars.len();
             if stripped_parsed.anchor_start {
                 return self
-                    .regex_match_end_from_caps_in_pkg(&stripped_parsed, &stripped_chars, 0, pkg)
+                    .regex_match_end_from_caps_in_pkg(&stripped_parsed, stripped_chars, 0, pkg)
                     .map(|(end, mut caps)| {
                         caps.from = caps.capture_start.unwrap_or(0);
                         caps.to = caps.capture_end.unwrap_or(end);
-                        super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                        super::regex_helpers::remap_caps_spans(
+                            &mut caps,
+                            stripped.stripped_map(),
+                            orig_len,
+                        );
                         caps.set_target(Some(target.clone()));
                         caps
                     });
@@ -260,13 +265,17 @@ impl Interpreter {
             for start in 0..=stripped_chars.len() {
                 if let Some((end, mut caps)) = self.regex_match_end_from_caps_in_pkg(
                     &stripped_parsed,
-                    &stripped_chars,
+                    stripped_chars,
                     start,
                     pkg,
                 ) {
                     caps.from = caps.capture_start.unwrap_or(start);
                     caps.to = caps.capture_end.unwrap_or(end);
-                    super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                    super::regex_helpers::remap_caps_spans(
+                        &mut caps,
+                        stripped.stripped_map(),
+                        orig_len,
+                    );
                     caps.set_target(Some(target.clone()));
                     return Some(caps);
                 }

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -715,6 +715,7 @@ pub(super) fn single_token_pattern(
         anchor_end: false,
         ignore_case,
         ignore_mark,
+        stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
     }
 }
 
@@ -1213,6 +1214,7 @@ pub(super) fn rewrite_tilde_tokens(
                 anchor_end: false,
                 ignore_case,
                 ignore_mark,
+                stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
             };
             out.push(RegexToken {
                 atom: RegexAtom::GoalMatch {
@@ -1407,6 +1409,7 @@ pub(super) fn regex_single_quote_atom(literal: String, ignore_case: bool) -> Reg
             anchor_end: false,
             ignore_case,
             ignore_mark: false,
+            stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
 }

--- a/src/runtime/regex_parse_charclass.rs
+++ b/src/runtime/regex_parse_charclass.rs
@@ -987,6 +987,7 @@ impl Interpreter {
                     anchor_end: false,
                     ignore_case: false,
                     ignore_mark: false,
+                    stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
                 },
                 negated: true,
                 is_behind: false,
@@ -1021,6 +1022,7 @@ impl Interpreter {
             anchor_end: false,
             ignore_case: false,
             ignore_mark: false,
+            stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         // Prepend the subtraction guard (if any) to a branch pattern.
         let guard_pattern = |mut p: RegexPattern| {

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -523,6 +523,7 @@ impl Interpreter {
             anchor_end: false,
             ignore_case,
             ignore_mark,
+            stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         RegexAtom::Lookaround {
             pattern: inner_pattern,
@@ -1055,6 +1056,7 @@ impl Interpreter {
                     anchor_end: false,
                     ignore_case,
                     ignore_mark,
+                    stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
                 });
             } else if alt_patterns.len() == 1 {
                 return alt_patterns.into_iter().next();
@@ -1105,6 +1107,7 @@ impl Interpreter {
                     anchor_end: false,
                     ignore_case,
                     ignore_mark,
+                    stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
                 });
             } else if conj_patterns.len() == 1 {
                 return conj_patterns.into_iter().next();
@@ -1201,6 +1204,7 @@ impl Interpreter {
                                 anchor_end: false,
                                 ignore_case,
                                 ignore_mark,
+                                stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
                             }),
                             quant,
                             named_capture: None,
@@ -2465,6 +2469,9 @@ impl Interpreter {
                                     anchor_end: false,
                                     ignore_case,
                                     ignore_mark,
+                                    stripped_pattern: std::sync::Arc::new(
+                                        std::sync::OnceLock::new(),
+                                    ),
                                 };
                                 RegexAtom::Lookaround {
                                     pattern: inner_pattern,
@@ -2609,6 +2616,9 @@ impl Interpreter {
                                     anchor_end: false,
                                     ignore_case,
                                     ignore_mark,
+                                    stripped_pattern: std::sync::Arc::new(
+                                        std::sync::OnceLock::new(),
+                                    ),
                                 }
                             } else {
                                 let Some(parsed) = self.parse_regex_with_mode(&inner, mode) else {
@@ -2725,6 +2735,9 @@ impl Interpreter {
                                                 anchor_end: false,
                                                 ignore_case,
                                                 ignore_mark,
+                                                stripped_pattern: std::sync::Arc::new(
+                                                    std::sync::OnceLock::new(),
+                                                ),
                                             }
                                         })
                                         .collect();
@@ -2873,6 +2886,9 @@ impl Interpreter {
                                         anchor_end: false,
                                         ignore_case,
                                         ignore_mark,
+                                        stripped_pattern: std::sync::Arc::new(
+                                            std::sync::OnceLock::new(),
+                                        ),
                                     };
                                     RegexAtom::Lookaround {
                                         pattern: inner_pattern,
@@ -2923,6 +2939,9 @@ impl Interpreter {
                                                 anchor_end: false,
                                                 ignore_case,
                                                 ignore_mark,
+                                                stripped_pattern: std::sync::Arc::new(
+                                                    std::sync::OnceLock::new(),
+                                                ),
                                             },
                                             negated: true,
                                             is_behind: false,
@@ -3006,6 +3025,9 @@ impl Interpreter {
                                                     anchor_end: false,
                                                     ignore_case,
                                                     ignore_mark,
+                                                    stripped_pattern: std::sync::Arc::new(
+                                                        std::sync::OnceLock::new(),
+                                                    ),
                                                 })
                                             } else {
                                                 RegexAtom::CharClass(CharClass {
@@ -3032,6 +3054,9 @@ impl Interpreter {
                                                 anchor_end: false,
                                                 ignore_case,
                                                 ignore_mark,
+                                                stripped_pattern: std::sync::Arc::new(
+                                                    std::sync::OnceLock::new(),
+                                                ),
                                             };
                                             RegexAtom::Lookaround {
                                                 pattern: inner_pattern,
@@ -3368,6 +3393,9 @@ impl Interpreter {
                                             anchor_end: false,
                                             ignore_case,
                                             ignore_mark,
+                                            stripped_pattern: std::sync::Arc::new(
+                                                std::sync::OnceLock::new(),
+                                            ),
                                         })
                                     } else {
                                         RegexAtom::CharClass(CharClass {
@@ -3395,6 +3423,9 @@ impl Interpreter {
                                             anchor_end: false,
                                             ignore_case,
                                             ignore_mark,
+                                            stripped_pattern: std::sync::Arc::new(
+                                                std::sync::OnceLock::new(),
+                                            ),
                                         },
                                         negated: false,
                                         is_behind: false,
@@ -3575,6 +3606,9 @@ impl Interpreter {
                                                     anchor_end: false,
                                                     ignore_case,
                                                     ignore_mark,
+                                                    stripped_pattern: std::sync::Arc::new(
+                                                        std::sync::OnceLock::new(),
+                                                    ),
                                                 })
                                             }
                                             _ => {
@@ -3804,6 +3838,7 @@ impl Interpreter {
                                 anchor_end: false,
                                 ignore_case,
                                 ignore_mark,
+                                stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
                             };
                             RegexAtom::CaptureGroup(group_pat)
                         }
@@ -4322,6 +4357,7 @@ impl Interpreter {
                         anchor_end: false,
                         ignore_case,
                         ignore_mark,
+                        stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
                     }),
                     quant: RegexQuant::One,
                     named_capture: primary_named,
@@ -4380,6 +4416,7 @@ impl Interpreter {
             anchor_end,
             ignore_case,
             ignore_mark,
+            stripped_pattern: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
 }

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -37,6 +37,10 @@ pub(crate) struct RegexPattern {
     pub(crate) anchor_end: bool,
     pub(crate) ignore_case: bool,
     pub(crate) ignore_mark: bool,
+    /// Lazily memoized mark-stripped form. Static parsed patterns are shared
+    /// through the regex parse cache, and scoped `:ignoremark` can enter the
+    /// same pattern many times during one match.
+    pub(crate) stripped_pattern: Arc<std::sync::OnceLock<Arc<RegexPattern>>>,
 }
 
 /// A single entry in a quantified capture list: (from, to, subcaptures).

--- a/t/regex/regex-ignoremark-scaling.t
+++ b/t/regex/regex-ignoremark-scaling.t
@@ -1,0 +1,37 @@
+use Test;
+
+plan 3;
+
+# A scoped :ignoremark subpattern is entered once for each item here. The
+# subject's mark-stripped view must be shared across those entries; rebuilding
+# the suffix for every item makes the parse quadratic in the document length.
+grammar IgnoremarkScale {
+    token TOP { [ <s> \s* ]+ }
+    token s { (:ignoremark '"') ~ '"' ( <-["]>* ) }
+}
+
+my $small = ('"abcdefgh"' xx 20).join(' ');
+my $large = ('"abcdefgh"' xx 640).join(' ');
+
+ok IgnoremarkScale.parse($small), 'the small repeated document parses';
+ok IgnoremarkScale.parse($large), 'the large repeated document parses';
+
+# Average a few runs so timer granularity does not dominate the small case.
+sub measure(Str:D $doc --> Numeric:D) {
+    my $elapsed = 0e0;
+    for ^3 {
+        my $started = now;
+        IgnoremarkScale.parse($doc);
+        $elapsed += now - $started;
+    }
+    $elapsed / 3;
+}
+
+my $small-time = measure($small);
+my $large-time = measure($large);
+my $size-ratio = $large.chars / $small.chars;
+my $time-ratio = $large-time / $small-time.max(0.000001);
+ok $time-ratio < $size-ratio * 3,
+    "ignoremark scaling stays near-linear (size {$size-ratio.round(0.1)}x, time {$time-ratio.round(0.1)}x)";
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Closes #8262\n\n## Summary\n- cache the mark-stripped subject and both position maps on MatchTarget for each engine entry\n- memoize the recursively stripped pattern alongside the parsed RegexPattern\n- keep scoped :ignoremark matching on the derived suffix while remapping captures to original subject positions\n- cover grammar scaling from 20 to 640 repeated quoted items\n\n## Validation\n- cargo fmt --all\n- make lint\n- make test\n- make roast\n