### PR TITLE
fix(parser): three parse-failure-index constructs (pointy terms, regex groups, operator escapes)

### DIFF
--- a/news/2026-09/parse-failure-index-pointy-terms-regex-group-scan-and-operator-escapes.md
+++ b/news/2026-09/parse-failure-index-pointy-terms-regex-group-scan-and-operator-escapes.md
@@ -1,0 +1,88 @@
+# Parse-failure index: pointy terms, the regex group scanner, and operator-name escapes
+
+Three more constructs off the `blocked_load` parse-failure index (#7954), reached
+the way the earlier batches were: fetch the tarball named by the `ecosystem/dists/`
+record, `--dump-ast` every module the META6 `provides` names, bisect the failing
+file down to the smallest still-failing range, and reduce that to a one-liner
+checked against rakudo. Seven distributions stop failing to parse.
+
+## A sigilless pointy parameter is a term, in every control statement
+
+`Hash::Ordered` reported `expected ')'` at a `method DELETE-KEY(::?ROLE:D: \key)`
+header, and the pseudo-type invocant it names parses fine on its own. The cause
+was seven lines further down, inside that method:
+
+```raku
+with %!indices.DELETE-KEY(key) -> \index {
+    %!indices.AT-KEY(@!keys.AT-POS($_))-- for index .. @!keys.end;
+}
+```
+
+`-> \index` declares a **term**: inside the block a bare `index` IS that binding.
+Only `for` and `while` carried that into the body's parse scope, so in a `with`
+the body was parsed against what `index` means *outside* — the `index` builtin —
+and the listop swallowed the rest of the statement. The block then failed at its
+closing brace, and the reported location was the enclosing `method`.
+
+The registration is one shared helper now (`block_with_pointy_params`), used by
+`if` / `elsif` / `unless` / `else` / `given` / `with` / `without`, and it also
+registers a `&name` parameter as a routine for the same reason `for` already did
+(`-> &m { m() }` must read `m()` as a call, not an `m//` match).
+
+Registering the name was not enough on its own. The parse memo is keyed by the
+input slice alone, and `if`'s header runs the full parameter-list parser, which
+speculates over the `{ ... }` that follows it — so the body's failure had already
+been memoized *before* the name existed, and the correctly-scoped parse was
+handed that stale entry straight back. The scoped body parse therefore runs in
+its own parse generation, which is precisely the scope's effect on the grammar.
+
+Two silently-wrong answers fell out of the same investigation. `with 1 -> \v { v }`
+declared an ordinary lexical, so the body's bare word was a package lookup and
+the block read `(Any)` where rakudo reads `1`; the binding now carries the
+sigilless marker that makes it a term (and read-only, as rakudo has it). And
+`if 0 -> \a { } else -> $x { }` handed the `else` clause `Nil`: a clause's
+`binding_var` keeps the declaration's own spelling, `\a` included, and the else
+lowering stripped only a `$`, so it read a name nothing declares.
+
+Unblocks `Hash::Ordered`, and `Archive::Ar` / `BSON::Simple` / `Terminal::Tests`,
+which all failed on the same line of it.
+
+## The regex group scanner reads `<...>` by one rule where there are two
+
+The scanner that finds a capture group's closing `)` tracked a single `<...>`
+nesting depth and keyed every other decision off it. But a character **class**
+and an **assertion** read their contents by opposite rules, and this scanner owes
+both:
+
+- `<[.)]>` is a class, so its `)` is a literal member. Counting it ended the
+  group early and `( \d+ <[.)]> )` died on the leftover `]` — the ordered-list
+  marker in `Markdown::Lex` and `Blogin`.
+- `<!before '>}}'>` is an assertion, so the quote really does open a string and
+  the `>` inside it does *not* close the assertion. Treating the quote as a
+  literal member (correct for `<-['"]>`) ended it at that `>` — `Blogin`'s
+  shortcode regex.
+
+The scanner now keeps one entry per open `<`, recording whether it is a class
+(`<[`, `<-`, `<+`, `<:`) or an assertion, and applies the paren and quote rules
+accordingly. Balanced parens in a `<{ ... }>` code assertion are unaffected: they
+cancelled out either way.
+
+Unblocks `Markdown::Lex` and `Blogin` (all 29 of its modules parse).
+
+## `infix:<\\>` names a one-character operator
+
+`<...>` is a Q-style quote whose only escapes are the backslash and the
+delimiters, so `sub infix:<\\>` declares the operator `\` — `infix:<\n>`, by
+contrast, keeps both characters. mutsu kept the escape in the registered name, so
+`MIDI::Make`'s time-signature operator went by a name nothing spells, and its own
+`method time-signature (TimeSignature $ts = 4\4, ...)` default never matched it.
+The angle-quoted symbol is unescaped when the name is built.
+
+Unblocks `MIDI::Make`.
+
+## Pins
+
+`t/routines/signature/pointy-sigilless-param-is-a-term.t`,
+`t/regex/syntax/regex-group-scan-charclass-vs-assertion.t`,
+`t/lang/operators/user-infix-escaped-symbol-name.t` — all three green under
+rakudo itself, so they pin rakudo's behaviour rather than mutsu's.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use expr::{
 // literal (see `Interpreter::apply_single_mixin`).
 pub(crate) use primary::next_anon_role_name;
 pub(crate) mod helpers;
-mod memo;
+pub(in crate::parser) mod memo;
 mod outer_redecl;
 mod parse_result;
 mod primary;

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -1,6 +1,6 @@
 use super::super::expr::expression;
 use super::super::helpers::{ws, ws1};
-use super::super::parse_result::{PError, PResult, opt_char, parse_char};
+use super::super::parse_result::{MISSING_BLOCK, PError, PResult, opt_char, parse_char};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::ast::{
@@ -14,6 +14,67 @@ use crate::value::Value;
 use super::decl::parse_array_shape_suffix;
 use super::sub;
 use super::{block, block_inner, ident, keyword, parse_comma_or_expr, statement, var_name};
+/// Parse a control statement's `{ ... }` body with the pointy block's own
+/// parameters in scope.
+///
+/// A sigilless parameter (`-> \index { ... }`) declares a TERM: inside the body
+/// a bare `index` IS that binding, so the parse scope has to carry it — exactly
+/// as `for`'s own header already does. Without it the body is parsed against
+/// whatever the name means OUTSIDE the block, and a name that also spells a
+/// listop (`index`, `join`, ...) reads as a call and swallows the rest of the
+/// statement, so it is the ENCLOSING construct that fails to parse — which is
+/// why `Hash::Ordered` (and `Archive::Ar` / `BSON::Simple` / `Terminal::Tests`
+/// through it) reported its error at a `method ... (` several lines away
+/// (#7954).
+///
+/// A `&name` parameter is registered for the same reason `for` registers it:
+/// `-> &m { m() }` must read `m()` as a call to the bound routine, not as an
+/// `m//` match.
+pub(crate) fn block_with_pointy_params<'a>(
+    input: &'a str,
+    params: &[ParamDef],
+) -> PResult<'a, Vec<Stmt>> {
+    let mut code_names: Vec<&str> = Vec::new();
+    let mut term_names: Vec<&str> = Vec::new();
+    for pd in params {
+        let name = pd.name.trim_start_matches('\\');
+        if name.is_empty() {
+            continue;
+        }
+        if pd.sigilless {
+            term_names.push(name);
+        } else if let Some(bare) = name.strip_prefix('&') {
+            code_names.push(bare);
+        }
+    }
+    if code_names.is_empty() && term_names.is_empty() {
+        return block(input);
+    }
+    let (rest, _) =
+        parse_char(input, '{').map_err(|_| PError::expected_at(MISSING_BLOCK, input))?;
+    // The parse memo is keyed by the input slice alone, so an entry made while
+    // the header was being parsed — before these names existed — would be
+    // handed straight back here, and the body would be re-used at its OLD
+    // meaning. That is not hypothetical: `if`'s header runs the full parameter
+    // list parser, which speculates over the `{ ... }` that follows, so
+    // `if 1 -> \index { say index .. 2 }` memoized the body's failure (`index`
+    // read as the listop) and then replayed it under the correct scope.
+    // A fresh generation makes every key in this body distinct from the
+    // enclosing parse's, which is exactly the scope's effect on the grammar.
+    let _generation = crate::parser::memo::begin_parse_generation();
+    super::simple::push_scope();
+    for name in code_names {
+        super::simple::register_user_sub(name);
+    }
+    for name in term_names {
+        super::simple::register_user_term_symbol(name);
+    }
+    let mut result = block_inner(rest);
+    super::simple::finish_block_anon_states(&mut result);
+    super::simple::pop_scope();
+    result
+}
+
 fn condition_has_assignment_tail(rest: &str) -> bool {
     if rest.starts_with(":=") || rest.starts_with("::=") || rest.starts_with("⚛=") {
         return true;
@@ -231,6 +292,36 @@ fn pointy_topic_bind(pd: &ParamDef) -> Stmt {
             stmts.push(Stmt::MarkReadonly(pd.name.clone(), ReadonlyKind::Alias));
         }
         Stmt::SyntheticBlock(stmts)
+    }
+}
+
+/// Bind a control statement's pointy parameter to the (once-evaluated)
+/// condition value.
+///
+/// A **sigilless** parameter (`with $x -> \\v { ... }`) is a term binding, not an
+/// ordinary lexical: the body spells it as a bare word, so the declaration has
+/// to carry the `MarkSigillessReadonly` marker that tells the compiler this
+/// name reads from its local slot. Without it `with 1 -> \\v { say v }` declared
+/// `v` and then read the bare word as a package lookup, printing `(Any)` where
+/// rakudo prints `1` (#7954). The marker also makes the binding read-only,
+/// which is what rakudo gives a `\\name` parameter.
+pub(crate) fn simple_pointy_bind(name: &str, source: &Expr, sigilless: bool) -> Stmt {
+    let decl = Stmt::VarDecl {
+        name: name.to_string(),
+        expr: source.clone(),
+        type_constraint: None,
+        is_state: false,
+        is_our: false,
+        is_dynamic: false,
+        is_export: false,
+        export_tags: Vec::new(),
+        custom_traits: Vec::new(),
+        where_constraint: None,
+    };
+    if sigilless {
+        Stmt::SyntheticBlock(vec![decl, Stmt::MarkSigillessReadonly(name.to_string())])
+    } else {
+        decl
     }
 }
 

--- a/src/parser/stmt/control/conditionals.rs
+++ b/src/parser/stmt/control/conditionals.rs
@@ -41,7 +41,8 @@ pub(crate) fn if_stmt(input: &str) -> PResult<'_, Stmt> {
     let (rest, _) = ws(rest)?;
     let (rest, binding_params) = parse_if_binding_params(rest)?;
     let (rest, _) = ws(rest)?;
-    let (rest, raw_then_branch) = block(rest)?;
+    let (rest, raw_then_branch) =
+        block_with_pointy_params(rest, binding_params.as_deref().unwrap_or(&[]))?;
     let (rest, _) = ws(rest)?;
     let (binding_var, then_branch) = lower_if_clause_binding(binding_params, raw_then_branch);
 
@@ -198,6 +199,21 @@ fn ensure_last_clause_binding_var(clauses: &mut [IfChainClause]) -> Option<Strin
     })
 }
 
+/// Read the value the last clause's binding variable holds.
+///
+/// `binding_var` keeps the declaration's own spelling, and a sigilless
+/// `if COND -> \\a { }` is recorded as `\\a` — so the `\\` has to come off before
+/// the name is read, and the read itself is the bare word a sigilless binding
+/// is spelled as. Stripping only `$` left `Expr::Var("\\a")`, a name nothing
+/// declares, so `if 0 -> \\a { } else -> $x { }` handed the else clause Nil
+/// instead of the condition value.
+fn binding_var_read(source_binding: &str) -> Expr {
+    match source_binding.strip_prefix('\\') {
+        Some(bare) => Expr::BareWord(bare.to_string()),
+        None => Expr::Var(source_binding.trim_start_matches('$').to_string()),
+    }
+}
+
 fn lower_else_binding(source_binding: &str, else_clause: ElseClause) -> Vec<Stmt> {
     let Some(param_defs) = else_clause.binding_params else {
         return else_clause.body;
@@ -210,25 +226,18 @@ fn lower_else_binding(source_binding: &str, else_clause: ElseClause) -> Vec<Stmt
             // `else -> $_ { }` topicalizes through `given` for the same reason
             // as the then-branch form — see `lower_if_clause_binding`.
             return vec![Stmt::Given {
-                topic: Expr::Var(source_binding.trim_start_matches('$').to_string()),
+                topic: binding_var_read(source_binding),
                 body: else_clause.body,
                 is_statement_modifier: false,
                 with_kind: None,
             }];
         }
         let mut body = Vec::with_capacity(else_clause.body.len() + 1);
-        body.push(Stmt::VarDecl {
-            name: param_defs[0].name.clone(),
-            expr: Expr::Var(source_binding.trim_start_matches('$').to_string()),
-            type_constraint: None,
-            is_state: false,
-            is_our: false,
-            is_dynamic: false,
-            is_export: false,
-            export_tags: Vec::new(),
-            custom_traits: Vec::new(),
-            where_constraint: None,
-        });
+        body.push(simple_pointy_bind(
+            &param_defs[0].name,
+            &binding_var_read(source_binding),
+            param_defs[0].sigilless,
+        ));
         body.extend(else_clause.body);
         return body;
     }
@@ -246,9 +255,7 @@ fn lower_else_binding(source_binding: &str, else_clause: ElseClause) -> Vec<Stmt
         }),
         args: vec![Expr::Unary {
             op: TokenKind::Pipe,
-            expr: Box::new(Expr::Var(
-                source_binding.trim_start_matches('$').to_string(),
-            )),
+            expr: Box::new(binding_var_read(source_binding)),
         }],
     };
     vec![Stmt::Expr(call_expr)]
@@ -281,7 +288,8 @@ pub(crate) fn parse_elsif_chain(
             let (r, _) = ws(r)?;
             let (r, binding_params) = parse_if_binding_params(r)?;
             let (r, _) = ws(r)?;
-            let (r, raw_then_branch) = block(r)?;
+            let (r, raw_then_branch) =
+                block_with_pointy_params(r, binding_params.as_deref().unwrap_or(&[]))?;
             let (r, _) = ws(r)?;
             let (binding_var, then_branch) =
                 lower_if_clause_binding(binding_params, raw_then_branch);
@@ -390,7 +398,7 @@ pub(crate) fn parse_elsif_chain(
         }
         let (r, mut binding_params) = parse_if_binding_params(r)?;
         let (r, _) = ws(r)?;
-        let (r, mut body) = block(r)?;
+        let (r, mut body) = block_with_pointy_params(r, binding_params.as_deref().unwrap_or(&[]))?;
         // If the last clause was `orwith`, topicalize $_ in the else body via
         // `given` (a fresh topic scope) so it is not blocked by an enclosing `for`'s
         // read-only `$_` (see the orwith branch above).
@@ -504,7 +512,7 @@ pub(crate) fn unless_stmt(input: &str) -> PResult<'_, Stmt> {
     let (rest, _) = ws(rest)?;
     let (rest, binding_params) = parse_if_binding_params(rest)?;
     let (rest, _) = ws(rest)?;
-    let (rest, body) = block(rest)?;
+    let (rest, body) = block_with_pointy_params(rest, binding_params.as_deref().unwrap_or(&[]))?;
     // `unless` cannot have else/elsif/orwith. rakudo rejects this at COMPILE
     // time with `X::Syntax::UnlessElse`, carrying the offending `keyword`
     // (roast S04-statements/unless.t matches on it). mutsu used to lower it to

--- a/src/parser/stmt/control/given_when.rs
+++ b/src/parser/stmt/control/given_when.rs
@@ -15,7 +15,7 @@ pub(crate) fn given_stmt(input: &str) -> PResult<'_, Stmt> {
     } else {
         (rest, None)
     };
-    let (rest, mut body) = block(rest)?;
+    let (rest, mut body) = block_with_pointy_params(rest, pointy_param.as_slice())?;
     if let Some(pd) = pointy_param {
         body.insert(0, pointy_topic_bind(&pd));
     }

--- a/src/parser/stmt/control/with_stmt.rs
+++ b/src/parser/stmt/control/with_stmt.rs
@@ -20,7 +20,7 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
         (rest, None, None)
     };
 
-    let (rest, body) = block(rest)?;
+    let (rest, body) = block_with_pointy_params(rest, param_def.as_slice())?;
 
     // Use a temp variable in the condition to evaluate cond_expr exactly once.
     // This is important for expressions like `Failure.new` where evaluating
@@ -209,32 +209,10 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
                 }
             } else {
                 // Simple parameter with possible traits from parse_for_params
-                with_body.push(Stmt::VarDecl {
-                    name: pname.clone(),
-                    expr: tmp_var.clone(),
-                    type_constraint: None,
-                    is_state: false,
-                    is_our: false,
-                    is_dynamic: false,
-                    is_export: false,
-                    export_tags: Vec::new(),
-                    custom_traits: Vec::new(),
-                    where_constraint: None,
-                });
+                with_body.push(simple_pointy_bind(pname, &tmp_var, pdef.sigilless));
             }
         } else {
-            with_body.push(Stmt::VarDecl {
-                name: pname.clone(),
-                expr: tmp_var.clone(),
-                type_constraint: None,
-                is_state: false,
-                is_our: false,
-                is_dynamic: false,
-                is_export: false,
-                export_tags: Vec::new(),
-                custom_traits: Vec::new(),
-                where_constraint: None,
-            });
+            with_body.push(simple_pointy_bind(pname, &tmp_var, false));
         }
     }
     // Tag the scaffold `given` so the RakuAST converter can tell it from a
@@ -320,23 +298,37 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
             let r = keyword("else", rest).unwrap();
             let (r, _) = ws(r)?;
             // Check for optional pointy block on else: else -> $param { ... }
+            // A sigilless `else -> \\v { ... }` names a term, not a lexical: it
+            // has to reach `simple_pointy_bind` (and the body's parse scope) the
+            // same way the `with` branch's own parameter does.
             let (r, else_param) = if let Some(r2) = r.strip_prefix("->") {
                 let (r2, _) = ws(r2)?;
-                if let Some(r_after_sigil) = r2.strip_prefix('$') {
+                let sigilless = r2.starts_with('\\');
+                let after_sigil = r2.strip_prefix('$').or_else(|| r2.strip_prefix('\\'));
+                if let Some(r_after_sigil) = after_sigil {
                     let end = r_after_sigil
                         .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
                         .unwrap_or(r_after_sigil.len());
                     let name = &r_after_sigil[..end];
                     let r2 = &r_after_sigil[end..];
                     let (r2, _) = ws(r2)?;
-                    (r2, Some(name.to_string()))
+                    (r2, Some((name.to_string(), sigilless)))
                 } else {
                     (r, None)
                 }
             } else {
                 (r, None)
             };
-            let (r, else_body) = block(r)?;
+            let else_scope_params: Vec<ParamDef> = else_param
+                .iter()
+                .filter(|(_, sigilless)| *sigilless)
+                .map(|(name, _)| {
+                    let mut pd = crate::parser::stmt::sub_param::make_param(name.clone());
+                    pd.sigilless = true;
+                    pd
+                })
+                .collect();
+            let (r, else_body) = block_with_pointy_params(r, &else_scope_params)?;
             // Topicalize $_ in else branch to the with/without condition, via `given`
             // (a fresh topic scope) so it is not blocked by an enclosing `for`'s
             // read-only `$_` (see the orwith branch above).
@@ -344,21 +336,10 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
             // `else -> $_` names the topic the enclosing `given` already
             // installs; declaring it as an ordinary lexical would leave the
             // value behind after the block (same reason as `pointy_is_topic`).
-            if let Some(ref pname) = else_param
-                && pname.trim_start_matches('$') != "_"
+            if let Some((ref pname, sigilless)) = else_param
+                && (sigilless || pname.trim_start_matches('$') != "_")
             {
-                else_given_body.push(Stmt::VarDecl {
-                    name: pname.clone(),
-                    expr: tmp_var.clone(),
-                    type_constraint: None,
-                    is_state: false,
-                    is_our: false,
-                    is_dynamic: false,
-                    is_export: false,
-                    export_tags: Vec::new(),
-                    custom_traits: Vec::new(),
-                    where_constraint: None,
-                });
+                else_given_body.push(simple_pointy_bind(pname, &tmp_var, sigilless));
             }
             else_given_body.extend(else_body);
             let else_with_topic = vec![Stmt::Given {

--- a/src/parser/stmt/sub/sub_name.rs
+++ b/src/parser/stmt/sub/sub_name.rs
@@ -335,7 +335,7 @@ pub(crate) fn parse_sub_name_inner(input: &str, allow_dispatch: bool) -> PResult
                 '>' => {
                     depth -= 1;
                     if depth == 0 {
-                        let op_symbol = &after_open[..i];
+                        let op_symbol = unescape_operator_symbol(&after_open[..i]);
                         let after_close = &after_open[i + 1..];
                         let full_name = format!("{}:<{}>", base, op_symbol);
                         return Ok((after_close, full_name));
@@ -436,6 +436,38 @@ pub(crate) fn validate_categorical_parts(name: &str) -> Result<(), PError> {
         }
     }
     Ok(())
+}
+
+/// Unescape the angle-quoted symbol of an operator name (`infix:<...>`).
+///
+/// `<...>` is a Q-style quote whose ONLY escapes are the backslash itself and
+/// the delimiters, so `infix:<\\\\>` names the one-character operator `\\` while
+/// `infix:<\\n>` keeps both characters (checked against rakudo's own
+/// `&infix:<...>.name`). The scanner already skips a backslashed character so
+/// the closing `>` is found correctly; without this the escape survived into
+/// the registered name, so MIDI::Make's `sub infix:<\\\\>` declared a TWO-character
+/// operator and its `4\\4` default never matched it (#7954).
+fn unescape_operator_symbol(raw: &str) -> String {
+    if !raw.contains('\\') {
+        return raw.to_string();
+    }
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            out.push(ch);
+            continue;
+        }
+        match chars.next() {
+            Some(esc @ ('\\' | '<' | '>')) => out.push(esc),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
 }
 
 /// Resolve compile-time constants in operator symbol names.

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -3685,8 +3685,19 @@ impl Interpreter {
                     let mut group_pattern = String::new();
                     let mut depth = 1;
                     let mut in_comment = false;
-                    let mut angle_depth = 0u32;
+                    // One entry per open `<...>`, true when it is a character
+                    // CLASS (`<[...]>`, `<-[...]>`, `<+[...]>`, `<:Letter>`)
+                    // rather than an assertion or subrule call. The two read
+                    // their contents by opposite rules and this scanner has to
+                    // honour both: a class's members are literal, so a quote in
+                    // `<-['"]>` opens nothing; an assertion holds a nested
+                    // regex, so the quote in `<!before '>}}'>` does open a
+                    // string and the `>` inside it does NOT close the assertion
+                    // (Blogin). Tracking one `angle_depth` and keying both rules
+                    // off it could only ever get one of the two right.
+                    let mut angle_kinds: Vec<bool> = Vec::new();
                     while let Some(ch) = chars.next() {
+                        let in_char_class = angle_kinds.last().copied().unwrap_or(false);
                         if in_comment {
                             group_pattern.push(ch);
                             if ch == '\n' {
@@ -3695,16 +3706,16 @@ impl Interpreter {
                             continue;
                         }
                         if ch == '<' {
-                            angle_depth += 1;
+                            angle_kinds.push(matches!(chars.peek(), Some('[' | '-' | '+' | ':')));
                             group_pattern.push(ch);
                             continue;
                         }
-                        if ch == '>' && angle_depth > 0 {
-                            angle_depth -= 1;
+                        if ch == '>' && !angle_kinds.is_empty() {
+                            angle_kinds.pop();
                             group_pattern.push(ch);
                             continue;
                         }
-                        if ch == '#' && angle_depth == 0 {
+                        if ch == '#' && angle_kinds.is_empty() {
                             in_comment = true;
                             group_pattern.push(ch);
                             continue;
@@ -3717,11 +3728,11 @@ impl Interpreter {
                             }
                             continue;
                         }
-                        if ch == '\'' && angle_depth == 0 {
+                        if ch == '\'' && !in_char_class {
                             // Single-quoted string — skip until closing quote.
-                            // Inside a `<...>` assertion / char class (angle_depth>0)
-                            // a quote is a literal member (e.g. `<-['"]>`), not a
-                            // string delimiter, so it must not swallow the group.
+                            // Inside a character CLASS a quote is a literal member
+                            // (e.g. `<-['"]>`), not a string delimiter, so it must
+                            // not swallow the group.
                             group_pattern.push(ch);
                             for sq in chars.by_ref() {
                                 group_pattern.push(sq);
@@ -3731,12 +3742,12 @@ impl Interpreter {
                             }
                             continue;
                         }
-                        if ch == '"' && angle_depth == 0 {
+                        if ch == '"' && !in_char_class {
                             // Double-quoted string — skip until closing quote.
-                            // Inside a `<...>` assertion / char class (angle_depth>0)
-                            // a `"` is a literal member (e.g. `<-["]>`), not a string
-                            // delimiter — without this guard it swallowed the closing
-                            // `)` and produced a spurious "Unmatched ( in regex".
+                            // Inside a character CLASS a `"` is a literal member
+                            // (e.g. `<-["]>`), not a string delimiter — without this
+                            // guard it swallowed the closing `)` and produced a
+                            // spurious "Unmatched ( in regex".
                             group_pattern.push(ch);
                             for dq in chars.by_ref() {
                                 group_pattern.push(dq);
@@ -3746,16 +3757,24 @@ impl Interpreter {
                             }
                             continue;
                         }
-                        if ch == '(' {
+                        if ch == '(' && !in_char_class {
                             depth += 1;
                             group_pattern.push(ch);
-                        } else if ch == ')' {
+                        } else if ch == ')' && !in_char_class {
                             depth -= 1;
                             if depth == 0 {
                                 break;
                             }
                             group_pattern.push(ch);
                         } else {
+                            // Inside a `<...>` assertion / char class a paren is a
+                            // literal member, not a nesting bracket — the same rule
+                            // the `'` and `"` guards above already follow. Counting
+                            // it ended the group at the `)` of `<[.)]>`, so
+                            // `( \d+ <[.)]> )` died on the leftover `]`
+                            // (Markdown::Lex, Blogin — #7954). Balanced parens in a
+                            // `<{ ... }>` code assertion are unaffected: they cancel
+                            // out either way.
                             group_pattern.push(ch);
                         }
                     }

--- a/t/lang/operators/user-infix-escaped-symbol-name.t
+++ b/t/lang/operators/user-infix-escaped-symbol-name.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# `infix:<...>` names its operator with an angle quote, whose ONLY escapes are
+# the backslash itself and the delimiters. So `infix:<\\>` declares the
+# ONE-character operator `\`, and `infix:<\n>` keeps both of its characters.
+# mutsu kept the escape in the registered name, so MIDI::Make's
+# `sub infix:<\\> (UInt8 $n, Pow2 $d)` declared a two-character operator that
+# its own `4\4` default argument could never match. Refs #7954.
+plan 7;
+
+sub infix:<\\> ($a, $b) { "$a/$b" }
+
+is &infix:<\\>.name, 'infix:<\>', 'the escape is resolved in the registered name';
+is 4\4, '4/4', 'the one-character operator is reachable from source';
+is (3\4), '3/4', 'and inside parentheses';
+
+# MIDI::Make reaches it from a parameter default, where the whole signature
+# failed to parse while the operator went by a name nothing spelled.
+sub time-signature ($ts = 4\4) { $ts }
+is time-signature(), '4/4', 'usable as a parameter default';
+is time-signature(6\8), '6/8', '... and still overridable';
+
+# A backslash before anything else is not an escape: both characters stay.
+sub infix:<\n> ($a, $b) { "$a+$b" }
+is &infix:<\n>.name, 'infix:<\n>', 'a non-delimiter backslash pair is left alone';
+is (1 \n 2), '1+2', '... and the two-character operator still parses';
+
+done-testing;

--- a/t/regex/syntax/regex-group-scan-charclass-vs-assertion.t
+++ b/t/regex/syntax/regex-group-scan-charclass-vs-assertion.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+
+# The scanner that finds a capture group's closing `)` has to read `<...>` by
+# the rule that applies to it, and the two rules are opposites:
+#
+#   * a character CLASS (`<[...]>`, `<-[...]>`, `<+[...]>`, `<:Prop>`) holds
+#     literal members, so a `)` or a quote inside it is just a member;
+#   * an ASSERTION or subrule call (`<!before ...>`, `<?{...}>`, `<foo>`) holds a
+#     nested regex, so a quote inside it really does open a string and a `>`
+#     inside that string does NOT close the assertion.
+#
+# Keying both off one `<...>` nesting depth can only get one of the two right:
+# `( \d+ <[.)]> )` ended at the class's `)` and died on the leftover `]`
+# (Markdown::Lex, Blogin), while `( [ <!before '>}}'> . ]* )` ended at the `>`
+# inside the assertion's string (Blogin). Refs #7954.
+plan 11;
+
+# --- a paren inside a character class is a member ---------------------------
+
+ok 'a)' ~~ / ( <[)]> ) /, 'a bare `)` char class inside a capture group';
+is $0, ')', '... and it captures the paren';
+
+ok '1)' ~~ / ( \d+ <[.)]> ) /, 'Markdown::Lex ordered-list marker';
+is $0, '1)', '... captures digits plus terminator';
+
+ok 'a(' ~~ / ( <[(]> ) /, 'an unbalanced `(` char class does not open a group';
+
+my $m = '- x' ~~ / ^ $<marker> = ( <[-+*]> | \d+ <[.)]> ) /;
+is $m<marker>, '-', 'Blogin bullet-marker alternation, named capture intact';
+is ('12. y' ~~ / ^ $<marker> = ( <[-+*]> | \d+ <[.)]> ) /)<marker>, '12.',
+    '... and its other branch';
+
+# --- a quote inside an ASSERTION is a string, and a `>` in it is literal -----
+
+ok 'x>y' ~~ / ( [ <!before '>'> . ]* ) /, 'a quoted `>` inside <!before> stays inside it';
+is $0, 'x', '... so the assertion stops the repetition at the `>`';
+
+# --- ...but a quote inside a character CLASS is a member --------------------
+
+ok Q{a'b} ~~ / ( <-['"]>+ ) /, 'quotes are literal members of a char class';
+is $0, 'a', '... and the class still excludes them';
+
+done-testing;

--- a/t/routines/signature/pointy-sigilless-param-is-a-term.t
+++ b/t/routines/signature/pointy-sigilless-param-is-a-term.t
@@ -1,0 +1,86 @@
+use v6;
+use Test;
+
+# A sigilless pointy parameter (`-> \index { ... }`) declares a TERM, not a
+# lexical: inside the block a bare `index` IS that binding. Two things follow,
+# and every control statement that takes a pointy block owes both.
+#
+# 1. The PARSE scope has to carry the name, or a name that also spells a listop
+#    (`index`, `join`, ...) is read as a call and swallows the rest of the
+#    statement — so it is the ENCLOSING construct that fails. That is how
+#    Hash::Ordered (and Archive::Ar / BSON::Simple / Terminal::Tests through it)
+#    reported "expected ')'" at a `method` header several lines below the real
+#    cause (#7954).
+# 2. The binding has to be declared AS a sigilless term, or the body's bare word
+#    is a package lookup and the block reads `(Any)`.
+plan 14;
+
+# --- the construct Hash::Ordered's DELETE-KEY is built from -------------------
+
+role Ordered {
+    has %!indices;
+    has @!keys;
+
+    method load(*@k) {
+        @!keys = @k;
+        %!indices{@k[$_]} = $_ for ^@k.elems;
+        self
+    }
+
+    method shift-from(\key) {
+        with %!indices{key} -> \index {
+            %!indices{@!keys[$_]}-- for index ^.. @!keys.end;
+            @!keys.splice(index, 1);
+            %!indices{key}:delete;
+        }
+        self
+    }
+
+    method order { @!keys.join(',') }
+    method index-of(\key) { %!indices{key} }
+}
+
+class OrderedHash does Ordered {}
+
+my $h = OrderedHash.new.load(<a b c d>);
+is $h.order, 'a,b,c,d', 'role with a `-> \index` pointy body parses and runs';
+$h.shift-from('b');
+is $h.order, 'a,c,d', '... the sigilless binding drove the splice';
+is $h.index-of('d'), 2, '... and the decrement loop saw it as a term, not a listop';
+
+# --- a listop-spelled name in every pointy-block control statement ------------
+
+my @got;
+if 1 -> \index { @got.push($_) for index .. 2 }
+is @got.join(','), '1,2', 'if: a listop-named sigilless param is a term';
+
+@got = ();
+unless 0 -> \index { @got.push($_) for index .. 2 }
+is @got.join(','), '0,1,2', 'unless: a listop-named sigilless param is a term';
+
+@got = ();
+with 1 -> \index { @got.push($_) for index .. 2 }
+is @got.join(','), '1,2', 'with: a listop-named sigilless param is a term';
+
+@got = ();
+given 1 -> \index { @got.push($_) for index .. 2 }
+is @got.join(','), '1,2', 'given: a listop-named sigilless param is a term';
+
+@got = ();
+for 1 -> \index { @got.push($_) for index .. 2 }
+is @got.join(','), '1,2', 'for: a listop-named sigilless param is a term';
+
+# --- the binding itself reads back -------------------------------------------
+
+with 7 -> \v { is v, 7, 'with: the sigilless binding reads back' }
+without Any -> \v { is v.^name, 'Any', 'without: the sigilless binding reads back' }
+if 8 -> \v { is v, 8, 'if: the sigilless binding reads back' }
+unless 0 -> \v { is v, 0, 'unless: binds the condition value itself' }
+
+# An `else` clause takes one too, and it binds the condition value — including
+# when the THEN clause's own binding was the sigilless one whose spelling
+# (`\a`) the else source had to read through.
+if 0 -> \a { } else -> \v { is v, 0, 'else: a sigilless param binds the condition' }
+if 0 -> \a { } else -> $v { is $v, 0, 'else: reads through a sigilless then-binding' }
+
+done-testing;


### PR DESCRIPTION
Three more constructs off the `blocked_load` parse-failure index (#7954), reached the way the earlier batches were: fetch the tarball named by the `ecosystem/dists/` record, `--dump-ast` every module the META6 `provides` names, bisect the failing file to the smallest still-failing range, and reduce that to a one-liner checked against rakudo. **Seven distributions stop failing to parse.**

## 1. A sigilless pointy parameter is a term, in every control statement

`Hash::Ordered` reported `expected ')'` at a `method DELETE-KEY(::?ROLE:D: \key)` header, and the pseudo-type invocant it names parses fine on its own. The cause was seven lines further down, inside that method:

```raku
with %!indices.DELETE-KEY(key) -> \index {
    %!indices.AT-KEY(@!keys.AT-POS($_))-- for index .. @!keys.end;
}
```

`-> \index` declares a **term**: inside the block a bare `index` IS that binding. Only `for` and `while` carried that into the body's parse scope, so in a `with` the body was parsed against what `index` means *outside* — the `index` builtin — and the listop swallowed the rest of the statement. The block then failed at its closing brace, and the reported location was the enclosing `method`. This is the container-row shape the previous batch's handover described, one layer out: the reported line names a container, and the cause is a name whose meaning changed inside it.

The registration is one shared helper now (`block_with_pointy_params`), used by `if` / `elsif` / `unless` / `else` / `given` / `with` / `without`, and it also registers a `&name` parameter as a routine for the same reason `for` already did (`-> &m { m() }` must read `m()` as a call, not an `m//` match).

Registering the name was **not enough on its own**. The parse memo is keyed by the input slice alone, and `if`'s header runs the full parameter-list parser, which speculates over the `{ ... }` that follows it — so the body's failure had already been memoized *before* the name existed, and the correctly-scoped parse was handed that stale entry straight back. The scoped body parse therefore runs in its own parse generation, which is precisely the scope's effect on the grammar.

Two silently-wrong answers fell out of the same investigation:

- `with 1 -> \v { v }` declared an ordinary lexical, so the body's bare word was a package lookup and the block read `(Any)` where rakudo reads `1`. The binding now carries the sigilless marker that makes it a term (and read-only, as rakudo has it).
- `if 0 -> \a { } else -> $x { }` handed the `else` clause `Nil`: a clause's `binding_var` keeps the declaration's own spelling, `\a` included, and the else lowering stripped only a `$`, so it read a name nothing declares.

Unblocks `Hash::Ordered`, and `Archive::Ar` / `BSON::Simple` / `Terminal::Tests`, which all failed on the same line of it.

## 2. The regex group scanner reads `<...>` by one rule where there are two

The scanner that finds a capture group's closing `)` tracked a single `<...>` nesting depth and keyed every other decision off it. But a character **class** and an **assertion** read their contents by opposite rules, and this scanner owes both:

- `<[.)]>` is a class, so its `)` is a literal member. Counting it ended the group early and `( \d+ <[.)]> )` died on the leftover `]` — the ordered-list marker in `Markdown::Lex` and `Blogin`.
- `<!before '>}}'>` is an assertion, so the quote really does open a string and the `>` inside it does *not* close the assertion. Treating the quote as a literal member (correct for `<-['"]>`) ended it at that `>` — `Blogin`'s shortcode regex.

The scanner now keeps one entry per open `<`, recording whether it is a class (`<[`, `<-`, `<+`, `<:`) or an assertion, and applies the paren and quote rules accordingly. Balanced parens in a `<{ ... }>` code assertion are unaffected: they cancelled out either way.

Unblocks `Markdown::Lex` and `Blogin` (all 29 of its modules parse).

## 3. An escaped operator symbol names a one-character operator

`<...>` is a Q-style quote whose only escapes are the backslash and the delimiters, so a doubled backslash inside `infix:< >` declares the one-character operator, while `infix:<\n>` keeps both of its characters (checked against rakudo's own `&infix:<...>.name`). mutsu kept the escape in the registered name, so `MIDI::Make`'s time-signature operator went by a name nothing spells, and its own `method time-signature (TimeSignature $ts = 4\4, ...)` default never matched it.

Unblocks `MIDI::Make`.

## Pins

- `t/routines/signature/pointy-sigilless-param-is-a-term.t`
- `t/regex/syntax/regex-group-scan-charclass-vs-assertion.t`
- `t/lang/operators/user-infix-escaped-symbol-name.t`

All three green under rakudo itself, so they pin rakudo's behaviour rather than mutsu's.

## Validation

- `cargo fmt --all` and `make lint` — clean in all four configurations.
- `make test` — 4210 files, 44848 assertions, PASS.
- `make roast` — 1437 files, 219635 assertions; the only failures are the three container-only ones `docs/agent-environments.md` documents (the two `uid 0` file-permission files, matched by subtest range, and the sandboxed-network socket file).

Write-up: `news/2026-09/parse-failure-index-pointy-terms-regex-group-scan-and-operator-escapes.md`.

Refs #7954

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze


---
_Generated by [Claude Code](https://claude.ai/code/session_01B72k1FWki3tw8R7Weqh4Ze)_