### PR TITLE
fix: three general gaps that kept the real JSON::Fast's suite from passing

### DIFF
--- a/news/2026-09/json-fast-upstream-suite-passes-whole.md
+++ b/news/2026-09/json-fast-upstream-suite-passes-whole.md
@@ -1,0 +1,105 @@
+# The real `JSON::Fast`'s upstream suite passes whole
+
+Upstream `JSON::Fast:ver<0.20.1>:auth<zef:timo>` — the distribution 541 of the
+1625 ecosystem distributions depend on, and which mutsu still answers with a
+native provider — now passes **all 14 of its upstream test files, 931
+assertions**, run directly against the real sources with `-I <dist>/lib`.
+
+The previous measurement ([#8239](https://github.com/tokuhirom/mutsu/issues/8239),
+the nine missing `nqp::` ops plus the `Uni`-as-codepoint-store rework) left
+`t/01-parse.t` blocked on two interpreter gaps, both since fixed
+([#8232](https://github.com/tokuhirom/mutsu/issues/8232) deep recursion raises
+instead of aborting, [#8233](https://github.com/tokuhirom/mutsu/issues/8233)
+`++$p` keeps the native reference). Re-measuring on top of those, `01-parse.t`
+was green and **three other files had failures nobody had looked at**. All three
+turned out to be general interpreter bugs with nothing to do with JSON, and this
+is what they were.
+
+## A brace was classified by what followed it, not by what was inside it
+
+```raku
+sub f($o, @k) { $o }
+say f({ "a" => 1 }, <x y>).^name;   # rakudo: Hash    mutsu: Block
+say f({ "a" => 1 }).^name;          # rakudo: Hash    mutsu: Hash
+```
+
+The same braces, two answers. `identifier_call`'s `name { block }, args` shape —
+what makes `map { $_ * 2 }, @list` work — claimed any brace that was followed by
+a comma, without ever asking whether the brace was a hash composer. Raku decides
+that purely on what is *between* the braces; what follows the `}` never enters
+into it.
+
+The classification `block_or_hash_expr` already performs is now exposed as
+`braces_are_hash_composer`, and the listop shape asks it before claiming the
+brace. One classification, two call sites — not two heuristics that can
+disagree. `BEGIN { … }` keeps its block unconditionally: it is a phaser, not a
+call taking a first argument.
+
+This is what made `to-json($obj, :sorted-keys)` die with "Don't know how to
+jsonify Block" in `t/08-sorted-keys.t`, where the test's helper is called as
+`assert-sorted { "aaaa" => { … } }, <aaaa aaab …>, message => "…"`.
+
+## A conditional over a native `is rw` reference lost the reference
+
+`#8233` taught the compiler that `f(++$p)` still denotes `$p` when `$p` is one
+of the enclosing routine's native `is rw` parameters. `JSON::Fast`'s comment
+scanner hands the position on through a conditional instead:
+
+```raku
+nom-ws($text, $ord == -1 ?? $pos !! ++$pos)
+```
+
+Each arm of rakudo's conditional yields the native reference, so the conditional
+as a whole *is* that reference — whichever arm ran. mutsu compiled it as an
+ordinary expression, collapsing both arms to a value, and the callee refused it
+with "expects a writable container".
+
+The fix compiles the *choice* into argument position: the condition, then each
+arm through the same argument chokepoint, so an arm spelled `++$p` still
+performs its increment and a bare `$p` still binds the caller's storage. Because
+each arm is compiled as an argument rather than folded to one variable, the arms
+may name different parameters (`f($c ?? $p !! $q)`), which rakudo also allows
+and the previous shape could not have expressed.
+
+`t/14-comments.t` went from dying before its first assertion to 3/3.
+
+## A punned `Rational[Int,Int]` could not say what number it was
+
+```raku
+say Rational[Int,Int].new(3, 10).Str;   # rakudo: 0.3   mutsu: Rational[Int,Int]()
+```
+
+mutsu's parametric `Rational` role (the prelude role injected for user classes
+written as `does Rational[…]`) carried a numerator, a denominator, `nude` and
+`Bool` — and nothing that answered what number those two attributes *denote*, so
+`.Str` fell through to the type-object rendering and `.Num`/`.Int`/`.abs` were
+not there at all. `JSON::Fast`'s `Rational` branch stringifies the value, so
+`to-json` emitted the literal text `Rational[Int,Int]()` inside its JSON and
+`t/04-roundtrip.t`'s round trip then died parsing it.
+
+The role now derives its whole numeric surface from the one division —
+`Rat`, `Numeric`, `Num`, `Bridge`, `Int`, `Str`, `abs`, `floor`, `ceiling` —
+which also gives `+` and `<` something to coerce through (`$r + 1` was `1`,
+rakudo's `1.3`). Deriving `.Int` from the Rat rather than from `numerator div
+denominator` is what makes it truncate toward zero instead of flooring, matching
+rakudo for a negative value.
+
+## Pins
+
+- `t/collections/hash/hash-composer-listop-argument.t` (14 assertions) — both
+  spellings, the block shapes that must stay blocks (`map`/`grep`/`sort`, a
+  placeholder body, a block whose body builds a hash).
+- `t/routines/signature/rw-param-incdec-arg-container.t` — 5 new conditional
+  cases on top of the 11 from #8233, including "the untaken arm never
+  increments" and the two-parameter conditional.
+- `t/oo/role/rational-role.t` — 13 new assertions across the numeric surface.
+
+Every expectation was measured against rakudo first.
+
+## What this does not do
+
+It does not vendor the distribution. Steps 3–4 of
+[#8226](https://github.com/tokuhirom/mutsu/issues/8226) — `modules/JSON-Fast/`
+plus deleting `src/runtime/json.rs` and `src/vm/vm_native_json.rs` — are the
+next slice, and are what actually retires the last unjustified ADR-0096 §D4
+rung-3 entry. This is the measurement that says they can go ahead.

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -463,6 +463,32 @@ impl Compiler {
             self.compile_call_arg_with_escape(&Expr::Var(name), escaping);
             return;
         }
+        // `f($at-eos ?? $p !! ++$p)` — JSON::Fast's whitespace scanner. Each
+        // arm of rakudo's conditional yields the native reference, so the
+        // conditional as a whole IS that reference: whichever arm ran is what
+        // binds. Compiling it as an ordinary expression would collapse both
+        // arms to a value and lose the container, so compile the choice itself
+        // into argument position — each arm through this same chokepoint, so
+        // an arm spelled `++$p` still performs its increment and a bare `$p`
+        // still binds the caller's storage. The arms may name different
+        // parameters; only the one evaluated is bound.
+        if let Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } = arg
+            && self.is_native_rw_param_reference(then_expr)
+            && self.is_native_rw_param_reference(else_expr)
+        {
+            self.compile_expr(cond);
+            let jump_else = self.code.emit(OpCode::JumpIfFalse(0));
+            self.compile_call_arg_with_escape(then_expr, escaping);
+            let jump_end = self.code.emit(OpCode::Jump(0));
+            self.code.patch_jump(jump_else);
+            self.compile_call_arg_with_escape(else_expr, escaping);
+            self.code.patch_jump(jump_end);
+            return;
+        }
         // Read-and-clear immediately: this call is the *direct* bind-target
         // compile iff the caller just set the flag for us. Clearing it up
         // front (before any nested `compile_expr`/`compile_call_arg`
@@ -1242,10 +1268,10 @@ impl Compiler {
             .collect();
     }
 
-    /// A call argument spelled `++$p` / `--$p` whose operand is one of the
-    /// enclosing routine's native `is rw` parameters — the one shape rakudo
-    /// lets bind through to another native `is rw` parameter. Returns the
-    /// operand's name.
+    /// A call argument that still denotes one of the enclosing routine's
+    /// native `is rw` parameters after being evaluated — `++$p` / `--$p`, or a
+    /// conditional whose arms both do — which is what rakudo lets bind through
+    /// to another native `is rw` parameter. Returns the parameter's name.
     ///
     /// Deliberately NOT matched: the postfix forms (`$p++` yields the old
     /// value, and rakudo rejects it here with "Expected a modifiable native
@@ -1266,6 +1292,18 @@ impl Compiler {
             return None;
         };
         self.native_rw_params.contains(name).then(|| name.clone())
+    }
+
+    /// Does this argument sub-expression still denote a native `is rw`
+    /// parameter after it is evaluated? True for the bare parameter and for a
+    /// prefix increment/decrement of one — the two shapes rakudo keeps as a
+    /// reference. Used to decide whether a conditional argument
+    /// ([`Compiler::compile_call_arg_with_escape`]) can bind through.
+    pub(super) fn is_native_rw_param_reference(&self, expr: &Expr) -> bool {
+        match expr {
+            Expr::Var(name) => self.native_rw_params.contains(name),
+            _ => self.native_rw_param_incdec_operand(expr).is_some(),
+        }
     }
 
     /// Check for assignment to native-typed read-only parameters inside a

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1648,8 +1648,16 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
 
     // Bareword followed by block { ... } and comma/colon — function call with block arg
     // e.g., map { $_ * 2 }, @arr  or  map { $_ * 2 }: @arr
+    //
+    // A brace is classified by what is between the braces, never by what
+    // follows the `}` — so `f { "a" => 1 }, @rest` passes a *Hash*, exactly as
+    // the same braces do with no `@rest` after them. Leave a hash composer to
+    // the ordinary term path (`block_or_hash_expr`) below instead of claiming
+    // it as a block here. `BEGIN { ... }` is the one shape that wants a block
+    // regardless: it is a phaser, not a call taking a first argument.
     if r.starts_with('{')
         && !is_keyword(&name)
+        && (name == "BEGIN" || !crate::parser::primary::misc::braces_are_hash_composer(r))
         && let Ok((r2, block_body)) = parse_block_body(r)
     {
         if name == "BEGIN" {

--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -23,8 +23,8 @@ pub(super) use reduction::reduction_op;
 pub(in crate::parser) use anon_decl::anon_role_expr;
 pub(in crate::parser) use colonpair::{colonpair_expr, wrap_colonpair_sink_source};
 pub(in crate::parser) use lambda::{
-    block_or_hash_expr, double_closure_error, parse_block_body, parse_block_body_routine,
-    parse_tracked_block_body,
+    block_or_hash_expr, braces_are_hash_composer, double_closure_error, parse_block_body,
+    parse_block_body_routine, parse_tracked_block_body,
 };
 pub(in crate::parser) use reduction::reduction_call_style_expr;
 

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -389,9 +389,7 @@ pub(crate) fn block_or_hash_expr(input: &str) -> PResult<'_, Expr> {
     }
 
     // Try to detect if this is a hash literal: { key => val, ... }
-    // Heuristic: if after ws we see `ident =>` or `"str" =>` or `'str' =>`, it's a hash.
-    // However, placeholder variables ($^x, @^x, %^x) force it to be a block.
-    if is_hash_literal_start(r) && !body_has_placeholder_vars(r) && !body_references_topic(r) {
+    if body_is_hash_composer(r) {
         return super::hash::parse_hash_literal_body(r);
     }
 
@@ -749,6 +747,35 @@ fn body_has_placeholder_vars(input: &str) -> bool {
         }
     }
     false
+}
+
+/// Does the text *after* a `{` (and its leading whitespace) compose a Hash
+/// rather than open a Block?
+///
+/// Heuristic: if we see `ident =>`, `"str" =>`, `'str' =>` or a leading
+/// `%hash`, it is a hash. Placeholder variables (`$^x`, `@^x`, `%^x`) and a
+/// reference to the topic force it back to a block.
+fn body_is_hash_composer(input: &str) -> bool {
+    is_hash_literal_start(input)
+        && !body_has_placeholder_vars(input)
+        && !body_references_topic(input)
+}
+
+/// Does the `{ … }` starting at `input` compose a Hash?
+///
+/// This is the *same* classification [`block_or_hash_expr`] performs, exposed
+/// for the call sites that must decide what a brace means before parsing it —
+/// the `name { … }, args` listop shape in `identifier_call`. Raku classifies a
+/// brace purely by what is between the braces; what follows the `}` never
+/// enters into it, so those call sites must ask here rather than assume a
+/// block.
+pub(crate) fn braces_are_hash_composer(input: &str) -> bool {
+    let Some(r) = input.strip_prefix('{') else {
+        return false;
+    };
+    let (r, _) = ws_inner(r);
+    // `{}` is the empty hash.
+    r.starts_with('}') || body_is_hash_composer(r)
 }
 
 /// Check if the input looks like a hash literal start.

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -25,6 +25,22 @@ role GLOBAL::Rational[::NuT = Int, ::DeT = Int] does Real {
     }
     method nude { self.numerator, self.denominator }
     method Bool { self.numerator != 0 }
+    # The numeric surface every Rakudo `Rational` carries. Without it a punned
+    # `Rational[Int,Int]` had a numerator and a denominator but no way to say
+    # what number it *is*: `.Str` fell through to the type-object rendering
+    # ("Rational[Int,Int]()"), which is what made JSON::Fast emit that in place
+    # of `0.3` for a `Rational[Int,Int]` value. Everything derives from the one
+    # division, so `.Int` truncates (Rat semantics) rather than flooring the way
+    # a bare `div` on the two attributes would.
+    method Rat { self.numerator / self.denominator }
+    method Numeric { self.Rat }
+    method Num { self.Rat.Num }
+    method Bridge { self.Rat.Num }
+    method Int { self.Rat.Int }
+    method Str { self.Rat.Str }
+    method abs { self.Rat.abs }
+    method floor { self.Rat.floor }
+    method ceiling { self.Rat.ceiling }
 }
 "#;
 

--- a/t/collections/hash/hash-composer-listop-argument.t
+++ b/t/collections/hash/hash-composer-listop-argument.t
@@ -1,0 +1,48 @@
+use Test;
+
+plan 14;
+
+# A brace is classified by what is between the braces, never by what follows
+# the `}`. `f { "a" => 1 }` composed a Hash, but the *same* braces in
+# `f { "a" => 1 }, @rest` were claimed by the `name { block }, args` listop
+# shape and became a Block -- so JSON::Fast's own `to-json($obj, :sorted-keys)`
+# suite died with "Don't know how to jsonify Block".
+
+sub takes-two($obj, @keys) { $obj }
+sub takes-one($obj) { $obj }
+sub takes-named($obj, @keys, :$message) { ($obj, $message) }
+
+# The regression: a hash composer followed by a second argument.
+isa-ok takes-two({ "a" => 1 }, <x y>), Hash,
+    'a quoted-key hash composer stays a hash with a second argument';
+my $no-paren = takes-two { "a" => 1 }, <x y>;
+isa-ok $no-paren, Hash, 'the no-paren listop spelling composes a hash too';
+isa-ok takes-two({ a => 1 }, <x y>), Hash,
+    'a bareword-key hash composer stays a hash with a second argument';
+isa-ok takes-two({ "a" => { "b" => 1 } }, <x y>), Hash,
+    'a nested hash composer stays a hash with a second argument';
+isa-ok takes-two({}, <x y>), Hash,
+    'empty braces stay a hash with a second argument';
+
+# The same braces with nothing after them were always right; pin both spellings
+# so the two can never disagree again.
+isa-ok takes-one({ "a" => 1 }), Hash, 'a hash composer as the only argument';
+is-deeply takes-two({ "a" => 1, "b" => 2 }, <x y>), {a => 1, b => 2},
+    'the hash keeps its contents through the call';
+
+# A named argument after the list is the `assert-sorted` shape from
+# JSON::Fast's t/08-sorted-keys.t.
+my ($obj, $msg) = takes-named { "aaaa" => { "aaac" => 1 } }, <aaaa aaac>,
+    message => "nested";
+isa-ok $obj, Hash, 'a hash composer before a trailing named argument';
+is $msg, 'nested', 'the trailing named argument still binds';
+
+# Blocks must stay blocks: the listop block-argument shape is what this path
+# exists for.
+is map({ $_ * 2 }, (1, 2, 3)).List, (2, 4, 6).List, 'map takes a block, not a hash';
+is (map { $_ * 2 }, (1, 2, 3)).List, (2, 4, 6).List, 'the no-paren spelling too';
+is (grep { $_ > 1 }, (1, 2, 3)).List, (2, 3).List, 'grep takes a block';
+is (sort { $^a <=> $^b }, (3, 1, 2)).List, (1, 2, 3).List,
+    'a placeholder body is a block, not a hash';
+is (map { %( x => $_ ) }, (1, 2)).map(*.<x>).List, (1, 2).List,
+    'a block whose body builds a hash is still a block';

--- a/t/oo/role/rational-role.t
+++ b/t/oo/role/rational-role.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 16;
+plan 29;
 
 # Parametric Rational role: a user class can compose `does Rational[...]`.
 my class MyRat does Rational[Int, Int] {};
@@ -35,3 +35,25 @@ is Foo.new(10) gcd Foo.new(4), 2, 'gcd reads Int-subclass payload';
 
 # Numeric coercion of Cool builtins.
 is-deeply Duration.new(42).Rat, <42/1>, 'Duration.Rat is exact';
+
+# The numeric surface. A punned `Rational[Int,Int]` used to carry a numerator
+# and a denominator with no way to say what number it IS: `.Str` fell through
+# to the type-object rendering, so JSON::Fast's `Rational` branch emitted
+# "Rational[Int,Int]()" where rakudo emits 0.3.
+my $third = Rational[Int, Int].new(3, 10);
+my $neg   = Rational[Int, Int].new(-7, 2);
+
+is $third.Str, '0.3', 'a punned Rational stringifies as its value';
+is $neg.Str, '-3.5', 'and so does a negative one';
+is $third.Num, 0.3e0, '.Num is the quotient';
+is $third.Numeric, 0.3, '.Numeric is the exact quotient';
+is $third.Rat, 0.3, '.Rat is the exact quotient';
+is $third.Bridge, 0.3e0, '.Bridge bridges to Num';
+is $neg.Int, -3, '.Int truncates toward zero, it does not floor';
+is $neg.abs, 3.5, '.abs';
+is $neg.floor, -4, '.floor';
+is $neg.ceiling, -3, '.ceiling';
+is $third + 1, 1.3, 'arithmetic goes through the numeric coercion';
+ok $third < 1, 'and so does comparison';
+dies-ok { Rational[Int, Int].new(1, 0).Str },
+    'a zero denominator still dies when coerced to Str';

--- a/t/routines/signature/rw-param-incdec-arg-container.t
+++ b/t/routines/signature/rw-param-incdec-arg-container.t
@@ -3,17 +3,17 @@ use Test;
 # `++$p` / `--$p` handed straight to another `is rw` parameter.
 #
 # A NATIVE-typed `is rw` parameter is bound to a native reference to the
-# caller's location, nonnative-outer rakudo's native prefix increment writes through that
+# caller's location, so rakudo's native prefix increment writes through that
 # reference and yields the reference again -- which means the callee's own
 # `is rw` parameter binds the ORIGINAL caller's storage, two frames up.
 # JSON::Fast's whitespace scanner relies on exactly this: `nom-comment($text,
 # ++$pos)` has to be able to un-eat the character it just consumed.
 #
 # The shape is narrow: rakudo accepts it ONLY when the operand is itself a
-# native `is rw` parameter. Every other spelling is an error there, nonnative-outer the
+# native `is rw` parameter. Every other spelling is an error there, so the
 # rejections below are as much a part of the pin as the acceptance.
 
-plan 11;
+plan 16;
 
 # --- accepted: the increment and the callee's decrement cancel ---------------
 
@@ -82,7 +82,7 @@ dies-ok {
     plain-native-callee(++$m);
 }, '++ on a plain native lexical is still refused';
 
-# ... while passing that same lexical WITHOUT the increment is fine, nonnative-outer the
+# ... while passing that same lexical WITHOUT the increment is fine, so the
 # refusal above is about the argument shape and not about native binding.
 {
     sub plain-pass-callee(int $p is rw) { --$p }
@@ -108,3 +108,52 @@ dies-ok {
     my int $q = 5;
     postfix-outer($q);
 }, 'postfix $p++ is still refused';
+
+# --- a conditional over the reference ----------------------------------------
+#
+# `nom-comment` hands the scan position on as `nom-ws($text, $ord == -1 ?? $pos
+# !! ++$pos)`. Each arm of rakudo's conditional yields the native reference, so
+# the conditional as a whole is still that reference -- whichever arm ran.
+
+{
+    sub inner(int $p is rw) { --$p }
+    sub outer(int $p is rw) { inner(True ?? $p !! ++$p) }
+    my int $pos = 5;
+    outer($pos);
+    is $pos, 4, 'the taken arm is a bare parameter: it binds, nothing increments';
+}
+
+{
+    sub inner(int $p is rw) { --$p }
+    sub outer(int $p is rw) { inner(False ?? $p !! ++$p) }
+    my int $pos = 5;
+    outer($pos);
+    is $pos, 5, 'the taken arm is ++$p: it increments, then binds';
+}
+
+{
+    sub inner(int $p is rw) { --$p }
+    sub outer(int $p is rw) { inner(True ?? ++$p !! $p) }
+    my int $pos = 5;
+    outer($pos);
+    is $pos, 5, 'the increment arm works on the then side too';
+}
+
+# Only the arm actually taken runs its increment.
+{
+    sub inner(int $p is rw) { }
+    sub outer(int $p is rw) { inner(False ?? ++$p !! --$p) }
+    my int $pos = 5;
+    outer($pos);
+    is $pos, 4, 'the untaken arm never increments';
+}
+
+# The two arms need not name the same parameter; the chosen reference binds.
+{
+    sub inner(int $p is rw) { --$p }
+    sub outer(int $p is rw, int $q is rw) { inner(True ?? $p !! $q) }
+    my int $a = 5;
+    my int $b = 9;
+    outer($a, $b);
+    is "$a,$b", '4,9', 'a conditional over two parameters binds the chosen one';
+}


### PR DESCRIPTION
Upstream `JSON::Fast:ver<0.20.1>:auth<zef:timo>` now passes **all 14 of its own
test files, 931 assertions**, run directly against the real sources with
`-I <dist>/lib`.

With #8232 and #8233 merged, `t/01-parse.t` — the file the previous slice
(#8239) named as the one blocker — came back green on its own. Re-measuring the
whole suite then showed **three other files failing on things nobody had looked
at**, and all three were general interpreter bugs with nothing to do with JSON.

## 1. A brace was classified by what followed it, not by what was inside it

```raku
sub f($o, @k) { $o }
say f({ "a" => 1 }, <x y>).^name;   # rakudo: Hash    mutsu: Block
say f({ "a" => 1 }).^name;          # rakudo: Hash    mutsu: Hash
```

The same braces, two answers. `identifier_call`'s `name { block }, args` shape —
what makes `map { $_ * 2 }, @list` work — claimed any brace followed by a comma
without ever asking whether the brace was a hash composer. Raku decides that
purely on what is *between* the braces; what follows the `}` never enters into
it.

The classification `block_or_hash_expr` already performs is now exposed as
`braces_are_hash_composer` and asked at both call sites, so the two cannot
disagree. `BEGIN { … }` keeps its block unconditionally: it is a phaser, not a
call taking a first argument.

This is what made `to-json($obj, :sorted-keys)` die with `Don't know how to
jsonify Block` in `t/08-sorted-keys.t`, whose helper is called as
`assert-sorted { "aaaa" => { … } }, <aaaa aaab …>, message => "…"`.

## 2. A conditional over a native `is rw` reference lost the reference

#8233 taught the compiler that `f(++$p)` still denotes `$p` when `$p` is one of
the enclosing routine's native `is rw` parameters. `JSON::Fast`'s comment
scanner hands the scan position on through a conditional instead:

```raku
nom-ws($text, $ord == -1 ?? $pos !! ++$pos)
```

Each arm of rakudo's conditional yields the native reference, so the conditional
as a whole *is* that reference — whichever arm ran. mutsu compiled it as an
ordinary expression, collapsing both arms to a value, and the callee refused it
with "expects a writable container".

The fix compiles the *choice* into argument position: the condition, then each
arm through the same argument chokepoint, so an arm spelled `++$p` still
performs its increment and a bare `$p` still binds the caller's storage. Because
each arm is compiled as an argument rather than folded to one variable, the arms
may name different parameters (`f($c ?? $p !! $q)`) — which rakudo also allows,
and which the shape #8233 introduced could not have expressed.

`t/14-comments.t` went from dying before its first assertion to 3/3.

## 3. A punned `Rational[Int,Int]` could not say what number it was

```raku
say Rational[Int,Int].new(3, 10).Str;   # rakudo: 0.3   mutsu: Rational[Int,Int]()
```

The prelude `Rational` role carried a numerator, a denominator, `nude` and
`Bool` — and nothing that answered what those two attributes *denote*. `.Str`
fell through to the type-object rendering and `.Num`/`.Int`/`.abs` were not
there at all, so `JSON::Fast`'s `Rational` branch emitted the literal text
`Rational[Int,Int]()` inside its JSON and `t/04-roundtrip.t` then died parsing
it back.

The role now derives its whole numeric surface from the one division — `Rat`,
`Numeric`, `Num`, `Bridge`, `Int`, `Str`, `abs`, `floor`, `ceiling` — which also
gives `+` and `<` something to coerce through (`$r + 1` answered `1`, rakudo's
`1.3`). Deriving `.Int` from the Rat rather than from `numerator div
denominator` is what makes it truncate toward zero instead of flooring, matching
rakudo on a negative value.

## Test plan

Every expectation below was measured against rakudo first.

- New `t/collections/hash/hash-composer-listop-argument.t` — 14 assertions: both
  spellings, quoted/bareword/nested/empty composers, a trailing named argument,
  and the block shapes that must stay blocks (`map`/`grep`/`sort`, a placeholder
  body, a block whose body builds a hash). 14/14 under rakudo and mutsu.
- `t/routines/signature/rw-param-incdec-arg-container.t` — 5 new conditional
  cases on top of #8233's 11, including "the untaken arm never increments" and
  the two-parameter conditional. 16/16 both sides. The file's prose is also
  repaired: three occurrences of "so" had been overwritten with a sub name when
  it landed.
- `t/oo/role/rational-role.t` — 13 new assertions across the numeric surface,
  including the negative-value `.Int`/`.floor`/`.ceiling` split and the
  zero-denominator death. 29/29 both sides.
- The real distribution: `prove -e 'mutsu -I lib' -r t/` over all 14 upstream
  files → `Files=14, Tests=931, Result: PASS` (was 11 of 14).
- `cargo fmt --all`, `make lint` (all four configurations), `make test`
  (`Files=4204, Tests=44793, Result: PASS`, exit 0) and `make roast` run
  locally. `make roast` comes back with only the three environment-only failures
  documented in `docs/agent-environments.md` for a remote container —
  `roast/6.c/S32-io/file-tests.t` and `roast/S16-filehandles/filetest.t` (both
  `uid 0` chmod-based file tests) and `roast/S32-io/IO-Socket-Async.t`
  (sandboxed network) — matching that table's recorded failure shapes test for
  test; everything else is green.

## Scope

This does **not** vendor the distribution. Steps 3–4 of #8226 —
`modules/JSON-Fast/` plus deleting `src/runtime/json.rs` and
`src/vm/vm_native_json.rs` — are the next slice, and are what actually retires
the last unjustified ADR-0096 §D4 rung-3 entry. This is the measurement that
says they can go ahead, so #8226 stays open.

Refs #8226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMQwQoZeiJDBM5iK3hvPsK)_