### PR TITLE
fix(regex): a $&lt;sym&gt;= named capture no longer declines a proto's whole subrule cache

### DIFF
--- a/news/2026-09/grammar-sym-token-proto-cache.md
+++ b/news/2026-09/grammar-sym-token-proto-cache.md
@@ -1,0 +1,36 @@
+# `<sym>` no longer costs a proto its subrule-resolution cache
+
+A `token value:sym<true> { <sym> }` variant — the common shape for a
+proto-dispatch grammar (`JSON::Tiny::Grammar` among them) — lowers `<sym>` to
+a named-capture binding, `:ratchet $<sym>=[true]`. `regex_pattern_is_static`
+misread that `$<...>` as runtime variable interpolation, and
+`resolve_parsed_token_candidates_in_pkg` declined its whole-proto memo the
+moment any one candidate looked non-static — so a proto with three
+`:sym<...>` variants using `<sym>` re-ran the full registry walk (which
+formats every candidate's pattern text from scratch) on **every single**
+`<value>` reference in the document, not just the ones that actually needed
+it.
+
+Two fixes:
+
+- `$<name>` (a named backreference) and `$<name>=`/`@<name>=`/`%<name>=`
+  (named-capture bindings) are resolved from their literal name text alone —
+  `interpolate_regex_scalars`, the actual substitution pass the predicate
+  exists to gate, has no `$</@</%<` branch at all. `regex_pattern_is_static`
+  no longer treats `<` as starting a variable form.
+- Even with that fixed, a proto can still have a genuinely dynamic sibling
+  candidate. `resolve_parsed_token_candidates_in_pkg` now caches the raw
+  (pre-parse) candidate list — the expensive part — regardless of
+  staticness, and only skips the persistent fully-parsed cache when some
+  candidate really is dynamic. That one candidate now re-pays just the cheap
+  per-call `parse_regex` step, never the registry walk, on every reference.
+
+Measured (steady-state, release, `benchmarks/bench-grammar-parse-big.raku`'s
+own grammar): mutsu goes from ~1.8x slower than warm rakudo to ~1.8x faster on
+this shape.
+
+A new `MUTSU_VM_STATS` counter (`regex-raw-token-candidates-cache`) pins the
+second fix deterministically — a timing assertion would be flaky — and Rust
+unit tests pin the classifier fix directly.
+
+See [#8265](https://github.com/tokuhirom/mutsu/issues/8265).

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -13,6 +13,15 @@ pub(super) type ParsedTokenCandidate = (std::sync::Arc<RegexPattern>, Symbol, Op
 /// Cache slot: the `TOKEN_DEFS_GEN` the entry was built under + the candidates.
 type CachedCandidates = (u64, std::sync::Arc<Vec<ParsedTokenCandidate>>);
 
+/// A raw (pre-parse) candidate: pattern source text, dispatch package, and
+/// `:sym<...>` key -- the same shape [`Interpreter::resolve_token_patterns_static_in_pkg`]
+/// returns, before any candidate's pattern has been checked for staticness or
+/// parsed.
+type RawTokenCandidate = (String, Symbol, Option<String>);
+
+/// Cache slot: the `TOKEN_DEFS_GEN` the entry was built under + the raw candidates.
+type CachedRawCandidates = (u64, std::sync::Arc<Vec<RawTokenCandidate>>);
+
 thread_local! {
     /// Memoized argument-less subrule resolution: (pkg, name) → candidates
     /// with their patterns already parsed. Rebuilding this on every
@@ -48,13 +57,46 @@ thread_local! {
     static PARSED_TOKEN_ARG_CANDIDATES: std::cell::RefCell<
         rustc_hash::FxHashMap<(String, String, String), CachedCandidates>,
     > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
+
+    /// Memoized RAW (pre-parse) subrule resolution: (pkg, name) → each
+    /// candidate's pattern SOURCE TEXT plus dispatch package and `:sym<...>`
+    /// key, before any candidate is checked for staticness or parsed (#8265).
+    ///
+    /// This is what actually dominates the cost `PARSED_TOKEN_CANDIDATES`
+    /// exists to avoid: `resolve_token_patterns_static_in_pkg` walks the whole
+    /// `token_defs` registry and re-derives every candidate's pattern text
+    /// (`instantiate_token_pattern`'s `format!`/`String::clone` per
+    /// `:sym<...>` substitution) from scratch on every call, regardless of
+    /// whether any candidate turns out to be non-static -- profiled at ~70%+
+    /// of a grammar-heavy parse for a proto with even ONE candidate that
+    /// declined `PARSED_TOKEN_CANDIDATES`, which fell back to re-running this
+    /// whole walk on every single reference.
+    ///
+    /// Caching the raw text here separately means a proto with a genuinely
+    /// dynamic sibling now pays only the comparatively cheap (~8% profiled)
+    /// per-call `parse_regex` cost for that one candidate, never the registry
+    /// walk again. Same `TOKEN_DEFS_GEN` invalidation as `PARSED_TOKEN_CANDIDATES`.
+    static RAW_TOKEN_CANDIDATES: std::cell::RefCell<
+        rustc_hash::FxHashMap<(Symbol, Symbol), CachedRawCandidates>,
+    > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
 }
 
 impl Interpreter {
     /// Resolve an argument-less subrule to parsed candidates, memoized per
-    /// (pkg, name). Returns `None` when any candidate's pattern is non-static
-    /// (its parse depends on runtime variable interpolation) or fails to
-    /// parse — callers fall back to the uncached per-call path.
+    /// (pkg, name). Returns `None` only when some candidate's pattern fails
+    /// to parse outright — callers fall back to the uncached per-call path,
+    /// which skips just the failing candidate instead of the whole set.
+    ///
+    /// A non-static candidate (its parse depends on runtime variable
+    /// interpolation) no longer declines the memo for its siblings (#8265):
+    /// the raw candidate list — the expensive part, see
+    /// [`RAW_TOKEN_CANDIDATES`] — is always cached, and only the fully-PARSED
+    /// form is skipped from the persistent cache when at least one candidate
+    /// is non-static, so that one candidate's stale-value risk cannot reach
+    /// its statically-cacheable siblings. It is still re-parsed on every call
+    /// (correctly, since its parse depends on the current runtime value), but
+    /// that per-call cost is now the cheap step (`parse_regex`, ~8% profiled),
+    /// not the registry walk this function used to redo for the whole proto.
     ///
     /// `name_sym` is `name` interned. Callers that already hold it (every
     /// `<subrule>` reference does — the memoized [`NamedRegexLookupSpec`]
@@ -80,21 +122,53 @@ impl Interpreter {
         }) {
             return Some(hit);
         }
-        let raw = self.resolve_token_patterns_static_in_pkg(name, pkg);
+        let raw = self.resolve_raw_token_candidates_in_pkg(name, pkg, cache_key, tok_gen);
         let mut parsed_list = Vec::with_capacity(raw.len());
-        for (sub_pat, sub_pkg, sym_key) in raw {
-            if !crate::runtime::regex_parse::regex_pattern_is_static(&sub_pat) {
-                return None;
+        let mut all_static = true;
+        for (sub_pat, sub_pkg, sym_key) in raw.iter() {
+            if !crate::runtime::regex_parse::regex_pattern_is_static(sub_pat) {
+                all_static = false;
             }
-            let parsed = self.parse_candidate_in_pkg(&sub_pat, sub_pkg)?;
-            parsed_list.push((parsed, sub_pkg, sym_key));
+            let parsed = self.parse_candidate_in_pkg(sub_pat, *sub_pkg)?;
+            parsed_list.push((parsed, *sub_pkg, sym_key.clone()));
         }
         let arc = std::sync::Arc::new(parsed_list);
-        PARSED_TOKEN_CANDIDATES.with(|c| {
-            c.borrow_mut()
-                .insert(cache_key, (tok_gen, std::sync::Arc::clone(&arc)));
-        });
+        if all_static {
+            PARSED_TOKEN_CANDIDATES.with(|c| {
+                c.borrow_mut()
+                    .insert(cache_key, (tok_gen, std::sync::Arc::clone(&arc)));
+            });
+        }
         Some(arc)
+    }
+
+    /// The raw (pre-parse) candidate list behind
+    /// [`Self::resolve_parsed_token_candidates_in_pkg`], memoized in
+    /// [`RAW_TOKEN_CANDIDATES`] independently of whether any candidate is
+    /// static — see that cache's doc comment for why this split is the fix.
+    fn resolve_raw_token_candidates_in_pkg(
+        &self,
+        name: &str,
+        pkg: Symbol,
+        cache_key: (Symbol, Symbol),
+        tok_gen: u64,
+    ) -> std::sync::Arc<Vec<RawTokenCandidate>> {
+        if let Some(hit) = RAW_TOKEN_CANDIDATES.with(|c| {
+            c.borrow()
+                .get(&cache_key)
+                .filter(|(cached_gen, _)| *cached_gen == tok_gen)
+                .map(|(_, v)| std::sync::Arc::clone(v))
+        }) {
+            crate::vm::vm_stats::record_regex_raw_token_candidates(true);
+            return hit;
+        }
+        crate::vm::vm_stats::record_regex_raw_token_candidates(false);
+        let raw = std::sync::Arc::new(self.resolve_token_patterns_static_in_pkg(name, pkg));
+        RAW_TOKEN_CANDIDATES.with(|c| {
+            c.borrow_mut()
+                .insert(cache_key, (tok_gen, std::sync::Arc::clone(&raw)));
+        });
+        raw
     }
 
     /// Parse a candidate's pattern in its OWN package so nested unqualified

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -225,13 +225,24 @@ pub(crate) static TOKEN_DEFS_GEN: std::sync::atomic::AtomicU64 =
 /// A sigil counts as interpolation only when what follows can actually start a
 /// variable form (see `interpolate_regex_scalars` / the `<...>` tokenizer
 /// forms): an identifier start, a digit (`$0` backrefs stay conservative), a
-/// twigil (`$*x`, `$?FILE`, `$^a`, `$!x`, `$.x`), `{`/`(` contextualizers,
-/// `$<name>` capture forms, or `@$var` derefs. This stays a conservative
-/// superset of what the parser substitutes; false "dynamic" only costs cache
-/// misses, never correctness.
+/// twigil (`$*x`, `$?FILE`, `$^a`, `$!x`, `$.x`), or `{`/`(` contextualizers.
+/// This stays a conservative superset of what the parser substitutes; false
+/// "dynamic" only costs cache misses, never correctness.
+///
+/// `<` is deliberately NOT one of these forms (#8265): `$<name>` is a named
+/// backreference and `$<name>=`/`@<name>=`/`%<name>=` are named-capture
+/// bindings, all resolved purely by the structural regex parser from the
+/// literal name text -- none of them is runtime variable interpolation, and
+/// `interpolate_regex_scalars` (the actual substitution pass this predicate
+/// exists to gate) has no `$</@</%<` branch at all; a `$<...>` occurrence
+/// reaches its final "copy verbatim" fallback untouched. Misclassifying it as
+/// dynamic declined the cache for every candidate that used the common
+/// `token value:sym<x> { <sym> }` shape (lowered to `:ratchet
+/// $<sym>=[x]`), which cost the whole proto's memo, not just this one
+/// candidate.
 pub(crate) fn regex_pattern_is_static(pattern: &str) -> bool {
     fn starts_variable_form(c: char) -> bool {
-        c.is_alphanumeric() || matches!(c, '_' | '{' | '(' | '<' | '*' | '?' | '^' | '.' | '!')
+        c.is_alphanumeric() || matches!(c, '_' | '{' | '(' | '*' | '?' | '^' | '.' | '!')
     }
     let chars: Vec<char> = pattern.chars().collect();
     let mut i = 0usize;
@@ -1648,6 +1659,43 @@ mod tests {
         }
         // Compound class missing operator (plain message, no typed exception).
         assert!(validate_regex_structurally("<[abc] [def]>").is_err());
+    }
+
+    #[test]
+    fn is_static_accepts_named_capture_and_backref_forms() {
+        // #8265: `$<name>`/`$<name>=`/`@<name>=`/`%<name>=` are resolved from
+        // their literal name text alone -- not runtime variable interpolation
+        // -- so none of these may classify as dynamic. `:ratchet
+        // $<sym>=[true]` is exactly what a bare `<sym>` inside `token
+        // value:sym<true> { <sym> }` lowers to.
+        for p in [
+            r"$<name>",
+            r"$<name>=[abc]",
+            r":ratchet $<sym>=[true]",
+            r"@<name>=[abc]+",
+            r"%<name>=[abc]",
+            r"a $<x>=[b] c",
+        ] {
+            assert!(
+                regex_pattern_is_static(p),
+                "expected `{p}` to be classified static (named capture/backref, not interpolation)"
+            );
+        }
+    }
+
+    #[test]
+    fn is_static_still_rejects_genuine_interpolation() {
+        // The fix must not widen the predicate beyond `<` -- every other
+        // dynamic form it already recognized stays dynamic.
+        for p in [
+            r"$var", r"@var", r"$*x", r"$?FILE", r"$^a", r"$!x", r"$.x", r"${expr}", r"$(expr)",
+            r"@$var",
+        ] {
+            assert!(
+                !regex_pattern_is_static(p),
+                "expected `{p}` to stay classified dynamic"
+            );
+        }
     }
 
     #[test]

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -396,7 +396,11 @@ mod static_pattern_tests {
         assert!(!regex_pattern_is_static("$(1 + 1)"));
         assert!(!regex_pattern_is_static("$*dyn"));
         assert!(!regex_pattern_is_static("$0"));
-        assert!(!regex_pattern_is_static("$<cap>"));
+        // `$<cap>` is NOT interpolation (#8265): it is a named backreference,
+        // resolved from its literal name text alone, never by
+        // `interpolate_regex_scalars` (which has no `$<` branch at all) --
+        // see `mod tests` below (`is_static_accepts_named_capture_and_backref_forms`)
+        // for the full set this predicate must accept, `$<cap>` included.
         assert!(!regex_pattern_is_static("@words"));
         assert!(!regex_pattern_is_static("@$deref"));
         assert!(!regex_pattern_is_static("@(list())"));

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -725,11 +725,14 @@ impl Interpreter {
     /// `$`/`@`/`%` variable values into the pattern first, and what follows is
     /// a function of the resulting string plus the grammar-token registry
     /// (pinned by `TOKEN_DEFS_GEN`). Keying on the source text instead would
-    /// have to refuse every pattern `regex_pattern_is_static` calls dynamic —
-    /// which on the profiled document is most of the repeated ones, since that
-    /// predicate conservatively counts `$<name>` *capture* forms
-    /// (`$<value> = [ … ]`) as interpolation. Measured: source-keyed -2.7%,
-    /// interpolated-keyed -9.0%.
+    /// have to refuse every pattern `regex_pattern_is_static` calls dynamic.
+    /// Measured: source-keyed -2.7%, interpolated-keyed -9.0% (before #8265,
+    /// when that predicate still conservatively -- and wrongly -- counted
+    /// every `$<name>` *capture* form (`$<value> = [ … ]`) as interpolation,
+    /// which was most of the repeated patterns on the profiled document; a
+    /// `$<name>` occurrence is resolved from its literal name text alone and
+    /// is not runtime interpolation at all, per `regex_pattern_is_static`'s
+    /// own doc comment).
     ///
     /// "Mostly", because a few parse steps read state the key does not carry —
     /// the `<$var>` / `<@var>` assertion forms take the variable's value at

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -185,6 +185,31 @@ pub(crate) fn record_regex_code_parse(hit: bool) {
     }
 }
 
+// #8265: RAW_TOKEN_CANDIDATES effectiveness -- the registry-walk resolution
+// (`resolve_token_patterns_static_in_pkg`, which formats each `:sym<...>`
+// candidate's pattern text from scratch) that a subrule reference needed on
+// EVERY call whenever any one of a proto's candidates was non-static, because
+// `regex_pattern_is_static` misclassified `$<name>=[...]` named-capture
+// bindings as runtime interpolation and declined the whole proto's
+// `PARSED_TOKEN_CANDIDATES` memo. A `misses` count that keeps growing with
+// the number of `<subrule>` references (rather than staying at one per
+// `TOKEN_DEFS_GEN`) means that walk is happening again on every reference --
+// the regression this counter exists to catch.
+static REGEX_RAW_TOKEN_CANDIDATES_HITS: AtomicU64 = AtomicU64::new(0);
+static REGEX_RAW_TOKEN_CANDIDATES_MISSES: AtomicU64 = AtomicU64::new(0);
+
+/// Record one lookup in `RAW_TOKEN_CANDIDATES` (#8265).
+#[inline]
+pub(crate) fn record_regex_raw_token_candidates(hit: bool) {
+    if enabled() {
+        if hit {
+            REGEX_RAW_TOKEN_CANDIDATES_HITS.fetch_add(1, Ordering::Relaxed);
+        } else {
+            REGEX_RAW_TOKEN_CANDIDATES_MISSES.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
 /// Record one `Arc::make_mut` on a stored regex capture node; `shared` means
 /// the node had other holders (strong_count > 1) so make_mut deep-copied it.
 #[inline]
@@ -1188,6 +1213,11 @@ pub(crate) fn dump() {
     let code_parse_misses = REGEX_CODE_PARSE_MISSES.load(Ordering::Relaxed);
     eprintln!(
         "[mutsu vm-stats] regex-code-parse-cache: hits={code_parse_hits} misses={code_parse_misses}"
+    );
+    let raw_candidates_hits = REGEX_RAW_TOKEN_CANDIDATES_HITS.load(Ordering::Relaxed);
+    let raw_candidates_misses = REGEX_RAW_TOKEN_CANDIDATES_MISSES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] regex-raw-token-candidates-cache: hits={raw_candidates_hits} misses={raw_candidates_misses}"
     );
     let registry_cow_clones = REGISTRY_COW_CLONES.load(Ordering::Relaxed);
     eprintln!("[mutsu vm-stats] registry-cow: clones={registry_cow_clones}");

--- a/tests/regex_proto_candidate_raw_cache.rs
+++ b/tests/regex_proto_candidate_raw_cache.rs
@@ -1,0 +1,84 @@
+//! Pins the #8265 fix: a proto with a mix of static and non-static `:sym<...>`
+//! candidates no longer re-runs the expensive registry walk
+//! (`resolve_token_patterns_static_in_pkg`, which formats every candidate's
+//! pattern text from scratch) on EVERY `<subrule>` reference.
+//!
+//! Two bugs combined to cause that: `regex_pattern_is_static` misclassified
+//! `$<sym>=[...]` (the lowering of a bare `<sym>` inside a `:sym<...>` token
+//! body) as runtime variable interpolation, and
+//! `resolve_parsed_token_candidates_in_pkg` declined its memo for the WHOLE
+//! proto the moment any one candidate looked non-static. Even with the first
+//! bug fixed, a proto with a genuinely dynamic sibling (this test's
+//! `value:sym<dynv>`, which really does interpolate an outer `$dyn`) still
+//! needs the second fix: the raw (pre-parse) candidate list is now cached
+//! separately (`RAW_TOKEN_CANDIDATES`) from the fully-parsed, all-static form
+//! (`PARSED_TOKEN_CANDIDATES`), so only the one dynamic candidate pays a
+//! per-call re-parse — never the registry walk that finds and formats all of
+//! them.
+//!
+//! A timing assertion would be flaky under load; the raw-cache hit/miss
+//! counter is deterministic and exact, so it is the pin instead.
+
+use std::process::Command;
+
+/// A proto with two static `:sym<...>` candidates (each lowering to `$<sym>=[...]`)
+/// and one genuinely dynamic candidate (`$dyn`, an outer lexical). Matched
+/// against 4 tokens, so a per-reference registry-walk regression shows up as
+/// `misses` tracking the reference count instead of staying at 1.
+const PROGRAM: &str = r#"
+my $dyn = 'zzz';
+grammar G {
+    token TOP { <value>+ % ' ' }
+    proto token value {*}
+    token value:sym<true>  { <sym> }
+    token value:sym<false> { <sym> }
+    token value:sym<dynv>  { $dyn }
+}
+say G.parse('true false zzz true') ?? "matched" !! "no match";
+"#;
+
+/// Run a Raku snippet through the built `mutsu` with `MUTSU_VM_STATS=1`.
+/// Returns (stdout, stderr, success).
+fn run_with_stats(src: &str) -> (String, String, bool) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.arg("-e").arg(src);
+    cmd.env("MUTSU_VM_STATS", "1");
+    let out = cmd.output().expect("failed to spawn mutsu");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    )
+}
+
+/// Extract `hits=N misses=M` from the "regex-raw-token-candidates-cache" line.
+fn raw_token_candidates_misses(stderr: &str) -> u64 {
+    let line = stderr
+        .lines()
+        .find(|l| l.contains("] regex-raw-token-candidates-cache:"))
+        .unwrap_or_else(|| panic!("no regex-raw-token-candidates-cache line in stderr: {stderr}"));
+    line.split_whitespace()
+        .find_map(|w| w.strip_prefix("misses="))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| panic!("missing misses= in: {line}"))
+}
+
+#[test]
+fn mixed_static_dynamic_proto_reuses_raw_candidate_resolution() {
+    let (out, err, ok) = run_with_stats(PROGRAM);
+    assert!(ok, "run failed: {err}");
+    assert_eq!(out, "matched\n");
+    let misses = raw_token_candidates_misses(&err);
+    // One miss per (pkg, name) resolution under a stable TOKEN_DEFS_GEN,
+    // regardless of how many of the 4 tokens `<value>` matched. Before the
+    // #8265 fix there was no raw-candidate cache at all, so every reference
+    // paid a fresh, uncached registry walk -- this assertion catches a
+    // regression back to that by refusing to let misses scale with the
+    // reference count.
+    assert_eq!(
+        misses, 1,
+        "the proto's raw candidate list is being re-resolved on more than one \
+         reference (a regression to the pre-#8265 whole-proto cache decline); \
+         full stderr: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Two caching-correctness bugs combined to make every `<value>` reference in a grammar with a `token value:sym<x> { <sym> }` shape (e.g. `JSON::Tiny::Grammar`) re-resolve and re-parse **all** its `:sym<...>` candidates from scratch on every match position — profiled at ~70%+ of a grammar-heavy parse ([ADR-0099](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0099-regex-engine-performance-strategy.md) §2.3):

1. **Misclassification.** `<sym>` inside a `token value:sym<x> { <sym> }` variant lowers to `:ratchet $<sym>=[x]` — a named-capture *binding*, resolved from its literal name text alone. `regex_pattern_is_static` treated `<` after `$`/`@`/`%` as starting a variable form, so it misclassified this as runtime interpolation — but `interpolate_regex_scalars` (the actual substitution pass that predicate exists to gate) has no `$</@</%<` branch at all; a `$<...>` occurrence reaches its final "copy verbatim" fallback completely untouched. Removed `<` from `starts_variable_form`. A pre-existing unit test (`static_pattern_tests::interpolations_are_dynamic`) encoded exactly this wrong assumption for `$<cap>`; updated.
2. **Whole-proto decline.** `resolve_parsed_token_candidates_in_pkg` declined the memo for the **whole proto** the moment *any one* candidate looked non-static — so a genuinely dynamic sibling cost its static candidates their cache too, not just itself. Split the cache in two: `RAW_TOKEN_CANDIDATES` (pattern source text + dispatch package + `:sym<...>` key — the expensive registry-walk part, `resolve_token_patterns_static_in_pkg`) is now cached regardless of staticness; `PARSED_TOKEN_CANDIDATES` (the fully-parsed form) is only cached when every candidate is static, as before. A dynamic candidate now re-pays only the cheap per-call `parse_regex` step, never the registry walk.

Closes #8265

## Test plan

- [x] New Rust unit tests (`src/runtime/regex_parse.rs`) pin the classifier fix directly: `$<name>`, `$<name>=`, `@<name>=`, `%<name>=` classify static; existing dynamic forms (`$var`, `@var`, `$*x`, `${expr}`, `$(expr)`, ...) stay dynamic.
- [x] New integration test `tests/regex_proto_candidate_raw_cache.rs` pins the raw-cache fix deterministically via a new `MUTSU_VM_STATS` counter (`regex-raw-token-candidates-cache`) — a mixed static/dynamic proto's raw candidate list is resolved once (`misses=1`), not once per `<value>` reference. Verified this test fails against the pre-fix code (reverted locally, confirmed failure, restored).
- [x] Manually verified against real `raku` (both the plain multi-static-candidate case and the mixed static/dynamic case) — same output.
- [x] `t/grammar/` (82 files, 681 tests) and `t/regex/` (266 files, 2812 tests) — PASS
- [x] `cargo fmt --all`
- [x] `make lint` (all 4 configurations green)
- [x] `make test` (4200 files, 44724 tests — PASS)
- [x] `make roast` — only the three documented container-only failures (`roast/6.c/S32-io/file-tests.t`, `roast/S16-filehandles/filetest.t`, `roast/S32-io/IO-Socket-Async.t`), per `docs/agent-environments.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZKspCKXhDnjrza1p1Ywxr)_