### PR TITLE
perf(regex): cache interpolated parse results

### DIFF
--- a/news/2026-09/regex-parse-cache-interpolated-patterns.md
+++ b/news/2026-09/regex-parse-cache-interpolated-patterns.md
@@ -1,0 +1,5 @@
+The regex parse cache now avoids allocating a formatted package-and-pattern
+key for static patterns, scans static-pattern candidates without a temporary
+character vector, and caches top-level regex parses after runtime interpolation.
+Repeated matches with the same interpolated value therefore reuse the parsed
+pattern, while patterns that consult ambient parse state remain uncached.

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -3,6 +3,10 @@ use crate::symbol::Symbol;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
+type RegexParseCacheBucket = rustc_hash::FxHashMap<String, (u64, std::sync::Arc<RegexPattern>)>;
+type RegexParseCache = rustc_hash::FxHashMap<(Symbol, Option<u64>), RegexParseCacheBucket>;
+type RegexInterpolatedParseCache = rustc_hash::FxHashMap<Symbol, RegexParseCacheBucket>;
+
 thread_local! {
     /// Thread-local storage for regex security errors that need to propagate
     /// from inside `parse_regex` (which takes `&self`) to callers that can throw.
@@ -31,14 +35,25 @@ thread_local! {
     /// rather than a deep clone of the whole token tree — the hot match loop
     /// re-fetches the same compiled pattern on every step / every iteration.
     ///
-    /// Keyed by `(current package, pattern)` because parsing resolves grammar
-    /// tokens against the current package (`parse_combined_class` both decides
-    /// token-ness and — since the static fold — inlines simple token bodies).
-    /// Each entry records the `TOKEN_DEFS_GEN` it was parsed under; a hit with
-    /// a stale generation re-parses so a token (re)definition after the first
-    /// parse is picked up.
-    pub(crate) static REGEX_PARSE_CACHE: RefCell<HashMap<String, (u64, std::sync::Arc<RegexPattern>)>> =
-        RefCell::new(HashMap::new());
+    /// Keyed by `(current package, optional source-tree fingerprint, pattern)`
+    /// because parsing resolves grammar tokens against the current package
+    /// (`parse_combined_class` both decides token-ness and — since the static
+    /// fold — inlines simple token bodies). The outer key is copyable and the
+    /// inner pattern map is probed with a borrowed `&str`, so cache hits do not
+    /// allocate a formatted package-plus-pattern key. Each entry records the
+    /// `TOKEN_DEFS_GEN` it was parsed under; a hit with a stale generation
+    /// re-parses so a token (re)definition after the first parse is picked up.
+    pub(crate) static REGEX_PARSE_CACHE: RefCell<RegexParseCache> =
+        RefCell::new(rustc_hash::FxHashMap::default());
+
+    /// Memoization cache for top-level patterns after runtime interpolation.
+    /// The interpolated text is already allocated by
+    /// `interpolate_regex_scalars`, so it can be retained as the owned cache
+    /// key. Keep this cache bounded because a pattern that splices a changing
+    /// value can otherwise mint one entry per match. As with the static cache,
+    /// entries are invalidated lazily by `TOKEN_DEFS_GEN`.
+    pub(crate) static REGEX_INTERPOLATED_PARSE_CACHE: RefCell<RegexInterpolatedParseCache> =
+        RefCell::new(rustc_hash::FxHashMap::default());
 
     /// Memoization cache for *sub-pattern* parses — every `parse_regex_uncached`
     /// entry, not just the outermost one [`REGEX_PARSE_CACHE`] covers.
@@ -244,33 +259,29 @@ pub(crate) fn regex_pattern_is_static(pattern: &str) -> bool {
     fn starts_variable_form(c: char) -> bool {
         c.is_alphanumeric() || matches!(c, '_' | '{' | '(' | '*' | '?' | '^' | '.' | '!')
     }
-    let chars: Vec<char> = pattern.chars().collect();
-    let mut i = 0usize;
-    while i < chars.len() {
-        let c = chars[i];
+    let mut chars = pattern.char_indices().peekable();
+    while let Some((_, c)) = chars.next() {
         if c == '\\' {
-            i += 2;
+            chars.next();
             continue;
         }
         if matches!(c, '$' | '@' | '%') {
-            let mut j = i + 1;
+            let mut next = chars.peek().map(|(_, next)| *next);
             // A doubled sigil is structural (`$$` line-end anchor, `%%`
             // separator op) — but if a variable form follows the pair, stay
             // conservative and treat the whole thing as dynamic.
-            if chars.get(j) == Some(&c) {
-                j += 1;
+            if next == Some(c) {
+                chars.next();
+                next = chars.peek().map(|(_, next)| *next);
             }
             // `@$var` scalar-deref interpolation.
-            if c == '@' && chars.get(j) == Some(&'$') {
+            if c == '@' && next == Some('$') {
                 return false;
             }
-            if chars.get(j).copied().is_some_and(starts_variable_form) {
+            if next.is_some_and(starts_variable_form) {
                 return false;
             }
-            i = j;
-            continue;
         }
-        i += 1;
     }
     true
 }
@@ -416,6 +427,12 @@ mod static_pattern_tests {
 /// interpolated pattern text — a regex that splices a loop counter mints a
 /// fresh one on every iteration.
 pub(crate) const SUBPATTERN_PARSE_CACHE_MAX: usize = 4096;
+
+/// Per-package entry cap for [`REGEX_INTERPOLATED_PARSE_CACHE`]. Reaching it
+/// clears the bucket: the memo is an optimization, so dropping it costs
+/// re-parses and nothing else, and a changing interpolated value must not grow
+/// the cache without bound.
+pub(crate) const INTERPOLATED_PARSE_CACHE_MAX: usize = 4096;
 
 /// Parsing mode for the shared regex grammar parser (`parse_regex_uncached`).
 ///

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -769,6 +769,17 @@ impl Interpreter {
         } else {
             pattern.to_string()
         };
+        self.parse_regex_uncached_interpolated(&interpolated, mode)
+    }
+
+    /// Parse a pattern whose runtime interpolation has already been performed.
+    /// This is used by the top-level interpolated-pattern cache so a cache miss
+    /// does not interpolate the same source twice before the structural parse.
+    pub(super) fn parse_regex_uncached_interpolated(
+        &self,
+        interpolated: &str,
+        mode: RegexParseMode,
+    ) -> Option<RegexPattern> {
         // `Validate` mode is not memoized: a structurally-questionable pattern
         // pushes non-fatal diagnostics onto `REGEX_SORROWS` on its way to a
         // successful parse, and `validate_regex_structurally` drains them — a
@@ -777,7 +788,7 @@ impl Interpreter {
         // times over the whole profiled document, against 10,958 match-mode
         // parses).
         if mode != RegexParseMode::Match {
-            return self.parse_regex_structural(&interpolated, mode);
+            return self.parse_regex_structural(interpolated, mode);
         }
         let tok_gen =
             crate::runtime::regex_parse::TOKEN_DEFS_GEN.load(std::sync::atomic::Ordering::Relaxed);
@@ -785,7 +796,7 @@ impl Interpreter {
         if let Some(hit) = crate::runtime::regex_parse::REGEX_SUBPATTERN_PARSE_CACHE.with(|c| {
             c.borrow()
                 .get(&bucket)
-                .and_then(|m| m.get(interpolated.as_str()))
+                .and_then(|m| m.get(interpolated))
                 .filter(|(entry_gen, _)| *entry_gen == tok_gen)
                 .map(|(_, p)| std::sync::Arc::clone(p))
         }) {
@@ -798,7 +809,7 @@ impl Interpreter {
         // back into this function for its own sub-patterns.
         let ambient = &crate::runtime::regex_parse::PARSE_CONSULTED_AMBIENT_STATE;
         let outer_read = ambient.with(|f| f.replace(false));
-        let parsed = self.parse_regex_structural(&interpolated, mode);
+        let parsed = self.parse_regex_structural(interpolated, mode);
         let this_read = ambient.with(|f| f.replace(outer_read || f.get()));
         let stored = std::sync::Arc::new(parsed?);
         if !this_read {
@@ -812,7 +823,10 @@ impl Interpreter {
                 if bucket_map.len() >= crate::runtime::regex_parse::SUBPATTERN_PARSE_CACHE_MAX {
                     bucket_map.clear();
                 }
-                bucket_map.insert(interpolated, (tok_gen, std::sync::Arc::clone(&stored)));
+                bucket_map.insert(
+                    interpolated.to_owned(),
+                    (tok_gen, std::sync::Arc::clone(&stored)),
+                );
             });
         }
         Some((*stored).clone())

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -1497,34 +1497,88 @@ impl Interpreter {
     /// than a deep clone of the whole token tree (the previous owned-`RegexPattern`
     /// cache cloned the tree on every hit — ANALYSIS §8.4).
     pub(super) fn parse_regex(&self, pattern: &str) -> Option<std::sync::Arc<RegexPattern>> {
+        let package = self.current_package_sym();
+        let tok_gen =
+            crate::runtime::regex_parse::TOKEN_DEFS_GEN.load(std::sync::atomic::Ordering::Relaxed);
         if regex_pattern_is_static(pattern) {
             // Parsing resolves grammar tokens against the current package (and
             // may fold their bodies in), so the cache key includes the package;
             // a stale token-registry generation forces a re-parse.
-            let tok_gen = crate::runtime::regex_parse::TOKEN_DEFS_GEN
-                .load(std::sync::atomic::Ordering::Relaxed);
-            let key = format!("{}\u{0}{}", self.current_package(), pattern);
-            if let Some(cached) = REGEX_PARSE_CACHE.with(|c| {
+            let cache_key = (package, None);
+            let cached = REGEX_PARSE_CACHE.with(|c| {
                 c.borrow()
-                    .get(&key)
+                    .get(&cache_key)
+                    .and_then(|bucket| bucket.get(pattern))
                     .filter(|(cached_gen, _)| *cached_gen == tok_gen)
                     .map(|(_, p)| std::sync::Arc::clone(p))
-            }) {
+            });
+            if let Some(cached) = cached {
+                crate::vm::vm_stats::record_regex_parse_cache(true);
                 return Some(cached);
             }
+            crate::vm::vm_stats::record_regex_parse_cache(false);
             let parsed = lower_static_execution_pattern(pattern)
                 .or_else(|| self.parse_regex_uncached(pattern, RegexParseMode::Match))
                 .map(std::sync::Arc::new);
             if let Some(ref p) = parsed {
                 REGEX_PARSE_CACHE.with(|c| {
                     c.borrow_mut()
-                        .insert(key, (tok_gen, std::sync::Arc::clone(p)));
+                        .entry(cache_key)
+                        .or_default()
+                        .insert(pattern.to_owned(), (tok_gen, std::sync::Arc::clone(p)));
                 });
             }
             return parsed;
         }
-        self.parse_regex_uncached(pattern, RegexParseMode::Match)
-            .map(std::sync::Arc::new)
+
+        // Interpolation is the unavoidable allocation for a dynamic pattern;
+        // retain that concrete text as the cache key so an unchanged runtime
+        // value parses only once. The structural parse can still consult
+        // ambient state (for example `<$var>` or `<~~>`), so such entries are
+        // kept out of this cache by the flag maintained by the parser.
+        let interpolated = match self.interpolate_regex_scalars(pattern) {
+            Ok(s) => s,
+            Err(e) => {
+                crate::runtime::regex_parse::PENDING_REGEX_ERROR.with(|err| {
+                    *err.borrow_mut() = Some(e);
+                });
+                return None;
+            }
+        };
+        let cached = crate::runtime::regex_parse::REGEX_INTERPOLATED_PARSE_CACHE.with(|c| {
+            c.borrow()
+                .get(&package)
+                .and_then(|bucket| bucket.get(interpolated.as_str()))
+                .filter(|(cached_gen, _)| *cached_gen == tok_gen)
+                .map(|(_, p)| std::sync::Arc::clone(p))
+        });
+        if let Some(cached) = cached {
+            crate::vm::vm_stats::record_regex_parse_cache(true);
+            return Some(cached);
+        }
+        crate::vm::vm_stats::record_regex_parse_cache(false);
+
+        // The ambient-read flag belongs to one top-level parse. Clear a flag
+        // left by a previous parse before entering the recursive parser, then
+        // consume this parse's result so an impure pattern does not disable
+        // caching for all later independent patterns.
+        crate::runtime::regex_parse::PARSE_CONSULTED_AMBIENT_STATE.with(|flag| flag.set(false));
+        let parsed = self
+            .parse_regex_uncached_interpolated(&interpolated, RegexParseMode::Match)
+            .map(std::sync::Arc::new);
+        let ambient_read = crate::runtime::regex_parse::PARSE_CONSULTED_AMBIENT_STATE
+            .with(|flag| flag.replace(false));
+        if !ambient_read && let Some(ref p) = parsed {
+            crate::runtime::regex_parse::REGEX_INTERPOLATED_PARSE_CACHE.with(|c| {
+                let mut cache = c.borrow_mut();
+                let bucket = cache.entry(package).or_default();
+                if bucket.len() >= crate::runtime::regex_parse::INTERPOLATED_PARSE_CACHE_MAX {
+                    bucket.clear();
+                }
+                bucket.insert(interpolated, (tok_gen, std::sync::Arc::clone(p)));
+            });
+        }
+        parsed
     }
 
     /// Parse a regex value while retaining parser-produced source provenance.
@@ -1583,22 +1637,21 @@ impl Interpreter {
         // with the same compatibility spelling.
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         tree.hash(&mut hasher);
-        let key = format!(
-            "{}\u{0}{}\u{0}tree:{:016x}",
-            self.current_package(),
-            pattern,
-            hasher.finish()
-        );
+        let cache_key = (self.current_package_sym(), Some(hasher.finish()));
         let tok_gen =
             crate::runtime::regex_parse::TOKEN_DEFS_GEN.load(std::sync::atomic::Ordering::Relaxed);
-        if let Some(cached) = REGEX_PARSE_CACHE.with(|c| {
+        let cached = REGEX_PARSE_CACHE.with(|c| {
             c.borrow()
-                .get(&key)
+                .get(&cache_key)
+                .and_then(|bucket| bucket.get(pattern.as_str()))
                 .filter(|(cached_gen, _)| *cached_gen == tok_gen)
                 .map(|(_, p)| std::sync::Arc::clone(p))
-        }) {
+        });
+        if let Some(cached) = cached {
+            crate::vm::vm_stats::record_regex_parse_cache(true);
             return Some(cached);
         }
+        crate::vm::vm_stats::record_regex_parse_cache(false);
 
         let parsed = lower_static_execution_tree(&pattern, tree)
             .map(std::sync::Arc::new)
@@ -1606,7 +1659,9 @@ impl Interpreter {
         if let Some(ref p) = parsed {
             REGEX_PARSE_CACHE.with(|c| {
                 c.borrow_mut()
-                    .insert(key, (tok_gen, std::sync::Arc::clone(p)));
+                    .entry(cache_key)
+                    .or_default()
+                    .insert(pattern, (tok_gen, std::sync::Arc::clone(p)));
             });
         }
         parsed

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -172,6 +172,10 @@ static REGEX_MATCH_TARGETS_BUILT: AtomicU64 = AtomicU64::new(0);
 // Regex embedded-code parse cache (REGEX_CODE_PARSE_CACHE) effectiveness.
 static REGEX_CODE_PARSE_HITS: AtomicU64 = AtomicU64::new(0);
 static REGEX_CODE_PARSE_MISSES: AtomicU64 = AtomicU64::new(0);
+// Top-level regex parse cache (REGEX_PARSE_CACHE and the interpolated-pattern
+// cache) effectiveness.
+static REGEX_PARSE_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
+static REGEX_PARSE_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
 
 /// Record one lookup in the regex embedded-code parse cache.
 #[inline]
@@ -206,6 +210,18 @@ pub(crate) fn record_regex_raw_token_candidates(hit: bool) {
             REGEX_RAW_TOKEN_CANDIDATES_HITS.fetch_add(1, Ordering::Relaxed);
         } else {
             REGEX_RAW_TOKEN_CANDIDATES_MISSES.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Record one lookup in the top-level regex parse cache.
+#[inline]
+pub(crate) fn record_regex_parse_cache(hit: bool) {
+    if enabled() {
+        if hit {
+            REGEX_PARSE_CACHE_HITS.fetch_add(1, Ordering::Relaxed);
+        } else {
+            REGEX_PARSE_CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
         }
     }
 }
@@ -1218,6 +1234,11 @@ pub(crate) fn dump() {
     let raw_candidates_misses = REGEX_RAW_TOKEN_CANDIDATES_MISSES.load(Ordering::Relaxed);
     eprintln!(
         "[mutsu vm-stats] regex-raw-token-candidates-cache: hits={raw_candidates_hits} misses={raw_candidates_misses}"
+    );
+    let regex_parse_cache_hits = REGEX_PARSE_CACHE_HITS.load(Ordering::Relaxed);
+    let regex_parse_cache_misses = REGEX_PARSE_CACHE_MISSES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] regex-parse-cache: hits={regex_parse_cache_hits} misses={regex_parse_cache_misses}"
     );
     let registry_cow_clones = REGISTRY_COW_CLONES.load(Ordering::Relaxed);
     eprintln!("[mutsu vm-stats] registry-cow: clones={registry_cow_clones}");

--- a/t/regex/regex-parse-cache.t
+++ b/t/regex/regex-parse-cache.t
@@ -1,0 +1,14 @@
+use Test;
+
+# Runtime interpolation changes the concrete regex text, but repeating the
+# same value should reuse the parsed top-level pattern. A later value must get
+# its own entry rather than reusing the old tree.
+plan 4;
+
+my $needle = 'a';
+ok 'a' ~~ /$needle/, 'the first interpolated pattern matches';
+ok 'a' ~~ /$needle/, 'the same interpolated pattern matches again';
+
+$needle = 'b';
+ok 'b' ~~ /$needle/, 'a changed interpolated value gets a matching pattern';
+ok 'a' !~~ /$needle/, 'a changed interpolated value does not use the old pattern';

--- a/tests/regex_parse_cache.rs
+++ b/tests/regex_parse_cache.rs
@@ -1,0 +1,42 @@
+use std::process::Command;
+
+#[test]
+fn interpolated_regex_patterns_are_cached_by_concrete_text() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.args([
+        "-e",
+        r#"
+my $needle = "a";
+for ^16 {
+    die unless "a" ~~ /$needle/;
+}
+"#,
+    ]);
+    cmd.env("MUTSU_VM_STATS", "1");
+    let output = cmd.output().expect("failed to spawn mutsu");
+    assert!(
+        output.status.success(),
+        "program failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stats_line = stderr
+        .lines()
+        .find(|line| line.contains("regex-parse-cache:"))
+        .unwrap_or_else(|| panic!("no regex-parse-cache stats line in stderr: {stderr}"));
+    let counter = |name: &str| {
+        stats_line
+            .split_whitespace()
+            .find_map(|word| word.strip_prefix(name))
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or_else(|| panic!("missing {name} in: {stats_line}"))
+    };
+
+    assert_eq!(counter("hits="), 15, "unexpected cache hits: {stats_line}");
+    assert_eq!(
+        counter("misses="),
+        1,
+        "the unchanged interpolated pattern was parsed more than once: {stats_line}"
+    );
+}


### PR DESCRIPTION
Closes #8270

- use package Symbols and borrowed pattern lookups for the static regex parse cache
- scan static-pattern candidates without allocating a character vector
- cache pure top-level patterns after runtime interpolation with generation invalidation and a bounded per-package cache
- add VM stats and regression coverage for interpolated cache hits

Validation:
- cargo fmt --all
- cargo clippy -- -D warnings
- make test
- make roast