### PR TITLE
fix(vm): a grammar under `X::` is not an exception, `splice` checks its bounds on every path, and a sigilless alias survives a method hop

### DIFF
--- a/news/2026-09/x-namespaced-grammars-splice-bounds-and-sigilless-alias-hops.md
+++ b/news/2026-09/x-namespaced-grammars-splice-bounds-and-sigilless-alias-hops.md
@@ -1,0 +1,108 @@
+# A grammar named `X::…` is not an exception, `splice` checks its bounds everywhere, and a `\c` alias survives a method hop
+
+Four general interpreter bugs, found by re-measuring `Crane` v0.1.2 (the
+dependency `Config::TOML` is built on, [#7539](https://github.com/tokuhirom/mutsu/issues/7539))
+against the `raku` oracle. `Crane` goes from 7/15 to 9/15 files, and the three
+files still red lose most of their remaining failing assertions.
+
+## 1. A `Match` of a grammar declared under `X::` was treated as an exception
+
+mutsu has no complete exception hierarchy to consult, so about twenty sites
+decide "is this an exception?" from the class name alone — `Exception`, or the
+reserved `X::` / `CX::` namespaces. That test has one systematic false
+positive. A grammar's `Match` is typed by the *grammar*, not by `Match`:
+rakudo answers `X::Foo::G` for `X::Foo::G.parse($s).^name`. So every one of
+those sites was handed a "class name in the exception namespace" that was a
+match object:
+
+```raku
+grammar X::Deep::G { token TOP { \d+ } }
+my $m = X::Deep::G.parse('42');
+say $m.Str;        # rakudo: 42      mutsu: X::Deep::G with no message
+say +$m;           # rakudo: 42      mutsu: Failure (numifying that text)
+say $m.chars;      # rakudo: 2       mutsu: 12
+say $m ~~ Exception;  # rakudo: False   mutsu: True
+```
+
+Not a contrived namespace. `Crane` declares a grammar inside
+`class X::Crane::PathOutOfRange`, to parse the `Range` back out of an
+`X::OutOfRange`; its action method is `method integer($/) { make(+$/) }`, so
+every out-of-range path error died while rendering its own message —
+`Type check failed for an element of @integer; expected Int:D but got Any`.
+
+The namespace test is now one predicate, `Value::instance_is_exception_by_name`,
+which excludes a `Match`, and the sites that carry extra terms (an MRO walk, a
+`*Exception` suffix) go through it too. The surviving bare-name checks are the
+ones that never see a `Match` — a declared parent, a parsed bareword.
+
+## 2. `splice` validated its offset only on the lvalue path
+
+Rakudo checks `splice`'s offset and size *before* it writes: an offset outside
+`0..elems` and a negative size are `X::OutOfRange`, not a splice clamped to the
+end. mutsu did that for a named-variable invocant and not at all for a
+by-value one — a literal, a function result, an element read, anything reached
+through `return-rw`:
+
+```raku
+[1,2,3].splice(5, 0, 'x')   # rakudo: X::OutOfRange   mutsu: appended silently
+```
+
+`Crane.add`'s whole out-of-range family is `Crane::At.at($root, @path).splice(...)`
+inside a `CATCH { when X::OutOfRange }`, so five `add`/`copy`/`move` subtests
+reported success where rakudo raises `X::Crane::AddPathOutOfRange`. The range
+check is now a shared helper both dispatch paths call, so the two cannot drift.
+
+## 3. A sigilless parameter forwarded to a *method* lost the caller's container
+
+A `\c` parameter IS the caller's container, so forwarding it must keep that
+identity however many hops it takes. A sub callee always worked: sub frames
+chain env, so the exit writeback's "resolve to the root of the alias chain"
+reached the original variable. A method callee does not chain env — its
+writeback merges only into the frame that called it, where the chain's root is
+not a key at all — so the write landed on a phantom entry, and the intermediate
+frame then reached its own exit still holding the pre-call value and clobbered
+the root with it:
+
+```raku
+class Leaf { method go(\c) { c = 1 } }
+class Mid  { method go(\c) { Leaf.go(c) } }
+my $v; Mid.go($v);   # rakudo: 1   mutsu: (Any)
+```
+
+Each frame's writeback now also updates the caller's own alias binding, so the
+hops compose into one another the way the chained-env sub path already reached
+the root. That is `Crane.add/set/remove($container, :path(), …, :in-place)`,
+which is a chain of class methods forwarding one `\container`.
+
+## 4. A raw alias of an `@`/`%` variable stored the bare `List`
+
+Raku gives `@a`/`%h` no `Scalar` of their own, so `\c := @a` makes `c` BE the
+array and `c = LIST` is `@a.STORE(LIST)`. The writeback that carries a
+sigilless parameter's final value back passed it through verbatim, so the
+caller kept a bare `List` — and, one relay hop further, the itemized
+`$("x", "y")` the hop's holder had put on it:
+
+```raku
+sub f(\c) { c = ('x','y') }
+my @a; f(@a);   # rakudo: ["x", "y"]   mutsu: ("x", "y")
+my %h; f(%h);   # rakudo: {:x("y")}    mutsu: ("x", "y")
+```
+
+The three writeback sites now shape the value for the target's own sigil, in
+one shared helper.
+
+## Measurement
+
+| Suite | raku | before | after |
+| --- | --- | --- | --- |
+| `Crane` v0.1.2 | 15/15 files | 7/15 | **9/15** |
+| `Config::TOML` v0.1.3 | 19/19 files | 14/19 | 14/19 |
+
+`Crane`'s `copy` and `move` are the two newly green files; `add` now passes
+every assertion of its exception subtest and every in-place assertion but the
+nested one.
+
+Pins: `t/grammar/match-of-x-namespaced-grammar-is-not-an-exception.t`,
+`t/collections/array/splice-offset-out-of-range-by-value-invocant.t`,
+`t/vm/sigilless-alias-forwarded-through-a-class-hop.t` — 55 assertions, each
+verified to fail without its fix and to pass under rakudo v2026.07.

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1477,7 +1477,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
     } = target.view()
     {
         let cn = class_name.resolve();
-        if cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::") {
+        if target.instance_is_exception_by_name() {
             match method {
                 "gist" => {
                     let bt = attributes

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -69,13 +69,11 @@ impl Interpreter {
         }
         if let ValueView::Instance { class_name, .. } = value.view() {
             let cn = class_name.resolve();
-            let is_exception = cn == "Exception"
-                || cn.starts_with("X::")
-                || cn.starts_with("CX::")
-                || self
-                    .mro_readonly(&cn)
-                    .iter()
-                    .any(|p| p == "Exception" || p.starts_with("X::") || p.starts_with("CX::"));
+            let is_exception = !value.is_match_instance()
+                && (value.instance_is_exception_by_name()
+                    || self.mro_readonly(&cn).iter().any(|p| {
+                        p == "Exception" || p.starts_with("X::") || p.starts_with("CX::")
+                    }));
             if is_exception {
                 err.exception = Some(Box::new(value.clone()));
             } else {

--- a/src/runtime/exception_message.rs
+++ b/src/runtime/exception_message.rs
@@ -83,10 +83,11 @@ impl Interpreter {
         let ValueView::Instance { class_name, .. } = target.view() else {
             return false;
         };
+        if target.is_match_instance() {
+            return false;
+        }
         let cn = class_name.resolve();
-        cn == "Exception"
-            || cn.starts_with("X::")
-            || cn.starts_with("CX::")
+        target.instance_is_exception_by_name()
             || cn.ends_with("Exception")
             || self
                 .class_mro(&cn)
@@ -112,6 +113,9 @@ impl Interpreter {
         let ValueView::Instance { attributes, .. } = target.view() else {
             return false;
         };
+        if target.is_match_instance() {
+            return false;
+        }
         let stored = {
             let map = attributes.as_map();
             let looks_like_exception = cn == "Exception"

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -1088,11 +1088,10 @@ impl Interpreter {
             let cn = class_name.resolve();
             let mro = self.class_mro(&cn);
             let does_x_control = cn == "X::Control" || mro.iter().any(|p| p == "X::Control");
-            let is_exception = cn == "Exception"
-                || cn == "Failure"
-                || cn.starts_with("X::")
-                || cn.starts_with("CX::")
-                || mro.iter().any(|p| p == "Exception" || p == "Failure");
+            let is_exception = !target.is_match_instance()
+                && (target.instance_is_exception_by_name()
+                    || cn == "Failure"
+                    || mro.iter().any(|p| p == "Exception" || p == "Failure"));
             if is_exception || does_x_control {
                 if method == "resume" {
                     return Err(crate::value::RuntimeError::resume_signal());
@@ -1724,6 +1723,14 @@ impl Interpreter {
                         return Err(make_multi_no_match_error("splice"));
                     }
                 }
+                // Bounds are checked before the write, exactly as the lvalue
+                // path does: an offset outside `0..len` and a negative size are
+                // X::OutOfRange in rakudo, not a clamped splice at the end.
+                let arr_len = match target.view() {
+                    ValueView::Array(items, ..) => items.len(),
+                    _ => 0,
+                };
+                Self::validate_splice_range(arr_len, &args)?;
             }
             // Splice replacements land in the shared node in place now, so
             // type-check them up front (flattened like do_splice flattens).
@@ -2617,13 +2624,11 @@ impl Interpreter {
             && let ValueView::Instance { class_name, .. } = target.view()
         {
             let cn = class_name.resolve();
-            let is_exception = cn == "Exception"
-                || cn.starts_with("X::")
-                || cn.starts_with("CX::")
-                || self
-                    .class_mro(&cn)
-                    .iter()
-                    .any(|p| p == "Exception" || p.starts_with("X::") || p.starts_with("CX::"));
+            let is_exception = !target.is_match_instance()
+                && (target.instance_is_exception_by_name()
+                    || self.class_mro(&cn).iter().any(|p| {
+                        p == "Exception" || p.starts_with("X::") || p.starts_with("CX::")
+                    }));
             if is_exception {
                 // Derive the human message via `.message` (X::AdHoc → `payload`,
                 // a typed exception → its formatted message) rather than the

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -276,6 +276,95 @@ impl Interpreter {
         resolved
     }
 
+    /// Reject a `splice` offset/size that falls outside the invocant's bounds.
+    ///
+    /// Rakudo's `splice` validates both positions before it touches the array:
+    /// an offset outside `0..len` and a negative size are `X::OutOfRange`, not a
+    /// clamped write. The lvalue path (`methods_mut_dispatch`) always did this;
+    /// the by-value path (`f().splice(...)`, an element read, a literal) did
+    /// not, so `[1,2,3].splice(5, 0, 'x')` silently spliced at the end and
+    /// `Crane`'s `CATCH { when X::OutOfRange }` never fired. Shared here so the
+    /// two cannot drift.
+    ///
+    /// `args` must already have had its callables resolved by
+    /// [`Interpreter::resolve_splice_callable_args`] — a `*-1` that still reads
+    /// as a `WhateverCode` resolves to no integer and would skip the check.
+    pub(crate) fn validate_splice_range(
+        arr_len: usize,
+        args: &[Value],
+    ) -> Result<(), RuntimeError> {
+        /// Resolve a splice position to a signed integer for validation.
+        fn resolve_raw(v: &Value, len: usize) -> Option<i64> {
+            match v.view() {
+                ValueView::Int(i) => Some(i),
+                ValueView::Whatever => Some(len as i64),
+                ValueView::Str(s) => s.parse::<i64>().ok(),
+                ValueView::Num(n) => Some(n as i64),
+                // Handle Mixin (allomorphic types like IntStr)
+                ValueView::Mixin(inner, _) => resolve_raw(inner, len),
+                _ => None,
+            }
+        }
+        if let Some(raw_offset) = args.first().and_then(|v| resolve_raw(v, arr_len))
+            && (raw_offset < 0 || raw_offset as usize > arr_len)
+        {
+            return Err(RuntimeError::typed(
+                "X::OutOfRange",
+                [
+                    (
+                        "message".to_string(),
+                        Value::str(format!(
+                            "Offset argument to splice out of range. Is: {}, should be in 0..{}",
+                            raw_offset, arr_len
+                        )),
+                    ),
+                    (
+                        "what".to_string(),
+                        Value::str_from("Offset argument to splice"),
+                    ),
+                    ("got".to_string(), Value::int(raw_offset)),
+                    ("range".to_string(), Value::str(format!("0..{}", arr_len))),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+        }
+        if let Some(raw_size) = args.get(1).and_then(|v| resolve_raw(v, arr_len))
+            && raw_size < 0
+        {
+            let resolved_start = args
+                .first()
+                .and_then(|v| resolve_raw(v, arr_len))
+                .unwrap_or(0)
+                .max(0) as usize;
+            let remaining = arr_len.saturating_sub(resolved_start);
+            return Err(RuntimeError::typed(
+                "X::OutOfRange",
+                [
+                    (
+                        "message".to_string(),
+                        Value::str(format!(
+                            "Size argument to splice out of range. Is: {}, should be in 0..^{}",
+                            raw_size, remaining
+                        )),
+                    ),
+                    (
+                        "what".to_string(),
+                        Value::str_from("Size argument to splice"),
+                    ),
+                    ("got".to_string(), Value::int(raw_size)),
+                    (
+                        "range".to_string(),
+                        Value::str(format!("0..^{}", remaining)),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Mutate an Array value in place for push/pop/shift/unshift/append/
     /// prepend/splice on a by-value invocant (function results, element
     /// reads, literals). Container identity (§3.2): the mutation writes

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1383,14 +1383,13 @@ impl Interpreter {
             // `message` already won dispatch above, so reaching here is the default.
             if args.is_empty() && matches!(method, "gist" | "Str" | "Stringy" | "message") {
                 let cn = class_name.resolve();
-                let is_exception = cn == "Exception"
-                    || cn.starts_with("X::")
-                    || cn.starts_with("CX::")
-                    || cn.ends_with("Exception")
-                    || self
-                        .class_mro(&cn)
-                        .iter()
-                        .any(|p| p == "Exception" || p == "Failure");
+                let is_exception = !target.is_match_instance()
+                    && (target.instance_is_exception_by_name()
+                        || cn.ends_with("Exception")
+                        || self
+                            .class_mro(&cn)
+                            .iter()
+                            .any(|p| p == "Exception" || p == "Failure"));
                 if is_exception {
                     // This arm is only the DEFAULT implementation of
                     // `Exception.message`/`.gist`/`.Str`. A class that defines

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1414,70 +1414,9 @@ impl Interpreter {
                             );
                         }
                     }
-                    // Validate offset range
-                    if let Some(offset_val) = resolved_args.first()
-                        && let Some(raw_offset) = resolve_splice_raw(offset_val, arr_len)
-                        && (raw_offset < 0 || raw_offset as usize > arr_len)
-                    {
-                        return Err(RuntimeError::typed(
-                            "X::OutOfRange",
-                            [
-                                (
-                                    "message".to_string(),
-                                    Value::str(format!(
-                                        "Offset argument to splice out of range. Is: {}, should be in 0..{}",
-                                        raw_offset, arr_len
-                                    )),
-                                ),
-                                (
-                                    "what".to_string(),
-                                    Value::str_from("Offset argument to splice"),
-                                ),
-                                ("got".to_string(), Value::int(raw_offset)),
-                                (
-                                    "range".to_string(),
-                                    Value::str(format!("0..{}", arr_len)),
-                                ),
-                            ]
-                            .into_iter()
-                            .collect(),
-                        ));
-                    }
-                    // Validate size range
-                    if let Some(size_val) = resolved_args.get(1)
-                        && let Some(raw_size) = resolve_splice_raw(size_val, arr_len)
-                        && raw_size < 0
-                    {
-                        let resolved_start = resolved_args
-                            .first()
-                            .and_then(|v| resolve_splice_raw(v, arr_len))
-                            .unwrap_or(0)
-                            .max(0) as usize;
-                        let remaining = arr_len.saturating_sub(resolved_start);
-                        return Err(RuntimeError::typed(
-                            "X::OutOfRange",
-                            [
-                                (
-                                    "message".to_string(),
-                                    Value::str(format!(
-                                        "Size argument to splice out of range. Is: {}, should be in 0..^{}",
-                                        raw_size, remaining
-                                    )),
-                                ),
-                                (
-                                    "what".to_string(),
-                                    Value::str_from("Size argument to splice"),
-                                ),
-                                ("got".to_string(), Value::int(raw_size)),
-                                (
-                                    "range".to_string(),
-                                    Value::str(format!("0..^{}", remaining)),
-                                ),
-                            ]
-                            .into_iter()
-                            .collect(),
-                        ));
-                    }
+                    // Validate the offset/size ranges. Shared with the by-value
+                    // invocant path so the two cannot drift.
+                    Self::validate_splice_range(arr_len, &resolved_args)?;
                     // ADR-0039 slice 1: see the twin comment on the `append`
                     // arm above — this is the site that regressed
                     // `roast/S32-array/splice.t`'s self-referential splice

--- a/src/runtime/methods_object_native_ctors_misc.rs
+++ b/src/runtime/methods_object_native_ctors_misc.rs
@@ -253,13 +253,12 @@ impl Interpreter {
         };
         let is_exception = if let ValueView::Instance { class_name, .. } = raw_exception.view() {
             let cn = class_name.resolve();
-            cn == "Exception"
-                || cn.starts_with("X::")
-                || cn.starts_with("CX::")
-                || self
-                    .mro_readonly(&cn)
-                    .iter()
-                    .any(|p| p == "Exception" || p.starts_with("X::") || p.starts_with("CX::"))
+            !raw_exception.is_match_instance()
+                && (raw_exception.instance_is_exception_by_name()
+                    || self
+                        .mro_readonly(&cn)
+                        .iter()
+                        .any(|p| p == "Exception" || p.starts_with("X::") || p.starts_with("CX::")))
         } else {
             false
         };

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -2194,7 +2194,26 @@ impl Interpreter {
                             // `inner(\container)` calling `Replace.replace(container)`).
                             let writeback_source =
                                 self.resolve_sigilless_alias_source_name(&source_name);
-                            rw_bindings.push((pd.name.clone(), writeback_source));
+                            rw_bindings.push((pd.name.clone(), writeback_source.clone()));
+                            // ...and to the IMMEDIATE source as well, when the
+                            // two differ. A method call does not chain envs: its
+                            // writeback merges only into the frame that called
+                            // it, where the chain's root is not a key at all, so
+                            // the root-only write landed on a phantom entry. The
+                            // intermediate frame then reached its own exit with
+                            // its `\c` still holding the pre-call value and
+                            // clobbered the root with it — `method go(\c) {
+                            // Inner.go(c) }` lost the callee's write entirely.
+                            // Updating the caller's own alias binding as well
+                            // lets each frame's writeback compose into the next,
+                            // which is how the chained-env sub path already
+                            // reaches the root. This is `Crane.add/set/remove
+                            // (container, ..., :in-place)` at the root path:
+                            // `Crane` is a chain of class methods forwarding one
+                            // `\container`.
+                            if writeback_source != source_name {
+                                rw_bindings.push((pd.name.clone(), source_name.clone()));
+                            }
                             // A plain scalar param aliasing a plain scalar caller
                             // variable binds through a shared `ContainerRef` cell
                             // (installed after type checks, below): the caller's

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -658,6 +658,18 @@ impl Interpreter {
                     target_env.insert(source_name.clone(), incoming.lock().unwrap().clone());
                     continue;
                 }
+                // A SIGILLESS param aliasing an `@`/`%` variable stores through
+                // that variable's own shape (`\c := @a; c = LIST` is
+                // `@a.STORE(LIST)`), so the writeback must not leave the caller
+                // holding the bare List the param's slot held. Gated on the
+                // parameter being sigilless: a plain `@`/`%` param already
+                // carries the caller's own container, and re-coercing that
+                // would strip its embedded type metadata.
+                let updated = if crate::runtime::utils::param_is_sigilless(param_name) {
+                    crate::runtime::utils::shape_value_for_sigiled_target(source_name, &updated)
+                } else {
+                    updated
+                };
                 target_env.insert(source_name.clone(), updated);
             }
         }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -424,6 +424,14 @@ impl Interpreter {
         if let ValueView::Scalar(inner) = value.view() {
             return self.type_matches_value(constraint, inner);
         }
+        // A grammar's Match is typed by the grammar itself, so a grammar
+        // declared under `X::` (`Crane` has one inside
+        // `class X::Crane::PathOutOfRange`) would otherwise satisfy the
+        // name-based `Exception` subtyping rule in `type_matches` and make
+        // `$/ ~~ Exception` True. See `Value::instance_is_exception_by_name`.
+        if constraint == "Exception" && value.is_match_instance() {
+            return false;
+        }
         // X::Await::Died role mixed into an exception by `await` of a broken
         // Promise (see `await_died_error`): the cause keeps its own class but
         // also does X::Await::Died.

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -104,6 +104,70 @@ pub(crate) fn deitemize_real_array_elements(mut value: Value) -> Value {
     value
 }
 
+/// Is this parameter name a **sigilless** binding (`\c`)?
+///
+/// The gate on [`shape_value_for_sigiled_target`] at the exit-writeback sites:
+/// only a sigilless parameter is the caller's container rather than having one
+/// of its own, so only it needs its final value re-shaped for the caller's
+/// sigil. A plain `@`/`%` parameter already carries the caller's own container,
+/// metadata and all, and re-coercing that strips it (a `%_` parameter relayed
+/// into `CompUnit::DependencySpecification.new` lost its values that way).
+pub(crate) fn param_is_sigilless(name: &str) -> bool {
+    name.as_bytes()
+        .first()
+        .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+}
+
+/// Shape a value the way a store through `target`'s own sigil would.
+///
+/// A sigilless alias is not a container of its own: `\c := @a` makes `c` BE
+/// `@a`, so `c = LIST` is `@a.STORE(LIST)` and `@a` stays an `Array`. The
+/// writeback that carries a sigilless parameter's final value back to the
+/// caller's variable passed it through verbatim, so `sub f(\c) { c = ('x','y') }`
+/// left the caller's `my @a` holding a bare `List` and a `my %h` holding that
+/// same List rather than a Hash. That is `Crane.add(@a, :path(), :value(...),
+/// :in-place)` — `add-to-positional`'s `container = $value` through a
+/// `\container` chain.
+///
+/// A `$`-sigiled or bare target keeps the value untouched, and so does a value
+/// that is ALREADY the target's own shape — returning it verbatim is what keeps
+/// this off the overwhelmingly common path, where the writeback carries a plain
+/// `@`/`%` parameter's container back and re-coercing it would strip its
+/// embedded type metadata and its itemization.
+///
+/// Only a value of the wrong shape is rebuilt, and only then is the scalar
+/// itemization a relay hop puts on it unwrapped: each `\c`-to-`\c` hop binds
+/// through an itemized holder, so a two-hop chain arrives as `$("x", "y")`
+/// where the one-hop one arrives as `("x", "y")`, and both have to land as
+/// `["x", "y"]`.
+pub(crate) fn shape_value_for_sigiled_target(target: &str, val: &Value) -> Value {
+    match target.as_bytes().first() {
+        Some(b'@') => {
+            if matches!(val.view(), ValueView::Array(_, k) if k.is_real_array()) {
+                return val.clone();
+            }
+            let val = val.clone().deitemize_element().into_descalarized();
+            if matches!(val.view(), ValueView::Array(_, k) if k.is_real_array()) {
+                val
+            } else {
+                Value::real_array(crate::runtime::utils::value_to_list(&val))
+            }
+        }
+        Some(b'%') => {
+            if matches!(val.view(), ValueView::Hash(_)) && !val.hash_is_itemized() {
+                return val.clone();
+            }
+            let val = val.clone().deitemize_element().into_descalarized();
+            if matches!(val.view(), ValueView::Hash(_)) {
+                val
+            } else {
+                coerce_to_hash(val)
+            }
+        }
+        _ => val.clone(),
+    }
+}
+
 pub(crate) fn coerce_to_hash(value: Value) -> Value {
     let mix_weight_value = crate::value::mix_weight_to_value;
     let value = value.into_descalarized();

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -859,16 +859,11 @@ impl Value {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Exception"
-                || class_name.resolve().starts_with("X::")
-                || class_name.resolve().starts_with("CX::") =>
-            {
-                attributes
-                    .as_map()
-                    .get("message")
-                    .map(|v: &Value| v.to_string_value())
-                    .unwrap_or_else(|| format!("{}()", class_name))
-            }
+            } if self.instance_is_exception_by_name() => attributes
+                .as_map()
+                .get("message")
+                .map(|v: &Value| v.to_string_value())
+                .unwrap_or_else(|| format!("{}()", class_name)),
             ValueView::Instance {
                 class_name,
                 attributes,

--- a/src/value/match_view.rs
+++ b/src/value/match_view.rs
@@ -56,6 +56,35 @@ impl Value {
             if class_name == "Match" || attributes.as_map().get(CURSOR_MATCH_MARKER).is_some())
     }
 
+    /// Is this value an instance mutsu classifies as an exception purely from
+    /// the namespace its class name sits in (`Exception`, `X::*`, `CX::*`)?
+    ///
+    /// mutsu has no complete exception hierarchy to consult, so a great many
+    /// sites decide "is this an exception?" from the class name alone. That
+    /// test has one systematic false positive: a grammar's Match is typed by
+    /// the grammar itself, not by `Match` (rakudo gives
+    /// `X::Foo::G.parse($s).^name` as `X::Foo::G`), so a grammar declared
+    /// under `X::` — `Crane` declares one inside
+    /// `class X::Crane::PathOutOfRange`, to parse the `Range` out of an
+    /// `X::OutOfRange` — hands every one of those sites a "class name in the
+    /// exception namespace" that is a match object. Its `.Str`/`.gist` then
+    /// rendered as `X::Foo::G with no message`, `+$/` numified THAT, and
+    /// `$/ ~~ Exception` was `True`.
+    ///
+    /// Use this instead of spelling the namespace test inline wherever the
+    /// value is at hand; the surviving bare-name checks are the ones that
+    /// never see a Match (a declared parent, a parsed bareword).
+    pub(crate) fn instance_is_exception_by_name(&self) -> bool {
+        let ValueView::Instance { class_name, .. } = self.view() else {
+            return false;
+        };
+        if self.is_match_instance() {
+            return false;
+        }
+        let cn = class_name.resolve();
+        cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::")
+    }
+
     /// The class name a Match receiver dispatches under: `"Match"` for a plain
     /// regex match, the grammar's own class for a parse cursor. Callers that
     /// used to hardcode `"Match"` for user-override / native-method lookups

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -341,13 +341,7 @@ impl Value {
                     ValueView::Instance { class_name, .. } if class_name == "Method"
                 ) || matches!(self.view(), ValueView::Package(name) if name == "Method")
             }
-            "Exception" => {
-                if let ValueView::Instance { class_name, .. } = self.view() {
-                    class_name.resolve().starts_with("X::") || class_name == "Exception"
-                } else {
-                    false
-                }
-            }
+            "Exception" => self.instance_is_exception_by_name(),
             "X::AdHoc" | "CX::Warn" | "CX::Return" | "X::OS" => {
                 if let ValueView::Instance { class_name, .. } = self.view() {
                     class_name == type_name

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -450,7 +450,7 @@ impl Interpreter {
             return Ok(None);
         };
         let cn = class_name.resolve();
-        if !(cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::"))
+        if !target.instance_is_exception_by_name()
             || attributes.as_map().contains_key("message")
             || !self.has_user_method(&cn, "message")
             || self.has_user_method(&cn, method)
@@ -940,14 +940,11 @@ impl Interpreter {
         // otherwise carry no frames (so `.backtrace().list` would be empty).
         let target = if matches!(method, "throw" | "rethrow")
             && args.is_empty()
+            && target.instance_is_exception_by_name()
             && matches!(
                 target.view(),
-                ValueView::Instance { class_name, attributes, .. }
-                    if {
-                        let cn = class_name.resolve();
-                        (cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::"))
-                            && !attributes.as_map().contains_key("backtrace")
-                    }
+                ValueView::Instance { attributes, .. }
+                    if !attributes.as_map().contains_key("backtrace")
             ) {
             if let ValueView::Instance {
                 class_name,

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -848,7 +848,17 @@ impl Interpreter {
                 if target == "_" || target == "@_" || target == "%_" {
                     continue;
                 }
-                restored_env.insert(target.clone(), val.clone());
+                // A sigilless param aliasing an `@`/`%` variable stores through
+                // that variable's own shape (`\c := @a; c = LIST` is
+                // `@a.STORE(LIST)`), as in `apply_rw_bindings_to_env`.
+                // A sigilless param aliasing an `@`/`%` variable stores through
+                // that variable's own shape (`\c := @a; c = LIST` is
+                // `@a.STORE(LIST)`), as in `apply_rw_bindings_to_env`. Every
+                // entry here comes from a `pd.sigilless` parameter already.
+                restored_env.insert(
+                    target.clone(),
+                    crate::runtime::utils::shape_value_for_sigiled_target(target, val),
+                );
             }
             // A by-name write whose target name only exists at run time
             // (`$::($n) = v`, an `EVAL`'d `$a = 32`) is invisible to the

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -99,13 +99,11 @@ impl Interpreter {
         }
         if let Some(class_name) = underlying_class {
             let cn = class_name.resolve();
-            let is_exception = cn == "Exception"
-                || cn.starts_with("X::")
-                || cn.starts_with("CX::")
-                || self
-                    .mro_readonly(&cn)
-                    .iter()
-                    .any(|p| p == "Exception" || p.starts_with("X::") || p.starts_with("CX::"));
+            let is_exception = !value.is_match_instance()
+                && (value.instance_is_exception_by_name()
+                    || self.mro_readonly(&cn).iter().any(|p| {
+                        p == "Exception" || p.starts_with("X::") || p.starts_with("CX::")
+                    }));
             if is_exception {
                 // Preserve the value verbatim (including a `but role` mixin) so its
                 // type still matches `when X::Foo` and any overridden `.message`

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1067,7 +1067,26 @@ impl Interpreter {
                             let qualified = format!("{}::{}", owner_class, param_name);
                             self.env().get(&qualified).cloned()
                         })
-                        .map(|val| (source_name.clone(), val))
+                        .map(|val| {
+                            // A SIGILLESS param aliasing an `@`/`%` variable
+                            // stores through that variable's own shape
+                            // (`\c := @a; c = LIST` is `@a.STORE(LIST)`), so the
+                            // writeback must not leave the caller holding the
+                            // bare List the param's slot held. Gated on the
+                            // parameter being sigilless, as in
+                            // `apply_rw_bindings_to_env`: a plain `@`/`%` param
+                            // already carries the caller's own container and
+                            // re-coercing it would strip its metadata.
+                            let val = if crate::runtime::utils::param_is_sigilless(param_name) {
+                                crate::runtime::utils::shape_value_for_sigiled_target(
+                                    source_name,
+                                    &val,
+                                )
+                            } else {
+                                val
+                            };
+                            (source_name.clone(), val)
+                        })
                 })
                 .collect();
 

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -936,6 +936,20 @@ impl Interpreter {
     /// cell so a sigilless attribute write (`has $x; $x = v`) reaches the cell
     /// (Phase 3 Stage 2c (ii)). Shared by the inc/dec ops; the cycle guard copes
     /// with the bidirectional `x ↔ !x` alias table.
+    /// Shape a value the way a store through `target`'s own sigil would.
+    ///
+    /// A sigilless alias is not a container: `\c := @a` makes `c` BE `@a`, so
+    /// `c = LIST` is `@a.STORE(LIST)` and `@a` stays an `Array`. Writing the
+    /// raw value through the alias chain left `@a` holding a bare `List` (and a
+    /// `%h` target holding a List rather than a Hash), which is what
+    /// `Crane.add(@a, :path(), :value(...), :in-place)` — `add-to-positional`'s
+    /// `container = $value` through a `\container` chain — produced.
+    ///
+    /// A `$`-sigiled or bare target keeps the value untouched.
+    fn coerce_alias_target_shape(&mut self, target: &str, val: &Value) -> Value {
+        crate::runtime::utils::shape_value_for_sigiled_target(target, val)
+    }
+
     pub(crate) fn propagate_sigilless_alias_chain(
         &mut self,
         code: &CompiledCode,
@@ -960,9 +974,17 @@ impl Interpreter {
             if !seen_aliases.insert(current_alias.clone()) {
                 break;
             }
-            self.set_env_with_main_alias(&current_alias, val.clone());
-            self.update_local_if_exists(code, &current_alias, val);
-            self.write_self_attr_cell(&current_alias, val.clone());
+            // A sigilless name has no container of its own, but the variable it
+            // aliases does: raku gives `@a`/`%h` no Scalar, so `\c := @a; c = LIST`
+            // IS `@a.STORE(LIST)` and leaves `@a` an Array, not the bare List.
+            // Propagating the value verbatim left `my @a; f(@a)` (for
+            // `sub f(\c) { c = ('x','y') }`) holding a List, and a `%` target
+            // holding a List rather than a Hash. Coerce to the target's own
+            // shape, exactly as a store through the sigiled name would.
+            let stored = self.coerce_alias_target_shape(&current_alias, val);
+            self.set_env_with_main_alias(&current_alias, stored.clone());
+            self.update_local_if_exists(code, &current_alias, &stored);
+            self.write_self_attr_cell(&current_alias, stored);
             // Slice F: an inc/dec through a sigilless param (`\target`) aliases a
             // caller variable; record it so the call-site drain writes the env
             // value through to the caller's local slot (without relying on the

--- a/t/collections/array/splice-offset-out-of-range-by-value-invocant.t
+++ b/t/collections/array/splice-offset-out-of-range-by-value-invocant.t
@@ -1,0 +1,106 @@
+use Test;
+
+# `splice` validates its offset and size BEFORE it writes: an offset outside
+# `0..elems` and a negative size are `X::OutOfRange` in rakudo, not a splice
+# clamped to the end. The lvalue path (`@a.splice(...)` on a named variable)
+# always did this; the by-value path -- a literal, a function result, an
+# element read, anything reached through `return-rw` -- did not, so
+# `[1,2,3].splice(5, 0, 'x')` silently appended and `Crane`'s
+# `CATCH { when X::OutOfRange }` never fired.
+#
+# Verified against rakudo v2026.07: every `throws-like` below is that
+# interpreter's own answer, message included.
+
+plan 13;
+
+sub at(\c) is rw { my $root := c; return-rw $root }
+
+# --- a literal invocant (no variable anywhere) ---------------------------
+
+throws-like(
+    { [1, 2, 3].splice(5, 0, 'x') },
+    X::OutOfRange,
+    :message(/'Offset argument to splice out of range. Is: 5, should be in 0..3'/),
+    'a literal array refuses an offset past the end',
+);
+
+throws-like(
+    { [1, 2, 3].splice(*-5, 0, 'x') },
+    X::OutOfRange,
+    :message(/'Offset argument to splice out of range. Is: -2, should be in 0..3'/),
+    'a from-the-end offset is resolved before the bounds check',
+);
+
+throws-like(
+    { [1, 2, 3].splice(1, -1) },
+    X::OutOfRange,
+    :message(/'Size argument to splice out of range. Is: -1, should be in 0..^2'/),
+    'a literal array refuses a negative size',
+);
+
+# --- a by-value invocant reached through a call --------------------------
+
+{
+    my @a;
+    throws-like(
+        { at(@a).splice(1, 0, 'x') },
+        X::OutOfRange,
+        :message(/'Offset argument to splice out of range. Is: 1, should be in 0..0'/),
+        'an empty array reached through return-rw refuses offset 1',
+    );
+    is-deeply(@a, [], 'and the refused splice wrote nothing');
+}
+
+{
+    my %doc = :a([]);
+    throws-like(
+        { at(%doc<a>).splice(*-1, 0, 'x') },
+        X::OutOfRange,
+        :message(/'Offset argument to splice out of range. Is: -1, should be in 0..0'/),
+        'an empty hash element reached through return-rw refuses *-1',
+    );
+    is-deeply(%doc, {:a([])}, 'and the refused splice wrote nothing');
+}
+
+# --- the lvalue path still agrees ---------------------------------------
+
+{
+    my @a;
+    throws-like(
+        { @a.splice(1, 0, 'x') },
+        X::OutOfRange,
+        :message(/'Offset argument to splice out of range. Is: 1, should be in 0..0'/),
+        'the named-variable path refuses the same offset',
+    );
+}
+
+# --- in-range splices are untouched --------------------------------------
+
+{
+    my @a = 1, 2, 3;
+    my @removed = at(@a).splice(1, 1, 'x');
+    is-deeply(@a, [1, 'x', 3], 'an in-range splice through return-rw still writes');
+    is-deeply(@removed, [2], 'and returns what it removed');
+}
+
+{
+    my @a = 1, 2, 3;
+    at(@a).splice(*-0, 0, 'x');
+    is-deeply(@a, [1, 2, 3, 'x'], 'offset == elems is in range (append)');
+}
+
+{
+    my @a;
+    at(@a).splice(0, 0, 'x');
+    is-deeply(@a, ['x'], 'offset 0 on an empty array is in range');
+}
+
+# A non-Int, non-Whatever, non-Callable offset matches no candidate at all --
+# that stays X::Multi::NoMatch and must not be reported as a range error.
+throws-like(
+    { [1, 2, 3].splice('x') },
+    X::Multi::NoMatch,
+    'a Str offset is still a no-candidate error, not a range error',
+);
+
+# done

--- a/t/grammar/match-of-x-namespaced-grammar-is-not-an-exception.t
+++ b/t/grammar/match-of-x-namespaced-grammar-is-not-an-exception.t
@@ -1,0 +1,83 @@
+use Test;
+
+# A grammar's Match is typed by the grammar itself, not by `Match`:
+# `X::Foo::G.parse($s).^name` is `X::Foo::G` in rakudo. mutsu has no complete
+# exception hierarchy to consult, so ~20 sites decide "is this an exception?"
+# from the class name alone (`Exception`, the `X::`/`CX::` namespaces). Every
+# one of them mistook such a Match for an exception: it stringified to
+# "X::Foo::G with no message", `+$/` numified THAT text into a Failure, and
+# `$/ ~~ Exception` was True.
+#
+# Not a contrived namespace: `Crane` (the dependency `Config::TOML` is built
+# on) declares a grammar inside `class X::Crane::PathOutOfRange` to parse the
+# `Range` out of an `X::OutOfRange`, so its `method integer($/) { make(+$/) }`
+# action made a Failure and every out-of-range path error died rendering its
+# own message.
+#
+# Verified against rakudo v2026.07: the `X::`-namespaced grammar's answers
+# below are identical to the plain one's, which is the whole point.
+
+plan 26;
+
+grammar Plain::G {
+    token integer { '-'? \d+ }
+    token TOP { ^ <integer> $ }
+}
+
+grammar X::Deep::G {
+    token integer { '-'? \d+ }
+    token TOP { ^ <integer> $ }
+}
+
+grammar CX::Deep::G {
+    token TOP { ^ \d+ $ }
+}
+
+for (Plain::G, 'Plain::G'), (X::Deep::G, 'X::Deep::G') -> ($grammar, $label) {
+    my $m = $grammar.parse('42');
+    ok($m.defined, "$label parses");
+    is($m.Str, '42', "$label: .Str is the matched text");
+    is(~$m, '42', "$label: ~ is the matched text");
+    is($m.Numeric, 42, "$label: .Numeric numifies the matched text");
+    is(+$m, 42, "$label: prefix + numifies the matched text");
+    is($m.Int, 42, "$label: .Int numifies the matched text");
+    is($m.chars, 2, "$label: .chars counts the matched text");
+    ok($m ~~ Match, "$label: the result is a Match");
+    nok($m ~~ Exception, "$label: the result is NOT an Exception");
+    is($m<integer>.Str, '42', "$label: its capture reads back");
+}
+
+# `CX::` is gated by the same namespace rule.
+{
+    my $m = CX::Deep::G.parse('7');
+    is(+$m, 7, 'CX::-namespaced grammar: prefix + numifies the matched text');
+    nok($m ~~ Exception, 'CX::-namespaced grammar: the result is NOT an Exception');
+}
+
+# An actual exception in those namespaces still reads as one.
+{
+    my $e = X::AdHoc.new(:payload<boom>);
+    ok($e ~~ Exception, 'a real X:: exception still smartmatches Exception');
+    is($e.message, 'boom', 'and still renders its message');
+}
+
+# The action-method shape the whole thing was found through: `make(+$/)` in a
+# grammar whose own package sits under `X::`.
+{
+    class X::Deep::Acts {
+        method integer($/ --> Nil) { make(+$/) }
+        method TOP($/ --> Nil) { make($<integer>.made) }
+    }
+    is(
+        X::Deep::G.parse('42', :actions(X::Deep::Acts.new)).made,
+        42,
+        'an action method of an X::-namespaced grammar can make(+$/)',
+    );
+    isa-ok(
+        X::Deep::G.parse('42', :actions(X::Deep::Acts.new)).made,
+        Int,
+        'and what it made is an Int, not a Failure',
+    );
+}
+
+# done

--- a/t/vm/sigilless-alias-forwarded-through-a-class-hop.t
+++ b/t/vm/sigilless-alias-forwarded-through-a-class-hop.t
@@ -1,0 +1,147 @@
+use Test;
+
+# A sigilless parameter (`\c`) IS the caller's container, so forwarding it on
+# to another routine must keep that identity however many hops it takes and
+# whatever kind of routine each hop is.
+#
+# A SUB callee always worked: sub frames chain env, so the exit writeback's
+# "resolve to the root of the alias chain" reached the original variable. A
+# METHOD callee does not chain env -- its writeback merges only into the frame
+# that called it, where the chain's root is not a key at all -- so the write
+# landed on a phantom entry, and the intermediate frame then reached its own
+# exit still holding the pre-call value and clobbered the root with it. Every
+# `method go(\c) { Other.go(c) }` therefore lost the callee's write entirely.
+#
+# That is `Crane.add/set/remove($container, :path(), ..., :in-place)`, which is
+# a chain of class methods forwarding one `\container`.
+#
+# Separately: a raw binding to an `@`/`%` variable is that aggregate, so
+# `c = LIST` is `@a.STORE(LIST)` and the caller keeps an Array/Hash rather
+# than the bare List the parameter's slot held.
+#
+# Every expectation below is rakudo v2026.07's own answer.
+
+plan 16;
+
+class Leaf { method go(\c) { c = 1 } }
+class LeafRw { method go($c is rw) { $c = 1 } }
+sub leaf-sub(\c) { c = 1 }
+
+# --- forwarding a raw parameter to a method ------------------------------
+
+{
+    class Mid { method go(\c) { Leaf.go(c) } }
+    my $v;
+    Mid.go($v);
+    is($v, 1, 'method -> method: the callee write reaches the original');
+}
+
+{
+    class MidRw { method go(\c) { LeafRw.go(c) } }
+    my $v;
+    MidRw.go($v);
+    is($v, 1, 'method -> is-rw method: the callee write reaches the original');
+}
+
+{
+    sub mid-sub(\c) { Leaf.go(c) }
+    my $v;
+    mid-sub($v);
+    is($v, 1, 'sub -> method: the callee write reaches the original');
+}
+
+{
+    class Deep1 { method go(\c) { Leaf.go(c) } }
+    class Deep2 { method go(\c) { Deep1.go(c) } }
+    my $v;
+    Deep2.go($v);
+    is($v, 1, 'three method hops still reach the original');
+}
+
+# The intermediate frame's own alias sees it too, not just the root.
+{
+    class MidSeen {
+        method go(\c) {
+            Leaf.go(c);
+            c;
+        }
+    }
+    my $v;
+    is(MidSeen.go($v), 1, 'the intermediate frame reads the new value after the call');
+    is($v, 1, 'and the original has it as well');
+}
+
+# --- the shapes that already worked must keep working --------------------
+
+{
+    sub mid-both(\c) { leaf-sub(c) }
+    my $v;
+    mid-both($v);
+    is($v, 1, 'sub -> sub still reaches the original');
+}
+
+{
+    class Own { method go { my $v; Leaf.go($v); $v } }
+    is(Own.go, 1, 'a method passing its own lexical still works');
+}
+
+{
+    my $v;
+    Leaf.go($v);
+    is($v, 1, 'a mainline lexical passed straight to a method still works');
+}
+
+# --- a raw alias of an aggregate stores through the aggregate ------------
+
+sub store-list(\c) { c = ('x', 'y') }
+sub store-pairs(\c) { c = (:a(1), :b(2)) }
+
+{
+    my @a;
+    store-list(@a);
+    is-deeply(@a, ['x', 'y'], 'sub: `c = LIST` on an @-alias stores into the Array');
+}
+
+{
+    my %h;
+    store-pairs(%h);
+    is-deeply(%h, {:a(1), :b(2)}, 'sub: `c = PAIRS` on a %-alias stores into the Hash');
+}
+
+{
+    class StoreList { method go(\c) { c = ('x', 'y') } }
+    my @a;
+    StoreList.go(@a);
+    is-deeply(@a, ['x', 'y'], 'method: `c = LIST` on an @-alias stores into the Array');
+}
+
+{
+    sub relay(\c) { store-list(c) }
+    my @a;
+    relay(@a);
+    is-deeply(@a, ['x', 'y'], 'sub -> sub: an @-alias relayed one hop still stores a flat Array');
+}
+
+{
+    class RelayB { method go(\c) { c = ('x', 'y') } }
+    class RelayA { method go(\c) { RelayB.go(c) } }
+    my @a;
+    RelayA.go(@a);
+    is-deeply(@a, ['x', 'y'], 'method -> method: an @-alias relayed one hop still stores a flat Array');
+}
+
+# A `$`-sigiled target keeps whatever it was given -- no aggregate shaping.
+{
+    sub store-scalar(\c) { c = ('x', 'y') }
+    my $s;
+    store-scalar($s);
+    is-deeply($s, ('x', 'y'), 'a $-sigiled target keeps the List it was assigned');
+}
+
+{
+    my @a = 1, 2, 3;
+    sub read-only(\c) { c.elems }
+    is(read-only(@a), 3, 'a read through a raw alias is unaffected');
+}
+
+# done


### PR DESCRIPTION
Four general interpreter bugs, found by re-measuring `Crane` v0.1.2 (the
dependency `Config::TOML` is built on, #7539) against the `raku` oracle.

| Suite | raku | before | after |
| --- | --- | --- | --- |
| `Crane` v0.1.2 | 15/15 files | 7/15 | **9/15** |
| `Config::TOML` v0.1.3 | 19/19 files | 14/19 | 14/19 |

`copy` and `move` are the two newly green `Crane` files. `add` now passes its
whole exception subtest and every in-place assertion but the nested one.

## 1. A `Match` of a grammar declared under `X::` was treated as an exception

mutsu has no complete exception hierarchy to consult, so about twenty sites
decide "is this an exception?" from the class name alone — `Exception`, or the
reserved `X::` / `CX::` namespaces. That test has one systematic false
positive. A grammar's `Match` is typed by the *grammar*, not by `Match`:
rakudo answers `X::Foo::G` for `X::Foo::G.parse($s).^name`.

```raku
grammar X::Deep::G { token TOP { \d+ } }
my $m = X::Deep::G.parse('42');
say $m.Str;           # rakudo: 42      mutsu: X::Deep::G with no message
say +$m;              # rakudo: 42      mutsu: Failure (numifying that text)
say $m.chars;         # rakudo: 2       mutsu: 12
say $m ~~ Exception;  # rakudo: False   mutsu: True
```

Not a contrived namespace. `Crane` declares a grammar inside
`class X::Crane::PathOutOfRange`, to parse the `Range` back out of an
`X::OutOfRange`; its action method is `method integer($/) { make(+$/) }`, so
every out-of-range path error died while rendering its own message
(`Type check failed for an element of @integer; expected Int:D but got Any`).

The namespace test is now one predicate, `Value::instance_is_exception_by_name`,
which excludes a `Match`; the sites carrying extra terms (an MRO walk, a
`*Exception` suffix) go through it too. The surviving bare-name checks are the
ones that never see a `Match` — a declared parent, a parsed bareword.

## 2. `splice` validated its offset only on the lvalue path

Rakudo checks `splice`'s offset and size *before* it writes: an offset outside
`0..elems` and a negative size are `X::OutOfRange`, not a splice clamped to the
end. mutsu did that for a named-variable invocant and not at all for a by-value
one — a literal, a function result, an element read, anything reached through
`return-rw`:

```raku
[1,2,3].splice(5, 0, 'x')   # rakudo: X::OutOfRange   mutsu: appended silently
```

`Crane.add`'s whole out-of-range family is
`Crane::At.at($root, @path).splice(...)` inside a `CATCH { when X::OutOfRange }`,
so five `add`/`copy`/`move` subtests reported success where rakudo raises
`X::Crane::AddPathOutOfRange`. The range check is now a shared helper both
dispatch paths call, so the two cannot drift.

## 3. A sigilless parameter forwarded to a *method* lost the caller's container

```raku
class Leaf { method go(\c) { c = 1 } }
class Mid  { method go(\c) { Leaf.go(c) } }
my $v; Mid.go($v);   # rakudo: 1   mutsu: (Any)
```

A sub callee always worked: sub frames chain env, so the exit writeback's
"resolve to the root of the alias chain" reached the original variable. A
method callee does not chain env — its writeback merges only into the frame
that called it, where the chain's root is not a key at all — so the write
landed on a phantom entry, and the intermediate frame then reached its own exit
still holding the pre-call value and clobbered the root with it. Each frame's
writeback now also updates the caller's own alias binding, so the hops compose
into one another the way the chained-env sub path already reached the root.

That is `Crane.add/set/remove($container, :path(), …, :in-place)`, which is a
chain of class methods forwarding one `\container`.

## 4. A raw alias of an `@`/`%` variable stored the bare `List`

Raku gives `@a`/`%h` no `Scalar` of their own, so `\c := @a` makes `c` BE the
array and `c = LIST` is `@a.STORE(LIST)`:

```raku
sub f(\c) { c = ('x','y') }
my @a; f(@a);   # rakudo: ["x", "y"]   mutsu: ("x", "y")
my %h; f(%h);   # rakudo: {:x("y")}    mutsu: ("x", "y")
```

The three writeback sites now shape the value for the target's own sigil, in
one shared helper — gated on the parameter actually being **sigilless**: a
plain `@`/`%` parameter already carries the caller's own container, and
re-coercing it strips its embedded type metadata (which is how an ungated first
cut broke `roast/S11-repository/cur-candidates.t`'s `%_` parameter, caught by
the local roast run before publishing).

## Tests

`t/grammar/match-of-x-namespaced-grammar-is-not-an-exception.t`,
`t/collections/array/splice-offset-out-of-range-by-value-invocant.t`,
`t/vm/sigilless-alias-forwarded-through-a-class-hop.t` — 55 assertions, each
verified to fail without its fix and to pass under rakudo v2026.07.

## Validation

`cargo fmt --all`, `make lint`, `make test` (4,207 files / 44,832 assertions)
and `make roast` (1,437 files / 219,635 assertions) all green, bar the three
failures `docs/agent-environments.md` documents for this container (`uid 0`
file-permission tests ×2, sandboxed network ×1), matched by name and by
subtest range.

Part of #7539 (the ticket stays open: `Crane` at 9/15 keeps the vendoring
steps parked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBmiJH8aYB8BQhXFJZaTQ7)_