### PR TITLE
fix(rakuast): preserve bare subrules

### DIFF
--- a/docs/adr/0088-rakuast-regex-boundary-tree.md
+++ b/docs/adr/0088-rakuast-regex-boundary-tree.md
@@ -2,7 +2,8 @@
 
 - Status: Accepted (static source-tree, RakuAST, execution-lowering,
   static-value-provenance, declaration-provenance, positional-capture,
-  scalar-interpolation, named-capture, and array-capture slices implemented
+  scalar-interpolation, named-capture, array-capture, subrule-alias, and
+  bare-subrule slices implemented
   2026-09-12/13; other dynamic contents and the complete execution-tree
   migration remain)
 - Date: 2026-09-12
@@ -548,3 +549,28 @@ the model can retain their name-part and argument semantics. The focused
 regression is `t/rakuast/rakuast-regex.t`, which pins the alias source shape,
 assertion hierarchy and accessors, model construction, alias/original captures,
 and end-to-end grammar EVAL execution.
+
+## 16. Bare and dot-suppressed subrule slice (2026-09-13)
+
+Simple bare and dot-suppressed subrule spellings (`<name>` and `<.name>`) now
+retain their source form in the shared tree as `RegexNode::Subrule`, with the
+`capturing` bit recording whether the dot was written. The read direction maps
+both forms to `RakuAST::Regex::Assertion::Named`, omitting `capturing` for the
+dot-suppressed form just as Rakudo does. The existing Named assertion model and
+write direction from the alias slice therefore cover both constructed and
+parser-created trees.
+
+The execution lowerer deliberately leaves `Subrule` nodes on the existing
+runtime parser path. Bare names overlap with context-sensitive assertions such
+as `<same>`, `<wb>`, `<ww>`, and builtin classes, while grammar-local tokens can
+shadow those names. Returning no direct execution plan for this node lets the
+existing matcher resolve that package state, builtin precedence, and capture
+side effects unchanged. This slice expands the RakuAST boundary without
+claiming that those names are static lookup operations.
+
+Only simple, unqualified names without arguments are included. Qualified and
+argumented subrules, code assertions, and other assertion forms remain
+follow-up boundaries. The focused regression is
+`t/rakuast/rakuast-regex.t`, which pins both AST spellings, the default and
+explicit capture flags, ordinary capture behavior, dot suppression, and a
+grammar-local override of the special `same` assertion.

--- a/news/2026-09/rakuast-regex-subrules.md
+++ b/news/2026-09/rakuast-regex-subrules.md
@@ -1,0 +1,4 @@
+The RakuAST regex boundary now preserves simple bare subrules (`<name>`) and
+dot-suppressed subrules (`<.name>`) as structured named assertions. Their
+execution continues through the existing context-sensitive matcher so builtin
+assertions and grammar-local subrule overrides retain their behavior.

--- a/src/regex_tree.rs
+++ b/src/regex_tree.rs
@@ -339,17 +339,12 @@ impl RegexTree {
                         };
                     Some(tokens)
                 }
-                RegexNode::Subrule { name, capturing } => {
-                    let name = if *capturing {
-                        name.clone()
-                    } else {
-                        format!(".{name}")
-                    };
-                    Some(vec![token(
-                        crate::runtime::RegexAtom::Named(name.into()),
-                        crate::runtime::RegexQuant::One,
-                        ratchet,
-                    )])
+                RegexNode::Subrule { .. } => {
+                    // Bare and dot-suppressed subrules share spelling with
+                    // builtin assertions and grammar-local names. Let the
+                    // runtime parser resolve that context-sensitive spelling
+                    // instead of reducing it to a generic Named atom here.
+                    None
                 }
                 RegexNode::SubruleAlias { alias, name } => Some(vec![token(
                     crate::runtime::RegexAtom::Named(format!("{alias}={name}").into()),
@@ -818,7 +813,15 @@ impl Parser {
             }
             return None;
         }
-        None
+        let (capturing, name) = if let Some(name) = contents.strip_prefix('.') {
+            (false, name)
+        } else {
+            (true, contents.as_str())
+        };
+        is_simple_subrule_name(name).then(|| RegexNode::Subrule {
+            name: name.to_string(),
+            capturing,
+        })
     }
 
     fn parse_variable_name(&mut self) -> Option<String> {

--- a/t/rakuast/rakuast-regex.t
+++ b/t/rakuast/rakuast-regex.t
@@ -8,7 +8,7 @@ use Test;
 # shapes Rakudo exposes. Dynamic assertions and non-scalar interpolations
 # remain explicit follow-up boundaries.
 
-plan 33;
+plan 40;
 
 is Q[/a/].AST.gist, q:to/END/.chomp, 'a regex literal has a Literal body';
     RakuAST::StatementList.new(
@@ -253,6 +253,31 @@ is Q[/<alias=foo>/].AST.gist, q:to/END/.chomp, 'a subrule alias retains its asse
     )
     END
 
+is Q[/<foo>/].AST.gist, q:to/END/.chomp, 'a capturing subrule retains its Named assertion';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedRegex.new(
+          body => RakuAST::Regex::Assertion::Named.new(
+            name      => RakuAST::Name.from-identifier("foo"),
+            capturing => True
+          )
+        )
+      )
+    )
+    END
+
+is Q[/<.foo>/].AST.gist, q:to/END/.chomp, 'a dot-suppressed subrule omits capturing';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedRegex.new(
+          body => RakuAST::Regex::Assertion::Named.new(
+            name => RakuAST::Name.from-identifier("foo")
+          )
+        )
+      )
+    )
+    END
+
 my $named-subrule = RakuAST::Regex::Assertion::Named.new(
     name => RakuAST::Name.from-identifier('part'),
     capturing => True,
@@ -263,6 +288,12 @@ is $named-subrule.name.raku, 'RakuAST::Name.from-identifier("part")',
     'named subrule assertions expose their Name child';
 is $named-subrule.capturing, True,
     'named subrule assertions expose their capturing flag';
+
+my $silent-subrule = RakuAST::Regex::Assertion::Named.new(
+    name => RakuAST::Name.from-identifier('suffix'),
+);
+is $silent-subrule.capturing, False,
+    'named subrule assertions default to non-capturing';
 
 my $alias-subrule = RakuAST::Regex::Assertion::Alias.new(
     name => 'word',
@@ -286,3 +317,23 @@ is ~$subrule-match<word>, 'a', 'a subrule alias captures under its alias name';
 is ~$subrule-match<part>, 'a', 'a subrule alias retains the original capture name';
 is $subrule-match.hash.keys.sort.join(','), 'part,word',
     'a subrule alias retains both alias and original captures';
+
+my $ordinary-subrule-grammar = EVAL(Q[grammar GRegexBareSubrule {
+    token TOP { <part><.suffix> };
+    token part { "a" };
+    token suffix { "b" };
+}].AST);
+my $ordinary-subrule-match = $ordinary-subrule-grammar.parse('ab');
+ok $ordinary-subrule-match,
+    'a bare and dot-suppressed subrule lower through the existing matcher';
+is ~$ordinary-subrule-match<part>, 'a',
+    'a bare subrule retains its named capture';
+ok !$ordinary-subrule-match<suffix>.defined,
+    'a dot-suppressed subrule does not publish a named capture';
+
+my $builtin-override-grammar = EVAL(Q[grammar GRegexBuiltinOverride {
+    token TOP { <same> };
+    token same { "a" };
+}].AST);
+ok $builtin-override-grammar.parse('a'),
+    'a grammar-local subrule keeps precedence over a special builtin assertion';


### PR DESCRIPTION
## Summary

- Preserve simple `<name>` and `<.name>` subrules in the shared RegexTree.
- Expose Rakudo-compatible `RakuAST::Regex::Assertion::Named` nodes.
- Keep context-sensitive special/builtin and grammar-local dispatch on the existing matcher path.

Part of #8033.

## Validation

- `cargo fmt --all`
- `make lint`
- `make test` (4205 files / 44788 tests, PASS)
- `make roast` (1437 files / 219658 tests, PASS)
- focused `t/rakuast/rakuast-regex.t` (40 tests, PASS)