### PR TITLE
perf(regex): stop re-interning the smartmatch env keys on every match

### DIFF
--- a/news/2026-09/smartmatch-stops-re-interning-its-env-keys.md
+++ b/news/2026-09/smartmatch-stops-re-interning-its-env-keys.md
@@ -1,0 +1,72 @@
+# A smartmatch stops re-interning its fixed env keys on every match
+
+`"a" ~~ /a/` spent more time interning the *names* of the env slots it touched
+than it did running the matcher. Callgrind put `Symbol::intern` at 16.4% of that
+call against 8.2% for the regex engine proper — and the interned names were all
+fixed literals the process had already seen millions of times.
+
+The cause was the string-keyed `Env` API. `env.get("_")` and
+`env.insert("_".to_string(), v)` intern their key on every call; the thread-local
+memo makes a repeat intern a hit rather than a table insert, but a hit still
+hashes and compares the whole key string, and `insert` additionally allocates the
+`String` to hand it. Four places on the per-match path did this:
+
+- `exec_smart_match_expr_op` (the VM opcode every compiled `~~` runs) reads or
+  writes `$_` up to five times per match — saving the topic, probing it for an
+  aliasing container, installing the subject, reading it back to decide whether a
+  destructive RHS modified it, and restoring it.
+- The runtime's single-regex arm does its own save/install/restore of `$_`,
+  removes and re-reads `made` around the inline-action reduction, and writes `$/`.
+- `smart_match_op` reads `$/` back to decide what the operator returns.
+- Both capture-application paths write `$0`..`$N` under an `i.to_string()` key —
+  a fresh `String` allocation plus an intern, per capture, per match, and twice
+  over, since positional captures are written first as strings and then upgraded
+  to `Match` objects.
+
+All of them now go through the symbol-keyed `Env` entry points. `_` was already
+in `symbol::wk`; `/` and `made` were added next to it, and positional-capture
+indices get a small `capture_index(i)` table that interns each index lazily on
+first use. Lazily, not eagerly: interning a numeric name registers it in the
+symbol table's capture-shape registry, which `reset_capture_env_vars` probes once
+per match, so priming all sixteen up front would have charged a program that only
+ever uses `$0` fifteen extra probes per match forever.
+
+One unrelated copy went with them. The arm built the topic as
+`Value::str(text.clone())` while handing `&text` to the matcher — a full copy of
+the subject string on every `~~`, purely to have it in two places. The topic is
+now built from the subject directly and the `&str` borrowed back out of it, so
+the two share one allocation and the second reference costs a refcount bump.
+
+Measured as interns per `~~`, net of the loop carrying it
+(`tests/regex_match_intern_budget.rs`):
+
+| match | before | after |
+|---|---:|---:|
+| `"a" ~~ /a/` | 16 | 4 |
+| `"abc" ~~ /(a)(b)(c)/` | 22 | 4 |
+| `"abc" ~~ /$<first>=(a)/` | 18 | 6 |
+
+Measured on top of #8262 and #8263, which landed first and removed most of what
+*else* a match interned (a `Match` that is never forced never interns its
+attribute names). Against the base those two left, this removes three quarters of
+what remains.
+
+The capturing case is the one worth reading twice: it now costs the same as the
+capture-free case, where before it cost six more. Captures no longer add
+interning at all.
+
+The pin is deterministic rather than timed. `symbol::intern_calls()` is a new
+exact per-thread counter of `Symbol::intern` calls — distinct from the existing
+`interned_count()`, which counts the names that exist rather than the asks — so
+the test measures how much interning one *additional* match performs and asserts
+a budget on it, with no dependence on machine speed or load.
+
+What is left on that path is other paths' interning, and is deliberately not
+addressed here: the type-object names a smartmatch resolves (`Bool`, `Any`,
+`Cool`, `Mu`, `Capture`), the `Match` object's own attribute names (`str`,
+`from`, `to`, `list`, `named`, `orig`), and the `<name>` keys of named captures,
+which are still built with `format!` per match. The last of those is a different
+fix from these fixed literals — the name varies per pattern — and the
+named-capture budget in the test documents it rather than asserting it away.
+
+Closes #8269. Part of Stage 0 of ADR-0099.

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -38,7 +38,10 @@ impl Interpreter {
 
     /// Clear `$/` and all numeric capture variables (`$0`, `$1`, ...) after a failed match.
     pub(in crate::runtime) fn clear_match_state(&mut self) {
-        self.env.insert("/".to_string(), Value::NIL);
+        // Symbol-keyed: this runs on every *failed* match, so a by-name insert
+        // puts an intern of the literal `/` on the per-match path (#8269).
+        self.env
+            .insert_sym(crate::symbol::wk::match_var(), Value::NIL);
         self.reset_capture_env_vars();
     }
 
@@ -49,8 +52,8 @@ impl Interpreter {
     /// what `clear_match_state` does.)
     pub(in crate::runtime) fn clear_multi_match_state(&mut self) {
         self.clear_match_state();
-        self.env.insert(
-            "/".to_string(),
+        self.env.insert_sym(
+            crate::symbol::wk::match_var(),
             Value::array_with_kind(
                 crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
                 crate::value::ArrayKind::List,
@@ -122,7 +125,8 @@ impl Interpreter {
         }
         attrs.insert("named".to_string(), Value::hash_bare_values(named));
         let match_obj = Value::make_instance(Symbol::intern("Match"), attrs);
-        self.env.insert("/".to_string(), match_obj.clone());
+        self.env
+            .insert_sym(crate::symbol::wk::match_var(), match_obj.clone());
 
         // Reset stale numeric/named captures before applying new ones.
         self.reset_capture_env_vars();
@@ -132,10 +136,12 @@ impl Interpreter {
                 Some((from, to)) => make_capture_match(&captures.span_text(*from, *to), *from, *to),
                 None => Value::NIL,
             };
-            self.env.insert(i.to_string(), value);
+            self.env
+                .insert_sym(crate::symbol::wk::capture_index(i), value);
         }
         if captures.positional_slots().is_empty() {
-            self.env.insert("0".to_string(), Value::NIL);
+            self.env
+                .insert_sym(crate::symbol::wk::capture_index(0), Value::NIL);
         }
         // Set named capture env vars from the match object's named hash
         let named_v = match_obj.match_named();

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -956,15 +956,28 @@ impl Interpreter {
                             if !a.global && !a.exhaustive && !a.overlap && !a.perl5
                     ) =>
             {
-                let text = self.regex_match_text(left);
-                // Set $_ to the match target so $( $_ ) works inside regex
-                let saved_topic = self.env.get("_").cloned();
-                self.env.insert("_".to_string(), Value::str(text.clone()));
-                let match_result = self.regex_match_with_captures_value(right, &text);
+                // The topic Value and the `&str` the matcher walks share one
+                // allocation. Building the topic as `Value::str(text.clone())`
+                // copied the whole subject on every `~~` purely to have it in
+                // two places; cloning the `Value` instead is a refcount bump
+                // (#8269).
+                let text_val = Value::str(self.regex_match_text(left));
+                // `Value::str` always constructs a `Str`, so the fallback is
+                // unreachable; spelling it as one rather than as an assertion
+                // keeps this path off the panic surface (#8186).
+                let text: &str = text_val.as_str().unwrap_or_default();
+                // Set $_ to the match target so $( $_ ) works inside regex.
+                // Symbol-keyed throughout: the by-name `Env` API re-interns its
+                // literal on every call, and interning `_` three times per
+                // match cost more than running the matcher did (#8269).
+                let topic = crate::symbol::wk::topic();
+                let saved_topic = self.env.get_sym(topic).cloned();
+                self.env.insert_sym(topic, text_val.clone());
+                let match_result = self.regex_match_with_captures_value(right, text);
                 if let Some(v) = &saved_topic {
-                    self.env.insert("_".to_string(), v.clone());
+                    self.env.insert_sym(topic, v.clone());
                 } else {
-                    self.env.remove("_");
+                    self.env.remove_sym(topic);
                 }
                 if let Some(mut captures) = match_result {
                     // Reset stale numeric/named capture vars from any previous match.
@@ -974,14 +987,16 @@ impl Interpreter {
                         if v.alternation_padding {
                             continue;
                         }
-                        self.env
-                            .insert(i.to_string(), Value::str(captures.slot_text(v)));
+                        self.env.insert_sym(
+                            crate::symbol::wk::capture_index(i),
+                            Value::str(captures.slot_text(v)),
+                        );
                     }
                     // Clear any previous `made` value before executing code blocks
-                    self.env.remove("made");
+                    self.env.remove_sym(crate::symbol::wk::made());
                     // Reduce-time inline actions: run each subrule's `{ make … }`
                     // once (children first) and commit per-node `.made`.
-                    let starget = captures.target_or_new(&text);
+                    let starget = captures.target_or_new(text);
                     self.reduce_regex_captures_made(&mut captures, Some(&starget));
                     // Merge hash captures into named for Match object
                     let mut named_with_hash = captures.named.clone();
@@ -1033,7 +1048,7 @@ impl Interpreter {
                     if left.as_str().is_none() {
                         updates.push(("orig", left.clone()));
                     }
-                    if let Some(made_val) = self.env.get("made").cloned() {
+                    if let Some(made_val) = self.env.get_sym(crate::symbol::wk::made()).cloned() {
                         updates.push(("ast", made_val));
                     }
                     let match_obj = if updates.is_empty() {
@@ -1054,8 +1069,10 @@ impl Interpreter {
                             .rposition(|slot| !slot.alternation_padding)
                             .map_or(0, |idx| idx + 1);
                         for (i, slot) in captures.positional[..visible_len].iter().enumerate() {
-                            self.env
-                                .insert(i.to_string(), Value::pos_slot_value(slot, &starget));
+                            self.env.insert_sym(
+                                crate::symbol::wk::capture_index(i),
+                                Value::pos_slot_value(slot, &starget),
+                            );
                         }
                         for (k, slot) in &named_with_hash {
                             if k.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
@@ -1070,7 +1087,8 @@ impl Interpreter {
                         let list_v = match_obj.match_list();
                         if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {
                             for (i, v) in list.iter().enumerate() {
-                                self.env.insert(i.to_string(), v.clone());
+                                self.env
+                                    .insert_sym(crate::symbol::wk::capture_index(i), v.clone());
                             }
                         }
                         let named_v = match_obj.match_named();
@@ -1081,7 +1099,8 @@ impl Interpreter {
                             }
                         }
                     }
-                    self.env.insert("/".to_string(), match_obj);
+                    self.env
+                        .insert_sym(crate::symbol::wk::match_var(), match_obj);
                     return true;
                 }
                 self.clear_match_state();

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::fmt;
 use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};
 use std::sync::{OnceLock, RwLock};
@@ -133,6 +133,17 @@ thread_local! {
     /// siblings, not as a claimed win.)
     static INTERN_CACHE: RefCell<FxHashMap<String, Symbol>> =
         const { RefCell::new(FxHashMap::with_hasher(rustc_hash::FxBuildHasher)) };
+
+    /// How many times this thread has called [`Symbol::intern`].
+    ///
+    /// Not a leak gauge (that is [`interned_count`], which counts *distinct*
+    /// names): this counts the *calls*, including the ones the memo above
+    /// serves. A repeat intern is not free — it hashes and compares the whole
+    /// key string — so a fixed name re-interned once per operation is pure
+    /// waste, and this is how a test pins that a hot path has stopped doing it
+    /// (#8269). Per-thread and non-atomic so the counting itself cannot
+    /// contend or perturb what it measures.
+    static INTERN_CALLS: Cell<u64> = const { Cell::new(0) };
 
     /// Per-thread `id -> &'static str` memo in front of `GLOBAL_TABLE`, the
     /// mirror of `INTERN_CACHE` for the resolve direction. Interned strings are
@@ -380,6 +391,13 @@ pub(crate) mod wk {
     well_known! {
         /// The topic `$_`. Env keys are stored sigil-less, so this is `"_"`.
         topic => "_";
+        /// The match variable `$/`, stored sigil-less. Written by every
+        /// successful `~~` and by every failed one (`clear_match_state`), so
+        /// it is on the per-match path twice over (#8269).
+        match_var => "/";
+        /// The pending `make` payload a regex code block leaves behind.
+        /// Removed before, and read after, every single-regex smartmatch.
+        made => "made";
         /// The `Any` type object, the value a routine's fresh topic is seeded with.
         any => "Any";
         /// The dynamic `$?FILE`, stored sigil-less with its twigil.
@@ -438,6 +456,34 @@ pub(crate) mod wk {
         in_eval => "__mutsu_in_eval";
     }
 
+    /// How many positional-capture index names ([`capture_index`]) are served
+    /// from the pre-interned table. `$0`..`$15` covers essentially every real
+    /// pattern; a wider one falls back to the allocating path.
+    const CAPTURE_INDEX_CACHED: usize = 16;
+
+    /// The env key for positional capture `$i`, i.e. the decimal spelling of
+    /// `i`. Capture vars are stored sigil-less, so `$0`'s key is `"0"`.
+    ///
+    /// The by-name spelling of this is `env.insert(i.to_string(), ...)`, which
+    /// allocates a `String` and then re-interns it — per capture, per match.
+    /// Interning a fixed name is exactly what this module exists to avoid
+    /// (#8269).
+    ///
+    /// Each index is interned **lazily**, on first use, rather than the whole
+    /// table at once: interning a numeric name registers it in the symbol
+    /// table's capture-shape registry, which `reset_capture_env_vars` probes
+    /// per match. Priming all sixteen up front would make a program that only
+    /// ever uses `$0` pay fifteen extra probes per match forever.
+    #[inline]
+    pub(crate) fn capture_index(i: usize) -> Symbol {
+        static CELLS: [std::sync::OnceLock<Symbol>; CAPTURE_INDEX_CACHED] =
+            [const { std::sync::OnceLock::new() }; CAPTURE_INDEX_CACHED];
+        match CELLS.get(i) {
+            Some(cell) => *cell.get_or_init(|| Symbol::intern(&i.to_string())),
+            None => Symbol::intern(&i.to_string()),
+        }
+    }
+
     /// Whether `key` is one of the fixed per-call env keys the well-known
     /// method-entry family above covers. Only used by debug assertions and
     /// tests that check the string-keyed and symbol-keyed spellings agree.
@@ -471,6 +517,7 @@ impl Symbol {
     /// Intern a string and return its `Symbol`.  If the string has already been
     /// interned, the existing symbol is returned (idempotent).
     pub fn intern(s: &str) -> Symbol {
+        INTERN_CALLS.with(|c| c.set(c.get().wrapping_add(1)));
         // Thread-local memo first: interned symbols are global and append-only
         // (an id, once assigned to a string, is never reused or remapped), so a
         // cached `str -> Symbol` mapping is valid for the life of the process
@@ -734,6 +781,19 @@ impl Symbol {
     pub fn is_empty(&self) -> bool {
         self.as_str().is_empty()
     }
+}
+
+/// How many times **this thread** has called [`Symbol::intern`], memo hits
+/// included.
+///
+/// Distinct from [`interned_count`]: that one counts the names that exist, this
+/// one counts the asks. A repeat intern still hashes and compares the whole key
+/// string, so a fixed name re-interned once per operation is measurable waste —
+/// and because this counter is exact and load-independent, a test can pin that a
+/// hot path has stopped doing it without timing anything (#8269). Pinned by
+/// `tests/regex_match_intern_budget.rs`.
+pub fn intern_calls() -> u64 {
+    INTERN_CALLS.with(|c| c.get())
 }
 
 /// How many distinct strings the process has interned so far.

--- a/src/vm/vm_helpers_junction.rs
+++ b/src/vm/vm_helpers_junction.rs
@@ -221,7 +221,11 @@ impl Interpreter {
             // A bare block may hold its lexically captured `$/` in a shared
             // cell. Smartmatch returns the Match value, never the container
             // implementing that lexical binding.
-            let slash = self.env().get("/").cloned().unwrap_or(Value::NIL);
+            let slash = self
+                .env()
+                .get_sym(crate::symbol::wk::match_var())
+                .cloned()
+                .unwrap_or(Value::NIL);
             let slash = if slash.is_container_ref() {
                 slash.into_deref()
             } else {

--- a/src/vm/vm_smartmatch_ops.rs
+++ b/src/vm/vm_smartmatch_ops.rs
@@ -79,7 +79,12 @@ impl Interpreter {
         // *this* match's embedded `{ }` code blocks wrote a caller variable by name
         // (the engine records them there but nothing consumes the log otherwise).
         self.pending_local_updates.clear();
-        let saved_topic = self.env().get("_").cloned();
+        // Symbol-keyed topic access throughout this op. The by-name `Env` API
+        // re-interns its literal on every call, and this op reads or writes
+        // `$_` up to five times per `~~` -- which callgrind put at more than
+        // the matcher itself costs (#8269).
+        let topic = crate::symbol::wk::topic();
+        let saved_topic = self.env().get_sym(topic).cloned();
         // ADR-0045: `$_ ~~ s///` where the topic is an *aliasing* binding — a
         // `for` loop parameter bound to its source's element container — must
         // keep that binding for the duration of the RHS and write through it.
@@ -87,7 +92,7 @@ impl Interpreter {
         // orphan the cell and the substitution would never reach the source
         // element (`t/smartmatch-subst-topic.t`). The topic already holds
         // exactly `left`'s container, so there is nothing to install.
-        let topic_cell = match self.env().get("_").map(Value::view) {
+        let topic_cell = match self.env().get_sym(topic).map(Value::view) {
             Some(ValueView::ContainerRef(arc)) if matches!(lhs, Some(SmartMatchLhs::Var { name, .. }) if name == "_") => {
                 Some(arc.clone())
             }
@@ -101,7 +106,7 @@ impl Interpreter {
         // really does answer `True` there, which is why the flag is set from the
         // RHS's written shape rather than from what it evaluates to.
         if topic_cell.is_none() && !rhs_is_bare_topic {
-            self.env_mut().insert("_".to_string(), left.clone());
+            self.env_mut().insert_sym(topic, left.clone());
         }
         // While the RHS runs, `$_` is *aliased* to the LHS variable (`$x ~~ s///`
         // topicalizes `$x`). A destructive `s///`/`tr///` checks `$_`'s readonly
@@ -161,9 +166,9 @@ impl Interpreter {
         if lhs_is_literal && (was_substitution || was_transliterate) && right.truthy() {
             // Restore the topic before propagating the error.
             if let Some(v) = saved_topic {
-                self.env_mut().insert("_".to_string(), v);
+                self.env_mut().insert_sym(topic, v);
             } else {
-                self.env_mut().remove("_");
+                self.env_mut().remove_sym(topic);
             }
             return Err(RuntimeError::assignment_ro(Some("Str")));
         }
@@ -185,7 +190,7 @@ impl Interpreter {
         // pure predicate match as "modified".
         let topic_after = self
             .env()
-            .get("_")
+            .get_sym(topic)
             .cloned()
             .unwrap_or(Value::NIL)
             .deref_container();
@@ -279,18 +284,18 @@ impl Interpreter {
             {
                 // Restore the topic before propagating the error.
                 if let Some(v) = saved_topic.clone() {
-                    self.env_mut().insert("_".to_string(), v);
+                    self.env_mut().insert_sym(topic, v);
                 } else {
-                    self.env_mut().remove("_");
+                    self.env_mut().remove_sym(topic);
                 }
                 return Err(e);
             }
         }
         if !lhs_is_topic {
             if let Some(v) = saved_topic {
-                self.env_mut().insert("_".to_string(), v);
+                self.env_mut().insert_sym(topic, v);
             } else {
-                self.env_mut().remove("_");
+                self.env_mut().remove_sym(topic);
             }
         }
         // When RHS was a transliterate (tr///), return the result directly.

--- a/tests/regex_match_intern_budget.rs
+++ b/tests/regex_match_intern_budget.rs
@@ -1,0 +1,100 @@
+//! #8269: a `~~` must not re-intern its fixed env keys once per match.
+//!
+//! The smartmatch path saved and restored the topic, cleared the pending `make`
+//! payload, wrote `$/`, and wrote one `$0`..`$N` per positional capture — all
+//! through the *string-keyed* `Env` API, which calls `Symbol::intern` on a
+//! literal every time. A repeat intern is memoized but not free: it hashes and
+//! compares the whole key string, and callgrind put `Symbol::intern` at 16.4% of
+//! `"a" ~~ /a/`, twice what running the matcher itself cost.
+//!
+//! The pin is deterministic rather than timed. `symbol::intern_calls()` is an
+//! exact per-thread counter, so this measures the *shape* of the cost — how much
+//! interning one additional match performs — with no dependence on machine speed
+//! or load. A budget, not an equality: the remaining interns are other paths'
+//! (type-object names, the `Match` object's attribute names), and this file's job
+//! is to stop the fixed *env keys* from coming back, not to freeze every caller.
+
+/// Interns performed while running `src`, measured after a warm-up run so that
+/// one-time interning (parsing, compiling, first pass through each code path)
+/// is not counted.
+fn interns_for(src: &str) -> u64 {
+    let mut warm = mutsu::Interpreter::new();
+    warm.run(src).expect("program runs");
+    drop(warm);
+
+    let before = mutsu::symbol::intern_calls();
+    let mut interp = mutsu::Interpreter::new();
+    interp.run(src).expect("program runs");
+    mutsu::symbol::intern_calls() - before
+}
+
+/// Interns attributable to one extra iteration of `body`, isolated from the
+/// program's fixed startup cost by running the same loop at two lengths.
+fn interns_per_iteration(body: &str) -> f64 {
+    const LOW: usize = 100;
+    const HIGH: usize = 1100;
+    let program = |n: usize| format!("my $hits = 0; for ^{n} {{ {body} }}; say $hits;");
+    let lo = interns_for(&program(LOW));
+    let hi = interns_for(&program(HIGH));
+    assert!(
+        hi >= lo,
+        "interning cannot shrink with more iterations: {lo} -> {hi}"
+    );
+    (hi - lo) as f64 / (HIGH - LOW) as f64
+}
+
+/// The loop body without the match: the same `$hits++`, the same `if`, the same
+/// string literal. Subtracting it leaves the smartmatch's own interning, so the
+/// budgets below are not inflated by whatever the surrounding loop costs.
+const CONTROL: &str = r#"$hits++ if "a";"#;
+
+/// Interns one `~~` performs, over and above the loop that carries it.
+fn interns_per_match(body: &str) -> f64 {
+    interns_per_iteration(body) - interns_per_iteration(CONTROL)
+}
+
+#[test]
+fn boolean_smartmatch_does_not_intern_its_fixed_env_keys() {
+    let per_match = interns_per_match(r#"$hits++ if "a" ~~ /a/;"#);
+    eprintln!("boolean `~~`: {per_match:.3} interns per match");
+    // Measured: 16 before #8269, 4 after. The twelve that went were `$_`
+    // (read and written by both the VM op and the runtime arm), `$/` (written
+    // on the match path and read back to decide the op's result), and `made`.
+    assert!(
+        per_match <= 8.0,
+        "a boolean smartmatch re-interns a fixed env key per match \
+         ({per_match:.3} interns/match, budget 8, was 16 before the fix); see #8269"
+    );
+}
+
+#[test]
+fn capturing_smartmatch_does_not_intern_its_capture_indices() {
+    let per_match = interns_per_match(r#"$hits++ if "abc" ~~ /(a)(b)(c)/;"#);
+    eprintln!("capturing `~~`: {per_match:.3} interns per match");
+    // Measured: 22 before, 4 after. Each positional capture used to be written
+    // under an `i.to_string()` key — a fresh `String` allocation plus an intern,
+    // per capture, per match, and twice over (once as a string, once upgraded to
+    // a `Match`). Note this now costs the same as the capture-free case above,
+    // which is the property worth keeping: captures no longer add interning.
+    assert!(
+        per_match <= 8.0,
+        "a capturing smartmatch re-interns a capture-index env key per match \
+         ({per_match:.3} interns/match, budget 8, was 22 before the fix); see #8269"
+    );
+}
+
+#[test]
+fn named_capture_smartmatch_does_not_intern_its_fixed_env_keys() {
+    let per_match = interns_per_match(r#"$hits++ if "abc" ~~ /$<first>=(a)/;"#);
+    eprintln!("named-capture `~~`: {per_match:.3} interns per match");
+    // Measured: 18 before, 6 after. The budget is two wider than its siblings
+    // on purpose: the `<name>` env keys are still built with `format!` and
+    // interned per match. That is left as it stands — the name varies per
+    // pattern, so it is a different fix from these fixed literals — and this
+    // budget documents it rather than asserting it away.
+    assert!(
+        per_match <= 10.0,
+        "a named-capture smartmatch interns more than its named keys per match \
+         ({per_match:.3} interns/match, budget 10, was 18 before the fix); see #8269"
+    );
+}


### PR DESCRIPTION
`"a" ~~ /a/` spent more time interning the *names* of the env slots it touched than it did running the matcher. Callgrind put `Symbol::intern` at 16.4% of the call against 8.2% for the regex engine proper — and every one of those interned names was a fixed literal the process had already seen millions of times.

## Root cause

The string-keyed `Env` API. `env.get("_")` and `env.insert("_".to_string(), v)` intern their key on every call; the thread-local memo makes a repeat intern a hit rather than a table insert, but a hit still hashes and compares the whole key string, and `insert` additionally allocates the `String` to hand it.

Four places on the per-match path did this:

- **`exec_smart_match_expr_op`** (`src/vm/vm_smartmatch_ops.rs`) — the VM opcode every compiled `~~` runs — reads or writes `$_` up to five times per match: saving the topic, probing it for an aliasing container, installing the subject, reading it back to decide whether a destructive RHS modified it, and restoring it. The issue located the defect in `smart_match.rs`; the debugger put most of the volume here, one frame up.
- **The runtime's single-regex arm** (`src/runtime/seq_helpers/smart_match.rs`) does its own save/install/restore of `$_`, removes and re-reads `made` around the inline-action reduction, and writes `$/`.
- **`smart_match_op`** (`src/vm/vm_helpers_junction.rs`) reads `$/` back to decide what the operator returns.
- **Both capture-application paths** write `$0`..`$N` under an `i.to_string()` key — a fresh `String` allocation plus an intern, per capture, per match, and twice over, since positional captures are written first as strings and then upgraded to `Match` objects.

## The fix

All of them now use the symbol-keyed `Env` entry points. `_` was already in `symbol::wk`; `/` and `made` join it, and positional-capture indices get a small `capture_index(i)` table.

That table interns each index **lazily**, on first use, rather than all sixteen at once — deliberately. Interning a numeric name registers it in the symbol table's capture-shape registry, which `reset_capture_env_vars` probes once per match, so priming the whole table would charge a program that only ever uses `$0` fifteen extra probes per match forever.

One unrelated copy went with them: the arm built the topic as `Value::str(text.clone())` while handing `&text` to the matcher — a full copy of the subject string on every `~~`, purely to have it in two places. The topic is now built from the subject directly and the `&str` borrowed back out of it, so the two share one allocation and the second reference costs a refcount bump.

## Measurement

Interns per `~~`, net of the loop carrying it:

| match | before | after |
|---|---:|---:|
| `"a" ~~ /a/` | 16 | 4 |
| `"abc" ~~ /(a)(b)(c)/` | 22 | 4 |
| `"abc" ~~ /$<first>=(a)/` | 18 | 6 |

Measured on top of #8262 and #8263, which landed while this was in flight and removed most of what *else* a match interned (a `Match` that is never forced never interns its attribute names). Against the base those two left, this removes about three quarters of what remains.

The capturing case is the one worth reading twice: it now costs what the capture-free case costs, where before it cost six more. Captures no longer add interning at all.

## Test

`tests/regex_match_intern_budget.rs` — deterministic, not timed, as the issue asked. `symbol::intern_calls()` is a new exact per-thread counter of `Symbol::intern` calls, distinct from the existing `interned_count()` (which counts the names that exist rather than the asks). The test runs the same match loop at two lengths and subtracts a control loop, so it measures how much interning one *additional* match performs, with no dependence on machine speed or load.

## Deliberately left alone

- The `<name>` env keys of named captures are still built with `format!` per match. The name varies per pattern, so that is a different fix from these fixed literals; the named-capture budget is two wider than its siblings to document it rather than assert it away.
- The multi-match (`:g`/`:ov`/`:ex`) arms keep their by-name writes — a separate path from the one measured here.

## Verification

- `cargo fmt --all --check`, `make lint` (all four configurations) — clean
- `make test` — exit 0
- `make roast` — red only on the three container-only files documented in `docs/agent-environments.md` (`file-tests.t` Failed: 4 and `filetest.t` Failed: 25, both because this container runs as `uid 0`; `IO-Socket-Async.t` exit 124 on the sandboxed network), each matching the documented shape exactly
- `scripts/check-panic-surface.py` — 1906/1906, unchanged

Closes #8269. Part of Stage 0 of ADR-0099.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_